### PR TITLE
chore: remove invalid Crud test

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/tests/NewButtonView.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/tests/NewButtonView.java
@@ -18,21 +18,9 @@ import com.vaadin.flow.router.Route;
 public class NewButtonView extends VerticalLayout {
 
     public NewButtonView() {
-        createCrudWithNewButtonNull();
-        createCrudWithNewButtonHidden();
-    }
-
-    private void createCrudWithNewButtonNull() {
         Crud<Person> crud = new Crud<>(Person.class, createPersonEditor());
         crud.setNewButton(null);
         crud.setId("crud-new-button-null");
-        add(crud);
-    }
-
-    private void createCrudWithNewButtonHidden() {
-        Crud<Person> crud = new Crud<>(Person.class, createPersonEditor());
-        crud.getNewButton().setVisible(false);
-        crud.setId("crud-new-button-hidden");
         add(crud);
     }
 }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/NewButtonIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/NewButtonIT.java
@@ -31,13 +31,6 @@ public class NewButtonIT extends AbstractComponentIT {
                 verifyButtonRendered(crud));
     }
 
-    @Test
-    public void newButtonVisibleFalse_noNewButtonPresent() {
-        CrudElement crud = $(CrudElement.class).id("crud-new-button-hidden");
-        Assert.assertFalse("New button should not be rendered",
-                verifyButtonRendered(crud));
-    }
-
     private boolean verifyButtonRendered(CrudElement crud) {
         return crud.$("*").withAttribute("slot", "new-button").exists();
     }


### PR DESCRIPTION
## Description

Since https://github.com/vaadin/flow/pull/24037, invisible components with a part attribute are now synced to the client-side immediately. This removes a Crud test that started failing due to that. The test was added in https://github.com/vaadin/flow-components/pull/6115, to ensure the web component does not create default buttons when the Flow component does not add them. Now with the Flow change the Flow component will always add its own invisible button, the remaining test still covers the case where the button is removed from the component by setting it null.

## Type of change

- Internal