### PR TITLE
chore: convert date-time-picker unit tests to JUnit 6

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerI18nTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerI18nTest.java
@@ -15,104 +15,114 @@
  */
 package com.vaadin.flow.component.datetimepicker;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import tools.jackson.databind.node.NullNode;
 import tools.jackson.databind.node.ObjectNode;
 
-public class DateTimePickerI18nTest {
+class DateTimePickerI18nTest {
 
     private DateTimePicker dateTimePicker;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         dateTimePicker = new DateTimePicker();
     }
 
     @Test
-    public void setDateAriaLabel_removeDateAriaLabel() {
+    void setDateAriaLabel_removeDateAriaLabel() {
         dateTimePicker.setDateAriaLabel("Custom date");
-        Assert.assertEquals("Custom date", getI18nPropertyAsJson(dateTimePicker)
-                .get("dateLabel").asString());
+        Assertions.assertEquals("Custom date",
+                getI18nPropertyAsJson(dateTimePicker).get("dateLabel")
+                        .asString());
 
         dateTimePicker.setDateAriaLabel(null);
-        Assert.assertTrue(getI18nPropertyAsJson(dateTimePicker)
+        Assertions.assertTrue(getI18nPropertyAsJson(dateTimePicker)
                 .get("dateLabel") instanceof NullNode);
     }
 
     @Test
-    public void setDateAriaLabel_setI18n() {
+    void setDateAriaLabel_setI18n() {
         dateTimePicker.setDateAriaLabel("Custom date");
 
         dateTimePicker.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setDateLabel("I18n date"));
-        Assert.assertEquals("Custom date", getI18nPropertyAsJson(dateTimePicker)
-                .get("dateLabel").asString());
+        Assertions.assertEquals("Custom date",
+                getI18nPropertyAsJson(dateTimePicker).get("dateLabel")
+                        .asString());
     }
 
     @Test
-    public void setTimeAriaLabel_removeTimeAriaLabel() {
+    void setTimeAriaLabel_removeTimeAriaLabel() {
         dateTimePicker.setTimeAriaLabel("Custom time");
-        Assert.assertEquals("Custom time", getI18nPropertyAsJson(dateTimePicker)
-                .get("timeLabel").asString());
+        Assertions.assertEquals("Custom time",
+                getI18nPropertyAsJson(dateTimePicker).get("timeLabel")
+                        .asString());
 
         dateTimePicker.setTimeAriaLabel(null);
-        Assert.assertTrue(getI18nPropertyAsJson(dateTimePicker)
+        Assertions.assertTrue(getI18nPropertyAsJson(dateTimePicker)
                 .get("timeLabel") instanceof NullNode);
     }
 
     @Test
-    public void setTimeAriaLabel_setI18n() {
+    void setTimeAriaLabel_setI18n() {
         dateTimePicker.setTimeAriaLabel("Custom time");
 
         dateTimePicker.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setTimeLabel("I18n time"));
-        Assert.assertEquals("Custom time", getI18nPropertyAsJson(dateTimePicker)
-                .get("timeLabel").asString());
+        Assertions.assertEquals("Custom time",
+                getI18nPropertyAsJson(dateTimePicker).get("timeLabel")
+                        .asString());
     }
 
     @Test
-    public void setI18n() {
+    void setI18n() {
         DateTimePicker.DateTimePickerI18n i18n = new DateTimePicker.DateTimePickerI18n()
                 .setDateLabel("I18n date").setTimeLabel("I18n time");
         dateTimePicker.setI18n(i18n);
 
-        Assert.assertEquals("I18n date", getI18nPropertyAsJson(dateTimePicker)
-                .get("dateLabel").asString());
-        Assert.assertEquals("I18n time", getI18nPropertyAsJson(dateTimePicker)
-                .get("timeLabel").asString());
+        Assertions.assertEquals("I18n date",
+                getI18nPropertyAsJson(dateTimePicker).get("dateLabel")
+                        .asString());
+        Assertions.assertEquals("I18n time",
+                getI18nPropertyAsJson(dateTimePicker).get("timeLabel")
+                        .asString());
     }
 
     @Test
-    public void setI18n_setDateAriaLabel_removeDateAriaLabel() {
+    void setI18n_setDateAriaLabel_removeDateAriaLabel() {
         DateTimePicker.DateTimePickerI18n i18n = new DateTimePicker.DateTimePickerI18n()
                 .setDateLabel("I18n date").setTimeLabel("I18n time");
         dateTimePicker.setI18n(i18n);
 
         dateTimePicker.setDateAriaLabel("Custom date");
-        Assert.assertEquals("Custom date", getI18nPropertyAsJson(dateTimePicker)
-                .get("dateLabel").asString());
+        Assertions.assertEquals("Custom date",
+                getI18nPropertyAsJson(dateTimePicker).get("dateLabel")
+                        .asString());
 
         dateTimePicker.setDateAriaLabel(null);
-        Assert.assertEquals("I18n date", getI18nPropertyAsJson(dateTimePicker)
-                .get("dateLabel").asString());
+        Assertions.assertEquals("I18n date",
+                getI18nPropertyAsJson(dateTimePicker).get("dateLabel")
+                        .asString());
     }
 
     @Test
-    public void setI18n_setTimeAriaLabel_removeTimeAriaLabel() {
+    void setI18n_setTimeAriaLabel_removeTimeAriaLabel() {
         DateTimePicker.DateTimePickerI18n i18n = new DateTimePicker.DateTimePickerI18n()
                 .setDateLabel("I18n date").setTimeLabel("I18n time");
         dateTimePicker.setI18n(i18n);
 
         dateTimePicker.setTimeAriaLabel("Custom time");
-        Assert.assertEquals("Custom time", getI18nPropertyAsJson(dateTimePicker)
-                .get("timeLabel").asString());
+        Assertions.assertEquals("Custom time",
+                getI18nPropertyAsJson(dateTimePicker).get("timeLabel")
+                        .asString());
 
         dateTimePicker.setTimeAriaLabel(null);
-        Assert.assertEquals("I18n time", getI18nPropertyAsJson(dateTimePicker)
-                .get("timeLabel").asString());
+        Assertions.assertEquals("I18n time",
+                getI18nPropertyAsJson(dateTimePicker).get("timeLabel")
+                        .asString());
     }
 
     private ObjectNode getI18nPropertyAsJson(DateTimePicker dateTimePicker) {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerLocaleTest.java
@@ -18,44 +18,44 @@ package com.vaadin.flow.component.datetimepicker;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
 import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
-public class DateTimePickerLocaleTest {
-    @Rule
-    public MockUIRule ui = new MockUIRule();
+class DateTimePickerLocaleTest {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     @Test
-    public void newDateTimePicker_returnsUiLocale() {
+    void newDateTimePicker_returnsUiLocale() {
         Locale finnishLocale = new Locale("fi-FI");
         ui.setLocale(finnishLocale);
         DateTimePicker dateTimePicker = new DateTimePicker();
-        Assert.assertEquals(finnishLocale, dateTimePicker.getLocale());
+        Assertions.assertEquals(finnishLocale, dateTimePicker.getLocale());
     }
 
     @Test
-    public void newDateTimePickerWithCustomLocale_returnsCustomLocale() {
+    void newDateTimePickerWithCustomLocale_returnsCustomLocale() {
         Locale finnishLocale = new Locale("fi-FI");
         Locale usLocale = new Locale("en-US");
         ui.setLocale(finnishLocale);
         DateTimePicker dateTimePicker = new DateTimePicker(LocalDateTime.now(),
                 usLocale);
-        Assert.assertEquals(usLocale, dateTimePicker.getLocale());
+        Assertions.assertEquals(usLocale, dateTimePicker.getLocale());
     }
 
     @Test
-    public void setCustomLocale_returnsCustomLocale() {
+    void setCustomLocale_returnsCustomLocale() {
         Locale finnishLocale = new Locale("fi-FI");
         Locale usLocale = new Locale("en-US");
         ui.setLocale(finnishLocale);
         DateTimePicker dateTimePicker = new DateTimePicker();
         dateTimePicker.setLocale(usLocale);
-        Assert.assertEquals(usLocale, dateTimePicker.getLocale());
+        Assertions.assertEquals(usLocale, dateTimePicker.getLocale());
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerSerializableTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerSerializableTest.java
@@ -17,6 +17,6 @@ package com.vaadin.flow.component.datetimepicker;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-public class DateTimePickerSerializableTest extends ClassesSerializableTest {
+class DateTimePickerSerializableTest extends ClassesSerializableTest {
 
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerSignalTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerSignalTest.java
@@ -17,15 +17,15 @@ package com.vaadin.flow.component.datetimepicker;
 
 import java.time.LocalDateTime;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.local.ValueSignal;
-import com.vaadin.tests.AbstractSignalsUnitTest;
+import com.vaadin.tests.AbstractSignalsJUnit6Test;
 
-public class DateTimePickerSignalTest extends AbstractSignalsUnitTest {
+class DateTimePickerSignalTest extends AbstractSignalsJUnit6Test {
 
     private final DateTimePicker dateTimePicker = new DateTimePicker();
     private final ValueSignal<LocalDateTime> signal = new ValueSignal<>(
@@ -34,137 +34,145 @@ public class DateTimePickerSignalTest extends AbstractSignalsUnitTest {
             false);
 
     @Test
-    public void bindMin_elementAttached_updatesWithSignal() {
+    void bindMin_elementAttached_updatesWithSignal() {
         UI.getCurrent().add(dateTimePicker);
         dateTimePicker.bindMin(signal);
 
-        Assert.assertEquals(signal.peek(), dateTimePicker.getMin());
-        Assert.assertEquals(signal.peek().toString(),
+        Assertions.assertEquals(signal.peek(), dateTimePicker.getMin());
+        Assertions.assertEquals(signal.peek().toString(),
                 dateTimePicker.getElement().getProperty("min"));
 
         LocalDateTime newValue = LocalDateTime.of(2023, 10, 2, 11, 0);
         signal.set(newValue);
-        Assert.assertEquals(newValue, dateTimePicker.getMin());
-        Assert.assertEquals(newValue.toString(),
+        Assertions.assertEquals(newValue, dateTimePicker.getMin());
+        Assertions.assertEquals(newValue.toString(),
                 dateTimePicker.getElement().getProperty("min"));
     }
 
     @Test
-    public void bindMin_elementNotAttached_initialValueApplied() {
+    void bindMin_elementNotAttached_initialValueApplied() {
         dateTimePicker.bindMin(signal);
 
         // Initial value is applied immediately (effect runs on creation)
-        Assert.assertEquals(signal.peek(), dateTimePicker.getMin());
+        Assertions.assertEquals(signal.peek(), dateTimePicker.getMin());
 
         UI.getCurrent().add(dateTimePicker);
-        Assert.assertEquals(signal.peek(), dateTimePicker.getMin());
-    }
-
-    @Test(expected = BindingActiveException.class)
-    public void setMin_whileBound_throwsException() {
-        UI.getCurrent().add(dateTimePicker);
-        dateTimePicker.bindMin(signal);
-        dateTimePicker.setMin(LocalDateTime.now());
-    }
-
-    @Test(expected = BindingActiveException.class)
-    public void bindMin_whileBound_throwsException() {
-        UI.getCurrent().add(dateTimePicker);
-        dateTimePicker.bindMin(signal);
-        dateTimePicker.bindMin(new ValueSignal<>(LocalDateTime.now()));
+        Assertions.assertEquals(signal.peek(), dateTimePicker.getMin());
     }
 
     @Test
-    public void bindMax_elementAttached_updatesWithSignal() {
+    void setMin_whileBound_throwsException() {
+        UI.getCurrent().add(dateTimePicker);
+        dateTimePicker.bindMin(signal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> dateTimePicker.setMin(LocalDateTime.now()));
+    }
+
+    @Test
+    void bindMin_whileBound_throwsException() {
+        UI.getCurrent().add(dateTimePicker);
+        dateTimePicker.bindMin(signal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> dateTimePicker
+                        .bindMin(new ValueSignal<>(LocalDateTime.now())));
+    }
+
+    @Test
+    void bindMax_elementAttached_updatesWithSignal() {
         UI.getCurrent().add(dateTimePicker);
         dateTimePicker.bindMax(signal);
 
-        Assert.assertEquals(signal.peek(), dateTimePicker.getMax());
-        Assert.assertEquals(signal.peek().toString(),
+        Assertions.assertEquals(signal.peek(), dateTimePicker.getMax());
+        Assertions.assertEquals(signal.peek().toString(),
                 dateTimePicker.getElement().getProperty("max"));
 
         LocalDateTime newValue = LocalDateTime.of(2023, 10, 2, 11, 0);
         signal.set(newValue);
-        Assert.assertEquals(newValue, dateTimePicker.getMax());
-        Assert.assertEquals(newValue.toString(),
+        Assertions.assertEquals(newValue, dateTimePicker.getMax());
+        Assertions.assertEquals(newValue.toString(),
                 dateTimePicker.getElement().getProperty("max"));
     }
 
     @Test
-    public void bindMax_elementNotAttached_initialValueApplied() {
+    void bindMax_elementNotAttached_initialValueApplied() {
         dateTimePicker.bindMax(signal);
 
         // Initial value is applied immediately (effect runs on creation)
-        Assert.assertEquals(signal.peek(), dateTimePicker.getMax());
+        Assertions.assertEquals(signal.peek(), dateTimePicker.getMax());
 
         UI.getCurrent().add(dateTimePicker);
-        Assert.assertEquals(signal.peek(), dateTimePicker.getMax());
-    }
-
-    @Test(expected = BindingActiveException.class)
-    public void setMax_whileBound_throwsException() {
-        UI.getCurrent().add(dateTimePicker);
-        dateTimePicker.bindMax(signal);
-        dateTimePicker.setMax(LocalDateTime.now());
-    }
-
-    @Test(expected = BindingActiveException.class)
-    public void bindMax_whileBound_throwsException() {
-        UI.getCurrent().add(dateTimePicker);
-        dateTimePicker.bindMax(signal);
-        dateTimePicker.bindMax(new ValueSignal<>(LocalDateTime.now()));
+        Assertions.assertEquals(signal.peek(), dateTimePicker.getMax());
     }
 
     @Test
-    public void bindReadOnly_elementAttached_updatesWithSignal() {
+    void setMax_whileBound_throwsException() {
+        UI.getCurrent().add(dateTimePicker);
+        dateTimePicker.bindMax(signal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> dateTimePicker.setMax(LocalDateTime.now()));
+    }
+
+    @Test
+    void bindMax_whileBound_throwsException() {
+        UI.getCurrent().add(dateTimePicker);
+        dateTimePicker.bindMax(signal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> dateTimePicker
+                        .bindMax(new ValueSignal<>(LocalDateTime.now())));
+    }
+
+    @Test
+    void bindReadOnly_elementAttached_updatesWithSignal() {
         UI.getCurrent().add(dateTimePicker);
         dateTimePicker.bindReadOnly(readonlySignal);
 
-        Assert.assertFalse(dateTimePicker.isReadOnly());
+        Assertions.assertFalse(dateTimePicker.isReadOnly());
 
         readonlySignal.set(true);
-        Assert.assertTrue(dateTimePicker.isReadOnly());
+        Assertions.assertTrue(dateTimePicker.isReadOnly());
     }
 
     @Test
-    public void bindReadOnly_elementNotAttached_initialValueApplied() {
+    void bindReadOnly_elementNotAttached_initialValueApplied() {
         readonlySignal.set(true);
         dateTimePicker.bindReadOnly(readonlySignal);
 
         // Initial value is applied immediately (effect runs on creation)
-        Assert.assertTrue(dateTimePicker.isReadOnly());
+        Assertions.assertTrue(dateTimePicker.isReadOnly());
 
         UI.getCurrent().add(dateTimePicker);
-        Assert.assertTrue(dateTimePicker.isReadOnly());
-    }
-
-    @Test(expected = BindingActiveException.class)
-    public void setReadOnly_whileBound_throwsException() {
-        UI.getCurrent().add(dateTimePicker);
-        dateTimePicker.bindReadOnly(readonlySignal);
-        dateTimePicker.setReadOnly(true);
-    }
-
-    @Test(expected = BindingActiveException.class)
-    public void bindReadOnly_whileBound_throwsException() {
-        UI.getCurrent().add(dateTimePicker);
-        dateTimePicker.bindReadOnly(readonlySignal);
-        dateTimePicker.bindReadOnly(new ValueSignal<>(true));
+        Assertions.assertTrue(dateTimePicker.isReadOnly());
     }
 
     @Test
-    public void bindReadOnly_synchronizesChildComponents() {
+    void setReadOnly_whileBound_throwsException() {
+        UI.getCurrent().add(dateTimePicker);
+        dateTimePicker.bindReadOnly(readonlySignal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> dateTimePicker.setReadOnly(true));
+    }
+
+    @Test
+    void bindReadOnly_whileBound_throwsException() {
+        UI.getCurrent().add(dateTimePicker);
+        dateTimePicker.bindReadOnly(readonlySignal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> dateTimePicker.bindReadOnly(new ValueSignal<>(true)));
+    }
+
+    @Test
+    void bindReadOnly_synchronizesChildComponents() {
         UI.getCurrent().add(dateTimePicker);
         dateTimePicker.bindReadOnly(readonlySignal);
 
-        Assert.assertFalse(dateTimePicker.isReadOnly());
-        Assert.assertFalse(getDatePicker().isReadOnly());
-        Assert.assertFalse(getTimePicker().isReadOnly());
+        Assertions.assertFalse(dateTimePicker.isReadOnly());
+        Assertions.assertFalse(getDatePicker().isReadOnly());
+        Assertions.assertFalse(getTimePicker().isReadOnly());
 
         readonlySignal.set(true);
-        Assert.assertTrue(dateTimePicker.isReadOnly());
-        Assert.assertTrue(getDatePicker().isReadOnly());
-        Assert.assertTrue(getTimePicker().isReadOnly());
+        Assertions.assertTrue(dateTimePicker.isReadOnly());
+        Assertions.assertTrue(getDatePicker().isReadOnly());
+        Assertions.assertTrue(getTimePicker().isReadOnly());
     }
 
     private DateTimePickerDatePicker getDatePicker() {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -15,17 +15,17 @@
  */
 package com.vaadin.flow.component.datetimepicker;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
@@ -35,47 +35,47 @@ import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
 import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
-public class DateTimePickerTest {
-    @Rule
-    public MockUIRule ui = new MockUIRule();
+class DateTimePickerTest {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     @Test
-    public void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
+    void initialValueIsNotSpecified_valuePropertyHasEmptyString() {
         DateTimePicker picker = new DateTimePicker();
-        Assert.assertNull(picker.getValue());
-        Assert.assertEquals("", picker.getElement().getProperty("value"));
+        Assertions.assertNull(picker.getValue());
+        Assertions.assertEquals("", picker.getElement().getProperty("value"));
     }
 
     @Test
-    public void initialValueIsNull_valuePropertyHasEmptyString() {
+    void initialValueIsNull_valuePropertyHasEmptyString() {
         DateTimePicker picker = new DateTimePicker((LocalDateTime) null);
-        Assert.assertNull(picker.getValue());
-        Assert.assertEquals("", picker.getElement().getProperty("value"));
+        Assertions.assertNull(picker.getValue());
+        Assertions.assertEquals("", picker.getElement().getProperty("value"));
     }
 
     @Test
-    public void initialValueIsDateTime_valuePropertyHasInitialValue() {
+    void initialValueIsDateTime_valuePropertyHasInitialValue() {
         DateTimePicker picker = new DateTimePicker(
                 LocalDateTime.of(2018, 4, 25, 13, 45, 10));
-        Assert.assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
+        Assertions.assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
                 picker.getValue());
-        Assert.assertEquals("2018-04-25T13:45:10",
+        Assertions.assertEquals("2018-04-25T13:45:10",
                 picker.getElement().getProperty("value"));
     }
 
     @Test
-    public void emptyField() {
+    void emptyField() {
         DateTimePicker picker = new DateTimePicker();
         assertEquals(null, picker.getValue());
     }
 
     @Test
-    public void setInitialValue() {
+    void setInitialValue() {
         DateTimePicker picker = new DateTimePicker(
                 LocalDateTime.of(2018, 4, 25, 13, 45, 10));
         assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
@@ -83,7 +83,7 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setInitialValue_truncatesToMilliseconds() {
+    void setInitialValue_truncatesToMilliseconds() {
         Duration oneMillisecondAndOneNano = Duration.ofMillis(1).plusNanos(1);
         Duration oneMillisecond = Duration.ofMillis(1);
         LocalDateTime baseDateTime = LocalDateTime.of(2018, 4, 25, 13, 45, 10);
@@ -97,7 +97,7 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setValue() {
+    void setValue() {
         DateTimePicker picker = new DateTimePicker();
         picker.setValue(LocalDateTime.of(2018, 4, 25, 13, 45, 10));
         assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
@@ -105,7 +105,7 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setValue_truncatesToMilliseconds() {
+    void setValue_truncatesToMilliseconds() {
         Duration oneMillisecondAndOneNano = Duration.ofMillis(1).plusNanos(1);
         Duration oneMillisecond = Duration.ofMillis(1);
         LocalDateTime baseDateTime = LocalDateTime.of(2018, 4, 25, 13, 45, 10);
@@ -120,7 +120,7 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setMinGetMin() {
+    void setMinGetMin() {
         DateTimePicker picker = new DateTimePicker();
         picker.setMin(LocalDateTime.of(2018, 4, 25, 13, 45, 10));
         assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
@@ -128,7 +128,7 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setMaxGetMax() {
+    void setMaxGetMax() {
         DateTimePicker picker = new DateTimePicker();
         picker.setMax(LocalDateTime.of(2018, 4, 25, 13, 45, 10));
         assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
@@ -136,14 +136,14 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setErrorMessage() {
+    void setErrorMessage() {
         DateTimePicker picker = new DateTimePicker();
         picker.setErrorMessage("error message");
         assertEquals("error message", picker.getErrorMessage());
     }
 
     @Test
-    public void setI18n() {
+    void setI18n() {
         DateTimePicker picker = new DateTimePicker();
 
         DatePicker.DatePickerI18n i18n = new DatePicker.DatePickerI18n()
@@ -162,20 +162,20 @@ public class DateTimePickerTest {
     }
 
     @Test
-    public void setAutoOpen() {
+    void setAutoOpen() {
         final DateTimePicker picker = new DateTimePicker();
-        assertTrue("Auto-open should be enabled by default",
-                picker.isAutoOpen());
+        assertTrue(picker.isAutoOpen(),
+                "Auto-open should be enabled by default");
         picker.setAutoOpen(false);
-        assertFalse("Should be possible to disable auto-open",
-                picker.isAutoOpen());
+        assertFalse(picker.isAutoOpen(),
+                "Should be possible to disable auto-open");
         picker.setAutoOpen(true);
-        assertTrue("Should be possible to enable auto-open",
-                picker.isAutoOpen());
+        assertTrue(picker.isAutoOpen(),
+                "Should be possible to enable auto-open");
     }
 
     @Test
-    public void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
+    void elementHasValue_wrapIntoField_propertyIsNotSetToInitialValue() {
         Element element = new Element("vaadin-date-time-picker");
 
         String value = LocalDateTime.now().toString();
@@ -190,55 +190,57 @@ public class DateTimePickerTest {
                 .thenAnswer(invocation -> new DateTimePicker());
 
         DateTimePicker field = Component.from(element, DateTimePicker.class);
-        Assert.assertEquals(value, field.getElement().getProperty("value"));
+        Assertions.assertEquals(value, field.getElement().getProperty("value"));
     }
 
     @Test
-    public void setAriaLabel() {
+    void setAriaLabel() {
         final DateTimePicker picker = new DateTimePicker();
-        Assert.assertTrue(picker.getAriaLabel().isEmpty());
+        Assertions.assertTrue(picker.getAriaLabel().isEmpty());
         picker.setAriaLabel("aria-label");
-        Assert.assertTrue(picker.getAriaLabel().isPresent());
-        Assert.assertEquals("aria-label", picker.getAriaLabel().get());
+        Assertions.assertTrue(picker.getAriaLabel().isPresent());
+        Assertions.assertEquals("aria-label", picker.getAriaLabel().get());
 
         picker.setAriaLabel(null);
-        Assert.assertTrue(picker.getAriaLabel().isEmpty());
+        Assertions.assertTrue(picker.getAriaLabel().isEmpty());
     }
 
     @Test
-    public void setDateAriaLabel() {
+    void setDateAriaLabel() {
         final DateTimePicker picker = new DateTimePicker();
-        Assert.assertTrue(picker.getDateAriaLabel().isEmpty());
+        Assertions.assertTrue(picker.getDateAriaLabel().isEmpty());
         picker.setDateAriaLabel("date-aria-label");
-        Assert.assertTrue(picker.getDateAriaLabel().isPresent());
-        Assert.assertEquals("date-aria-label", picker.getDateAriaLabel().get());
+        Assertions.assertTrue(picker.getDateAriaLabel().isPresent());
+        Assertions.assertEquals("date-aria-label",
+                picker.getDateAriaLabel().get());
 
         picker.setDateAriaLabel(null);
-        Assert.assertTrue(picker.getDateAriaLabel().isEmpty());
+        Assertions.assertTrue(picker.getDateAriaLabel().isEmpty());
     }
 
     @Test
-    public void setTimeAriaLabel() {
+    void setTimeAriaLabel() {
         final DateTimePicker picker = new DateTimePicker();
-        Assert.assertTrue(picker.getTimeAriaLabel().isEmpty());
+        Assertions.assertTrue(picker.getTimeAriaLabel().isEmpty());
         picker.setTimeAriaLabel("time-aria-label");
-        Assert.assertTrue(picker.getTimeAriaLabel().isPresent());
-        Assert.assertEquals("time-aria-label", picker.getTimeAriaLabel().get());
+        Assertions.assertTrue(picker.getTimeAriaLabel().isPresent());
+        Assertions.assertEquals("time-aria-label",
+                picker.getTimeAriaLabel().get());
 
         picker.setTimeAriaLabel(null);
-        Assert.assertTrue(picker.getTimeAriaLabel().isEmpty());
+        Assertions.assertTrue(picker.getTimeAriaLabel().isEmpty());
     }
 
     @Test
-    public void implementsHasTooltip() {
+    void implementsHasTooltip() {
         DateTimePicker picker = new DateTimePicker();
-        Assert.assertTrue(picker instanceof HasTooltip);
+        Assertions.assertTrue(picker instanceof HasTooltip);
     }
 
     @Test
-    public void implementsInputField() {
+    void implementsInputField() {
         DateTimePicker field = new DateTimePicker();
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 field instanceof InputField<AbstractField.ComponentValueChangeEvent<DateTimePicker, LocalDateTime>, LocalDateTime>);
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerVariantTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerVariantTest.java
@@ -15,23 +15,23 @@
  */
 package com.vaadin.flow.component.datetimepicker;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class DateTimePickerVariantTest {
+class DateTimePickerVariantTest {
 
     private DateTimePicker dateTimePicker;
 
-    @Before
-    public void initTest() {
+    @BeforeEach
+    void initTest() {
         dateTimePicker = new DateTimePicker();
     }
 
     @Test
-    public void addAndRemoveLumoAlignCenterVariant_themeAttributeUpdated() {
+    void addAndRemoveLumoAlignCenterVariant_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker
                 .addThemeVariants(DateTimePickerVariant.LUMO_ALIGN_CENTER);
@@ -42,28 +42,28 @@ public class DateTimePickerVariantTest {
     }
 
     @Test
-    public void addLumoAlignRightVariant_themeAttributeUpdated() {
+    void addLumoAlignRightVariant_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_ALIGN_RIGHT);
         assertThemeAttribute("align-right");
     }
 
     @Test
-    public void addLumoSmallVariant_themeAttributeUpdated() {
+    void addLumoSmallVariant_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_SMALL);
         assertThemeAttribute("small");
     }
 
     @Test
-    public void addLumoAlignLeftVariant_themeAttributeUpdated() {
+    void addLumoAlignLeftVariant_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_ALIGN_LEFT);
         assertThemeAttribute("align-left");
     }
 
     @Test
-    public void addLumoHelperAboveField_themeAttributeUpdated() {
+    void addLumoHelperAboveField_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(
                 DateTimePickerVariant.LUMO_HELPER_ABOVE_FIELD);
@@ -71,7 +71,7 @@ public class DateTimePickerVariantTest {
     }
 
     @Test
-    public void addAndRemoveMultipleVariants_themeAttributeUpdated() {
+    void addAndRemoveMultipleVariants_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_SMALL);
         dateTimePicker.addThemeVariants(
@@ -84,7 +84,7 @@ public class DateTimePickerVariantTest {
     }
 
     @Test
-    public void addAndRemoveAllMultipleVariants_themeAttributeUpdated() {
+    void addAndRemoveAllMultipleVariants_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_SMALL);
         dateTimePicker.addThemeVariants(
@@ -94,7 +94,7 @@ public class DateTimePickerVariantTest {
     }
 
     @Test
-    public void addTwiceAndSeeIbce_themeAttributeUpdated() {
+    void addTwiceAndSeeIbce_themeAttributeUpdated() {
         assertThemeAttribute(null);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_SMALL);
         dateTimePicker.addThemeVariants(DateTimePickerVariant.LUMO_SMALL);
@@ -103,13 +103,13 @@ public class DateTimePickerVariantTest {
 
     private void assertThemeAttribute(String expected) {
         String actual = dateTimePicker.getThemeName();
-        assertEquals("Unexpected theme attribute on date time picker", expected,
-                actual);
+        assertEquals(expected, actual,
+                "Unexpected theme attribute on date time picker");
     }
 
     private void assertThemeAttributeContains(String expected) {
         String actual = dateTimePicker.getThemeName();
-        assertTrue("Theme attribute not present on date time picker",
-                actual.contains(expected));
+        assertTrue(actual.contains(expected),
+                "Theme attribute not present on date time picker");
     }
 }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationTest.java
@@ -21,8 +21,8 @@ import java.time.LocalTime;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
@@ -32,108 +32,108 @@ import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
-import com.vaadin.tests.validation.AbstractBasicValidationTest;
+import com.vaadin.tests.validation.AbstractBasicValidationJUnit6Test;
 
-public class BasicValidationTest
-        extends AbstractBasicValidationTest<DateTimePicker, LocalDateTime> {
+class BasicValidationTest extends
+        AbstractBasicValidationJUnit6Test<DateTimePicker, LocalDateTime> {
 
     @Test
-    public void badInputOnDatePicker_validate_emptyErrorMessageDisplayed() {
+    void badInputOnDatePicker_validate_emptyErrorMessageDisplayed() {
         getDatePicker().getElement().setProperty("_inputElementValue", "foo");
         fireDomEvent("unparsable-change", getDatePicker().getElement());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void badInputOnTimePicker_validate_emptyErrorMessageDisplayed() {
+    void badInputOnTimePicker_validate_emptyErrorMessageDisplayed() {
         getTimePicker().getElement().setProperty("_inputElementValue", "foo");
         fireDomEvent("unparsable-change", getTimePicker().getElement());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void badInputOnDatePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void badInputOnDatePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         var errorMessage = "Value has invalid format";
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setBadInputErrorMessage(errorMessage));
         getDatePicker().getElement().setProperty("_inputElementValue", "foo");
         fireDomEvent("unparsable-change", getDatePicker().getElement());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals(errorMessage, testField.getErrorMessage());
+        Assertions.assertEquals(errorMessage, testField.getErrorMessage());
     }
 
     @Test
-    public void badInputOnTimePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void badInputOnTimePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         var errorMessage = "Value has invalid format";
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setBadInputErrorMessage(errorMessage));
         getTimePicker().getElement().setProperty("_inputElementValue", "foo");
         fireDomEvent("unparsable-change", getTimePicker().getElement());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals(errorMessage, testField.getErrorMessage());
+        Assertions.assertEquals(errorMessage, testField.getErrorMessage());
     }
 
     @Test
-    public void incompleteInputOnDatePicker_validate_emptyErrorMessageDisplayed() {
+    void incompleteInputOnDatePicker_validate_emptyErrorMessageDisplayed() {
         var picker = getDatePicker();
         picker.setValue(LocalDate.now());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void incompleteInputOnTimePicker_validate_emptyErrorMessageDisplayed() {
+    void incompleteInputOnTimePicker_validate_emptyErrorMessageDisplayed() {
         var picker = getTimePicker();
         picker.setValue(LocalTime.now());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void incompleteInputOnDatePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void incompleteInputOnDatePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         var errorMessage = "Value is incomplete";
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setIncompleteInputErrorMessage(errorMessage));
         var picker = getDatePicker();
         picker.setValue(LocalDate.now());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals(errorMessage, testField.getErrorMessage());
+        Assertions.assertEquals(errorMessage, testField.getErrorMessage());
     }
 
     @Test
-    public void incompleteInputOnTimePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void incompleteInputOnTimePicker_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         var errorMessage = "Value is incomplete";
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setIncompleteInputErrorMessage(errorMessage));
         var picker = getTimePicker();
         picker.setValue(LocalTime.now());
         fireUnparsableChangeDomEvent();
-        Assert.assertEquals(errorMessage, testField.getErrorMessage());
+        Assertions.assertEquals(errorMessage, testField.getErrorMessage());
     }
 
     @Test
-    public void setIncompleteInputErrorMessage_errorMessageIsSet() {
+    void setIncompleteInputErrorMessage_errorMessageIsSet() {
         var errorMessage = "Value is incomplete";
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setIncompleteInputErrorMessage(errorMessage));
-        Assert.assertEquals(errorMessage,
+        Assertions.assertEquals(errorMessage,
                 testField.getI18n().getIncompleteInputErrorMessage());
     }
 
     @Test
-    public void required_validate_emptyErrorMessageDisplayed() {
+    void required_validate_emptyErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setValue(LocalDateTime.now());
         fireChangeDomEvent();
         testField.setValue(null);
         fireChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setRequiredErrorMessage("Field is required"));
@@ -141,47 +141,50 @@ public class BasicValidationTest
         fireChangeDomEvent();
         testField.setValue(null);
         fireChangeDomEvent();
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
     }
 
     @Test
-    public void min_validate_emptyErrorMessageDisplayed() {
+    void min_validate_emptyErrorMessageDisplayed() {
         testField.setMin(LocalDateTime.now());
         testField.setValue(LocalDateTime.now().minusDays(1));
         fireChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setMin(LocalDateTime.now());
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setMinErrorMessage("Value is too small"));
         testField.setValue(LocalDateTime.now().minusDays(1));
         fireChangeDomEvent();
-        Assert.assertEquals("Value is too small", testField.getErrorMessage());
+        Assertions.assertEquals("Value is too small",
+                testField.getErrorMessage());
     }
 
     @Test
-    public void max_validate_emptyErrorMessageDisplayed() {
+    void max_validate_emptyErrorMessageDisplayed() {
         testField.setMax(LocalDateTime.now());
         testField.setValue(LocalDateTime.now().plusDays(1));
         fireChangeDomEvent();
-        Assert.assertEquals("", testField.getErrorMessage());
+        Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
-    public void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setMax(LocalDateTime.now());
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setMaxErrorMessage("Value is too big"));
         testField.setValue(LocalDateTime.now().plusDays(1));
         fireChangeDomEvent();
-        Assert.assertEquals("Value is too big", testField.getErrorMessage());
+        Assertions.assertEquals("Value is too big",
+                testField.getErrorMessage());
     }
 
     @Test
-    public void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+    void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setRequiredErrorMessage("Field is required"));
@@ -190,12 +193,12 @@ public class BasicValidationTest
         fireChangeDomEvent();
         testField.setValue(null);
         fireChangeDomEvent();
-        Assert.assertEquals("Custom error message",
+        Assertions.assertEquals("Custom error message",
                 testField.getErrorMessage());
     }
 
     @Test
-    public void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
+    void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new DateTimePicker.DateTimePickerI18n()
                 .setRequiredErrorMessage("Field is required"));
@@ -209,57 +212,58 @@ public class BasicValidationTest
         fireChangeDomEvent();
         testField.setValue(null);
         fireChangeDomEvent();
-        Assert.assertEquals("Field is required", testField.getErrorMessage());
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
     }
 
     @Test
-    public void setInvalid_nestedPickersAreInvalid() {
+    void setInvalid_nestedPickersAreInvalid() {
         testField.setInvalid(true);
-        Assert.assertTrue(getDatePicker().isInvalid());
-        Assert.assertTrue(getTimePicker().isInvalid());
+        Assertions.assertTrue(getDatePicker().isInvalid());
+        Assertions.assertTrue(getTimePicker().isInvalid());
     }
 
     @Test
-    public void setValueProgrammatically_fieldValidatedOnce() {
+    void setValueProgrammatically_fieldValidatedOnce() {
         var dateTimePicker = new TestDateTimePicker();
         dateTimePicker.setValue(LocalDateTime.now());
-        Assert.assertEquals(1, dateTimePicker.getValidationCount());
+        Assertions.assertEquals(1, dateTimePicker.getValidationCount());
     }
 
     @Test
-    public void clearValueProgrammatically_fieldValidatedOnce() {
+    void clearValueProgrammatically_fieldValidatedOnce() {
         var dateTimePicker = new TestDateTimePicker();
         dateTimePicker.setValue(LocalDateTime.now());
         var validationCount = dateTimePicker.getValidationCount();
         dateTimePicker.setValue(null);
-        Assert.assertEquals(validationCount + 1,
+        Assertions.assertEquals(validationCount + 1,
                 dateTimePicker.getValidationCount());
     }
 
     @Test
-    public void setValueProgrammatically_invalidStateIsUpdatedInValueChangeListener() {
+    void setValueProgrammatically_invalidStateIsUpdatedInValueChangeListener() {
         var isInvalid = new AtomicBoolean();
         testField.addValueChangeListener(
                 e -> isInvalid.set(e.getSource().isInvalid()));
         testField.setMax(LocalDateTime.now());
         testField.setValue(LocalDateTime.now().plusDays(1));
-        Assert.assertTrue(isInvalid.get());
+        Assertions.assertTrue(isInvalid.get());
     }
 
     @Test
-    public void incompleteInput_setValidValueProgrammatically_invalidStateCleared() {
+    void incompleteInput_setValidValueProgrammatically_invalidStateCleared() {
         // Simulate incomplete input: date picker has value, time picker is
         // empty
         getDatePicker().setValue(LocalDate.of(2000, 1, 1));
         fireUnparsableChangeDomEvent();
-        Assert.assertTrue("Field should be invalid with incomplete input",
-                testField.isInvalid());
+        Assertions.assertTrue(testField.isInvalid(),
+                "Field should be invalid with incomplete input");
 
         // Set a valid complete value programmatically
         testField.setValue(LocalDateTime.of(2000, 1, 1, 12, 0));
 
-        Assert.assertFalse("Field should be valid after setting complete value",
-                testField.isInvalid());
+        Assertions.assertFalse(testField.isInvalid(),
+                "Field should be valid after setting complete value");
     }
 
     @Override

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BinderValidationTest.java
@@ -17,9 +17,9 @@ package com.vaadin.flow.component.datetimepicker.validation;
 
 import java.time.LocalDateTime;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -31,7 +31,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.BindingValidationStatus;
 import com.vaadin.flow.data.binder.BindingValidationStatusHandler;
 
-public class BinderValidationTest {
+class BinderValidationTest {
 
     private static final String BINDER_FAIL_MESSAGE = "BINDER_FAIL_MESSAGE";
     private static final String BINDER_REQUIRED_MESSAGE = "REQUIRED";
@@ -56,64 +56,64 @@ public class BinderValidationTest {
         }
     }
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         MockitoAnnotations.openMocks(this);
         field = new DateTimePicker();
         field.setMax(LocalDateTime.now().plusDays(1));
     }
 
     @Test
-    public void elementWithConstraints_componentValidationNotMet_elementValidationFails() {
+    void elementWithConstraints_componentValidationNotMet_elementValidationFails() {
         attachBinderToField();
 
         field.setValue(LocalDateTime.now().plusDays(2));
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertTrue(statusCaptor.getValue().isError());
     }
 
     @Test
-    public void elementWithConstraints_binderValidationNotMet_binderValidationFails() {
+    void elementWithConstraints_binderValidationNotMet_binderValidationFails() {
         attachBinderToField();
 
         field.setValue(LocalDateTime.now().minusYears(1));
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertTrue(statusCaptor.getValue().isError());
-        Assert.assertEquals(BINDER_FAIL_MESSAGE,
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_FAIL_MESSAGE,
                 statusCaptor.getValue().getMessage().orElse(""));
     }
 
     @Test
-    public void setRequiredOnBinder_validate_binderValidationFails() {
+    void setRequiredOnBinder_validate_binderValidationFails() {
         var binder = attachBinderToField(true);
         binder.validate();
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertTrue(statusCaptor.getValue().isError());
-        Assert.assertEquals(BINDER_REQUIRED_MESSAGE,
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_REQUIRED_MESSAGE,
                 statusCaptor.getValue().getMessage().orElse(""));
     }
 
     @Test
-    public void setRequiredOnComponent_validate_binderValidationPasses() {
+    void setRequiredOnComponent_validate_binderValidationPasses() {
         var binder = attachBinderToField();
         field.setRequiredIndicatorVisible(true);
         binder.validate();
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertFalse(statusCaptor.getValue().isError());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
     }
 
     @Test
-    public void elementWithConstraints_validValue_validationPasses() {
+    void elementWithConstraints_validValue_validationPasses() {
         attachBinderToField();
 
         field.setValue(LocalDateTime.now());
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
-        Assert.assertFalse(statusCaptor.getValue().isError());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
 
     }
 


### PR DESCRIPTION
Convert DateTimePicker unit tests to JUnit 6.