### PR TITLE
fix: reset freeze pane split positions when switching sheets

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -1080,9 +1080,12 @@ public class SpreadsheetFactory implements Serializable {
                             .boxed().collect(Collectors.toMap(
                                     Function.identity(), index -> true)));
                 }
-            } else if (leftCol > 0) {
-                // TODO: should scroll vertically to restore viewport state
-                // This needs API on the Spreadsheet side
+            } else {
+                spreadsheet.setHorizontalSplitPosition(0);
+                if (leftCol > 0) {
+                    // TODO: should scroll horizontally to restore viewport
+                    // state. This needs API on the Spreadsheet side
+                }
             }
 
             if (hSplit > 0) {
@@ -1092,9 +1095,12 @@ public class SpreadsheetFactory implements Serializable {
                             .collect(Collectors.toMap(Function.identity(),
                                     index -> true)));
                 }
-            } else if (topRow > 0) {
-                // TODO: should scroll vertically to restore viewport state
-                // This needs API on the Spreadsheet side
+            } else {
+                spreadsheet.setVerticalSplitPosition(0);
+                if (topRow > 0) {
+                    // TODO: should scroll vertically to restore viewport
+                    // state. This needs API on the Spreadsheet side
+                }
             }
         } else {
             spreadsheet.setVerticalSplitPosition(0);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactoryTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactoryTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+class SpreadsheetFactoryTest {
+
+    @Mock
+    private Spreadsheet spreadsheet;
+
+    private XSSFWorkbook workbook;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        workbook = new XSSFWorkbook();
+    }
+
+    @Test
+    void loadFreezePane_bothSplits_setsBothPositions() {
+        // POI: createFreezePane(colSplit, rowSplit)
+        // colSplit → POI verticalSplitPosition (columns)
+        // rowSplit → POI horizontalSplitPosition (rows)
+        Sheet sheet = workbook.createSheet();
+        sheet.createFreezePane(5, 4);
+
+        when(spreadsheet.getActiveSheet()).thenReturn(sheet);
+
+        SpreadsheetFactory.loadFreezePane(spreadsheet);
+
+        // Spreadsheet swaps the naming:
+        // POI verticalSplit (cols=5) → Spreadsheet horizontalSplitPosition
+        // POI horizontalSplit (rows=4) → Spreadsheet verticalSplitPosition
+        verify(spreadsheet).setHorizontalSplitPosition(5);
+        verify(spreadsheet).setVerticalSplitPosition(4);
+    }
+
+    @Test
+    void loadFreezePane_onlyFrozenRows_resetsHorizontalToZero() {
+        // Only frozen rows (POI horizontalSplit), no frozen columns
+        Sheet sheet = workbook.createSheet();
+        sheet.createFreezePane(0, 3);
+
+        when(spreadsheet.getActiveSheet()).thenReturn(sheet);
+
+        SpreadsheetFactory.loadFreezePane(spreadsheet);
+
+        verify(spreadsheet).setHorizontalSplitPosition(0);
+        verify(spreadsheet).setVerticalSplitPosition(3);
+    }
+
+    @Test
+    void loadFreezePane_onlyFrozenColumns_resetsVerticalToZero() {
+        // Only frozen columns (POI verticalSplit), no frozen rows
+        Sheet sheet = workbook.createSheet();
+        sheet.createFreezePane(2, 0);
+
+        when(spreadsheet.getActiveSheet()).thenReturn(sheet);
+
+        SpreadsheetFactory.loadFreezePane(spreadsheet);
+
+        verify(spreadsheet).setHorizontalSplitPosition(2);
+        verify(spreadsheet).setVerticalSplitPosition(0);
+    }
+
+    @Test
+    void loadFreezePane_noFreezePane_resetsBothToZero() {
+        Sheet sheet = workbook.createSheet();
+
+        when(spreadsheet.getActiveSheet()).thenReturn(sheet);
+
+        SpreadsheetFactory.loadFreezePane(spreadsheet);
+
+        verify(spreadsheet).setHorizontalSplitPosition(0);
+        verify(spreadsheet).setVerticalSplitPosition(0);
+    }
+
+    @Test
+    void loadFreezePane_switchingSheets_doesNotBleedState() {
+        // Simulate switching from a sheet with both splits to one with
+        // only frozen columns — the vertical split (frozen rows) must
+        // be reset to 0 and not retain the previous sheet's value.
+        Sheet bothSplits = workbook.createSheet();
+        bothSplits.createFreezePane(5, 4);
+
+        Sheet onlyColumns = workbook.createSheet();
+        onlyColumns.createFreezePane(2, 0);
+
+        // Load first sheet (both splits)
+        when(spreadsheet.getActiveSheet()).thenReturn(bothSplits);
+        SpreadsheetFactory.loadFreezePane(spreadsheet);
+
+        verify(spreadsheet).setHorizontalSplitPosition(5);
+        verify(spreadsheet).setVerticalSplitPosition(4);
+
+        Mockito.reset(spreadsheet);
+
+        // Switch to second sheet (only columns) — vertical must reset
+        when(spreadsheet.getActiveSheet()).thenReturn(onlyColumns);
+        SpreadsheetFactory.loadFreezePane(spreadsheet);
+
+        verify(spreadsheet).setHorizontalSplitPosition(2);
+        verify(spreadsheet).setVerticalSplitPosition(0);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes freeze pane state bleeding between sheets when switching tabs in Spreadsheet
- When switching from a sheet with a freeze pane split to one without that split type, the previous sheet's split position was not reset to 0, causing it to persist visually
- Root cause: commit a1963f962 guarded `setHorizontalSplitPosition`/`setVerticalSplitPosition` behind split-exists checks but the `else` branches never explicitly reset the positions to 0

Fixes #9006

## Test plan
- [x] New unit tests in `SpreadsheetFactoryTest` verify all freeze pane combinations (both splits, only rows, only columns, none) and the sheet-switching bleed scenario
- [x] Rollback verification: 3 of 5 unit tests fail without the fix, pass with it
- [x] Existing regression tests (`HiddenAndFrozenIT`, `LoadFileWithFrozenPaneScrolledIT`, `MergedCellFrozenIT`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)