### PR TITLE
refactor: use merge behavior for chart configuration updates

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -131,6 +131,10 @@ public class ChartAIController implements AIController {
 
             @Override
             public void updateConfiguration(String chartId, String configJson) {
+                // Parse eagerly to validate. If the JSON contains
+                // invalid values, the exception propagates back to the
+                // LLM as an error so it can fix the configuration.
+                ChartConfigurationParser.parse(configJson);
                 ChartEntry.getOrCreate(chart, chartId)
                         .setPendingConfigurationJson(configJson);
             }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -277,17 +277,15 @@ public final class ChartAITools {
             @Override
             public String getDescription() {
                 return """
-                        Updates the Highcharts configuration of a chart. The configuration \
-                        object follows the same structure as the Highcharts options object \
-                        (as returned by get_chart_state), supporting: chart (type, dimensions, \
-                        margins, spacing, borders, background, inverted, polar, animation, \
-                        zoomType), title, subtitle, xAxis, yAxis, zAxis, colorAxis, tooltip, \
-                        legend, plotOptions (series defaults, stacking, dataLabels, markers, \
-                        pie innerSize for donuts), credits, and pane.
+                        Updates the Highcharts configuration of a chart. Only include the \
+                        properties you want to change — existing properties are preserved. \
+                        Changing chart.type resets the entire configuration.
 
-                        CRITICAL: ALWAYS specify the chart type in configuration.chart.type - this is essential for proper rendering.
+                        CRITICAL: ALWAYS specify the chart type in configuration.chart.type \
+                        when creating a new chart or changing chart type.
 
-                        IMPORTANT: Do NOT include 'series' in the configuration - chart data is managed separately via update_chart_data_source tool.
+                        IMPORTANT: Do NOT include series data in the configuration — chart data \
+                        is managed separately via update_chart_data_source tool.
 
                         Parameters:
                         - chartId (string, optional): The ID of the chart to update. Required when multiple charts exist.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
@@ -66,6 +66,16 @@ public final class ChartConfigurationParser implements Serializable {
     private ChartConfigurationParser() {
     }
 
+    /**
+     * Parses a Highcharts JSON configuration string into a new
+     * {@link Configuration} object.
+     *
+     * @param configJson
+     *            the Highcharts JSON configuration string to parse
+     * @return a new {@link Configuration} populated with the parsed values
+     * @throws IllegalArgumentException
+     *             if the JSON string is invalid or not an object
+     */
     public static Configuration parse(String configJson) {
         Configuration config = new Configuration();
         merge(configJson, config);
@@ -76,6 +86,14 @@ public final class ChartConfigurationParser implements Serializable {
      * Parses a JSON configuration string and applies the values onto the given
      * {@link Configuration}. Only properties present in the JSON are modified;
      * existing properties not mentioned in the JSON are preserved.
+     *
+     * @param configJson
+     *            the Highcharts JSON configuration string to parse
+     * @param config
+     *            the existing {@link Configuration} to merge the parsed values
+     *            into
+     * @throws IllegalArgumentException
+     *             if the JSON string is invalid or not an object
      */
     public static void merge(String configJson, Configuration config) {
         ObjectNode configNode = parseJsonToNode(configJson);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
@@ -26,9 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.charts.model.Axis;
 import com.vaadin.flow.component.charts.model.AxisTitle;
 import com.vaadin.flow.component.charts.model.AxisType;
@@ -54,6 +51,7 @@ import com.vaadin.flow.component.charts.model.VerticalAlign;
 import com.vaadin.flow.component.charts.model.style.SolidColor;
 import com.vaadin.flow.internal.JacksonUtils;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -65,84 +63,92 @@ import tools.jackson.databind.node.ObjectNode;
  */
 public final class ChartConfigurationParser implements Serializable {
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(ChartConfigurationParser.class);
-
     private ChartConfigurationParser() {
     }
 
     public static Configuration parse(String configJson) {
         Configuration config = new Configuration();
+        merge(configJson, config);
+        return config;
+    }
+
+    /**
+     * Parses a JSON configuration string and applies the values onto the given
+     * {@link Configuration}. Only properties present in the JSON are modified;
+     * existing properties not mentioned in the JSON are preserved.
+     */
+    public static void merge(String configJson, Configuration config) {
+        ObjectNode configNode = parseJsonToNode(configJson);
+
+        String chartType = null;
+        if (configNode.has(TYPE)) {
+            chartType = configNode.get(TYPE).asString();
+        } else if (configNode.has(CHART) && configNode.get(CHART).isObject()) {
+            JsonNode chartNode = configNode.get(CHART);
+            if (chartNode.has(TYPE)) {
+                chartType = chartNode.get(TYPE).asString();
+            }
+        }
+        if (chartType != null) {
+            applyChartType(config, chartType);
+        }
+
+        if (configNode.has(CHART) && configNode.get(CHART).isObject()) {
+            applyChartModelConfig(config.getChart(), configNode.get(CHART));
+        }
+        if (configNode.has(TITLE)) {
+            applyTitleConfig(config, configNode.get(TITLE));
+        }
+        if (configNode.has(SUBTITLE)) {
+            applySubtitleConfig(config, configNode.get(SUBTITLE));
+        }
+        if (configNode.has(TOOLTIP) && configNode.get(TOOLTIP).isObject()) {
+            applyTooltipConfig(config.getTooltip(), configNode.get(TOOLTIP));
+        }
+        if (configNode.has(LEGEND) && configNode.get(LEGEND).isObject()) {
+            applyLegendConfig(config.getLegend(), configNode.get(LEGEND));
+        }
+        if (configNode.has(X_AXIS)) {
+            applyAxisConfig(config.getxAxis(), configNode.get(X_AXIS));
+        }
+        if (configNode.has(Y_AXIS)) {
+            applyAxisConfig(config.getyAxis(), configNode.get(Y_AXIS));
+        }
+        if (configNode.has(Z_AXIS)) {
+            applyAxisConfig(config.getzAxis(), configNode.get(Z_AXIS));
+        }
+        if (configNode.has(COLOR_AXIS)) {
+            applyColorAxisConfig(config, configNode.get(COLOR_AXIS));
+        }
+        if (configNode.has(CREDITS) && configNode.get(CREDITS).isObject()) {
+            applyCreditsConfig(config.getCredits(), configNode.get(CREDITS));
+        }
+        if (configNode.has(PANE) && configNode.get(PANE).isObject()) {
+            applyPaneConfig(config, configNode.get(PANE));
+        }
+        if (configNode.has(PLOT_OPTIONS)
+                && configNode.get(PLOT_OPTIONS).isObject()) {
+            applyPlotOptionsConfig(config, configNode.get(PLOT_OPTIONS));
+        }
+    }
+
+    private static ObjectNode parseJsonToNode(String configJson) {
         try {
             JsonNode parsedNode = JacksonUtils.getMapper().readTree(configJson);
-            // Handle double-encoded JSON strings from LLM
             if (parsedNode.isString()) {
                 parsedNode = JacksonUtils.getMapper()
                         .readTree(parsedNode.asString());
             }
-            if (!(parsedNode instanceof ObjectNode configNode)) {
-                LOGGER.warn("Expected JSON object for chart config but got: {}",
-                        parsedNode.getNodeType());
-                return config;
+            if (parsedNode instanceof ObjectNode objectNode) {
+                return objectNode;
             }
-
-            String chartType = null;
-            if (configNode.has(TYPE)) {
-                chartType = configNode.get(TYPE).asString();
-            } else if (configNode.has(CHART)
-                    && configNode.get(CHART).isObject()) {
-                JsonNode chartNode = configNode.get(CHART);
-                if (chartNode.has(TYPE)) {
-                    chartType = chartNode.get(TYPE).asString();
-                }
-            }
-            if (chartType != null) {
-                applyChartType(config, chartType);
-            }
-
-            if (configNode.has(CHART) && configNode.get(CHART).isObject()) {
-                applyChartModelConfig(config.getChart(), configNode.get(CHART));
-            }
-            if (configNode.has(TITLE)) {
-                applyTitleConfig(config, configNode.get(TITLE));
-            }
-            if (configNode.has(SUBTITLE)) {
-                applySubtitleConfig(config, configNode.get(SUBTITLE));
-            }
-            if (configNode.has(TOOLTIP) && configNode.get(TOOLTIP).isObject()) {
-                applyTooltipConfig(config.getTooltip(),
-                        configNode.get(TOOLTIP));
-            }
-            if (configNode.has(LEGEND) && configNode.get(LEGEND).isObject()) {
-                applyLegendConfig(config.getLegend(), configNode.get(LEGEND));
-            }
-            if (configNode.has(X_AXIS)) {
-                applyAxisConfig(config.getxAxis(), configNode.get(X_AXIS));
-            }
-            if (configNode.has(Y_AXIS)) {
-                applyAxisConfig(config.getyAxis(), configNode.get(Y_AXIS));
-            }
-            if (configNode.has(Z_AXIS)) {
-                applyAxisConfig(config.getzAxis(), configNode.get(Z_AXIS));
-            }
-            if (configNode.has(COLOR_AXIS)) {
-                applyColorAxisConfig(config, configNode.get(COLOR_AXIS));
-            }
-            if (configNode.has(CREDITS) && configNode.get(CREDITS).isObject()) {
-                applyCreditsConfig(config.getCredits(),
-                        configNode.get(CREDITS));
-            }
-            if (configNode.has(PANE) && configNode.get(PANE).isObject()) {
-                applyPaneConfig(config, configNode.get(PANE));
-            }
-            if (configNode.has(PLOT_OPTIONS)
-                    && configNode.get(PLOT_OPTIONS).isObject()) {
-                applyPlotOptionsConfig(config, configNode.get(PLOT_OPTIONS));
-            }
-        } catch (Exception e) {
-            LOGGER.error("Error applying chart config", e);
+            throw new IllegalArgumentException(
+                    "Expected JSON object for chart config but got: "
+                            + parsedNode.getNodeType());
+        } catch (JacksonException e) {
+            throw new IllegalArgumentException(
+                    "Invalid chart configuration JSON: " + e.getMessage(), e);
         }
-        return config;
     }
 
     private static final Map<String, ChartType> CHART_TYPES_BY_NAME;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -69,11 +69,17 @@ public final class ChartRenderer implements Serializable {
             allSeries.addAll(dataConverter.convertToSeries(results));
         }
 
+        Configuration config = chart.getConfiguration();
         if (configJson != null) {
-            chart.setConfiguration(ChartConfigurationParser.parse(configJson));
+            var parsed = ChartConfigurationParser.parse(configJson);
+            if (chartTypeChanged(config, parsed)) {
+                config = parsed;
+                chart.setConfiguration(config);
+            } else {
+                ChartConfigurationParser.merge(configJson, config);
+            }
         }
 
-        Configuration config = chart.getConfiguration();
         config.setSeries(allSeries.toArray(new Series[0]));
 
         // Apply axis defaults from series data after LLM config,
@@ -89,6 +95,18 @@ public final class ChartRenderer implements Serializable {
         // lost when the chart is rendered via async Push (see
         // DashboardChartControllerIT).
         chart.drawChart(true);
+    }
+
+    /**
+     * Returns {@code true} if the new configuration specifies a different chart
+     * type than the current one, indicating a full configuration reset is
+     * needed.
+     */
+    private static boolean chartTypeChanged(Configuration current,
+            Configuration incoming) {
+        var currentType = current.getChart().getType();
+        var incomingType = incoming.getChart().getType();
+        return incomingType != null && !incomingType.equals(currentType);
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -143,6 +143,17 @@ class ChartAIControllerTest {
         }
 
         @Test
+        void updateConfiguration_validatesEagerly() {
+            var tool = findTool(controller.getTools(),
+                    "update_chart_configuration");
+
+            String result = tool
+                    .execute("{\"configuration\": \"not a json object\"}");
+            Assertions.assertTrue(result.contains("Error"),
+                    "Invalid config should return error: " + result);
+        }
+
+        @Test
         void updateData_validatesQueriesEagerly() {
             databaseProvider.throwOnExecute = new RuntimeException("Bad SQL");
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
@@ -475,15 +475,15 @@ class ChartConfigurationParserTest {
         }
 
         @Test
-        void invalidJson_doesNotThrow() {
-            parse("not json");
-            // Should log error but not throw
+        void invalidJson_throws() {
+            Assertions.assertThrows(IllegalArgumentException.class,
+                    () -> parse("not json"));
         }
 
         @Test
-        void nonObjectJson_doesNotThrow() {
-            parse("[1,2,3]");
-            // Should log warning but not throw
+        void nonObjectJson_throws() {
+            Assertions.assertThrows(IllegalArgumentException.class,
+                    () -> parse("[1,2,3]"));
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -361,7 +361,7 @@ class ChartRenderingTest {
         }
 
         @Test
-        void emptySeriesResetsAxisType() {
+        void emptySeriesPreservesAxisType() {
             controller.setDataConverter(data -> List.of(new DataSeries()));
             databaseProvider.results = List.of();
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -147,6 +147,31 @@ class ChartRenderingTest {
         }
 
         @Test
+        void sameChartTypeMergesConfigIntoExisting() {
+            databaseProvider.results = List
+                    .of(row("category", "A", "value", 10));
+
+            // First render: line chart with title
+            updateConfiguration(
+                    "{\"chart\":{\"type\":\"line\"},\"title\":{\"text\":\"Original\"}}");
+            updateData("SELECT category, value FROM t");
+            controller.onRequestCompleted();
+
+            Assertions.assertEquals("Original",
+                    chart.getConfiguration().getTitle().getText());
+
+            // Second render: same type, only update title (merge path)
+            updateConfiguration("{\"title\":{\"text\":\"Updated\"}}");
+            updateData("SELECT category, value FROM t");
+            controller.onRequestCompleted();
+
+            Assertions.assertEquals("Updated",
+                    chart.getConfiguration().getTitle().getText());
+            Assertions.assertEquals(ChartType.LINE,
+                    chart.getConfiguration().getChart().getType());
+        }
+
+        @Test
         void configOnlyAfterGaugeResetsPane() {
             // First: full render as gauge
             databaseProvider.results = List.of(row(ColumnNames.Y, 78));
@@ -349,15 +374,16 @@ class ChartRenderingTest {
             Assertions.assertEquals(AxisType.LINEAR,
                     chart.getConfiguration().getxAxis().getType());
 
-            // Second render: config without axis type — should clear it
+            // Second render: same chart type preserves existing config
+            // (merge behavior). Axis type remains LINEAR since config
+            // doesn't override it and there is no series data to
+            // trigger auto-detection.
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT 1");
             controller.onRequestCompleted();
 
-            // Configuration reset clears stale axis type when config
-            // doesn't specify one, so Highcharts auto-detects
-            Assertions
-                    .assertNull(chart.getConfiguration().getxAxis().getType());
+            Assertions.assertEquals(AxisType.LINEAR,
+                    chart.getConfiguration().getxAxis().getType());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Chart configuration updates now merge into the existing configuration instead of replacing it, so the LLM only needs to send changed properties
- Full configuration reset only happens when the chart type changes
- Invalid configuration JSON is eagerly validated and reported back to the LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)