### PR TITLE
test: migrate renderer unit tests from JUnit 4 to JUnit 6

### DIFF
--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -33,7 +33,7 @@ import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.node.ObjectNode;
 
-public class ComponentRendererTest {
+class ComponentRendererTest {
 
     private static class TestUIInternals extends UIInternals {
 
@@ -65,7 +65,7 @@ public class ComponentRendererTest {
     }
 
     @Test
-    public void componentRenderer_parentAttachedBeforeChild() {
+    void componentRenderer_parentAttachedBeforeChild() {
         UI ui = new TestUI();
         TestUIInternals internals = (TestUIInternals) ui.getInternals();
 
@@ -87,10 +87,9 @@ public class ComponentRendererTest {
                                             .createObjectNode();
                                     rendering.getDataGenerator().get()
                                             .generateData("item", value);
-                                    Assert.assertEquals(
-                                            "generateData should add one element in the jsonobject",
-                                            1,
-                                            JacksonUtils.getKeys(value).size());
+                                    Assertions.assertEquals(1,
+                                            JacksonUtils.getKeys(value).size(),
+                                            "generateData should add one element in the jsonobject");
                                 }));
 
         // attach the parent (ex: grid) before the child (ex: column)
@@ -102,7 +101,7 @@ public class ComponentRendererTest {
     }
 
     @Test
-    public void componentRenderer_childAttachedBeforeParent() {
+    void componentRenderer_childAttachedBeforeParent() {
         UI ui = new TestUI();
         TestUIInternals internals = (TestUIInternals) ui.getInternals();
 
@@ -124,10 +123,9 @@ public class ComponentRendererTest {
                                             .createObjectNode();
                                     rendering.getDataGenerator().get()
                                             .generateData("item", value);
-                                    Assert.assertEquals(
-                                            "generateData should add one element in the jsonobject",
-                                            1,
-                                            JacksonUtils.getKeys(value).size());
+                                    Assertions.assertEquals(1,
+                                            JacksonUtils.getKeys(value).size(),
+                                            "generateData should add one element in the jsonobject");
                                 }));
         // attach the child (ex: container) before the parent (ex: grid)
         attachElement(ui, container);
@@ -138,7 +136,7 @@ public class ComponentRendererTest {
     }
 
     @Test
-    public void nullValues() {
+    void nullValues() {
         ComponentRenderer<Component, String> renderer = new ComponentRenderer<>(
                 e -> {
                     return null;
@@ -149,14 +147,14 @@ public class ComponentRendererTest {
                 keyMapper);
 
         Component c = cdg.createComponent("foo");
-        Assert.assertNotNull(
-                "Placeholder component should be generated for null values", c);
-        Assert.assertEquals(0, c.getElement().getChildCount());
+        Assertions.assertNotNull(c,
+                "Placeholder component should be generated for null values");
+        Assertions.assertEquals(0, c.getElement().getChildCount());
 
         c = cdg.updateComponent(c, "foo");
-        Assert.assertNotNull(
-                "Placeholder component should be generated for null values", c);
-        Assert.assertEquals(0, c.getElement().getChildCount());
+        Assertions.assertNotNull(c,
+                "Placeholder component should be generated for null values");
+        Assertions.assertEquals(0, c.getElement().getChildCount());
     }
 
     private void attachElement(UI ui, Element contentTemplate) {
@@ -164,55 +162,53 @@ public class ComponentRendererTest {
     }
 
     @Test
-    public void componentFunction_invokedOnCreate() {
+    void componentFunction_invokedOnCreate() {
         AtomicInteger createInvocations = new AtomicInteger();
         ComponentRenderer<TestDiv, String> renderer = new ComponentRenderer<>(
                 item -> {
                     createInvocations.incrementAndGet();
-                    Assert.assertEquals("New item", item);
+                    Assertions.assertEquals("New item", item);
                     return new TestDiv();
                 });
 
         renderer.createComponent("New item");
 
-        Assert.assertEquals(
-                "The component creation function should have been invoked once",
-                1, createInvocations.get());
+        Assertions.assertEquals(1, createInvocations.get(),
+                "The component creation function should have been invoked once");
     }
 
     @Test
-    public void componentFunction_noUpdateFunction_invokedOnUpdate() {
+    void componentFunction_noUpdateFunction_invokedOnUpdate() {
         AtomicInteger createInvocations = new AtomicInteger();
         TestDiv div = new TestDiv();
         ComponentRenderer<TestDiv, String> renderer = new ComponentRenderer<>(
                 item -> {
                     createInvocations.incrementAndGet();
-                    Assert.assertEquals("New item", item);
+                    Assertions.assertEquals("New item", item);
                     return div;
                 });
 
         Component updatedComponent = renderer.updateComponent(div, "New item");
 
-        Assert.assertEquals(
-                "The component creation function should have been invoked once",
-                1, createInvocations.get());
+        Assertions.assertEquals(1, createInvocations.get(),
+                "The component creation function should have been invoked once");
 
-        Assert.assertEquals("The two components should be the same", div,
-                updatedComponent);
+        Assertions.assertEquals(div, updatedComponent,
+                "The two components should be the same");
     }
 
     @Test
-    public void updateFunction_invokedOnUpdate() {
+    void updateFunction_invokedOnUpdate() {
         AtomicInteger createInvocations = new AtomicInteger();
         AtomicInteger updateInvocations = new AtomicInteger();
         ComponentRenderer<TestDiv, String> renderer = new ComponentRenderer<>(
                 item -> {
                     createInvocations.incrementAndGet();
-                    Assert.assertEquals("New item", item);
+                    Assertions.assertEquals("New item", item);
                     return new TestDiv();
                 }, (component, item) -> {
                     updateInvocations.incrementAndGet();
-                    Assert.assertEquals("Updated item", item);
+                    Assertions.assertEquals("Updated item", item);
                     return component;
                 });
 
@@ -220,15 +216,13 @@ public class ComponentRendererTest {
         Component updatedComponent = renderer.updateComponent(div,
                 "Updated item");
 
-        Assert.assertEquals(
-                "The component creation function should have been invoked once",
-                1, createInvocations.get());
-        Assert.assertEquals(
-                "The component update function should have been invoked once",
-                1, updateInvocations.get());
+        Assertions.assertEquals(1, createInvocations.get(),
+                "The component creation function should have been invoked once");
+        Assertions.assertEquals(1, updateInvocations.get(),
+                "The component update function should have been invoked once");
 
-        Assert.assertEquals("The two components should be the same", div,
-                updatedComponent);
+        Assertions.assertEquals(div, updatedComponent,
+                "The two components should be the same");
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/FormattedRenderersSerializableTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/FormattedRenderersSerializableTest.java
@@ -24,12 +24,12 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FormattedRenderersSerializableTest {
+class FormattedRenderersSerializableTest {
 
     @Test
-    public void numberRendererIsSerializable() throws IOException {
+    void numberRendererIsSerializable() throws IOException {
         NumberRenderer<?> renderer = new NumberRenderer<>(value -> 42);
         new ObjectOutputStream(new ByteArrayOutputStream())
                 .writeObject(renderer);
@@ -41,7 +41,7 @@ public class FormattedRenderersSerializableTest {
     }
 
     @Test
-    public void localDateTimeRendererIsSerializable() throws IOException {
+    void localDateTimeRendererIsSerializable() throws IOException {
         LocalDateTimeRenderer<?> renderer = new LocalDateTimeRenderer<>(
                 value -> LocalDateTime.now());
         new ObjectOutputStream(new ByteArrayOutputStream())
@@ -55,7 +55,7 @@ public class FormattedRenderersSerializableTest {
     }
 
     @Test
-    public void localDateRendererIsSerializable() throws IOException {
+    void localDateRendererIsSerializable() throws IOException {
         LocalDateRenderer<?> renderer = new LocalDateRenderer<>(
                 (v) -> LocalDate.now());
         new ObjectOutputStream(new ByteArrayOutputStream())

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/IconRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/IconRendererTest.java
@@ -15,29 +15,32 @@
  */
 package com.vaadin.flow.data.renderer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 
-public class IconRendererTest {
+class IconRendererTest {
 
     @Tag(Tag.A)
     public static class TestComponent extends Component {
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void dontAllowNullInLabelGenerator() {
+    @Test
+    void dontAllowNullInLabelGenerator() {
         IconRenderer<Object> renderer = new IconRenderer<>(
                 obj -> new TestComponent(), obj -> null);
-        renderer.createComponent(new Object());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> renderer.createComponent(new Object()));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void dontAllowNullInIconGenerator() {
+    @Test
+    void dontAllowNullInIconGenerator() {
         IconRenderer<Object> renderer = new IconRenderer<>(obj -> null,
                 obj -> "");
-        renderer.createComponent(new Object());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> renderer.createComponent(new Object()));
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/LitRendererTest.java
@@ -15,57 +15,61 @@
  */
 package com.vaadin.flow.data.renderer;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
-public class LitRendererTest {
-    @Rule
-    public final MockUIRule ui = new MockUIRule();
+class LitRendererTest {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
-    @Test(expected = IllegalArgumentException.class)
-    public void doNotAllowFunctionNamesWithFunctions() {
-        LitRenderer.of("").withFunction("foo=0; alert(\"gotcha\"); const bar",
-                item -> {
-                });
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void doNotAllowFunctionNamesWithSpaces() {
-        LitRenderer.of("").withFunction("illegal name", item -> {
-        });
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void doNotAllowFunctionNamesWithDots() {
-        LitRenderer.of("").withFunction("illegal.name", item -> {
-        });
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void doNotAllowFunctionNamesWithParenthesis() {
-        LitRenderer.of("").withFunction("illegalname()", item -> {
-        });
+    @Test
+    void doNotAllowFunctionNamesWithFunctions() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> LitRenderer.of("").withFunction(
+                        "foo=0; alert(\"gotcha\"); const bar", item -> {
+                        }));
     }
 
     @Test
-    public void allowAlphaNumericFunctionNames() {
+    void doNotAllowFunctionNamesWithSpaces() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> LitRenderer.of("").withFunction("illegal name", item -> {
+                }));
+    }
+
+    @Test
+    void doNotAllowFunctionNamesWithDots() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> LitRenderer.of("").withFunction("illegal.name", item -> {
+                }));
+    }
+
+    @Test
+    void doNotAllowFunctionNamesWithParenthesis() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> LitRenderer.of("").withFunction("illegalname()", item -> {
+                }));
+    }
+
+    @Test
+    void allowAlphaNumericFunctionNames() {
         LitRenderer.of("<div></div>").withFunction("legalName1", item -> {
         });
     }
 
     @Test
-    public void supportGettingValueProviders() {
+    void supportGettingValueProviders() {
         LitRenderer<?> renderer = LitRenderer.of("<div></div>")
                 .withProperty("foo", item -> 1).withProperty("bar", item -> 2);
 
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 renderer.getValueProviders().keySet().contains("foo"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 renderer.getValueProviders().keySet().contains("bar"));
-        Assert.assertTrue(renderer.getValueProviders().size() == 2);
+        Assertions.assertTrue(renderer.getValueProviders().size() == 2);
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/NativeButtonRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/NativeButtonRendererTest.java
@@ -18,8 +18,8 @@ package com.vaadin.flow.data.renderer;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.data.provider.DataGenerator;
 import com.vaadin.flow.data.provider.KeyMapper;
@@ -32,18 +32,18 @@ import com.vaadin.flow.shared.Registration;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
-public class NativeButtonRendererTest {
+class NativeButtonRendererTest {
 
     @Test
-    public void templateRenderered_containerIsDisabled_buttonIsDisabled() {
+    void templateRenderered_containerIsDisabled_buttonIsDisabled() {
         NativeButtonRenderer<String> renderer = new NativeButtonRenderer<>(
                 "Label");
         Element container = new Element("div");
         KeyMapper<String> keyMapper = new KeyMapper<>();
         Rendering<String> rendering = renderer.render(container, keyMapper);
 
-        Assert.assertTrue("The DataGenerator should be present",
-                rendering.getDataGenerator().isPresent());
+        Assertions.assertTrue(rendering.getDataGenerator().isPresent(),
+                "The DataGenerator should be present");
         DataGenerator<String> dataGenerator = rendering.getDataGenerator()
                 .get();
 
@@ -53,19 +53,19 @@ public class NativeButtonRendererTest {
         // Find the mapped key for "disabled" property
         var keyForDisabled = JacksonUtils.getKeys(json).stream()
                 .filter(key -> key.endsWith("disabled")).findFirst().get();
-        Assert.assertFalse("The button shouldn't be disabled",
-                json.get(keyForDisabled).booleanValue());
+        Assertions.assertFalse(json.get(keyForDisabled).booleanValue(),
+                "The button shouldn't be disabled");
 
         mockDisabled(container);
 
         json = JacksonUtils.createObjectNode();
         dataGenerator.generateData("something", json);
-        Assert.assertTrue("The button should be disabled",
-                json.get(keyForDisabled).booleanValue());
+        Assertions.assertTrue(json.get(keyForDisabled).booleanValue(),
+                "The button should be disabled");
     }
 
     @Test
-    public void removeListenerInListener_shouldNotThrowException() {
+    void removeListenerInListener_shouldNotThrowException() {
         // Create a new renderer
         var renderer = new NativeButtonRenderer<String>("Label");
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/NumberRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/NumberRendererTest.java
@@ -17,26 +17,26 @@ package com.vaadin.flow.data.renderer;
 
 import java.util.Locale;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.function.ValueProvider;
 
-public class NumberRendererTest {
+class NumberRendererTest {
 
     @Test
-    public void getFormattedValue_numberIsFormattedUsingLocale() {
+    void getFormattedValue_numberIsFormattedUsingLocale() {
         NumberRenderer<Number> renderer = new NumberRenderer<>(
                 ValueProvider.identity(), Locale.GERMANY);
 
         String formatted = renderer.getFormattedValue(1.2);
-        Assert.assertEquals("1,2", formatted);
+        Assertions.assertEquals("1,2", formatted);
 
         renderer = new NumberRenderer<>(ValueProvider.identity(),
                 Locale.ENGLISH);
 
         formatted = renderer.getFormattedValue(1.2);
-        Assert.assertEquals("1.2", formatted);
+        Assertions.assertEquals("1.2", formatted);
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/TextRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/TextRendererTest.java
@@ -15,14 +15,16 @@
  */
 package com.vaadin.flow.data.renderer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class TextRendererTest {
+class TextRendererTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void dontAllowNullInLabelGenerator() {
+    @Test
+    void dontAllowNullInLabelGenerator() {
         TextRenderer<Object> renderer = new TextRenderer<>(obj -> null);
-        renderer.createComponent(new Object());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> renderer.createComponent(new Object()));
     }
 
 }

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/tests/RendererSerializableTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/tests/RendererSerializableTest.java
@@ -17,5 +17,5 @@ package com.vaadin.flow.data.renderer.tests;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-public class RendererSerializableTest extends ClassesSerializableTest {
+class RendererSerializableTest extends ClassesSerializableTest {
 }


### PR DESCRIPTION
## Description

Convert `Renderer` unit tests to JUnit 6.