### PR TITLE
feat: add detail placeholder API to MasterDetailLayout

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -56,6 +56,7 @@ public class MasterDetailLayout extends Component implements HasSize,
         HasThemeVariant<MasterDetailLayoutVariant>, RouterLayout {
 
     public static final String MASTER_SLOT = "";
+    public static final String DETAIL_PLACEHOLDER_SLOT = "detail-placeholder";
 
     private HasElement detail;
     private PendingJavaScriptResult pendingDetailsUpdate;
@@ -175,6 +176,34 @@ public class MasterDetailLayout extends Component implements HasSize,
      */
     public void setDetail(Component component) {
         doSetDetail(component);
+    }
+
+    /**
+     * Gets the component currently in the detail placeholder area.
+     *
+     * @return the component in the detail placeholder area, or {@code null} if
+     *         there is no component in the detail placeholder area
+     */
+    public Component getDetailPlaceholder() {
+        return SlotUtils.getElementsInSlot(this, DETAIL_PLACEHOLDER_SLOT)
+                .findFirst().flatMap(Element::getComponent).orElse(null);
+    }
+
+    /**
+     * Sets the component to be displayed in the detail placeholder area. The
+     * placeholder is shown when no detail content is set, and is hidden when
+     * the layout is in overlay mode. Unlike the detail content, the placeholder
+     * does not become an overlay when there is not enough space.
+     *
+     * @param component
+     *            the component to display in the detail placeholder area, or
+     *            {@code null} to clear the detail placeholder area
+     */
+    public void setDetailPlaceholder(Component component) {
+        SlotUtils.clearSlot(this, DETAIL_PLACEHOLDER_SLOT);
+        if (component != null) {
+            SlotUtils.addToSlot(this, DETAIL_PLACEHOLDER_SLOT, component);
+        }
     }
 
     private void doSetDetail(HasElement hasElement) {

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -191,6 +191,48 @@ class MasterDetailLayoutTest {
     }
 
     @Test
+    void setDetailPlaceholder() {
+        var placeholder = new Div();
+        layout.setDetailPlaceholder(placeholder);
+
+        Assertions.assertEquals("detail-placeholder",
+                placeholder.getElement().getAttribute("slot"));
+        Assertions.assertEquals(layout.getElement(),
+                placeholder.getElement().getParent());
+    }
+
+    @Test
+    void getDetailPlaceholder() {
+        var placeholder = new Div();
+        layout.setDetailPlaceholder(placeholder);
+
+        Assertions.assertEquals(placeholder, layout.getDetailPlaceholder());
+    }
+
+    @Test
+    void setDetailPlaceholder_replacePlaceholder() {
+        var placeholder = new Div();
+        layout.setDetailPlaceholder(placeholder);
+
+        var newPlaceholder = new Div();
+        layout.setDetailPlaceholder(newPlaceholder);
+
+        Assertions.assertEquals(newPlaceholder, layout.getDetailPlaceholder());
+        Assertions.assertNull(placeholder.getElement().getParent());
+    }
+
+    @Test
+    void setDetailPlaceholderNull_removesPlaceholder() {
+        var placeholder = new Div();
+        layout.setDetailPlaceholder(placeholder);
+
+        layout.setDetailPlaceholder(null);
+
+        Assertions.assertNull(layout.getDetailPlaceholder());
+        Assertions.assertNull(placeholder.getElement().getParent());
+    }
+
+    @Test
     void showRouterLayoutContent() {
         var detail = new Div();
         layout.showRouterLayoutContent(detail);


### PR DESCRIPTION
## Summary
- Add `setDetailPlaceholder`/`getDetailPlaceholder` API for content shown in the detail area when no detail is selected
- The placeholder uses the `detail-placeholder` slot and is hidden in overlay mode (unlike detail content which becomes an overlay)
- Add `DETAIL_PLACEHOLDER_SLOT` constant

## Test plan
- [x] Unit tests pass (`mvn test -pl vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow`)
- [ ] Integration tests pass with updated web component

🤖 Generated with [Claude Code](https://claude.com/claude-code)