### PR TITLE
chore: avoid logging warnings / exceptions in AI components tests

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/pom.xml
@@ -24,6 +24,12 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>com.github.valfirst</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <version>3.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>3.0.1</version>
@@ -74,11 +80,6 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.ai.AIComponentsFeatureFlagProvider;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
@@ -71,6 +73,9 @@ class AIOrchestratorTest {
     private AIInput mockInput;
     private AIFileReceiver mockFileReceiver;
 
+    private TestLogger logger = TestLoggerFactory
+            .getTestLogger(AIOrchestrator.class);
+
     @BeforeEach
     void setup() {
         mockProvider = Mockito.mock(LLMProvider.class);
@@ -79,6 +84,7 @@ class AIOrchestratorTest {
         mockFileReceiver = Mockito.mock(AIFileReceiver.class);
         Mockito.when(mockFileReceiver.takeAttachments())
                 .thenReturn(Collections.emptyList());
+        logger.clear();
     }
 
     @Test
@@ -1688,19 +1694,15 @@ class AIOrchestratorTest {
                 .withMessageList(mockMessageList).withController(controller)
                 .build();
 
-        var originalErr = System.err;
-        var errStream = new java.io.ByteArrayOutputStream();
-        System.setErr(new java.io.PrintStream(errStream));
-        try {
-            orchestrator.prompt("Hello");
-            var errContent = errStream
-                    .toString(java.nio.charset.StandardCharsets.UTF_8);
-            Assertions.assertTrue(
-                    errContent.contains("Duplicate tool name 'sameName'"),
-                    "Expected duplicate tool name warning, got: " + errContent);
-        } finally {
-            System.setErr(originalErr);
-        }
+        orchestrator.prompt("Hello");
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage().equals(
+                        "Duplicate tool name '{}': previous tool will be replaced"))
+                .findFirst();
+
+        Assertions.assertTrue(warning.isPresent(),
+                "Expected duplicate tool name warning");
     }
 
     private static AIController createController(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.ai.provider;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +30,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
 import com.vaadin.flow.component.ai.provider.LLMProvider.LLMRequest;
@@ -64,12 +64,16 @@ class LangChain4JLLMProviderTest {
     private LangChain4JLLMProvider provider;
     private LangChain4JLLMProvider streamingProvider;
 
+    private TestLogger logger = TestLoggerFactory
+            .getTestLogger(LangChain4JLLMProvider.class);
+
     @BeforeEach
     void setup() {
         mockChatModel = Mockito.mock(ChatModel.class);
         mockStreamingChatModel = Mockito.mock(StreamingChatModel.class);
         provider = new LangChain4JLLMProvider(mockChatModel);
         streamingProvider = new LangChain4JLLMProvider(mockStreamingChatModel);
+        logger.clear();
     }
 
     @Test
@@ -581,54 +585,43 @@ class LangChain4JLLMProviderTest {
     void stream_withStreamingModelAndPushDisabled_logsWarning() {
         ui.getUI().getPushConfiguration().setPushMode(PushMode.DISABLED);
 
-        var originalErr = System.err;
-        var errStream = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(errStream));
-        try {
-            var request = createSimpleRequest("Hello");
-            Mockito.doAnswer(invocation -> {
-                StreamingChatResponseHandler handler = invocation
-                        .getArgument(1);
-                handler.onPartialResponse("Hi");
-                var aiMessage = Mockito.mock(AiMessage.class);
-                Mockito.when(aiMessage.hasToolExecutionRequests())
-                        .thenReturn(false);
-                var response = Mockito.mock(ChatResponse.class);
-                Mockito.when(response.aiMessage()).thenReturn(aiMessage);
-                handler.onCompleteResponse(response);
-                return null;
-            }).when(mockStreamingChatModel).chat(Mockito.any(ChatRequest.class),
-                    Mockito.any(StreamingChatResponseHandler.class));
+        var request = createSimpleRequest("Hello");
+        Mockito.doAnswer(invocation -> {
+            StreamingChatResponseHandler handler = invocation.getArgument(1);
+            handler.onPartialResponse("Hi");
+            var aiMessage = Mockito.mock(AiMessage.class);
+            Mockito.when(aiMessage.hasToolExecutionRequests())
+                    .thenReturn(false);
+            var response = Mockito.mock(ChatResponse.class);
+            Mockito.when(response.aiMessage()).thenReturn(aiMessage);
+            handler.onCompleteResponse(response);
+            return null;
+        }).when(mockStreamingChatModel).chat(Mockito.any(ChatRequest.class),
+                Mockito.any(StreamingChatResponseHandler.class));
 
-            streamingProvider.stream(request).collectList().block();
+        streamingProvider.stream(request).collectList().block();
 
-            var errContent = errStream.toString(StandardCharsets.UTF_8);
-            Assertions.assertTrue(errContent.contains("Push is not enabled"));
-        } finally {
-            System.setErr(originalErr);
-        }
+        var warning = logger.getLoggingEvents().stream().filter(
+                event -> event.getMessage().contains("Push is not enabled"))
+                .findFirst();
+        Assertions.assertTrue(warning.isPresent(), "Expected push warning");
     }
 
     @Test
     void stream_withNonStreamingModelAndPushDisabled_doesNotLogWarning() {
         ui.getUI().getPushConfiguration().setPushMode(PushMode.DISABLED);
 
-        var originalErr = System.err;
-        var errStream = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(errStream));
-        try {
-            var request = createSimpleRequest("Hello");
-            var response = mockSimpleResponse("Hi there");
-            Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
-                    .thenReturn(response);
+        var request = createSimpleRequest("Hello");
+        var response = mockSimpleResponse("Hi there");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
 
-            provider.stream(request).collectList().block();
+        provider.stream(request).collectList().block();
 
-            var errContent = errStream.toString(StandardCharsets.UTF_8);
-            Assertions.assertFalse(errContent.contains("Push is not enabled"));
-        } finally {
-            System.setErr(originalErr);
-        }
+        var warning = logger.getLoggingEvents().stream().filter(
+                event -> event.getMessage().contains("Push is not enabled"))
+                .findFirst();
+        Assertions.assertFalse(warning.isPresent(), "Expected no push warning");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.ai.provider;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +41,8 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.annotation.Tool;
 
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
 import com.vaadin.flow.component.ai.provider.LLMProvider.LLMRequest;
@@ -58,10 +58,14 @@ class SpringAILLMProviderTest {
     private ChatModel mockChatModel;
     private SpringAILLMProvider provider;
 
+    private TestLogger logger = TestLoggerFactory
+            .getTestLogger(SpringAILLMProvider.class);
+
     @BeforeEach
     void setup() {
         mockChatModel = Mockito.mock(ChatModel.class);
         provider = new SpringAILLMProvider(mockChatModel);
+        logger.clear();
     }
 
     @Test
@@ -556,23 +560,18 @@ class SpringAILLMProviderTest {
     void stream_withStreamingAndPushDisabled_logsWarning() {
         ui.getUI().getPushConfiguration().setPushMode(PushMode.DISABLED);
 
-        var originalErr = System.err;
-        var errStream = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(errStream));
-        try {
-            var request = createSimpleRequest("Hello");
-            var tokens = List.of("Hello", " ", "World");
-            Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
-                    .thenReturn(Flux.fromIterable(tokens.stream()
-                            .map(this::mockSimpleChatResponse).toList()));
+        var request = createSimpleRequest("Hello");
+        var tokens = List.of("Hello", " ", "World");
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.fromIterable(tokens.stream()
+                        .map(this::mockSimpleChatResponse).toList()));
 
-            provider.stream(request).collectList().block();
+        provider.stream(request).collectList().block();
 
-            var errContent = errStream.toString(StandardCharsets.UTF_8);
-            Assertions.assertTrue(errContent.contains("Push is not enabled"));
-        } finally {
-            System.setErr(originalErr);
-        }
+        var warning = logger.getLoggingEvents().stream().filter(
+                event -> event.getMessage().contains("Push is not enabled"))
+                .findFirst();
+        Assertions.assertTrue(warning.isPresent(), "Expected push warning");
     }
 
     @Test
@@ -580,20 +579,15 @@ class SpringAILLMProviderTest {
         provider.setStreaming(false);
         ui.getUI().getPushConfiguration().setPushMode(PushMode.DISABLED);
 
-        var originalErr = System.err;
-        var errStream = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(errStream));
-        try {
-            var request = createSimpleRequest("Hello");
-            mockSimpleChat("Hi there");
+        var request = createSimpleRequest("Hello");
+        mockSimpleChat("Hi there");
 
-            provider.stream(request).collectList().block();
+        provider.stream(request).collectList().block();
 
-            var errContent = errStream.toString(StandardCharsets.UTF_8);
-            Assertions.assertFalse(errContent.contains("Push is not enabled"));
-        } finally {
-            System.setErr(originalErr);
-        }
+        var warning = logger.getLoggingEvents().stream().filter(
+                event -> event.getMessage().contains("Push is not enabled"))
+                .findFirst();
+        Assertions.assertFalse(warning.isPresent(), "Expected no push warning");
     }
 
     @Test


### PR DESCRIPTION
AI components unit tests currently log a lot of warnings and exceptions during test runs:
- Warnings about push mode not enabled
- Exceptions caught and logged by AIOrchestrator
- Exceptions thrown from Spring AI, probably due to incomplete mock setup

All of those create a lot of noise and make it hard to discern whether there actually was a problem with a test or not.

This replaces the `slf4j-simple` logger implementation with a `slf4j-test` test logger implementation. The test logger does not print to console by default. It also makes it easier to make assertions on logged messages, which currently requires temporarily patching the error output stream.
