### PR TITLE
chore: add --ignore-scripts to all npm install calls

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -148,7 +148,7 @@ then
 fi
 
 ## Install node modules used for merging ITs
-cmd="npm install --silent --quiet --no-progress"
+cmd="npm install --ignore-scripts --silent --quiet --no-progress"
 tcLog "Install NPM packages - $cmd"
 $cmd || exit 1
 

--- a/scripts/copy-theme-distribution.js
+++ b/scripts/copy-theme-distribution.js
@@ -74,7 +74,7 @@ fs.writeFileSync(
   JSON.stringify(packageJson, null, 2)
 );
 
-execSync('npm install', {
+execSync('npm install --ignore-scripts', {
   cwd: tempDir,
   stdio: 'inherit'
 });

--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -53,7 +53,7 @@ function runTests() {
       });
 
       // Install dependencies required to run the web-test-runner tests
-      execSync(`npm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon @vaadin/testing-helpers --save-dev --legacy-peer-deps`, {
+      execSync(`npm install --ignore-scripts @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon @vaadin/testing-helpers --save-dev --legacy-peer-deps`, {
         cwd: itFolder,
         stdio: 'inherit'
       });


### PR DESCRIPTION
## Summary

- Add `--ignore-scripts` flag to all `npm install` invocations in build scripts
- Prevents execution of arbitrary lifecycle scripts during dependency installation, reducing supply chain risk
- Affected files: `scripts/wtr.js`, `scripts/build.sh`, `scripts/copy-theme-distribution.js`