### PR TITLE
refactor: migrate popover unit tests from JUnit 4 to JUnit 6

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -15,38 +15,38 @@
  */
 package com.vaadin.flow.component.popover;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.shared.internal.ModalRoot;
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
 /**
  * @author Vaadin Ltd.
  */
-public class PopoverAutoAddTest {
-    @Rule
-    public MockUIRule ui = new MockUIRule();
+class PopoverAutoAddTest {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     @Test
-    public void setTarget_autoAdded() {
+    void setTarget_autoAdded() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
         ui.add(target);
 
         ui.fakeClientCommunication();
-        Assert.assertEquals(ui.getUI().getElement(),
+        Assertions.assertEquals(ui.getUI().getElement(),
                 popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_clearTarget_autoRemoved() {
+    void setTarget_clearTarget_autoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -56,11 +56,11 @@ public class PopoverAutoAddTest {
         popover.setTarget(null);
 
         ui.fakeClientCommunication();
-        Assert.assertNull(popover.getElement().getParent());
+        Assertions.assertNull(popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_detachTarget_autoRemoved() {
+    void setTarget_detachTarget_autoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -70,11 +70,11 @@ public class PopoverAutoAddTest {
         ui.remove(target);
 
         ui.fakeClientCommunication();
-        Assert.assertNull(popover.getElement().getParent());
+        Assertions.assertNull(popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_removeAll_noException() {
+    void setTarget_removeAll_noException() {
         Div target = new Div();
         Popover popover = new Popover();
         popover.setTarget(target);
@@ -82,12 +82,12 @@ public class PopoverAutoAddTest {
 
         ui.removeAll();
 
-        Assert.assertNull(popover.getElement().getParent());
-        Assert.assertEquals(0, ui.getUI().getChildren().count());
+        Assertions.assertNull(popover.getElement().getParent());
+        Assertions.assertEquals(0, ui.getUI().getChildren().count());
     }
 
     @Test
-    public void setTarget_changeTarget_notAutoRemoved() {
+    void setTarget_changeTarget_notAutoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -99,12 +99,12 @@ public class PopoverAutoAddTest {
         popover.setTarget(other);
         ui.fakeClientCommunication();
 
-        Assert.assertEquals(ui.getUI().getElement(),
+        Assertions.assertEquals(ui.getUI().getElement(),
                 popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_changeTarget_detachOldTarget_notAutoRemoved() {
+    void setTarget_changeTarget_detachOldTarget_notAutoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -118,12 +118,12 @@ public class PopoverAutoAddTest {
 
         ui.remove(target);
         ui.fakeClientCommunication();
-        Assert.assertEquals(ui.getUI().getElement(),
+        Assertions.assertEquals(ui.getUI().getElement(),
                 popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_changeToDetachedTarget_autoRemoved() {
+    void setTarget_changeToDetachedTarget_autoRemoved() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -134,11 +134,11 @@ public class PopoverAutoAddTest {
         popover.setTarget(other);
         ui.fakeClientCommunication();
 
-        Assert.assertNull(popover.getElement().getParent());
+        Assertions.assertNull(popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_changeUI_autoAdded() {
+    void setTarget_changeUI_autoAdded() {
         Popover popover = new Popover();
         Div target = new Div();
         popover.setTarget(target);
@@ -151,12 +151,12 @@ public class PopoverAutoAddTest {
         ui.add(target);
 
         ui.fakeClientCommunication();
-        Assert.assertEquals(ui.getUI().getElement(),
+        Assertions.assertEquals(ui.getUI().getElement(),
                 popover.getElement().getParent());
     }
 
     @Test
-    public void setTarget_openModal_popoverIsAttachedToUi() {
+    void setTarget_openModal_popoverIsAttachedToUi() {
         Div target = new Div();
         Popover popover = new Popover();
         popover.setTarget(target);
@@ -166,11 +166,11 @@ public class PopoverAutoAddTest {
         ui.getUI().setChildComponentModal(modalElement, true);
         ui.fakeClientCommunication();
 
-        Assert.assertEquals(ui.getUI(), popover.getParent().orElseThrow());
+        Assertions.assertEquals(ui.getUI(), popover.getParent().orElseThrow());
     }
 
     @Test
-    public void openModal_setTargetOutsideOfModal_popoverIsAttachedToUi() {
+    void openModal_setTargetOutsideOfModal_popoverIsAttachedToUi() {
         Div modal = new Div();
         ui.add(modal);
         ui.getUI().setChildComponentModal(modal, true);
@@ -180,11 +180,11 @@ public class PopoverAutoAddTest {
         popover.setTarget(target);
         ui.add(target);
 
-        Assert.assertEquals(ui.getUI(), popover.getParent().orElseThrow());
+        Assertions.assertEquals(ui.getUI(), popover.getParent().orElseThrow());
     }
 
     @Test
-    public void popoverWithTargetInPopover_popoverAttachedToPopover() {
+    void popoverWithTargetInPopover_popoverAttachedToPopover() {
         var firstPopover = new Popover();
         ui.add(firstPopover);
         var target = new Div();
@@ -192,13 +192,13 @@ public class PopoverAutoAddTest {
         var secondPopover = new Popover();
         secondPopover.setTarget(target);
         ui.fakeClientCommunication();
-        Assert.assertEquals(
-                "Second popover should be attached to first popover",
-                firstPopover, secondPopover.getParent().orElse(null));
+        Assertions.assertEquals(firstPopover,
+                secondPopover.getParent().orElse(null),
+                "Second popover should be attached to first popover");
     }
 
     @Test
-    public void popoverWithTargetInModalComponent_popoverAttachedToModal() {
+    void popoverWithTargetInModalComponent_popoverAttachedToModal() {
         var modal = new TestModalComponent();
         ui.add(modal);
         var target = new Div();
@@ -206,12 +206,12 @@ public class PopoverAutoAddTest {
         var popover = new Popover();
         popover.setTarget(target);
         ui.fakeClientCommunication();
-        Assert.assertEquals("Popover should be attached to modal", modal,
-                popover.getParent().orElse(null));
+        Assertions.assertEquals(modal, popover.getParent().orElse(null),
+                "Popover should be attached to modal");
     }
 
     @Test
-    public void popoverWithTargetInModalComponent_targetRemoved_popoverDetached() {
+    void popoverWithTargetInModalComponent_targetRemoved_popoverDetached() {
         var modal = new TestModalComponent();
         ui.add(modal);
         var target = new Div();
@@ -222,12 +222,12 @@ public class PopoverAutoAddTest {
 
         target.removeFromParent();
         ui.fakeClientCommunication();
-        Assert.assertFalse("Popover should be detached",
-                popover.getParent().isPresent());
+        Assertions.assertFalse(popover.getParent().isPresent(),
+                "Popover should be detached");
     }
 
     @Test
-    public void popoverWithTargetInModalContainer_popoverAttachedToModal() {
+    void popoverWithTargetInModalContainer_popoverAttachedToModal() {
         var modal = new TestModalContainer();
         ui.add(modal);
         var target = new Div();
@@ -235,12 +235,12 @@ public class PopoverAutoAddTest {
         var popover = new Popover();
         popover.setTarget(target);
         ui.fakeClientCommunication();
-        Assert.assertEquals("Popover should be attached to modal", modal,
-                popover.getParent().orElse(null));
+        Assertions.assertEquals(modal, popover.getParent().orElse(null),
+                "Popover should be attached to modal");
     }
 
     @Test
-    public void popoverWithTargetInModalSubContainer_popoverAttachedToModal() {
+    void popoverWithTargetInModalSubContainer_popoverAttachedToModal() {
         var modal = new TestModalSubContainer();
         ui.add(modal);
         var target = new Div();
@@ -248,12 +248,12 @@ public class PopoverAutoAddTest {
         var popover = new Popover();
         popover.setTarget(target);
         ui.fakeClientCommunication();
-        Assert.assertEquals("Popover should be attached to modal", modal,
-                popover.getParent().orElse(null));
+        Assertions.assertEquals(modal, popover.getParent().orElse(null),
+                "Popover should be attached to modal");
     }
 
     @Test
-    public void popoverWithTargetInModalContainer_targetRemoved_popoverDetached() {
+    void popoverWithTargetInModalContainer_targetRemoved_popoverDetached() {
         var modal = new TestModalContainer();
         ui.add(modal);
         var target = new Div();
@@ -264,12 +264,12 @@ public class PopoverAutoAddTest {
 
         target.removeFromParent();
         ui.fakeClientCommunication();
-        Assert.assertFalse("Popover should be detached",
-                popover.getParent().isPresent());
+        Assertions.assertFalse(popover.getParent().isPresent(),
+                "Popover should be detached");
     }
 
     @Test
-    public void targetWithinModalWithSlotDefined_popoverInheritsSlotAttribute() {
+    void targetWithinModalWithSlotDefined_popoverInheritsSlotAttribute() {
         var modal = new TestModalContainerWithSlot();
         ui.add(modal);
         var target = new Div();
@@ -278,7 +278,7 @@ public class PopoverAutoAddTest {
         modal.add(target);
         ui.fakeClientCommunication();
 
-        Assert.assertEquals("custom-slot",
+        Assertions.assertEquals("custom-slot",
                 popover.getElement().getAttribute("slot"));
 
         ui.fakeClientCommunication();
@@ -286,12 +286,12 @@ public class PopoverAutoAddTest {
         ui.add(newModal);
         newModal.add(target);
         ui.fakeClientCommunication();
-        Assert.assertFalse("Popover should not have value for slot attribute",
-                popover.getElement().hasAttribute("slot"));
+        Assertions.assertFalse(popover.getElement().hasAttribute("slot"),
+                "Popover should not have value for slot attribute");
     }
 
     @Test
-    public void popoverWithTargetAddedAsVirtualChild_popoverAttachedToModal() {
+    void popoverWithTargetAddedAsVirtualChild_popoverAttachedToModal() {
         var modal = new TestModalComponent();
         ui.add(modal);
         var target = new Div();
@@ -299,8 +299,8 @@ public class PopoverAutoAddTest {
         var popover = new Popover();
         popover.setTarget(target);
         ui.fakeClientCommunication();
-        Assert.assertEquals("Popover should be attached to modal", modal,
-                popover.getParent().orElse(null));
+        Assertions.assertEquals(modal, popover.getParent().orElse(null),
+                "Popover should be attached to modal");
     }
 
     @ModalRoot

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverHasStyleTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverHasStyleTest.java
@@ -15,20 +15,22 @@
  */
 package com.vaadin.flow.component.popover;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class PopoverHasStyleTest {
+class PopoverHasStyleTest {
 
     private Popover popover;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         popover = new Popover();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void getStyle_unsupported() {
-        popover.getStyle();
+    @Test
+    void getStyle_unsupported() {
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> popover.getStyle());
     }
 }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverOpenedChangeListenerTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverOpenedChangeListenerTest.java
@@ -17,9 +17,9 @@ package com.vaadin.flow.component.popover;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.ComponentEventListener;
@@ -28,14 +28,14 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 
-public class PopoverOpenedChangeListenerTest {
+class PopoverOpenedChangeListenerTest {
     private Popover popover;
     private AtomicReference<Popover.OpenedChangeEvent> event;
     private ComponentEventListener<Popover.OpenedChangeEvent> mockListener;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         popover = new Popover();
 
         event = new AtomicReference<>();
@@ -46,37 +46,37 @@ public class PopoverOpenedChangeListenerTest {
     }
 
     @Test
-    public void open() {
+    void open() {
         popover.open();
 
-        Assert.assertFalse(event.get().isFromClient());
-        Assert.assertTrue(event.get().isOpened());
+        Assertions.assertFalse(event.get().isFromClient());
+        Assertions.assertTrue(event.get().isOpened());
         assertListenerCalls(1);
 
         clearCapturedData();
         popover.open();
-        Assert.assertNull(event.get());
+        Assertions.assertNull(event.get());
         assertListenerCalls(0);
     }
 
     @Test
-    public void close() {
+    void close() {
         popover.open();
         clearCapturedData();
 
         popover.close();
-        Assert.assertFalse(event.get().isFromClient());
-        Assert.assertFalse(event.get().isOpened());
+        Assertions.assertFalse(event.get().isFromClient());
+        Assertions.assertFalse(event.get().isOpened());
         assertListenerCalls(1);
 
         clearCapturedData();
         popover.close();
-        Assert.assertNull(event.get());
+        Assertions.assertNull(event.get());
         assertListenerCalls(0);
     }
 
     @Test
-    public void openedChangeFromClient_noChangeEvent() {
+    void openedChangeFromClient_noChangeEvent() {
         Element element = popover.getElement();
         element.getNode().getFeature(ElementListenerMap.class)
                 .fireEvent(new DomEvent(element, "opened-changed",
@@ -84,7 +84,7 @@ public class PopoverOpenedChangeListenerTest {
 
         // The event should only be fired when the opened state changes, not for
         // any opened-changed event from the client
-        Assert.assertNull(event.get());
+        Assertions.assertNull(event.get());
         assertListenerCalls(0);
     }
 

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverSerializableTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverSerializableTest.java
@@ -17,5 +17,5 @@ package com.vaadin.flow.component.popover;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-public class PopoverSerializableTest extends ClassesSerializableTest {
+class PopoverSerializableTest extends ClassesSerializableTest {
 }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -23,9 +23,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Text;
@@ -38,310 +38,318 @@ import tools.jackson.databind.node.ArrayNode;
 /**
  * @author Vaadin Ltd.
  */
-public class PopoverTest {
+class PopoverTest {
     private Popover popover;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         popover = new Popover();
     }
 
     @Test
-    public void setFor_getFor() {
+    void setFor_getFor() {
         popover.setFor("target-id");
-        Assert.assertEquals("target-id", popover.getFor());
+        Assertions.assertEquals("target-id", popover.getFor());
     }
 
     @Test
-    public void setTarget_getTarget() {
+    void setTarget_getTarget() {
         Div target = new Div();
         popover.setTarget(target);
-        Assert.assertEquals(popover.getTarget(), target);
+        Assertions.assertEquals(popover.getTarget(), target);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void setTarget_textNodeAsComponent_throws() {
+    @Test
+    void setTarget_textNodeAsComponent_throws() {
         Text textNode = new Text("Text");
-        popover.setTarget(textNode);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> popover.setTarget(textNode));
     }
 
     @Test
-    public void setPosition_getPosition() {
+    void setPosition_getPosition() {
         popover.setPosition(PopoverPosition.END);
-        Assert.assertEquals("end",
+        Assertions.assertEquals("end",
                 popover.getElement().getProperty("position"));
-        Assert.assertEquals(PopoverPosition.END, popover.getPosition());
+        Assertions.assertEquals(PopoverPosition.END, popover.getPosition());
     }
 
     @Test
-    public void defaultPosition_equalsNull() {
-        Assert.assertEquals(null, popover.getPosition());
+    void defaultPosition_equalsNull() {
+        Assertions.assertEquals(null, popover.getPosition());
     }
 
     @Test
-    public void setWidth_widthPropertyUpdated() {
+    void setWidth_widthPropertyUpdated() {
         popover.setWidth("200px");
-        Assert.assertEquals("200px",
+        Assertions.assertEquals("200px",
                 popover.getElement().getProperty("width", ""));
 
         popover.setWidth(null);
-        Assert.assertEquals("", popover.getElement().getProperty("width", ""));
+        Assertions.assertEquals("",
+                popover.getElement().getProperty("width", ""));
     }
 
     @Test
-    public void setHeight_heightPropertyUpdated() {
+    void setHeight_heightPropertyUpdated() {
         popover.setHeight("200px");
-        Assert.assertEquals("200px",
+        Assertions.assertEquals("200px",
                 popover.getElement().getProperty("height", ""));
 
         popover.setHeight(null);
-        Assert.assertEquals("", popover.getElement().getProperty("height", ""));
+        Assertions.assertEquals("",
+                popover.getElement().getProperty("height", ""));
     }
 
     @Test
-    public void setFocusDelay_getFocusDelay() {
-        Assert.assertEquals(0, popover.getFocusDelay());
+    void setFocusDelay_getFocusDelay() {
+        Assertions.assertEquals(0, popover.getFocusDelay());
 
         popover.setFocusDelay(1000);
-        Assert.assertEquals(1000, popover.getFocusDelay());
-        Assert.assertEquals(1000,
+        Assertions.assertEquals(1000, popover.getFocusDelay());
+        Assertions.assertEquals(1000,
                 popover.getElement().getProperty("focusDelay", 0));
     }
 
     @Test
-    public void setHoverDelay_getHoverDelay() {
-        Assert.assertEquals(0, popover.getHoverDelay());
+    void setHoverDelay_getHoverDelay() {
+        Assertions.assertEquals(0, popover.getHoverDelay());
 
         popover.setHoverDelay(1000);
-        Assert.assertEquals(1000, popover.getHoverDelay());
-        Assert.assertEquals(1000,
+        Assertions.assertEquals(1000, popover.getHoverDelay());
+        Assertions.assertEquals(1000,
                 popover.getElement().getProperty("hoverDelay", 0));
     }
 
     @Test
-    public void setHideDelay_getHideDelay() {
-        Assert.assertEquals(0, popover.getHideDelay());
+    void setHideDelay_getHideDelay() {
+        Assertions.assertEquals(0, popover.getHideDelay());
 
         popover.setHideDelay(1000);
-        Assert.assertEquals(1000, popover.getHideDelay());
-        Assert.assertEquals(1000,
+        Assertions.assertEquals(1000, popover.getHideDelay());
+        Assertions.assertEquals(1000,
                 popover.getElement().getProperty("hideDelay", 0));
     }
 
     @Test
-    public void isOpenOnClick_trueByDefault() {
-        Assert.assertTrue(popover.isOpenOnClick());
+    void isOpenOnClick_trueByDefault() {
+        Assertions.assertTrue(popover.isOpenOnClick());
     }
 
     @Test
-    public void isOpenOnFocus_falseByDefault() {
-        Assert.assertFalse(popover.isOpenOnFocus());
+    void isOpenOnFocus_falseByDefault() {
+        Assertions.assertFalse(popover.isOpenOnFocus());
     }
 
     @Test
-    public void isOpenOnHover_falseByDefault() {
-        Assert.assertFalse(popover.isOpenOnHover());
+    void isOpenOnHover_falseByDefault() {
+        Assertions.assertFalse(popover.isOpenOnHover());
     }
 
     @Test
-    public void setOpenOnClick_isOpenOnClick() {
+    void setOpenOnClick_isOpenOnClick() {
         popover.setOpenOnClick(false);
-        Assert.assertFalse(popover.isOpenOnClick());
+        Assertions.assertFalse(popover.isOpenOnClick());
 
         popover.setOpenOnClick(true);
-        Assert.assertTrue(popover.isOpenOnClick());
+        Assertions.assertTrue(popover.isOpenOnClick());
     }
 
     @Test
-    public void setOpenOnFocus_isOpenOnFocus() {
+    void setOpenOnFocus_isOpenOnFocus() {
         popover.setOpenOnFocus(true);
-        Assert.assertTrue(popover.isOpenOnFocus());
+        Assertions.assertTrue(popover.isOpenOnFocus());
 
         popover.setOpenOnFocus(false);
-        Assert.assertFalse(popover.isOpenOnFocus());
+        Assertions.assertFalse(popover.isOpenOnFocus());
     }
 
     @Test
-    public void setOpenOnHover_isOpenOnHover() {
+    void setOpenOnHover_isOpenOnHover() {
         popover.setOpenOnHover(true);
-        Assert.assertTrue(popover.isOpenOnHover());
+        Assertions.assertTrue(popover.isOpenOnHover());
 
         popover.setOpenOnHover(false);
-        Assert.assertFalse(popover.isOpenOnHover());
+        Assertions.assertFalse(popover.isOpenOnHover());
     }
 
     @Test
-    public void getTriggerProperty_defaultValue_click() {
+    void getTriggerProperty_defaultValue_click() {
         ArrayNode jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(1, jsonArray.size());
-        Assert.assertEquals("click", jsonArray.get(0).asString());
+        Assertions.assertEquals(1, jsonArray.size());
+        Assertions.assertEquals("click", jsonArray.get(0).asString());
     }
 
     @Test
-    public void setOpenOnClick_triggerPropertyUpdated() {
+    void setOpenOnClick_triggerPropertyUpdated() {
         popover.setOpenOnClick(false);
 
         ArrayNode jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(0, jsonArray.size());
+        Assertions.assertEquals(0, jsonArray.size());
     }
 
     @Test
-    public void setOpenOnFocus_triggerPropertyUpdated() {
+    void setOpenOnFocus_triggerPropertyUpdated() {
         popover.setOpenOnFocus(true);
 
         ArrayNode jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(2, jsonArray.size());
-        Assert.assertEquals("click", jsonArray.get(0).asString());
-        Assert.assertEquals("focus", jsonArray.get(1).asString());
+        Assertions.assertEquals(2, jsonArray.size());
+        Assertions.assertEquals("click", jsonArray.get(0).asString());
+        Assertions.assertEquals("focus", jsonArray.get(1).asString());
     }
 
     @Test
-    public void setOpenOnHover_triggerPropertyUpdated() {
+    void setOpenOnHover_triggerPropertyUpdated() {
         popover.setOpenOnHover(true);
 
         ArrayNode jsonArray = (ArrayNode) popover.getElement()
                 .getPropertyRaw("trigger");
-        Assert.assertEquals(2, jsonArray.size());
-        Assert.assertEquals("click", jsonArray.get(0).asString());
-        Assert.assertEquals("hover", jsonArray.get(1).asString());
+        Assertions.assertEquals(2, jsonArray.size());
+        Assertions.assertEquals("click", jsonArray.get(0).asString());
+        Assertions.assertEquals("hover", jsonArray.get(1).asString());
     }
 
     @Test
-    public void setAriaLabel_getAriaLabel() {
+    void setAriaLabel_getAriaLabel() {
         popover.setAriaLabel("aria-label");
-        Assert.assertTrue(popover.getAriaLabel().isPresent());
-        Assert.assertEquals("aria-label", popover.getAriaLabel().get());
+        Assertions.assertTrue(popover.getAriaLabel().isPresent());
+        Assertions.assertEquals("aria-label", popover.getAriaLabel().get());
 
         popover.setAriaLabel(null);
-        Assert.assertTrue(popover.getAriaLabel().isEmpty());
+        Assertions.assertTrue(popover.getAriaLabel().isEmpty());
     }
 
     @Test
-    public void setAriaLabelledBy_getAriaLabelledBy() {
+    void setAriaLabelledBy_getAriaLabelledBy() {
         popover.setAriaLabelledBy("aria-labelledby");
-        Assert.assertTrue(popover.getAriaLabelledBy().isPresent());
-        Assert.assertEquals("aria-labelledby",
+        Assertions.assertTrue(popover.getAriaLabelledBy().isPresent());
+        Assertions.assertEquals("aria-labelledby",
                 popover.getAriaLabelledBy().get());
 
         popover.setAriaLabelledBy(null);
-        Assert.assertTrue(popover.getAriaLabelledBy().isEmpty());
+        Assertions.assertTrue(popover.getAriaLabelledBy().isEmpty());
     }
 
     @Test
-    public void getRole_defaultDialog() {
+    void getRole_defaultDialog() {
         Popover popover = new Popover();
 
-        Assert.assertEquals("dialog", popover.getRole());
-        Assert.assertEquals("dialog", popover.getOverlayRole());
-        Assert.assertEquals("dialog", popover.getElement().getProperty("role"));
+        Assertions.assertEquals("dialog", popover.getRole());
+        Assertions.assertEquals("dialog", popover.getOverlayRole());
+        Assertions.assertEquals("dialog",
+                popover.getElement().getProperty("role"));
     }
 
     @Test
-    public void setOverlayRole_getOverlayRole() {
+    void setOverlayRole_getOverlayRole() {
         popover.setOverlayRole("alertdialog");
 
-        Assert.assertEquals("alertdialog", popover.getRole());
-        Assert.assertEquals("alertdialog", popover.getOverlayRole());
-        Assert.assertEquals("alertdialog",
+        Assertions.assertEquals("alertdialog", popover.getRole());
+        Assertions.assertEquals("alertdialog", popover.getOverlayRole());
+        Assertions.assertEquals("alertdialog",
                 popover.getElement().getProperty("role"));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void setOverlayRole_null_throws() {
-        popover.setOverlayRole(null);
+    @Test
+    void setOverlayRole_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> popover.setOverlayRole(null));
     }
 
     @Test
-    public void setRole_getRole() {
+    void setRole_getRole() {
         popover.setRole("alertdialog");
 
-        Assert.assertEquals("alertdialog", popover.getRole());
-        Assert.assertEquals("alertdialog", popover.getOverlayRole());
-        Assert.assertEquals("alertdialog",
+        Assertions.assertEquals("alertdialog", popover.getRole());
+        Assertions.assertEquals("alertdialog", popover.getOverlayRole());
+        Assertions.assertEquals("alertdialog",
                 popover.getElement().getProperty("role"));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void setRole_null_throws() {
-        popover.setRole(null);
+    @Test
+    void setRole_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> popover.setRole(null));
     }
 
     @Test
-    public void setModal_isModal() {
-        Assert.assertFalse(popover.isModal());
-        Assert.assertFalse(popover.getElement().getProperty("modal", false));
+    void setModal_isModal() {
+        Assertions.assertFalse(popover.isModal());
+        Assertions
+                .assertFalse(popover.getElement().getProperty("modal", false));
 
         popover.setModal(true);
-        Assert.assertTrue(popover.isModal());
-        Assert.assertTrue(popover.getElement().getProperty("modal", false));
+        Assertions.assertTrue(popover.isModal());
+        Assertions.assertTrue(popover.getElement().getProperty("modal", false));
     }
 
     @Test
-    public void setBackdropVisible_isBackdropVisible() {
-        Assert.assertFalse(popover.isBackdropVisible());
-        Assert.assertFalse(
+    void setBackdropVisible_isBackdropVisible() {
+        Assertions.assertFalse(popover.isBackdropVisible());
+        Assertions.assertFalse(
                 popover.getElement().getProperty("withBackdrop", false));
 
         popover.setBackdropVisible(true);
-        Assert.assertTrue(popover.isBackdropVisible());
-        Assert.assertTrue(
+        Assertions.assertTrue(popover.isBackdropVisible());
+        Assertions.assertTrue(
                 popover.getElement().getProperty("withBackdrop", false));
     }
 
     @Test
-    public void setModalAndBackdropVisible() {
+    void setModalAndBackdropVisible() {
         popover.setModal(true, true);
-        Assert.assertTrue(popover.isModal());
-        Assert.assertTrue(popover.isBackdropVisible());
+        Assertions.assertTrue(popover.isModal());
+        Assertions.assertTrue(popover.isBackdropVisible());
 
         popover.setModal(false, false);
-        Assert.assertFalse(popover.isModal());
-        Assert.assertFalse(popover.isBackdropVisible());
+        Assertions.assertFalse(popover.isModal());
+        Assertions.assertFalse(popover.isBackdropVisible());
     }
 
     @Test
-    public void setAutofocus_isAutofocus() {
-        Assert.assertFalse(popover.isAutofocus());
-        Assert.assertFalse(
+    void setAutofocus_isAutofocus() {
+        Assertions.assertFalse(popover.isAutofocus());
+        Assertions.assertFalse(
                 popover.getElement().getProperty("autofocus", false));
 
         popover.setAutofocus(true);
-        Assert.assertTrue(popover.isAutofocus());
-        Assert.assertTrue(popover.getElement().getProperty("autofocus", false));
+        Assertions.assertTrue(popover.isAutofocus());
+        Assertions.assertTrue(
+                popover.getElement().getProperty("autofocus", false));
     }
 
     @Test
-    public void popoverWithContent() {
+    void popoverWithContent() {
         Div content = new Div();
         Popover popoverWithContent = new Popover(content);
-        Assert.assertEquals(1, popoverWithContent.getChildren().count());
-        Assert.assertSame(content,
+        Assertions.assertEquals(1, popoverWithContent.getChildren().count());
+        Assertions.assertSame(content,
                 popoverWithContent.getChildren().findFirst().get());
     }
 
     @Test
-    public void testSetDefaultFocusDelay_threadSafety() {
+    void testSetDefaultFocusDelay_threadSafety() {
         testStaticSettersThreadsSafety(
                 () -> Popover.setDefaultFocusDelay(1000));
     }
 
     @Test
-    public void testSetDefaultHoverDelay_threadSafety() {
+    void testSetDefaultHoverDelay_threadSafety() {
         testStaticSettersThreadsSafety(
                 () -> Popover.setDefaultHoverDelay(1000));
     }
 
     @Test
-    public void testSetDefaultHideDelay_threadSafety() {
+    void testSetDefaultHideDelay_threadSafety() {
         testStaticSettersThreadsSafety(() -> Popover.setDefaultHideDelay(1000));
     }
 
     @Test
-    public void implementsHasThemeVariant() {
-        Assert.assertTrue(
+    void implementsHasThemeVariant() {
+        Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(Popover.class));
     }
 


### PR DESCRIPTION
## Description

Convert `Popover` unit tests to JUnit 6.