### PR TITLE
chore: migrate messages unit tests from JUnit 4 to JUnit 6

### DIFF
--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageInputTest.java
@@ -17,9 +17,9 @@ package com.vaadin.flow.component.messages.tests;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Focusable;
@@ -28,63 +28,65 @@ import com.vaadin.flow.component.messages.MessageInputI18n;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
 
-public class MessageInputTest {
+class MessageInputTest {
 
     private MessageInput messageInput;
     private MessageInputI18n i18n;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         messageInput = new MessageInput();
         i18n = new MessageInputI18n();
     }
 
     @Test
-    public void getI18n_returnsNull() {
-        Assert.assertNull(messageInput.getI18n());
+    void getI18n_returnsNull() {
+        Assertions.assertNull(messageInput.getI18n());
     }
 
     @Test
-    public void setI18n_getI18n() {
+    void setI18n_getI18n() {
         messageInput.setI18n(i18n);
-        Assert.assertSame(i18n, messageInput.getI18n());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void setI18n_null_throws() {
-        messageInput.setI18n(null);
+        Assertions.assertSame(i18n, messageInput.getI18n());
     }
 
     @Test
-    public void i18nPropertySetters_returnI18n() {
-        Assert.assertSame(i18n, i18n.setMessage("foo"));
-        Assert.assertSame(i18n, i18n.setSend("bar"));
+    void setI18n_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> messageInput.setI18n(null));
     }
 
     @Test
-    public void constructWithSubmitListener_fireEvent_listenerCalled() {
+    void i18nPropertySetters_returnI18n() {
+        Assertions.assertSame(i18n, i18n.setMessage("foo"));
+        Assertions.assertSame(i18n, i18n.setSend("bar"));
+    }
+
+    @Test
+    void constructWithSubmitListener_fireEvent_listenerCalled() {
         AtomicReference<MessageInput.SubmitEvent> eventRef = new AtomicReference<>();
         MessageInput messageInput = new MessageInput(eventRef::set);
         MessageInput.SubmitEvent event = new MessageInput.SubmitEvent(
                 messageInput, false, "foo");
         ComponentUtil.fireEvent(messageInput, event);
-        Assert.assertSame(event, eventRef.get());
+        Assertions.assertSame(event, eventRef.get());
     }
 
     @Test
-    public void implementsHasTooltip() {
-        Assert.assertTrue(messageInput instanceof HasTooltip);
+    void implementsHasTooltip() {
+        Assertions.assertTrue(messageInput instanceof HasTooltip);
     }
 
     @Test
-    public void implementsFocusable() {
-        Assert.assertTrue("MessageInput should be focusable",
-                Focusable.class.isAssignableFrom(messageInput.getClass()));
+    void implementsFocusable() {
+        Assertions.assertTrue(
+                Focusable.class.isAssignableFrom(messageInput.getClass()),
+                "MessageInput should be focusable");
     }
 
     @Test
-    public void implementsHasThemeVariant() {
-        Assert.assertTrue(
+    void implementsHasThemeVariant() {
+        Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(MessageInput.class));
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListSignalTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListSignalTest.java
@@ -17,30 +17,30 @@ package com.vaadin.flow.component.messages.tests;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.messages.MessageListItem;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.local.ValueSignal;
-import com.vaadin.tests.AbstractSignalsUnitTest;
+import com.vaadin.tests.AbstractSignalsJUnit6Test;
 
 import tools.jackson.databind.node.ArrayNode;
 
-public class MessageListSignalTest extends AbstractSignalsUnitTest {
+class MessageListSignalTest extends AbstractSignalsJUnit6Test {
 
     private MessageList messageList;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         messageList = new MessageList();
     }
 
     @Test
-    public void signalConstructor_setsItemsFromSignal() {
+    void signalConstructor_setsItemsFromSignal() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var item2Signal = new ValueSignal<>(new MessageListItem("World"));
         var listSignal = new ValueSignal<>(List.of(item1Signal, item2Signal));
@@ -48,15 +48,17 @@ public class MessageListSignalTest extends AbstractSignalsUnitTest {
         messageList = new MessageList(listSignal);
         ui.add(messageList);
 
-        Assert.assertEquals(2, messageList.getItems().size());
-        Assert.assertEquals("Hello", messageList.getItems().get(0).getText());
-        Assert.assertEquals("World", messageList.getItems().get(1).getText());
+        Assertions.assertEquals(2, messageList.getItems().size());
+        Assertions.assertEquals("Hello",
+                messageList.getItems().get(0).getText());
+        Assertions.assertEquals("World",
+                messageList.getItems().get(1).getText());
 
         assertFullUpdate();
     }
 
     @Test
-    public void signalConstructor_updatesWhenSignalChanges() {
+    void signalConstructor_updatesWhenSignalChanges() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
@@ -67,23 +69,24 @@ public class MessageListSignalTest extends AbstractSignalsUnitTest {
         var item2Signal = new ValueSignal<>(new MessageListItem("World"));
         listSignal.set(List.of(item1Signal, item2Signal));
 
-        Assert.assertEquals(2, messageList.getItems().size());
+        Assertions.assertEquals(2, messageList.getItems().size());
         assertFullUpdate();
     }
 
-    @Test(expected = BindingActiveException.class)
-    public void signalConstructor_setItemsWhileBound_throws() {
+    @Test
+    void signalConstructor_setItemsWhileBound_throws() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
         messageList = new MessageList(listSignal);
         ui.add(messageList);
 
-        messageList.setItems(List.of(new MessageListItem("World")));
+        Assertions.assertThrows(BindingActiveException.class, () -> messageList
+                .setItems(List.of(new MessageListItem("World"))));
     }
 
     @Test
-    public void bindItems_setsItemsFromSignal() {
+    void bindItems_setsItemsFromSignal() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var item2Signal = new ValueSignal<>(new MessageListItem("World"));
         var listSignal = new ValueSignal<>(List.of(item1Signal, item2Signal));
@@ -91,84 +94,91 @@ public class MessageListSignalTest extends AbstractSignalsUnitTest {
         messageList.bindItems(listSignal);
         ui.add(messageList);
 
-        Assert.assertEquals(2, messageList.getItems().size());
-        Assert.assertEquals("Hello", messageList.getItems().get(0).getText());
-        Assert.assertEquals("World", messageList.getItems().get(1).getText());
+        Assertions.assertEquals(2, messageList.getItems().size());
+        Assertions.assertEquals("Hello",
+                messageList.getItems().get(0).getText());
+        Assertions.assertEquals("World",
+                messageList.getItems().get(1).getText());
         assertFullUpdate();
     }
 
     @Test
-    public void bindItems_updatesWhenListSignalChanges() {
+    void bindItems_updatesWhenListSignalChanges() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
         messageList.bindItems(listSignal);
         ui.add(messageList);
 
-        Assert.assertEquals(1, messageList.getItems().size());
+        Assertions.assertEquals(1, messageList.getItems().size());
         assertFullUpdate();
 
         var item2Signal = new ValueSignal<>(new MessageListItem("World"));
         var item3Signal = new ValueSignal<>(new MessageListItem("Foo"));
         listSignal.set(List.of(item1Signal, item2Signal, item3Signal));
 
-        Assert.assertEquals(3, messageList.getItems().size());
-        Assert.assertEquals("Foo", messageList.getItems().get(2).getText());
+        Assertions.assertEquals(3, messageList.getItems().size());
+        Assertions.assertEquals("Foo", messageList.getItems().get(2).getText());
         assertFullUpdate();
     }
 
     @Test
-    public void bindItems_updatesWhenItemSignalChanges() {
+    void bindItems_updatesWhenItemSignalChanges() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
         messageList.bindItems(listSignal);
         ui.add(messageList);
 
-        Assert.assertEquals("Hello", messageList.getItems().get(0).getText());
+        Assertions.assertEquals("Hello",
+                messageList.getItems().get(0).getText());
         assertFullUpdate();
 
         item1Signal.set(new MessageListItem("Updated Hello"));
 
-        Assert.assertEquals("Updated Hello",
+        Assertions.assertEquals("Updated Hello",
                 messageList.getItems().get(0).getText());
         assertFullUpdate();
     }
 
-    @Test(expected = BindingActiveException.class)
-    public void setItemsWhileBound_throws() {
+    @Test
+    void setItemsWhileBound_throws() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
         messageList.bindItems(listSignal);
         ui.add(messageList);
 
-        messageList.setItems(List.of(new MessageListItem("World")));
+        Assertions.assertThrows(BindingActiveException.class, () -> messageList
+                .setItems(List.of(new MessageListItem("World"))));
     }
 
-    @Test(expected = BindingActiveException.class)
-    public void addItemWhileBound_throws() {
+    @Test
+    void addItemWhileBound_throws() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
         messageList.bindItems(listSignal);
         ui.add(messageList);
 
-        messageList.addItem(new MessageListItem("World"));
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> messageList.addItem(new MessageListItem("World")));
     }
 
-    @Test(expected = BindingActiveException.class)
-    public void bindItems_calledTwice_throws() {
+    @Test
+    void bindItems_calledTwice_throws() {
         var item1Signal = new ValueSignal<>(new MessageListItem("Hello"));
         var listSignal = new ValueSignal<>(List.of(item1Signal));
 
         messageList.bindItems(listSignal);
-        messageList.bindItems(listSignal);
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> messageList.bindItems(listSignal));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void bindItems_nullSignal_throws() {
-        messageList.bindItems(null);
+    @Test
+    void bindItems_nullSignal_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> messageList.bindItems(null));
     }
 
     /**
@@ -179,18 +189,18 @@ public class MessageListSignalTest extends AbstractSignalsUnitTest {
     private void assertFullUpdate() {
         var pendingInvocations = ui.dumpPendingJavaScriptInvocations();
         // Expect only one pending invocation
-        Assert.assertEquals(1, pendingInvocations.size());
+        Assertions.assertEquals(1, pendingInvocations.size());
 
         var invocation = pendingInvocations.getFirst();
         // Expect the only invocation to be setItems
-        Assert.assertTrue(invocation.getInvocation().getExpression()
+        Assertions.assertTrue(invocation.getInvocation().getExpression()
                 .contains("setItems"));
 
         // Expect the parameters to equal the items in the message list
         var parameterItems = (ArrayNode) invocation.getInvocation()
                 .getParameters().getFirst();
         var expectedItems = JacksonUtils.listToJson(messageList.getItems());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 JacksonUtils.jsonEquals(expectedItems, parameterItems));
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -19,10 +19,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.messages.MessageListItem;
@@ -30,191 +30,198 @@ import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.DownloadResponse;
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
 import net.jcip.annotations.NotThreadSafe;
 import tools.jackson.databind.JsonNode;
 
 @NotThreadSafe
-public class MessageListTest {
-    @Rule
-    public final MockUIRule ui = new MockUIRule();
+class MessageListTest {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     private MessageList messageList;
     private MessageListItem item1;
     private MessageListItem item2;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         messageList = new MessageList();
         item1 = new MessageListItem();
         item2 = new MessageListItem();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void getItems_returnsUnmodifiableList() {
-        messageList.getItems().add(new MessageListItem());
+    @Test
+    void getItems_returnsUnmodifiableList() {
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> messageList.getItems().add(new MessageListItem()));
     }
 
     @Test
-    public void setItemsCollection_getItems() {
+    void setItemsCollection_getItems() {
         messageList.setItems(Arrays.asList(item1, item2));
-        Assert.assertEquals(Arrays.asList(item1, item2),
+        Assertions.assertEquals(Arrays.asList(item1, item2),
                 messageList.getItems());
     }
 
     @Test
-    public void setItemsVarArgs_getItems() {
+    void setItemsVarArgs_getItems() {
         messageList.setItems(item1, item2);
-        Assert.assertEquals(Arrays.asList(item1, item2),
+        Assertions.assertEquals(Arrays.asList(item1, item2),
                 messageList.getItems());
     }
 
     @Test
-    public void addClassNames_removeClassNames_hasClassName() {
+    void addClassNames_removeClassNames_hasClassName() {
         item1.addClassNames("foo", "bar");
-        Assert.assertTrue(item1.hasClassName("foo"));
-        Assert.assertTrue(item1.hasClassName("bar"));
+        Assertions.assertTrue(item1.hasClassName("foo"));
+        Assertions.assertTrue(item1.hasClassName("bar"));
 
         item1.removeClassNames("foo");
-        Assert.assertFalse(item1.hasClassName("foo"));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void setItems_nullCollection_throws() {
-        messageList.setItems((Collection<MessageListItem>) null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void setItems_containsNullItem_throws() {
-        messageList.setItems(item1, null, item2);
+        Assertions.assertFalse(item1.hasClassName("foo"));
     }
 
     @Test
-    public void setImageAsStreamResource_overridesImageUrl() {
+    void setItems_nullCollection_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> messageList.setItems((Collection<MessageListItem>) null));
+    }
+
+    @Test
+    void setItems_containsNullItem_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> messageList.setItems(item1, null, item2));
+    }
+
+    @Test
+    void setImageAsStreamResource_overridesImageUrl() {
         item1.setUserImage("foo/bar");
         item1.setUserImageResource(new StreamResource("message-list-img",
                 () -> getClass().getResourceAsStream("baz/qux")));
         String userImage = item1.getUserImage();
-        Assert.assertTrue("User image should start with 'VAADIN/dynamic'",
-                userImage.startsWith("VAADIN/dynamic"));
+        Assertions.assertTrue(userImage.startsWith("VAADIN/dynamic"),
+                "User image should start with 'VAADIN/dynamic'");
     }
 
     @Test
-    public void setImageAsUrl_streamResourceBecomesNull() {
+    void setImageAsUrl_streamResourceBecomesNull() {
         item1.setUserImageResource(new StreamResource("message-list-img",
                 () -> getClass().getResourceAsStream("baz/qux")));
         item1.setUserImage("foo/bar");
-        Assert.assertNull(item1.getUserImageResource());
+        Assertions.assertNull(item1.getUserImageResource());
     }
 
     @Test
-    public void setImageHandler_overridesImageUrl() {
+    void setImageHandler_overridesImageUrl() {
         item1.setUserImage("foo/bar");
         item1.setUserImageHandler(
                 DownloadHandler.fromInputStream(data -> new DownloadResponse(
                         getClass().getResourceAsStream("baz/qux"),
                         "message-list-img", null, -1)));
         String userImage = item1.getUserImage();
-        Assert.assertTrue("User image should start with 'VAADIN/dynamic'",
-                userImage.startsWith("VAADIN/dynamic"));
+        Assertions.assertTrue(userImage.startsWith("VAADIN/dynamic"),
+                "User image should start with 'VAADIN/dynamic'");
     }
 
     @Test
-    public void setImageHandler_streamResourceBecomesNull() {
+    void setImageHandler_streamResourceBecomesNull() {
         item1.setUserImageHandler(
                 DownloadHandler.fromInputStream(data -> new DownloadResponse(
                         getClass().getResourceAsStream("baz/qux"),
                         "message-list-img", null, -1)));
         item1.setUserImage("foo/bar");
-        Assert.assertNull(item1.getUserImageResource());
+        Assertions.assertNull(item1.getUserImageResource());
     }
 
     @Test
-    public void addThemeNames_serialize_separatedBySpaces() {
+    void addThemeNames_serialize_separatedBySpaces() {
         item1.addThemeNames("foo", "bar");
         item1.addThemeNames("baz");
-        Assert.assertEquals("foo bar baz", getSerializedThemeProperty(item1));
+        Assertions.assertEquals("foo bar baz",
+                getSerializedThemeProperty(item1));
     }
 
     @Test
-    public void addThemeNames_serialize_noDuplicates() {
+    void addThemeNames_serialize_noDuplicates() {
         item1.addThemeNames("foo", "foo");
-        Assert.assertEquals("foo", getSerializedThemeProperty(item1));
+        Assertions.assertEquals("foo", getSerializedThemeProperty(item1));
     }
 
     @Test
-    public void removeThemeNames_serialize_themeNamesRemoved() {
+    void removeThemeNames_serialize_themeNamesRemoved() {
         item1.addThemeNames("foo", "bar", "baz");
         item1.removeThemeNames("foo", "bar", "qux");
-        Assert.assertEquals("baz", getSerializedThemeProperty(item1));
+        Assertions.assertEquals("baz", getSerializedThemeProperty(item1));
     }
 
     @Test
-    public void clearThemeNames_serialize_nullProperty() {
+    void clearThemeNames_serialize_nullProperty() {
         item1.addThemeNames("foo");
         item1.removeThemeNames("foo");
-        Assert.assertNull(getSerializedThemeProperty(item1));
+        Assertions.assertNull(getSerializedThemeProperty(item1));
     }
 
     @Test
-    public void hasThemeName_falseForNonExistingThemeName() {
-        Assert.assertFalse(item1.hasThemeName("foo"));
+    void hasThemeName_falseForNonExistingThemeName() {
+        Assertions.assertFalse(item1.hasThemeName("foo"));
     }
 
     @Test
-    public void hasThemeName_trueForExistingThemeName() {
+    void hasThemeName_trueForExistingThemeName() {
         item1.addThemeNames("foo");
-        Assert.assertTrue(item1.hasThemeName("foo"));
+        Assertions.assertTrue(item1.hasThemeName("foo"));
     }
 
     @Test
-    public void unattachedItem_setText_doesNotThrow() {
+    void unattachedItem_setText_doesNotThrow() {
         item1.setText("foo");
     }
 
     @Test
-    public void setMarkdown_isMarkdown() {
-        Assert.assertFalse(messageList.isMarkdown());
+    void setMarkdown_isMarkdown() {
+        Assertions.assertFalse(messageList.isMarkdown());
         messageList.setMarkdown(true);
-        Assert.assertTrue(messageList.isMarkdown());
+        Assertions.assertTrue(messageList.isMarkdown());
     }
 
     @Test
-    public void setAnnounceMessages_isAnnounceMessages() {
-        Assert.assertFalse(messageList.isAnnounceMessages());
-        Assert.assertFalse(messageList.getElement()
+    void setAnnounceMessages_isAnnounceMessages() {
+        Assertions.assertFalse(messageList.isAnnounceMessages());
+        Assertions.assertFalse(messageList.getElement()
                 .getProperty("announceMessages", false));
 
         messageList.setAnnounceMessages(true);
-        Assert.assertTrue(messageList.isAnnounceMessages());
-        Assert.assertTrue(messageList.getElement()
+        Assertions.assertTrue(messageList.isAnnounceMessages());
+        Assertions.assertTrue(messageList.getElement()
                 .getProperty("announceMessages", false));
     }
 
     @Test
-    public void getAttachments_defaultIsEmpty() {
-        Assert.assertTrue(item1.getAttachments().isEmpty());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void getAttachments_returnsUnmodifiableList() {
-        item1.getAttachments().add(
-                new MessageListItem.Attachment("test", "url", "text/plain"));
+    void getAttachments_defaultIsEmpty() {
+        Assertions.assertTrue(item1.getAttachments().isEmpty());
     }
 
     @Test
-    public void addAttachment_getAttachments() {
+    void getAttachments_returnsUnmodifiableList() {
+        Assertions
+                .assertThrows(UnsupportedOperationException.class,
+                        () -> item1.getAttachments()
+                                .add(new MessageListItem.Attachment("test",
+                                        "url", "text/plain")));
+    }
+
+    @Test
+    void addAttachment_getAttachments() {
         var attachment = new MessageListItem.Attachment("file.pdf",
                 "http://example.com/file.pdf", "application/pdf");
         item1.addAttachment(attachment);
 
-        Assert.assertEquals(1, item1.getAttachments().size());
-        Assert.assertEquals(attachment, item1.getAttachments().get(0));
+        Assertions.assertEquals(1, item1.getAttachments().size());
+        Assertions.assertEquals(attachment, item1.getAttachments().get(0));
     }
 
     @Test
-    public void setAttachments_getAttachments() {
+    void setAttachments_getAttachments() {
         var attachment1 = new MessageListItem.Attachment("file1.pdf",
                 "http://example.com/file1.pdf", "application/pdf");
         var attachment2 = new MessageListItem.Attachment("file2.png",
@@ -222,46 +229,50 @@ public class MessageListTest {
 
         item1.setAttachments(List.of(attachment1, attachment2));
 
-        Assert.assertEquals(2, item1.getAttachments().size());
-        Assert.assertEquals(attachment1, item1.getAttachments().get(0));
-        Assert.assertEquals(attachment2, item1.getAttachments().get(1));
+        Assertions.assertEquals(2, item1.getAttachments().size());
+        Assertions.assertEquals(attachment1, item1.getAttachments().get(0));
+        Assertions.assertEquals(attachment2, item1.getAttachments().get(1));
     }
 
     @Test
-    public void setAttachments_emptyList_clearsAttachments() {
+    void setAttachments_emptyList_clearsAttachments() {
         item1.addAttachment(new MessageListItem.Attachment("file.pdf",
                 "http://example.com/file.pdf", "application/pdf"));
         item1.setAttachments(List.of());
 
-        Assert.assertTrue(item1.getAttachments().isEmpty());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void setAttachments_null_throws() {
-        item1.setAttachments(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void addAttachment_null_throws() {
-        item1.addAttachment(null);
+        Assertions.assertTrue(item1.getAttachments().isEmpty());
     }
 
     @Test
-    public void attachmentSerialization_containsExpectedFields() {
+    void setAttachments_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> item1.setAttachments(null));
+    }
+
+    @Test
+    void addAttachment_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> item1.addAttachment(null));
+    }
+
+    @Test
+    void attachmentSerialization_containsExpectedFields() {
         item1.addAttachment(new MessageListItem.Attachment("proposal.pdf",
                 "#proposal.pdf", "application/pdf"));
 
         var json = JacksonUtils.beanToJson(item1);
         var attachments = json.get("attachments");
 
-        Assert.assertNotNull(attachments);
-        Assert.assertTrue(attachments.isArray());
-        Assert.assertEquals(1, attachments.size());
+        Assertions.assertNotNull(attachments);
+        Assertions.assertTrue(attachments.isArray());
+        Assertions.assertEquals(1, attachments.size());
 
         var attachment = attachments.get(0);
-        Assert.assertEquals("proposal.pdf", attachment.get("name").asString());
-        Assert.assertEquals("#proposal.pdf", attachment.get("url").asString());
-        Assert.assertEquals("application/pdf",
+        Assertions.assertEquals("proposal.pdf",
+                attachment.get("name").asString());
+        Assertions.assertEquals("#proposal.pdf",
+                attachment.get("url").asString());
+        Assertions.assertEquals("application/pdf",
                 attachment.get("type").asString());
     }
 

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListUpdatesTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListUpdatesTest.java
@@ -19,28 +19,28 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.messages.MessageListItem;
 import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.tests.MockUIRule;
+import com.vaadin.tests.MockUIExtension;
 
 import tools.jackson.databind.node.ArrayNode;
 
-public class MessageListUpdatesTest {
-    @Rule
-    public MockUIRule ui = new MockUIRule();
+class MessageListUpdatesTest {
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     private MessageList messageList;
     private MessageListItem item1;
     private MessageListItem item2;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         messageList = new MessageList();
         item1 = new MessageListItem();
         item2 = new MessageListItem();
@@ -49,7 +49,7 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setSameTextAfterSetItems_noJSInvocations() {
+    void setSameTextAfterSetItems_noJSInvocations() {
         messageList.setItems(Arrays.asList(item1, item2));
         item1.setText("foo");
         assertFullUpdate();
@@ -59,7 +59,7 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setText_setNullText_doesNotThrow() {
+    void setText_setNullText_doesNotThrow() {
         messageList.setItems(Arrays.asList(item1, item2));
         item1.setText("foo");
         assertFullUpdate();
@@ -69,17 +69,17 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setItems_appendText() {
+    void setItems_appendText() {
         messageList.setItems(Arrays.asList(item1, item2));
         assertFullUpdate();
 
         item1.appendText("foo");
-        Assert.assertEquals("foo", item1.getText());
+        Assertions.assertEquals("foo", item1.getText());
         assertSetItemTextUpdate(item1, "foo");
     }
 
     @Test
-    public void setItems_setText_appendText() {
+    void setItems_setText_appendText() {
         messageList.setItems(Arrays.asList(item1, item2));
         assertFullUpdate();
 
@@ -89,11 +89,11 @@ public class MessageListUpdatesTest {
         item1.appendText("bar");
         assertAppendItemTextUpdate(item1, "bar");
 
-        Assert.assertEquals("foobar", item1.getText());
+        Assertions.assertEquals("foobar", item1.getText());
     }
 
     @Test
-    public void setItems_setText_appendTextNull() {
+    void setItems_setText_appendTextNull() {
         messageList.setItems(Arrays.asList(item1, item2));
         item1.setText("foo");
         assertFullUpdate();
@@ -103,7 +103,7 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setItems_setText_appendTextEmpty() {
+    void setItems_setText_appendTextEmpty() {
         messageList.setItems(Arrays.asList(item1, item2));
         item1.setText("foo");
         assertFullUpdate();
@@ -113,20 +113,21 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void addItem() {
+    void addItem() {
         messageList.addItem(item1);
         assertAddItemUpdate(item1);
-        Assert.assertEquals(item1, messageList.getItems().getFirst());
-        Assert.assertEquals(1, messageList.getItems().size());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void addItemNull_throws() {
-        messageList.addItem(null);
+        Assertions.assertEquals(item1, messageList.getItems().getFirst());
+        Assertions.assertEquals(1, messageList.getItems().size());
     }
 
     @Test
-    public void addItem_updateText() {
+    void addItemNull_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> messageList.addItem(null));
+    }
+
+    @Test
+    void addItem_updateText() {
         messageList.addItem(item1);
         assertAddItemUpdate(item1);
 
@@ -135,7 +136,7 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setItems_addItem() {
+    void setItems_addItem() {
         messageList.setItems(Collections.singletonList(item1));
         assertFullUpdate();
 
@@ -144,7 +145,7 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setTextAfterAddItem_expectAddItemUpdate() {
+    void setTextAfterAddItem_expectAddItemUpdate() {
         messageList.setItems(Collections.singletonList(item1));
         assertFullUpdate();
 
@@ -155,28 +156,28 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void addItem_setItems_expectFullUpdate() {
+    void addItem_setItems_expectFullUpdate() {
         messageList.addItem(item1);
         messageList.setItems(List.of(new MessageListItem("Foo", null, "User")));
         assertFullUpdate();
     }
 
     @Test
-    public void addItem_addItem_expectAddItemUpdate() {
+    void addItem_addItem_expectAddItemUpdate() {
         messageList.addItem(item1);
         messageList.addItem(item2);
         assertAddItemUpdate(item1, item2);
     }
 
     @Test
-    public void setItems_addItem_expectFullUpdate() {
+    void setItems_addItem_expectFullUpdate() {
         messageList.setItems(List.of(new MessageListItem("Foo", null, "User")));
         messageList.addItem(item1);
         assertFullUpdate();
     }
 
     @Test
-    public void setText_setItems_expectFullUpdate() {
+    void setText_setItems_expectFullUpdate() {
         messageList.setItems(Collections.singletonList(item1));
         assertFullUpdate();
 
@@ -186,7 +187,7 @@ public class MessageListUpdatesTest {
     }
 
     @Test
-    public void setItems_setText_expectFullUpdate() {
+    void setItems_setText_expectFullUpdate() {
         messageList.setItems(Collections.singletonList(item1));
         assertFullUpdate();
 
@@ -203,54 +204,54 @@ public class MessageListUpdatesTest {
     private void assertFullUpdate() {
         var pendingInvocations = ui.dumpPendingJavaScriptInvocations();
         // Expect only one pending invocation
-        Assert.assertEquals(1, pendingInvocations.size());
+        Assertions.assertEquals(1, pendingInvocations.size());
 
         var invocation = pendingInvocations.getFirst();
         // Expect the only invocation to be setItems
-        Assert.assertTrue(invocation.getInvocation().getExpression()
+        Assertions.assertTrue(invocation.getInvocation().getExpression()
                 .contains("setItems"));
 
         // Expect the parameters to equal the items in the message list
         var parameterItems = (ArrayNode) invocation.getInvocation()
                 .getParameters().getFirst();
         var expectedItems = JacksonUtils.listToJson(messageList.getItems());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 JacksonUtils.jsonEquals(expectedItems, parameterItems));
     }
 
     private void assertAddItemUpdate(MessageListItem... items) {
         var pendingInvocations = ui.dumpPendingJavaScriptInvocations();
         // Expect only one pending invocation
-        Assert.assertEquals(1, pendingInvocations.size());
+        Assertions.assertEquals(1, pendingInvocations.size());
 
         var invocation = pendingInvocations.getFirst();
         // Expect the only invocation to be addItems
-        Assert.assertTrue(invocation.getInvocation().getExpression()
+        Assertions.assertTrue(invocation.getInvocation().getExpression()
                 .contains("addItems"));
 
         // Expect the parameters to equal the provided items as JSON
         var parameterItems = (ArrayNode) invocation.getInvocation()
                 .getParameters().getFirst();
         var expectedItems = JacksonUtils.listToJson(Arrays.asList(items));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 JacksonUtils.jsonEquals(expectedItems, parameterItems));
     }
 
     private void assertSetItemTextUpdate(MessageListItem item, String newText) {
         var pendingInvocations = ui.dumpPendingJavaScriptInvocations();
         // Expect only one pending invocation
-        Assert.assertEquals(1, pendingInvocations.size());
+        Assertions.assertEquals(1, pendingInvocations.size());
 
         var invocation = pendingInvocations.getFirst();
         // Expect the only invocation to be setItemText
-        Assert.assertTrue(invocation.getInvocation().getExpression()
+        Assertions.assertTrue(invocation.getInvocation().getExpression()
                 .contains("setItemText"));
 
         // Expect the parameters to match the text and item index
         var parameters = invocation.getInvocation().getParameters();
-        Assert.assertEquals(newText, parameters.get(0));
+        Assertions.assertEquals(newText, parameters.get(0));
         var expectedIndex = messageList.getItems().indexOf(item);
-        Assert.assertEquals(expectedIndex,
+        Assertions.assertEquals(expectedIndex,
                 ((Number) parameters.get(1)).intValue());
     }
 
@@ -258,23 +259,23 @@ public class MessageListUpdatesTest {
             String appendedText) {
         var pendingInvocations = ui.dumpPendingJavaScriptInvocations();
         // Expect only one pending invocation
-        Assert.assertEquals(1, pendingInvocations.size());
+        Assertions.assertEquals(1, pendingInvocations.size());
 
         var invocation = pendingInvocations.getFirst();
         // Expect the only invocation to be appendItemText
-        Assert.assertTrue(invocation.getInvocation().getExpression()
+        Assertions.assertTrue(invocation.getInvocation().getExpression()
                 .contains("appendItemText"));
 
         // Expect the parameters to match the text and item index
         var parameters = invocation.getInvocation().getParameters();
-        Assert.assertEquals(appendedText, parameters.get(0));
+        Assertions.assertEquals(appendedText, parameters.get(0));
         var expectedIndex = messageList.getItems().indexOf(item);
-        Assert.assertEquals(expectedIndex,
+        Assertions.assertEquals(expectedIndex,
                 ((Number) parameters.get(1)).intValue());
     }
 
     private void assertNoUpdate() {
         var pendingInvocations = ui.dumpPendingJavaScriptInvocations();
-        Assert.assertEquals(0, pendingInvocations.size());
+        Assertions.assertEquals(0, pendingInvocations.size());
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessagesSerializableTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessagesSerializableTest.java
@@ -17,5 +17,5 @@ package com.vaadin.flow.component.messages.tests;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-public class MessagesSerializableTest extends ClassesSerializableTest {
+class MessagesSerializableTest extends ClassesSerializableTest {
 }


### PR DESCRIPTION
## Description

Convert `Messages` unit tests to JUnit 6.