### PR TITLE
chore: convert accordion unit tests to JUnit 6

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/test/java/com/vaadin/flow/component/accordion/AccordionSerializableTest.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/test/java/com/vaadin/flow/component/accordion/AccordionSerializableTest.java
@@ -17,5 +17,5 @@ package com.vaadin.flow.component.accordion;
 
 import com.vaadin.flow.testutil.ClassesSerializableTest;
 
-public class AccordionSerializableTest extends ClassesSerializableTest {
+class AccordionSerializableTest extends ClassesSerializableTest {
 }


### PR DESCRIPTION
Convert Accordion unit tests to JUnit 6.