### PR TITLE
refactor: remove tab enabled sync

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -693,22 +692,7 @@ public class Tabs extends Component
             fireEvent(new SelectedChangeEvent(this, previousTab,
                     changedFromClient));
         } else {
-            updateEnabled(currentlySelected);
             setSelectedTab(selectedTab);
-        }
-    }
-
-    private void updateEnabled(Tab tab) {
-        boolean enabled = tab.getElement().getNode().isEnabledSelf();
-        Serializable rawValue = tab.getElement().getPropertyRaw("disabled");
-        if (rawValue instanceof Boolean) {
-            // convert the boolean value to a String to force update the
-            // property value. Otherwise since the provided value is the same as
-            // the current one the update don't do anything.
-            tab.getElement().setProperty("disabled",
-                    enabled ? null : Boolean.TRUE.toString());
-        } else {
-            tab.setEnabled(enabled);
         }
     }
 


### PR DESCRIPTION
## Description

`Tabs` contains logic to prevent selecting a tab from the client-side when that tab is disabled (added in https://github.com/vaadin/vaadin-tabs-flow/pull/63). While that part makes sense, the change also added logic to revert the disabled state on the client-side. That now causes problems when using `bindEnabled` with a `Tab` component, as `Tabs` tries to modify the enabled state on selection.

This removes the logic that forces the disabled state back onto the client. If someone tampers with the disabled state on the client there is no point in making sure the UI works correctly for them afterwards.

Fixes https://github.com/vaadin/flow-components/issues/9019

## Type of change

- Refactor