### PR TITLE
feat: add generic plot options schema generation and lookup tool

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/pom.xml
@@ -104,6 +104,27 @@
                 <artifactId>bnd-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>generate-plot-options-descriptions</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <mainClass>com.vaadin.flow.component.ai.chart.PlotOptionsSchemaGenerator</mainClass>
+                            <arguments>
+                                <argument>${project.basedir}/../../vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model</argument>
+                                <argument>${project.build.outputDirectory}/com/vaadin/flow/component/ai/chart/plot-options-schemas.json</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -219,7 +219,7 @@ public final class ChartAITools {
         Objects.requireNonNull(callbacks, "callbacks must not be null");
         return List.of(getChartState(callbacks),
                 updateChartConfiguration(callbacks),
-                updateChartDataSource(callbacks));
+                updateChartDataSource(callbacks), getPlotOptionsSchema());
     }
 
     public static LLMProvider.ToolSpec getChartState(Callbacks callbacks) {
@@ -436,73 +436,8 @@ public final class ChartAITools {
                                 },
                                 "{c:PLOT_OPTIONS}": {
                                   "type": "object",
-                                  "description": "Default options for series types. Use 'series' key for options applying to all series, or a chart type key (e.g., 'pie', 'column') for type-specific options.",
-                                  "properties": {
-                                    "{c:SERIES}": {
-                                      "type": "object",
-                                      "description": "Default options for all series types",
-                                      "properties": {
-                                        "{c:STACKING}": { "type": "string", "enum": ["normal", "percent"], "description": "Stack series by value or percentage" },
-                                        "{c:DATA_LABELS}": {
-                                          "type": "object",
-                                          "properties": {
-                                            "{c:ENABLED}": { "type": "boolean" },
-                                            "{c:FORMAT}": { "type": "string", "description": "Label format string" }
-                                          }
-                                        },
-                                        "{c:MARKER}": {
-                                          "type": "object",
-                                          "properties": {
-                                            "{c:ENABLED}": { "type": "boolean" }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "{c:PIE}": {
-                                      "type": "object",
-                                      "description": "Default options for pie series",
-                                      "properties": {
-                                        "{c:INNER_SIZE}": { "type": "string", "description": "Inner diameter for donut charts (e.g., '50%')" },
-                                        "{c:DATA_LABELS}": {
-                                          "type": "object",
-                                          "properties": {
-                                            "{c:ENABLED}": { "type": "boolean" },
-                                            "{c:FORMAT}": { "type": "string" }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "{c:COLUMN}": {
-                                      "type": "object",
-                                      "description": "Default options for column series",
-                                      "properties": {
-                                        "{c:STACKING}": { "type": "string", "enum": ["normal", "percent"] },
-                                        "{c:DATA_LABELS}": {
-                                          "type": "object",
-                                          "properties": {
-                                            "{c:ENABLED}": { "type": "boolean" },
-                                            "{c:FORMAT}": { "type": "string" }
-                                          }
-                                        },
-                                        "{c:BORDER_RADIUS}": { "type": "number", "description": "Border radius for column corners" }
-                                      }
-                                    },
-                                    "{c:BAR}": {
-                                      "type": "object",
-                                      "description": "Default options for bar series",
-                                      "properties": {
-                                        "{c:STACKING}": { "type": "string", "enum": ["normal", "percent"] },
-                                        "{c:DATA_LABELS}": {
-                                          "type": "object",
-                                          "properties": {
-                                            "{c:ENABLED}": { "type": "boolean" },
-                                            "{c:FORMAT}": { "type": "string" }
-                                          }
-                                        },
-                                        "{c:BORDER_RADIUS}": { "type": "number" }
-                                      }
-                                    }
-                                  }
+                                  "description": "Default options for series types. Use 'series' key for options applying to all series, or a chart type key (e.g. 'pie', 'column', 'line') for type-specific defaults. Call get_plot_options_schema(chartType) to discover available properties.",
+                                  "additionalProperties": { "type": "object" }
                                 }
                               }
                             }
@@ -678,6 +613,67 @@ public final class ChartAITools {
                 } catch (Exception e) {
                     LOGGER.error("update_chart_data_source failed", e);
                     return "Error updating chart data: " + e.getMessage();
+                }
+            }
+        };
+    }
+
+    /**
+     * Tool that returns the JSON schema for a specific chart type's plot
+     * options. Stateless — no callbacks needed.
+     */
+    public static LLMProvider.ToolSpec getPlotOptionsSchema() {
+        return new LLMProvider.ToolSpec() {
+            @Override
+            public String getName() {
+                return "get_plot_options_schema";
+            }
+
+            @Override
+            public String getDescription() {
+                return """
+                        Returns the JSON schema for plot options of a specific chart type.
+                        Use this to discover available styling properties (dataLabels, stacking, marker, lineWidth, etc.)
+                        before setting plotOptions or seriesOptions in update_chart_configuration.
+                        Use 'series' as the type for base options that apply to all chart types.""";
+            }
+
+            @Override
+            public String getParametersSchema() {
+                return """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "chartType": {
+                              "type": "string",
+                              "description": "The chart type (e.g. 'column', 'line', 'bar', 'area', 'pie', 'series')"
+                            }
+                          },
+                          "required": ["chartType"]
+                        }""";
+            }
+
+            @Override
+            public String execute(String arguments) {
+                try {
+                    LOGGER.info("get_plot_options_schema called with: {}",
+                            arguments);
+                    JsonNode args = JacksonUtils.readTree(arguments);
+                    JsonNode typeNode = args.get("chartType");
+                    if (typeNode == null || typeNode.isNull()) {
+                        return "Error: 'chartType' parameter is required.";
+                    }
+                    String chartType = typeNode.asString();
+                    String schema = PlotOptionsSchema.getSchema(chartType);
+                    if (schema == null) {
+                        return "Error: unknown chart type '" + chartType
+                                + "'. Supported types: " + String.join(", ",
+                                        PlotOptionsSchema.supportedTypes());
+                    }
+                    return schema;
+                } catch (Exception e) {
+                    LOGGER.error("get_plot_options_schema failed", e);
+                    return "Error: " + e.getMessage();
                 }
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
+import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
 import com.vaadin.flow.component.charts.model.Axis;
 import com.vaadin.flow.component.charts.model.AxisTitle;
 import com.vaadin.flow.component.charts.model.AxisType;
@@ -34,25 +34,28 @@ import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.ColorAxis;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.Credits;
-import com.vaadin.flow.component.charts.model.DataLabels;
 import com.vaadin.flow.component.charts.model.Dimension;
 import com.vaadin.flow.component.charts.model.HorizontalAlign;
 import com.vaadin.flow.component.charts.model.LayoutDirection;
 import com.vaadin.flow.component.charts.model.Legend;
-import com.vaadin.flow.component.charts.model.Marker;
 import com.vaadin.flow.component.charts.model.Pane;
-import com.vaadin.flow.component.charts.model.PlotOptionsBar;
-import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
-import com.vaadin.flow.component.charts.model.PlotOptionsPie;
-import com.vaadin.flow.component.charts.model.PlotOptionsSeries;
-import com.vaadin.flow.component.charts.model.Stacking;
 import com.vaadin.flow.component.charts.model.Tooltip;
 import com.vaadin.flow.component.charts.model.VerticalAlign;
+import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.SolidColor;
 import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.DeserializationProblemHandler;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.node.ObjectNode;
 
 /**
@@ -458,86 +461,73 @@ public final class ChartConfigurationParser implements Serializable {
         }
     }
 
+    /**
+     * Applies global plot options from the {@code plotOptions} configuration
+     * section. Each key (e.g. "series", "column", "pie") maps to a chart type
+     * whose PlotOptions class is resolved and deserialized.
+     */
     private static void applyPlotOptionsConfig(Configuration config,
             JsonNode plotOptionsNode) {
-        if (plotOptionsNode.has(SERIES)
-                && plotOptionsNode.get(SERIES).isObject()) {
-            PlotOptionsSeries series = new PlotOptionsSeries();
-            applySeriesPlotOptions(series, plotOptionsNode.get(SERIES));
-            config.setPlotOptions(series);
-        }
-        if (plotOptionsNode.has(PIE) && plotOptionsNode.get(PIE).isObject()) {
-            PlotOptionsPie pie = new PlotOptionsPie();
-            JsonNode pieNode = plotOptionsNode.get(PIE);
-            applyDataLabelsConfig(pie.getDataLabels(), pieNode);
-            if (pieNode.has(INNER_SIZE) && pieNode.get(INNER_SIZE).isString()) {
-                pie.setInnerSize(pieNode.get(INNER_SIZE).asString());
+        for (var entry : plotOptionsNode.properties()) {
+            String typeName = entry.getKey();
+            JsonNode optionNode = entry.getValue();
+            if (!optionNode.isObject()) {
+                continue;
             }
-            config.setPlotOptions(pie);
-        }
-        if (plotOptionsNode.has(COLUMN)
-                && plotOptionsNode.get(COLUMN).isObject()) {
-            PlotOptionsColumn column = new PlotOptionsColumn();
-            JsonNode columnNode = plotOptionsNode.get(COLUMN);
-            parseStacking(columnNode).ifPresent(column::setStacking);
-            applyDataLabelsConfig(column.getDataLabels(), columnNode);
-            if (columnNode.has(BORDER_RADIUS)
-                    && columnNode.get(BORDER_RADIUS).isNumber()) {
-                column.setBorderRadius(columnNode.get(BORDER_RADIUS).asInt());
+            Class<? extends AbstractPlotOptions> clazz = PlotOptionsSchema
+                    .getPlotOptionsClass(typeName);
+            if (clazz == null) {
+                continue;
             }
-            config.setPlotOptions(column);
-        }
-        if (plotOptionsNode.has(BAR) && plotOptionsNode.get(BAR).isObject()) {
-            PlotOptionsBar bar = new PlotOptionsBar();
-            JsonNode barNode = plotOptionsNode.get(BAR);
-            parseStacking(barNode).ifPresent(bar::setStacking);
-            applyDataLabelsConfig(bar.getDataLabels(), barNode);
-            if (barNode.has(BORDER_RADIUS)
-                    && barNode.get(BORDER_RADIUS).isNumber()) {
-                bar.setBorderRadius(barNode.get(BORDER_RADIUS).asInt());
-            }
-            config.setPlotOptions(bar);
+            var plotOptions = PLOT_OPTIONS_READER.treeToValue(optionNode,
+                    clazz);
+            config.addPlotOptions(plotOptions);
         }
     }
 
-    private static void applySeriesPlotOptions(PlotOptionsSeries options,
-            JsonNode node) {
-        parseStacking(node).ifPresent(options::setStacking);
-        applyDataLabelsConfig(options.getDataLabels(), node);
-        if (node.has(MARKER) && node.get(MARKER).isObject()) {
-            JsonNode markerNode = node.get(MARKER);
-            Marker marker = new Marker();
-            if (markerNode.has(ENABLED)
-                    && markerNode.get(ENABLED).isBoolean()) {
-                marker.setEnabled(markerNode.get(ENABLED).asBoolean());
-            }
-            options.setMarker(marker);
+    /**
+     * ObjectMapper configured for deserializing plot options from JSON. Uses
+     * field-based access (matching ChartSerialization), case-insensitive enums,
+     * and ignores unknown properties.
+     */
+    private static final ObjectMapper PLOT_OPTIONS_READER;
+
+    private static final class ColorDeserializer
+            extends ValueDeserializer<Color> implements Serializable {
+        @Override
+        public Color deserialize(JsonParser p, DeserializationContext ctxt)
+                throws JacksonException {
+            return new SolidColor(p.getString());
         }
     }
 
-    private static Optional<Stacking> parseStacking(JsonNode node) {
-        if (node.has(STACKING) && node.get(STACKING).isString()) {
-            try {
-                return Optional.of(Stacking
-                        .valueOf(node.get(STACKING).asString().toUpperCase()));
-            } catch (IllegalArgumentException e) {
-                // skip
+    private static final class LenientEnumHandler
+            extends DeserializationProblemHandler implements Serializable {
+        @Override
+        public Object handleWeirdStringValue(DeserializationContext ctxt,
+                Class<?> targetType, String valueToConvert, String failureMsg) {
+            if (targetType.isEnum()) {
+                return null;
             }
+            return NOT_HANDLED;
         }
-        return Optional.empty();
     }
 
-    private static void applyDataLabelsConfig(DataLabels dataLabels,
-            JsonNode node) {
-        if (node.has(DATA_LABELS) && node.get(DATA_LABELS).isObject()) {
-            JsonNode dlNode = node.get(DATA_LABELS);
-            if (dlNode.has(ENABLED) && dlNode.get(ENABLED).isBoolean()) {
-                dataLabels.setEnabled(dlNode.get(ENABLED).asBoolean());
-            }
-            if (dlNode.has(FORMAT) && dlNode.get(FORMAT).isString()) {
-                dataLabels.setFormat(dlNode.get(FORMAT).asString());
-            }
-        }
+    static {
+        var colorModule = new SimpleModule("ColorDeserializer");
+        colorModule.addDeserializer(Color.class, new ColorDeserializer());
+
+        PLOT_OPTIONS_READER = JsonMapper.builder()
+                .changeDefaultVisibility(handler -> handler.withVisibility(
+                        com.fasterxml.jackson.annotation.PropertyAccessor.ALL,
+                        com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE)
+                        .withVisibility(
+                                com.fasterxml.jackson.annotation.PropertyAccessor.FIELD,
+                                com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY))
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .addHandler(new LenientEnumHandler()).addModule(colorModule)
+                .build();
     }
 
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
@@ -50,7 +50,6 @@ import com.vaadin.flow.internal.JacksonUtils;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
-import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
@@ -523,7 +522,6 @@ public final class ChartConfigurationParser implements Serializable {
                 .changeDefaultVisibility(handler -> handler
                         .withVisibility(PropertyAccessor.ALL, Visibility.NONE)
                         .withVisibility(PropertyAccessor.FIELD, Visibility.ANY))
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .addHandler(new LenientEnumHandler()).addModule(colorModule)
                 .build();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
 import com.vaadin.flow.component.charts.model.Axis;
 import com.vaadin.flow.component.charts.model.AxisTitle;
@@ -518,12 +520,9 @@ public final class ChartConfigurationParser implements Serializable {
         colorModule.addDeserializer(Color.class, new ColorDeserializer());
 
         PLOT_OPTIONS_READER = JsonMapper.builder()
-                .changeDefaultVisibility(handler -> handler.withVisibility(
-                        com.fasterxml.jackson.annotation.PropertyAccessor.ALL,
-                        com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE)
-                        .withVisibility(
-                                com.fasterxml.jackson.annotation.PropertyAccessor.FIELD,
-                                com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY))
+                .changeDefaultVisibility(handler -> handler
+                        .withVisibility(PropertyAccessor.ALL, Visibility.NONE)
+                        .withVisibility(PropertyAccessor.FIELD, Visibility.ANY))
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .addHandler(new LenientEnumHandler()).addModule(colorModule)

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ConfigurationKeys.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ConfigurationKeys.java
@@ -114,15 +114,4 @@ public final class ConfigurationKeys implements Serializable {
     public static final String END_ANGLE = "endAngle";
     public static final String CENTER = "center";
     public static final String SIZE = "size";
-
-    // --- Plot options ---
-
-    public static final String SERIES = "series";
-    public static final String PIE = "pie";
-    public static final String COLUMN = "column";
-    public static final String BAR = "bar";
-    public static final String STACKING = "stacking";
-    public static final String DATA_LABELS = "dataLabels";
-    public static final String MARKER = "marker";
-    public static final String INNER_SIZE = "innerSize";
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchema.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchema.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.chart;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
+import com.vaadin.flow.internal.JacksonUtils;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Provides pre-generated JSON schemas for {@link AbstractPlotOptions}
+ * subclasses. Schemas are generated at build time by
+ * {@link PlotOptionsSchemaGenerator} and loaded from a classpath resource.
+ *
+ * @author Vaadin Ltd
+ */
+final class PlotOptionsSchema implements Serializable {
+
+    private static final String SCHEMAS_RESOURCE = "plot-options-schemas.json";
+
+    private static final Map<String, String> SCHEMAS;
+    private static final Map<String, Class<? extends AbstractPlotOptions>> PLOT_OPTIONS_BY_TYPE;
+
+    static {
+        PLOT_OPTIONS_BY_TYPE = PlotOptionsSchemaGenerator.buildTypeMap();
+        SCHEMAS = loadSchemas();
+    }
+
+    private PlotOptionsSchema() {
+    }
+
+    /**
+     * Returns the pre-generated JSON schema for the plot options of the given
+     * chart type.
+     *
+     * @param chartType
+     *            chart type name (case-insensitive), e.g. "column", "series"
+     * @return JSON schema string, or {@code null} if the type is unknown
+     */
+    static String getSchema(String chartType) {
+        return SCHEMAS.get(chartType.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Returns the set of supported chart type names.
+     */
+    static Set<String> supportedTypes() {
+        return PLOT_OPTIONS_BY_TYPE.keySet();
+    }
+
+    /**
+     * Returns the PlotOptions class for the given chart type name, or
+     * {@code null} if the type is unknown.
+     */
+    static Class<? extends AbstractPlotOptions> getPlotOptionsClass(
+            String chartType) {
+        return PLOT_OPTIONS_BY_TYPE.get(chartType.toLowerCase(Locale.ENGLISH));
+    }
+
+    private static Map<String, String> loadSchemas() {
+        try (var input = PlotOptionsSchema.class
+                .getResourceAsStream(SCHEMAS_RESOURCE)) {
+            if (input == null) {
+                return Map.of();
+            }
+            JsonNode root = JacksonUtils.getMapper().readTree(input);
+            var result = new HashMap<String, String>();
+            var entries = root.properties().iterator();
+            while (entries.hasNext()) {
+                var entry = entries.next();
+                result.put(entry.getKey(), entry.getValue().toString());
+            }
+            return Map.copyOf(result);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -94,8 +94,9 @@ public final class PlotOptionsSchemaGenerator {
             findClass("com.vaadin.flow.component.charts.model.SeriesTooltip"));
 
     // Matches the JavaDoc block immediately preceding a setter.
+    // Uses (?:[^*]+|\*(?!/))* to stay within a single /** ... */ block.
     private static final Pattern SETTER_JAVADOC_PATTERN = Pattern.compile(
-            "/\\*\\*([\\s\\S]*?)\\*/\\s*public\\s+(?:abstract\\s+)?void\\s+set(\\w+)\\s*\\(");
+            "/\\*\\*((?:[^*]+|\\*(?!/))*+)\\*/\\s*public\\s+(?:abstract\\s+)?void\\s+set(\\w+)\\s*\\(");
 
     private PlotOptionsSchemaGenerator() {
     }
@@ -347,7 +348,7 @@ public final class PlotOptionsSchemaGenerator {
         cleaned = cleaned.replaceAll("@param\\s+\\w+\\s*", "");
         cleaned = cleaned.replaceAll("@return\\s*", "");
         // Replace {@link ClassName#method} and {@code text} keeping the text
-        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^#}]*#)?+([^}]*)\\}",
+        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^#}]*#)?+([^}]*)\\}", // NOSONAR
                 "$1");
         // Remove HTML tags
         cleaned = cleaned.replaceAll("<[^>]+>", "");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -195,10 +195,8 @@ public final class PlotOptionsSchemaGenerator {
         if (depth < MAX_DEPTH && EXPANDABLE_TYPES.contains(type)) {
             return buildObjectSchema(type, depth + 1, descriptions);
         }
-        if (depth < MAX_DEPTH
-                && AbstractConfigurationObject.class.isAssignableFrom(type)) {
-            return typeNode("object");
-        }
+        // Skip non-expandable complex objects — an opaque "type":"object"
+        // gives the LLM no useful information about valid keys.
         return null;
     }
 
@@ -242,6 +240,10 @@ public final class PlotOptionsSchemaGenerator {
                 var itemNode = typeNode("string");
                 itemNode.put("description", "CSS color");
                 node.set("items", itemNode);
+            } else {
+                // Skip arrays of complex objects — without an items schema
+                // the LLM cannot know what to put in the array.
+                return null;
             }
         }
         return node;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -32,6 +32,9 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.charts.model.AbstractConfigurationObject;
 import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
 import com.vaadin.flow.component.charts.model.PlotOptionsArea;
@@ -80,6 +83,9 @@ import tools.jackson.databind.node.ObjectNode;
  */
 public final class PlotOptionsSchemaGenerator {
 
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(PlotOptionsSchemaGenerator.class);
+
     private static final int MAX_DEPTH = 1;
 
     private static final Set<Class<?>> EXPANDABLE_TYPES = Set.of(
@@ -87,10 +93,9 @@ public final class PlotOptionsSchemaGenerator {
             findClass("com.vaadin.flow.component.charts.model.Marker"),
             findClass("com.vaadin.flow.component.charts.model.SeriesTooltip"));
 
-    // Matches only the JavaDoc block immediately preceding a setter (the
-    // negative lookahead (?!/\*\*) prevents matching across multiple blocks)
+    // Matches the JavaDoc block immediately preceding a setter.
     private static final Pattern SETTER_JAVADOC_PATTERN = Pattern.compile(
-            "/\\*\\*((?:(?!/\\*\\*)[\\s\\S])*?)\\*/\\s*public\\s+(?:abstract\\s+)?void\\s+set(\\w+)\\s*\\(");
+            "/\\*\\*([\\s\\S]*?)\\*/\\s*public\\s+(?:abstract\\s+)?void\\s+set(\\w+)\\s*\\(");
 
     private PlotOptionsSchemaGenerator() {
     }
@@ -104,7 +109,7 @@ public final class PlotOptionsSchemaGenerator {
      */
     public static void main(String[] args) throws IOException {
         if (args.length < 2) {
-            System.err.println(
+            LOGGER.error(
                     "Usage: PlotOptionsSchemaGenerator <sourceDir> <outputFile>");
             System.exit(1);
         }
@@ -113,8 +118,8 @@ public final class PlotOptionsSchemaGenerator {
         Path outputFile = Path.of(args[1]);
 
         if (!Files.isDirectory(sourceDir)) {
-            System.err.println("Source directory not found: " + sourceDir
-                    + " — skipping schema generation");
+            LOGGER.warn("Source directory not found: {}"
+                    + " — skipping schema generation", sourceDir);
             return;
         }
 
@@ -342,7 +347,8 @@ public final class PlotOptionsSchemaGenerator {
         cleaned = cleaned.replaceAll("@param\\s+\\w+\\s*", "");
         cleaned = cleaned.replaceAll("@return\\s*", "");
         // Replace {@link ClassName#method} and {@code text} keeping the text
-        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^}]*#)?([^}]*)\\}", "$1");
+        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^#}]*#)?([^}]*)\\}",
+                "$1");
         // Remove HTML tags
         cleaned = cleaned.replaceAll("<[^>]+>", "");
         // Normalize whitespace
@@ -354,7 +360,6 @@ public final class PlotOptionsSchemaGenerator {
 
     // ── Type mapping ────────────────────────────────────────────────────
 
-    @SuppressWarnings("unchecked")
     static Map<String, Class<? extends AbstractPlotOptions>> buildTypeMap() {
         var map = new HashMap<String, Class<? extends AbstractPlotOptions>>();
         for (var supplier : plotOptionsSuppliers()) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.chart;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.vaadin.flow.component.charts.model.AbstractConfigurationObject;
+import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
+import com.vaadin.flow.component.charts.model.PlotOptionsArea;
+import com.vaadin.flow.component.charts.model.PlotOptionsArearange;
+import com.vaadin.flow.component.charts.model.PlotOptionsAreaspline;
+import com.vaadin.flow.component.charts.model.PlotOptionsAreasplinerange;
+import com.vaadin.flow.component.charts.model.PlotOptionsBar;
+import com.vaadin.flow.component.charts.model.PlotOptionsBoxplot;
+import com.vaadin.flow.component.charts.model.PlotOptionsBubble;
+import com.vaadin.flow.component.charts.model.PlotOptionsBullet;
+import com.vaadin.flow.component.charts.model.PlotOptionsCandlestick;
+import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
+import com.vaadin.flow.component.charts.model.PlotOptionsColumnrange;
+import com.vaadin.flow.component.charts.model.PlotOptionsErrorbar;
+import com.vaadin.flow.component.charts.model.PlotOptionsFlags;
+import com.vaadin.flow.component.charts.model.PlotOptionsFunnel;
+import com.vaadin.flow.component.charts.model.PlotOptionsGantt;
+import com.vaadin.flow.component.charts.model.PlotOptionsGauge;
+import com.vaadin.flow.component.charts.model.PlotOptionsHeatmap;
+import com.vaadin.flow.component.charts.model.PlotOptionsLine;
+import com.vaadin.flow.component.charts.model.PlotOptionsOhlc;
+import com.vaadin.flow.component.charts.model.PlotOptionsOrganization;
+import com.vaadin.flow.component.charts.model.PlotOptionsPie;
+import com.vaadin.flow.component.charts.model.PlotOptionsPolygon;
+import com.vaadin.flow.component.charts.model.PlotOptionsPyramid;
+import com.vaadin.flow.component.charts.model.PlotOptionsSankey;
+import com.vaadin.flow.component.charts.model.PlotOptionsScatter;
+import com.vaadin.flow.component.charts.model.PlotOptionsSeries;
+import com.vaadin.flow.component.charts.model.PlotOptionsSolidgauge;
+import com.vaadin.flow.component.charts.model.PlotOptionsSpline;
+import com.vaadin.flow.component.charts.model.PlotOptionsTimeline;
+import com.vaadin.flow.component.charts.model.PlotOptionsTreemap;
+import com.vaadin.flow.component.charts.model.PlotOptionsWaterfall;
+import com.vaadin.flow.component.charts.model.PlotOptionsXrange;
+import com.vaadin.flow.component.charts.model.style.Color;
+import com.vaadin.flow.internal.JacksonUtils;
+
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Build-time generator that produces complete JSON schemas for each chart
+ * type's plot options, including property descriptions parsed from JavaDoc.
+ * <p>
+ * Invoked automatically during the Maven build via {@code exec-maven-plugin}.
+ * The output is consumed by {@link PlotOptionsSchema} at runtime.
+ */
+public final class PlotOptionsSchemaGenerator {
+
+    private static final int MAX_DEPTH = 1;
+
+    private static final Set<Class<?>> EXPANDABLE_TYPES = Set.of(
+            findClass("com.vaadin.flow.component.charts.model.DataLabels"),
+            findClass("com.vaadin.flow.component.charts.model.Marker"),
+            findClass("com.vaadin.flow.component.charts.model.SeriesTooltip"));
+
+    // Matches only the JavaDoc block immediately preceding a setter (the
+    // negative lookahead (?!/\*\*) prevents matching across multiple blocks)
+    private static final Pattern SETTER_JAVADOC_PATTERN = Pattern.compile(
+            "/\\*\\*((?:(?!/\\*\\*)[\\s\\S])*?)\\*/\\s*public\\s+(?:abstract\\s+)?void\\s+set(\\w+)\\s*\\(");
+
+    private PlotOptionsSchemaGenerator() {
+    }
+
+    /**
+     * Entry point for the build-time generation.
+     *
+     * @param args
+     *            {@code args[0]} = chart model source directory,
+     *            {@code args[1]} = output file path
+     */
+    public static void main(String[] args) throws IOException {
+        if (args.length < 2) {
+            System.err.println(
+                    "Usage: PlotOptionsSchemaGenerator <sourceDir> <outputFile>");
+            System.exit(1);
+        }
+
+        Path sourceDir = Path.of(args[0]);
+        Path outputFile = Path.of(args[1]);
+
+        if (!Files.isDirectory(sourceDir)) {
+            System.err.println("Source directory not found: " + sourceDir
+                    + " — skipping schema generation");
+            return;
+        }
+
+        // Parse descriptions from source files
+        Map<String, Map<String, String>> descriptions = parseDescriptions(
+                sourceDir);
+
+        // Build complete schemas for each chart type
+        var plotOptionsByType = buildTypeMap();
+        var schemas = JacksonUtils.createObjectNode();
+
+        for (var entry : plotOptionsByType.entrySet()) {
+            var schema = buildObjectSchema(entry.getValue(), 0, descriptions);
+            schemas.set(entry.getKey(), schema);
+        }
+
+        Files.createDirectories(outputFile.getParent());
+        Files.writeString(outputFile, schemas.toString());
+    }
+
+    // ── Schema building (reflection-based) ──────────────────────────────
+
+    private static ObjectNode buildObjectSchema(Class<?> clazz, int depth,
+            Map<String, Map<String, String>> descriptions) {
+        var schema = JacksonUtils.createObjectNode();
+        schema.put("type", "object");
+        var properties = schema.putObject("properties");
+
+        for (var field : collectFields(clazz)) {
+            if (Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            var name = field.getName();
+            if (name.startsWith("_fn_")) {
+                continue;
+            }
+            var fieldSchema = fieldToSchema(field, depth, descriptions);
+            if (fieldSchema != null) {
+                addDescription(fieldSchema, field, descriptions);
+                properties.set(name, fieldSchema);
+            }
+        }
+        return schema;
+    }
+
+    private static ObjectNode fieldToSchema(Field field, int depth,
+            Map<String, Map<String, String>> descriptions) {
+        var type = field.getType();
+
+        if (type == Boolean.class || type == boolean.class) {
+            return typeNode("boolean");
+        }
+        if (Number.class.isAssignableFrom(type) || type == int.class
+                || type == long.class || type == double.class
+                || type == float.class) {
+            return typeNode("number");
+        }
+        if (type == String.class) {
+            return typeNode("string");
+        }
+        if (Color.class.isAssignableFrom(type)) {
+            var node = typeNode("string");
+            node.put("description", "CSS color (e.g. '#ff0000')");
+            return node;
+        }
+        if (type.isEnum()) {
+            return enumSchema(type);
+        }
+        if (type == ArrayList.class || type == List.class) {
+            return arraySchema(field);
+        }
+        if (depth < MAX_DEPTH && EXPANDABLE_TYPES.contains(type)) {
+            return buildObjectSchema(type, depth + 1, descriptions);
+        }
+        if (depth < MAX_DEPTH
+                && AbstractConfigurationObject.class.isAssignableFrom(type)) {
+            return typeNode("object");
+        }
+        return null;
+    }
+
+    private static void addDescription(ObjectNode schema, Field field,
+            Map<String, Map<String, String>> descriptions) {
+        if (schema.has("description")) {
+            return;
+        }
+        var classDescriptions = descriptions
+                .get(field.getDeclaringClass().getSimpleName());
+        if (classDescriptions != null) {
+            var description = classDescriptions.get(field.getName());
+            if (description != null) {
+                schema.put("description", description);
+            }
+        }
+    }
+
+    private static ObjectNode enumSchema(Class<?> enumClass) {
+        var node = typeNode("string");
+        var values = node.putArray("enum");
+        for (var constant : enumClass.getEnumConstants()) {
+            var value = constant.toString();
+            if (!value.isEmpty()) {
+                values.add(value);
+            }
+        }
+        return node;
+    }
+
+    private static ObjectNode arraySchema(Field field) {
+        var node = typeNode("array");
+        var genericType = field.getGenericType();
+        if (genericType instanceof ParameterizedType pt
+                && pt.getActualTypeArguments().length == 1) {
+            var itemType = pt.getActualTypeArguments()[0];
+            if (itemType == String.class) {
+                node.set("items", typeNode("string"));
+            } else if (itemType instanceof Class<?> itemClass
+                    && Color.class.isAssignableFrom(itemClass)) {
+                var itemNode = typeNode("string");
+                itemNode.put("description", "CSS color");
+                node.set("items", itemNode);
+            }
+        }
+        return node;
+    }
+
+    private static ObjectNode typeNode(String type) {
+        var node = JacksonUtils.createObjectNode();
+        node.put("type", type);
+        return node;
+    }
+
+    private static List<Field> collectFields(Class<?> clazz) {
+        var fields = new ArrayList<Field>();
+        var current = clazz;
+        while (current != null && current != AbstractPlotOptions.class
+                && current != AbstractConfigurationObject.class
+                && current != Object.class) {
+            for (var field : current.getDeclaredFields()) {
+                if (!Modifier.isStatic(field.getModifiers())) {
+                    fields.add(field);
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return fields;
+    }
+
+    // ── Description parsing (source-based) ──────────────────────────────
+
+    private static Map<String, Map<String, String>> parseDescriptions(
+            Path sourceDir) throws IOException {
+        Set<Class<?>> classesToParse = collectClassesToParse();
+        Map<String, Map<String, String>> allDescriptions = new HashMap<>();
+
+        for (Class<?> clazz : classesToParse) {
+            Path sourceFile = sourceDir
+                    .resolve(clazz.getSimpleName() + ".java");
+            if (!Files.exists(sourceFile)) {
+                continue;
+            }
+
+            String source = Files.readString(sourceFile);
+            Map<String, String> descriptions = extractDescriptions(source);
+            if (!descriptions.isEmpty()) {
+                allDescriptions.put(clazz.getSimpleName(), descriptions);
+            }
+        }
+
+        return allDescriptions;
+    }
+
+    private static Set<Class<?>> collectClassesToParse() {
+        var plotOptionsByType = buildTypeMap();
+        Set<Class<?>> classes = new LinkedHashSet<>();
+
+        for (Class<?> clazz : plotOptionsByType.values()) {
+            Class<?> current = clazz;
+            while (current != null && current != AbstractPlotOptions.class
+                    && current != AbstractConfigurationObject.class
+                    && current != Object.class) {
+                classes.add(current);
+                current = current.getSuperclass();
+            }
+        }
+
+        for (Class<?> clazz : classes.toArray(Class<?>[]::new)) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                Class<?> fieldType = field.getType();
+                if (AbstractConfigurationObject.class
+                        .isAssignableFrom(fieldType)
+                        && fieldType != AbstractConfigurationObject.class) {
+                    classes.add(fieldType);
+                }
+            }
+        }
+
+        return classes;
+    }
+
+    static Map<String, String> extractDescriptions(String source) {
+        Map<String, String> descriptions = new LinkedHashMap<>();
+        Matcher matcher = SETTER_JAVADOC_PATTERN.matcher(source);
+        while (matcher.find()) {
+            String javadoc = matcher.group(1);
+            String setterSuffix = matcher.group(2);
+            String fieldName = Character.toLowerCase(setterSuffix.charAt(0))
+                    + setterSuffix.substring(1);
+            String description = cleanJavadoc(javadoc);
+            if (!description.isEmpty()) {
+                descriptions.put(fieldName, description);
+            }
+        }
+        return descriptions;
+    }
+
+    static String cleanJavadoc(String javadoc) {
+        // Remove leading * from each line
+        String cleaned = javadoc.replaceAll("(?m)^\\s*\\*\\s?", " ");
+        // Remove @see, @param, @return tags
+        cleaned = cleaned.replaceAll("@see\\s+[^\\s]+", "");
+        cleaned = cleaned.replaceAll("@param\\s+\\w+\\s*", "");
+        cleaned = cleaned.replaceAll("@return\\s*", "");
+        // Replace {@link ClassName#method} and {@code text} keeping the text
+        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^}]*#)?([^}]*)\\}", "$1");
+        // Remove HTML tags
+        cleaned = cleaned.replaceAll("<[^>]+>", "");
+        // Normalize whitespace
+        cleaned = cleaned.replaceAll("\\s+", " ").trim();
+        // Remove "Defaults to: ..." suffix
+        cleaned = cleaned.replaceAll("\\s*Defaults to:.*$", "").trim();
+        return cleaned;
+    }
+
+    // ── Type mapping ────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    static Map<String, Class<? extends AbstractPlotOptions>> buildTypeMap() {
+        var map = new HashMap<String, Class<? extends AbstractPlotOptions>>();
+        for (var supplier : plotOptionsSuppliers()) {
+            var instance = supplier.get();
+            map.put(instance.getChartType().toString(), instance.getClass());
+        }
+        map.put("series", PlotOptionsSeries.class);
+        return Map.copyOf(map);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Supplier<AbstractPlotOptions>[] plotOptionsSuppliers() {
+        return new Supplier[] { PlotOptionsArea::new, PlotOptionsArearange::new,
+                PlotOptionsAreaspline::new, PlotOptionsAreasplinerange::new,
+                PlotOptionsBar::new, PlotOptionsBoxplot::new,
+                PlotOptionsBubble::new, PlotOptionsBullet::new,
+                PlotOptionsCandlestick::new, PlotOptionsColumn::new,
+                PlotOptionsColumnrange::new, PlotOptionsErrorbar::new,
+                PlotOptionsFlags::new, PlotOptionsFunnel::new,
+                PlotOptionsGantt::new, PlotOptionsGauge::new,
+                PlotOptionsHeatmap::new, PlotOptionsLine::new,
+                PlotOptionsOhlc::new, PlotOptionsOrganization::new,
+                PlotOptionsPie::new, PlotOptionsPolygon::new,
+                PlotOptionsPyramid::new, PlotOptionsSankey::new,
+                PlotOptionsScatter::new, PlotOptionsSolidgauge::new,
+                PlotOptionsSpline::new, PlotOptionsTimeline::new,
+                PlotOptionsTreemap::new, PlotOptionsWaterfall::new,
+                PlotOptionsXrange::new };
+    }
+
+    private static Class<?> findClass(String name) {
+        try {
+            return Class.forName(name);
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -88,6 +88,43 @@ public final class PlotOptionsSchemaGenerator {
 
     private static final int MAX_DEPTH = 1;
 
+    /**
+     * Fields that are internal, technical, or accessibility-related and not
+     * useful for natural-language chart customization. Excluded from the
+     * generated schema to reduce noise for the LLM.
+     */
+    private static final Set<String> EXCLUDED_FIELDS = Set.of(
+            // Accessibility
+            "description", "exposeElementToA11y", "skipKeyboardNavigation",
+            // Performance internals
+            "animationLimit", "cropThreshold", "turboThreshold",
+            // Developer / styled-mode only
+            "className", "colorIndex", "colorKey",
+            // Rendering internals
+            "clip", "crisp", "linecap", "boostBlending",
+            // Event tracking
+            "enableMouseTracking", "stickyTracking", "findNearestPointBy",
+            "trackByArea",
+            // Internal data mapping
+            "keys", "compare", "compareBase", "gapSize", "gapUnit",
+            // Series linking / legend internals
+            "linkedTo", "legendIndex", "showInNavigator", "legendType",
+            // Axis / point calculation internals
+            "getExtremesFromAll", "pointRange", "pointStart", "pointInterval",
+            "pointIntervalUnit", "pointPlacement", "softThreshold", "zoneAxis",
+            // Selection internals
+            "selected", "showCheckbox",
+            // Null / gap handling
+            "connectNulls", "connectEnds",
+            // Treemap internals
+            "levelIsConstant", "interactByLeaf", "layoutAlgorithm",
+            "layoutStartingDirection", "alternateStartingDirection",
+            "sortIndex",
+            // Export / rendering
+            "includeInDataExport", "useHTML",
+            // Other internals
+            "allowDrillToNode", "allowTraversingTree", "inactiveOtherPoints");
+
     private static final Set<Class<?>> EXPANDABLE_TYPES = Set.of(
             findClass("com.vaadin.flow.component.charts.model.DataLabels"),
             findClass("com.vaadin.flow.component.charts.model.Marker"),
@@ -95,7 +132,7 @@ public final class PlotOptionsSchemaGenerator {
 
     // Matches the JavaDoc block immediately preceding a setter.
     // Uses (?:[^*]+|\*(?!/))* to stay within a single /** ... */ block.
-    private static final Pattern SETTER_JAVADOC_PATTERN = Pattern.compile(
+    private static final Pattern SETTER_JAVADOC_PATTERN = Pattern.compile( // NOSONAR
             "/\\*\\*((?:[^*]+|\\*(?!/))*+)\\*/\\s*public\\s+(?:abstract\\s+)?void\\s+set(\\w+)\\s*\\(");
 
     private PlotOptionsSchemaGenerator() {
@@ -154,7 +191,7 @@ public final class PlotOptionsSchemaGenerator {
                 continue;
             }
             var name = field.getName();
-            if (name.startsWith("_fn_")) {
+            if (name.startsWith("_fn_") || EXCLUDED_FIELDS.contains(name)) {
                 continue;
             }
             var fieldSchema = fieldToSchema(field, depth, descriptions);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -347,14 +347,17 @@ public final class PlotOptionsSchemaGenerator {
         cleaned = cleaned.replaceAll("@param\\s+\\w+\\s*", "");
         cleaned = cleaned.replaceAll("@return\\s*", "");
         // Replace {@link ClassName#method} and {@code text} keeping the text
-        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^#}]*#)?([^}]*)\\}",
+        cleaned = cleaned.replaceAll("\\{@\\w+\\s+(?:[^#}]*#)?+([^}]*)\\}",
                 "$1");
         // Remove HTML tags
         cleaned = cleaned.replaceAll("<[^>]+>", "");
         // Normalize whitespace
         cleaned = cleaned.replaceAll("\\s+", " ").trim();
         // Remove "Defaults to: ..." suffix
-        cleaned = cleaned.replaceAll("\\s*Defaults to:.*$", "").trim();
+        int defaultsIdx = cleaned.indexOf("Defaults to:");
+        if (defaultsIdx >= 0) {
+            cleaned = cleaned.substring(0, defaultsIdx).trim();
+        }
         return cleaned;
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -73,7 +73,9 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAITools(\\$\\d+)?",
                 // ChartAIController — intentionally not serializable;
                 // restored via reconnect()
-                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAIController"));
+                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAIController",
+                // Build-time generator — not a runtime component
+                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.PlotOptionsSchemaGenerator"));
     }
 
     @BeforeEach

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.ai.chart;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -32,8 +30,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.SpecificationVersion;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.charts.Chart;
@@ -45,8 +41,6 @@ import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
 import com.vaadin.flow.component.charts.model.Stacking;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
 import com.vaadin.tests.MockUIExtension;
-
-import tools.jackson.databind.ObjectMapper;
 
 class ChartAIControllerTest {
 
@@ -204,9 +198,6 @@ class ChartAIControllerTest {
             plotOptions.setColorByPoint(true);
             plotOptions.getDataLabels().setEnabled(true);
             configuration.setPlotOptions(plotOptions);
-
-            // Verify plot options validate against the schema
-            assertPlotOptionsMatchSchema(tools, configuration);
 
             // Apply and render
             findTool(tools, "update_chart_configuration")
@@ -730,32 +721,6 @@ class ChartAIControllerTest {
     }
 
     // --- Helpers ---
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    /**
-     * Asserts that every plot options object in the given configuration
-     * validates against the schema returned by {@code get_plot_options_schema}
-     * for the configuration's chart type.
-     */
-    private static void assertPlotOptionsMatchSchema(
-            List<LLMProvider.ToolSpec> tools, Configuration configuration) {
-        String chartType = configuration.getChart().getType().toString();
-        String schemaJson = findTool(tools, "get_plot_options_schema")
-                .execute("{\"chartType\":\"" + chartType + "\"}");
-        var schema = SchemaRegistry
-                .withDefaultDialect(SpecificationVersion.DRAFT_4)
-                .getSchema(schemaJson);
-
-        Assertions.assertFalse(configuration.getPlotOptions().isEmpty(),
-                "Configuration must have at least one plot options entry");
-        for (var plotOptions : configuration.getPlotOptions()) {
-            var json = ChartSerialization.toJSON(plotOptions);
-            var errors = schema.validate(MAPPER.readTree(json));
-            assertTrue(errors.isEmpty(), "Plot options JSON does not match "
-                    + chartType + " schema: " + errors);
-        }
-    }
 
     private static LLMProvider.ToolSpec findTool(
             List<LLMProvider.ToolSpec> tools, String name) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.ai.chart;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -30,6 +32,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.charts.Chart;
@@ -37,7 +41,12 @@ import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
+import com.vaadin.flow.component.charts.model.Stacking;
+import com.vaadin.flow.component.charts.util.ChartSerialization;
 import com.vaadin.tests.MockUIExtension;
+
+import tools.jackson.databind.ObjectMapper;
 
 class ChartAIControllerTest {
 
@@ -180,6 +189,41 @@ class ChartAIControllerTest {
 
             Assertions
                     .assertDoesNotThrow(() -> controller.onRequestCompleted());
+        }
+
+        @Test
+        void updateConfiguration_appliesColumnPlotOptions() {
+            var tools = controller.getTools();
+
+            // Build a configuration with column plot options
+            var configuration = new Configuration();
+            configuration.getChart().setType(ChartType.COLUMN);
+            var plotOptions = new PlotOptionsColumn();
+            plotOptions.setStacking(Stacking.NORMAL);
+            plotOptions.setBorderRadius(5);
+            plotOptions.setColorByPoint(true);
+            plotOptions.getDataLabels().setEnabled(true);
+            configuration.setPlotOptions(plotOptions);
+
+            // Verify plot options validate against the schema
+            assertPlotOptionsMatchSchema(tools, configuration);
+
+            // Apply and render
+            findTool(tools, "update_chart_configuration")
+                    .execute("{\"configuration\":"
+                            + ChartSerialization.toJSON(configuration) + "}");
+            findTool(tools, "update_chart_data_source")
+                    .execute("{\"queries\":[\"SELECT 1\"]}");
+            controller.onRequestCompleted();
+
+            // Verify plot options were applied to the chart
+            var applied = (PlotOptionsColumn) chart.getConfiguration()
+                    .getPlotOptions(ChartType.COLUMN);
+            Assertions.assertNotNull(applied);
+            Assertions.assertEquals(Stacking.NORMAL, applied.getStacking());
+            Assertions.assertEquals(5, applied.getBorderRadius().intValue());
+            Assertions.assertTrue(applied.getColorByPoint());
+            Assertions.assertTrue(applied.getDataLabels().getEnabled());
         }
 
         @Test
@@ -686,6 +730,32 @@ class ChartAIControllerTest {
     }
 
     // --- Helpers ---
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Asserts that every plot options object in the given configuration
+     * validates against the schema returned by {@code get_plot_options_schema}
+     * for the configuration's chart type.
+     */
+    private static void assertPlotOptionsMatchSchema(
+            List<LLMProvider.ToolSpec> tools, Configuration configuration) {
+        String chartType = configuration.getChart().getType().toString();
+        String schemaJson = findTool(tools, "get_plot_options_schema")
+                .execute("{\"chartType\":\"" + chartType + "\"}");
+        var schema = SchemaRegistry
+                .withDefaultDialect(SpecificationVersion.DRAFT_4)
+                .getSchema(schemaJson);
+
+        Assertions.assertFalse(configuration.getPlotOptions().isEmpty(),
+                "Configuration must have at least one plot options entry");
+        for (var plotOptions : configuration.getPlotOptions()) {
+            var json = ChartSerialization.toJSON(plotOptions);
+            var errors = schema.validate(MAPPER.readTree(json));
+            assertTrue(errors.isEmpty(), "Plot options JSON does not match "
+                    + chartType + " schema: " + errors);
+        }
+    }
 
     private static LLMProvider.ToolSpec findTool(
             List<LLMProvider.ToolSpec> tools, String name) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -561,7 +561,7 @@ class ChartAIToolsSchemaTest {
             // Number field
             assertPropertyType(series, "lineWidth", "number");
             // String field
-            assertPropertyType(series, "className", "string");
+            assertPropertyType(series, "cursor", "string");
             // Color → string with CSS color description
             assertPropertyEquals(series, "color", "{\"type\":\"string\","
                     + "\"description\":\"CSS color (e.g. '#ff0000')\"}");
@@ -570,11 +570,6 @@ class ChartAIToolsSchemaTest {
             Assertions.assertEquals("string", stacking.get("type").asString());
             Assertions.assertTrue(stacking.has("enum"),
                     "Enum field should have 'enum' values");
-            // String array
-            JsonNode keys = series.get("keys");
-            Assertions.assertEquals("array", keys.get("type").asString());
-            Assertions.assertEquals("string",
-                    keys.get("items").get("type").asString());
             // Non-expandable objects are excluded (no useful schema)
             Assertions.assertNull(series.get("states"),
                     "Opaque object properties should be excluded");
@@ -595,6 +590,12 @@ class ChartAIToolsSchemaTest {
             // _fn_ fields excluded
             Assertions.assertFalse(series.has("_fn_pointFormatter"),
                     "_fn_ fields should be excluded");
+            // Internal/technical fields excluded
+            for (String excluded : List.of("className", "enableMouseTracking",
+                    "turboThreshold", "skipKeyboardNavigation")) {
+                Assertions.assertFalse(series.has(excluded),
+                        "Internal field should be excluded: " + excluded);
+            }
             // Color array (on pie)
             JsonNode pie = getSchemaNode("pie").get("properties");
             JsonNode colors = pie.get("colors");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -620,6 +620,32 @@ class ChartAIToolsSchemaTest {
         }
 
         @Test
+        void descriptions_containNoJavaCodeFragments() {
+            for (String type : PlotOptionsSchema.supportedTypes()) {
+                JsonNode schema = getSchemaNode(type);
+                JsonNode properties = schema.get("properties");
+                if (properties == null) {
+                    continue;
+                }
+                for (var field : properties.properties()) {
+                    JsonNode desc = field.getValue().get("description");
+                    if (desc == null) {
+                        continue;
+                    }
+                    String text = desc.asString();
+                    Assertions.assertFalse(
+                            text.contains("public ")
+                                    || text.contains("private ")
+                                    || text.contains("return "),
+                            type + "." + field.getKey()
+                                    + " description contains Java code: "
+                                    + text.substring(0,
+                                            Math.min(text.length(), 80)));
+                }
+            }
+        }
+
+        @Test
         void allChartTypes_haveSchemas() {
             // Hardcoded list independent of the generator's supplier
             // list so this catches accidentally removed types.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -24,7 +24,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.networknt.schema.Error;
@@ -32,11 +34,14 @@ import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.SpecificationVersion;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.ColorAxis;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.Credits;
+import com.vaadin.flow.component.charts.model.Cursor;
+import com.vaadin.flow.component.charts.model.DashStyle;
 import com.vaadin.flow.component.charts.model.DataLabels;
 import com.vaadin.flow.component.charts.model.Dimension;
 import com.vaadin.flow.component.charts.model.HorizontalAlign;
@@ -46,8 +51,10 @@ import com.vaadin.flow.component.charts.model.Marker;
 import com.vaadin.flow.component.charts.model.Pane;
 import com.vaadin.flow.component.charts.model.PlotOptionsBar;
 import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
+import com.vaadin.flow.component.charts.model.PlotOptionsLine;
 import com.vaadin.flow.component.charts.model.PlotOptionsPie;
 import com.vaadin.flow.component.charts.model.PlotOptionsSeries;
+import com.vaadin.flow.component.charts.model.SeriesTooltip;
 import com.vaadin.flow.component.charts.model.Stacking;
 import com.vaadin.flow.component.charts.model.Tooltip;
 import com.vaadin.flow.component.charts.model.VerticalAlign;
@@ -399,6 +406,145 @@ class ChartAIToolsSchemaTest {
             config.getChart().setType(type);
             config.setTitle(type.toString() + " chart");
             assertMatchesSchema(config);
+        }
+    }
+
+    /**
+     * Tests that serialized {@link AbstractPlotOptions} objects validate
+     * against the JSON schema returned by {@code get_plot_options_schema}. Each
+     * test targets a specific field type handled by
+     * {@link PlotOptionsSchemaGenerator}.
+     */
+    @Nested
+    class PlotOptionsSchemaValidation {
+
+        private static LLMProvider.ToolSpec schemaTool;
+
+        @BeforeAll
+        static void setUp() {
+            schemaTool = ChartAITools.getPlotOptionsSchema();
+        }
+
+        @Test
+        void column_booleanAndNumberFields() {
+            var opts = new PlotOptionsColumn();
+            opts.setColorByPoint(true);
+            opts.setAnimation(false);
+            opts.setBorderRadius(5);
+            opts.setBorderWidth(1);
+            opts.setGroupPadding(0.2);
+            assertPlotOptionsMatchSchema("column", opts);
+        }
+
+        @Test
+        void column_stringAndColorFields() {
+            var opts = new PlotOptionsColumn();
+            opts.setClassName("custom-class");
+            opts.setColor(new SolidColor("#ff0000"));
+            opts.setNegativeColor(new SolidColor("#0000ff"));
+            opts.setBorderColor(new SolidColor("#cccccc"));
+            assertPlotOptionsMatchSchema("column", opts);
+        }
+
+        @Test
+        void column_enumField_stacking() {
+            var opts = new PlotOptionsColumn();
+            opts.setStacking(Stacking.NORMAL);
+            assertPlotOptionsMatchSchema("column", opts);
+        }
+
+        @Test
+        void series_enumFields_dashStyleAndCursor() {
+            var opts = new PlotOptionsSeries();
+            opts.setDashStyle(DashStyle.LONGDASHDOT);
+            opts.setCursor(Cursor.POINTER);
+            assertPlotOptionsMatchSchema("series", opts);
+        }
+
+        @Test
+        void series_stringArrayField_keys() {
+            var opts = new PlotOptionsSeries();
+            opts.setKeys("x", "y", "name");
+            assertPlotOptionsMatchSchema("series", opts);
+        }
+
+        @Test
+        void pie_colorArrayField() {
+            var opts = new PlotOptionsPie();
+            opts.setColors(new SolidColor("#ff0000"), new SolidColor("#00ff00"),
+                    new SolidColor("#0000ff"));
+            assertPlotOptionsMatchSchema("pie", opts);
+        }
+
+        @Test
+        void series_expandableObject_dataLabels() {
+            var opts = new PlotOptionsSeries();
+            DataLabels dataLabels = new DataLabels();
+            dataLabels.setEnabled(true);
+            dataLabels.setFormat("{point.y:.1f}");
+            dataLabels.setRotation(45);
+            dataLabels.setColor(new SolidColor("#333333"));
+            opts.setDataLabels(dataLabels);
+            assertPlotOptionsMatchSchema("series", opts);
+        }
+
+        @Test
+        void series_expandableObject_marker() {
+            var opts = new PlotOptionsSeries();
+            Marker marker = new Marker();
+            marker.setEnabled(true);
+            marker.setRadius(4);
+            marker.setLineWidth(2);
+            marker.setFillColor(new SolidColor("#ff0000"));
+            opts.setMarker(marker);
+            assertPlotOptionsMatchSchema("series", opts);
+        }
+
+        @Test
+        void series_expandableObject_seriesTooltip() {
+            var opts = new PlotOptionsSeries();
+            SeriesTooltip tooltip = new SeriesTooltip();
+            tooltip.setValueSuffix(" units");
+            tooltip.setValuePrefix("$");
+            tooltip.setPointFormat("{series.name}: <b>{point.y}</b>");
+            opts.setTooltip(tooltip);
+            assertPlotOptionsMatchSchema("series", opts);
+        }
+
+        @Test
+        void line_lineWidthAndMarkerCombined() {
+            var opts = new PlotOptionsLine();
+            opts.setLineWidth(3);
+            Marker marker = new Marker();
+            marker.setEnabled(false);
+            opts.setMarker(marker);
+            assertPlotOptionsMatchSchema("line", opts);
+        }
+
+        @Test
+        void pie_uniqueFields() {
+            var opts = new PlotOptionsPie();
+            opts.setInnerSize("50%");
+            opts.setStartAngle(-90);
+            opts.setEndAngle(90);
+            opts.setSlicedOffset(10);
+            assertPlotOptionsMatchSchema("pie", opts);
+        }
+
+        private void assertPlotOptionsMatchSchema(String chartType,
+                AbstractPlotOptions plotOptions) {
+            String schemaJson = schemaTool
+                    .execute("{\"chartType\":\"" + chartType + "\"}");
+            Assertions.assertFalse(schemaJson.startsWith("Error"),
+                    "Schema lookup failed: " + schemaJson);
+            var schema = SchemaRegistry
+                    .withDefaultDialect(SpecificationVersion.DRAFT_4)
+                    .getSchema(schemaJson);
+            var json = toJSON(plotOptions);
+            var errors = schema.validate(MAPPER.readTree(json));
+            Assertions.assertTrue(errors.isEmpty(),
+                    "Plot options JSON does not match " + chartType
+                            + " schema: " + errors);
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -575,8 +575,9 @@ class ChartAIToolsSchemaTest {
             Assertions.assertEquals("array", keys.get("type").asString());
             Assertions.assertEquals("string",
                     keys.get("items").get("type").asString());
-            // Non-expandable AbstractConfigurationObject → plain object
-            assertPropertyType(series, "states", "object");
+            // Non-expandable objects are excluded (no useful schema)
+            Assertions.assertNull(series.get("states"),
+                    "Opaque object properties should be excluded");
             // Expandable types → nested properties
             for (String expanded : List.of("dataLabels", "marker", "tooltip")) {
                 Assertions.assertTrue(series.get(expanded).has("properties"),

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -426,6 +426,20 @@ class ChartAIToolsSchemaTest {
         }
 
         @Test
+        void parametersSchema_chartTypeHasTypeAndDescription()
+                throws Exception {
+            JsonNode paramSchema = MAPPER
+                    .readTree(schemaTool.getParametersSchema());
+            JsonNode chartType = paramSchema.get("properties").get("chartType");
+            Assertions.assertNotNull(chartType, "chartType property missing");
+            Assertions.assertTrue(chartType.has("type"),
+                    "chartType should declare a type");
+            Assertions.assertEquals("string", chartType.get("type").asString());
+            Assertions.assertTrue(chartType.has("description"),
+                    "chartType should have a description");
+        }
+
+        @Test
         void column_booleanAndNumberFields() {
             var opts = new PlotOptionsColumn();
             opts.setColorByPoint(true);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -469,25 +469,58 @@ class ChartAIToolsSchemaTest {
             return;
         }
 
-        if (jsonNode.isObject() && schemaNode.has("properties")) {
-            JsonNode schemaProperties = schemaNode.get("properties");
-            Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.properties()
-                    .iterator();
-            while (fields.hasNext()) {
-                Map.Entry<String, JsonNode> field = fields.next();
-                String fieldName = field.getKey();
-                String fieldPath = path + "." + fieldName;
+        if (jsonNode.isObject()) {
+            // An object node's schema should declare "type": "object"
+            if (!schemaNode.has("type") && (schemaNode.has("properties")
+                    || schemaNode.has("additionalProperties"))) {
+                uncovered.add(path + ": missing \"type\": \"object\"");
+            }
+            if (schemaNode.has("properties")) {
+                JsonNode schemaProperties = schemaNode.get("properties");
+                JsonNode additionalProps = schemaNode
+                        .get("additionalProperties");
+                Iterator<Map.Entry<String, JsonNode>> fields = jsonNode
+                        .properties().iterator();
+                while (fields.hasNext()) {
+                    Map.Entry<String, JsonNode> field = fields.next();
+                    String fieldName = field.getKey();
+                    String fieldPath = path + "." + fieldName;
 
-                if (!schemaProperties.has(fieldName)) {
-                    if (!EXCLUDED_PROPERTIES.contains(fieldPath)
+                    if (schemaProperties.has(fieldName)) {
+                        assertAllPropertiesCovered(field.getValue(),
+                                schemaProperties.get(fieldName), fieldPath,
+                                uncovered);
+                    } else if (additionalProps != null
+                            && additionalProps.isObject()
+                            && additionalProps.has("properties")) {
+                        assertAllPropertiesCovered(field.getValue(),
+                                additionalProps, fieldPath, uncovered);
+                    } else if (additionalProps == null
+                            && !EXCLUDED_PROPERTIES.contains(fieldPath)
                             && !INTERNAL_FIELD_NAMES.contains(fieldName)) {
                         uncovered.add(fieldPath);
                     }
-                    continue;
                 }
-
-                assertAllPropertiesCovered(field.getValue(),
-                        schemaProperties.get(fieldName), fieldPath, uncovered);
+            } else if (schemaNode.has("additionalProperties")
+                    && schemaNode.get("additionalProperties").isObject()
+                    && schemaNode.get("additionalProperties")
+                            .has("properties")) {
+                JsonNode additionalProps = schemaNode
+                        .get("additionalProperties");
+                for (var field : jsonNode.properties()) {
+                    assertAllPropertiesCovered(field.getValue(),
+                            additionalProps, path + "." + field.getKey(),
+                            uncovered);
+                }
+            } else if (!schemaNode.has("additionalProperties")
+                    && jsonNode.size() > 0) {
+                for (var field : jsonNode.properties()) {
+                    String fieldPath = path + "." + field.getKey();
+                    if (!EXCLUDED_PROPERTIES.contains(fieldPath)
+                            && !INTERNAL_FIELD_NAMES.contains(field.getKey())) {
+                        uncovered.add(fieldPath);
+                    }
+                }
             }
         }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -583,9 +583,14 @@ class ChartAIToolsSchemaTest {
                         expanded + " should be expanded with nested "
                                 + "properties");
             }
-            // Descriptions parsed from JavaDoc
+            // Descriptions parsed from JavaDoc, with {@link} tags cleaned
             Assertions.assertTrue(series.get("lineWidth").has("description"),
                     "Fields should have descriptions from JavaDoc");
+            String animationDesc = series.get("animation").get("description")
+                    .asString();
+            Assertions.assertFalse(animationDesc.contains("{@link"),
+                    "Descriptions should not contain raw JavaDoc tags: "
+                            + animationDesc);
             // _fn_ fields excluded
             Assertions.assertFalse(series.has("_fn_pointFormatter"),
                     "_fn_ fields should be excluded");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -538,11 +538,107 @@ class ChartAIToolsSchemaTest {
         @Test
         void pie_uniqueFields() {
             var opts = new PlotOptionsPie();
+            opts.setDataLabels(null);
             opts.setInnerSize("50%");
             opts.setStartAngle(-90);
             opts.setEndAngle(90);
             opts.setSlicedOffset(10);
             assertPlotOptionsMatchSchema("pie", opts);
+        }
+
+        /**
+         * Verifies the generated schema structure for specific properties,
+         * covering every code path in {@link PlotOptionsSchemaGenerator}:
+         * boolean, number, string, Color, enum, array, expandable nested
+         * objects, non-expandable objects, descriptions, and field filters.
+         */
+        @Test
+        void generatedSchema_coversAllFieldTypes() {
+            JsonNode series = getSchemaNode("series").get("properties");
+
+            // Boolean field
+            assertPropertyType(series, "animation", "boolean");
+            // Number field
+            assertPropertyType(series, "lineWidth", "number");
+            // String field
+            assertPropertyType(series, "className", "string");
+            // Color → string with CSS color description
+            assertPropertyEquals(series, "color", "{\"type\":\"string\","
+                    + "\"description\":\"CSS color (e.g. '#ff0000')\"}");
+            // Enum → string with enum values
+            JsonNode stacking = series.get("stacking");
+            Assertions.assertEquals("string", stacking.get("type").asString());
+            Assertions.assertTrue(stacking.has("enum"),
+                    "Enum field should have 'enum' values");
+            // String array
+            JsonNode keys = series.get("keys");
+            Assertions.assertEquals("array", keys.get("type").asString());
+            Assertions.assertEquals("string",
+                    keys.get("items").get("type").asString());
+            // Non-expandable AbstractConfigurationObject → plain object
+            assertPropertyType(series, "states", "object");
+            // Expandable types → nested properties
+            for (String expanded : List.of("dataLabels", "marker", "tooltip")) {
+                Assertions.assertTrue(series.get(expanded).has("properties"),
+                        expanded + " should be expanded with nested "
+                                + "properties");
+            }
+            // Descriptions parsed from JavaDoc
+            Assertions.assertTrue(series.get("lineWidth").has("description"),
+                    "Fields should have descriptions from JavaDoc");
+            // _fn_ fields excluded
+            Assertions.assertFalse(series.has("_fn_pointFormatter"),
+                    "_fn_ fields should be excluded");
+            // Color array (on pie)
+            JsonNode pie = getSchemaNode("pie").get("properties");
+            JsonNode colors = pie.get("colors");
+            Assertions.assertEquals("array", colors.get("type").asString());
+            Assertions.assertEquals("CSS color",
+                    colors.get("items").get("description").asString());
+        }
+
+        private void assertPropertyType(JsonNode properties, String name,
+                String expectedType) {
+            Assertions.assertNotNull(properties.get(name),
+                    "Missing property: " + name);
+            Assertions.assertEquals(expectedType,
+                    properties.get(name).get("type").asString(),
+                    name + " should have type " + expectedType);
+        }
+
+        private void assertPropertyEquals(JsonNode properties, String name,
+                String expectedJson) {
+            Assertions.assertNotNull(properties.get(name),
+                    "Missing property: " + name);
+            Assertions.assertEquals(MAPPER.readTree(expectedJson),
+                    properties.get(name), name + " schema mismatch");
+        }
+
+        @Test
+        void allChartTypes_haveSchemas() {
+            // Hardcoded list independent of the generator's supplier
+            // list so this catches accidentally removed types.
+            var expectedTypes = new String[] { "series", "area", "arearange",
+                    "areaspline", "areasplinerange", "bar", "boxplot", "bubble",
+                    "bullet", "candlestick", "column", "columnrange",
+                    "errorbar", "flags", "funnel", "gantt", "gauge", "heatmap",
+                    "line", "ohlc", "organization", "pie", "polygon", "pyramid",
+                    "sankey", "scatter", "solidgauge", "spline", "timeline",
+                    "treemap", "waterfall", "xrange" };
+            for (String type : expectedTypes) {
+                String result = schemaTool
+                        .execute("{\"chartType\":\"" + type + "\"}");
+                Assertions.assertFalse(result.startsWith("Error"),
+                        "Missing schema for type '" + type + "': " + result);
+            }
+        }
+
+        private JsonNode getSchemaNode(String chartType) {
+            String json = schemaTool
+                    .execute("{\"chartType\":\"" + chartType + "\"}");
+            Assertions.assertFalse(json.startsWith("Error"),
+                    "Schema lookup failed: " + json);
+            return MAPPER.readTree(json);
         }
 
         private void assertPlotOptionsMatchSchema(String chartType,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -353,24 +353,6 @@ class ChartAIToolsTest {
         }
 
         @Test
-        void knownType_returnsSchemaWithProperties() {
-            String result = tool.execute("{\"chartType\":\"column\"}");
-            Assertions.assertFalse(result.contains("Error"), result);
-            Assertions.assertTrue(result.contains("\"properties\""));
-            Assertions.assertTrue(result.contains("stacking"));
-            Assertions.assertTrue(result.contains("borderRadius"));
-        }
-
-        @Test
-        void seriesType_returnsBaseProperties() {
-            String result = tool.execute("{\"chartType\":\"series\"}");
-            Assertions.assertFalse(result.contains("Error"), result);
-            Assertions.assertTrue(result.contains("stacking"));
-            Assertions.assertTrue(result.contains("dataLabels"));
-            Assertions.assertTrue(result.contains("marker"));
-        }
-
-        @Test
         void unknownType_returnsError() {
             String result = tool.execute("{\"chartType\":\"nonexistent\"}");
             Assertions.assertTrue(result.contains("Error"));
@@ -391,43 +373,6 @@ class ChartAIToolsTest {
             Assertions.assertTrue(result.contains("\"properties\""));
         }
 
-        @Test
-        void lineType_containsLineWidthAndMarker() {
-            String result = tool.execute("{\"chartType\":\"line\"}");
-            Assertions.assertFalse(result.contains("Error"), result);
-            Assertions.assertTrue(result.contains("lineWidth"));
-            Assertions.assertTrue(result.contains("marker"));
-        }
-
-        @Test
-        void pieType_containsInnerSize() {
-            String result = tool.execute("{\"chartType\":\"pie\"}");
-            Assertions.assertFalse(result.contains("Error"), result);
-            Assertions.assertTrue(result.contains("innerSize"));
-        }
-
-        @Test
-        void schemaContainsNestedObjectForDataLabels() {
-            String result = tool.execute("{\"chartType\":\"column\"}");
-            // dataLabels should be expanded with its own properties
-            Assertions.assertTrue(result.contains("dataLabels"));
-            Assertions.assertTrue(result.contains("enabled"));
-            Assertions.assertTrue(result.contains("format"));
-        }
-
-        @Test
-        void enumFieldsHaveEnumValues() {
-            String result = tool.execute("{\"chartType\":\"column\"}");
-            // stacking should include enum values
-            Assertions.assertTrue(result.contains("\"enum\""));
-        }
-
-        @Test
-        void colorFieldsMappedAsString() {
-            String result = tool.execute("{\"chartType\":\"column\"}");
-            // color field should be a string type
-            Assertions.assertTrue(result.contains("CSS color"));
-        }
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -357,6 +357,10 @@ class ChartAIToolsTest {
             String result = tool.execute("{\"chartType\":\"nonexistent\"}");
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("unknown chart type"));
+            Assertions.assertTrue(result.contains("Supported types:"),
+                    "Error should list supported types");
+            Assertions.assertTrue(result.contains("column"),
+                    "Supported types should include 'column'");
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -36,9 +36,9 @@ class ChartAIToolsTest {
     }
 
     @Test
-    void createAll_returnsThreeTools() {
+    void createAll_returnsFourTools() {
         var tools = ChartAITools.createAll(callbacks);
-        Assertions.assertEquals(3, tools.size());
+        Assertions.assertEquals(4, tools.size());
     }
 
     @Test
@@ -54,6 +54,7 @@ class ChartAIToolsTest {
         Assertions.assertTrue(names.contains("get_chart_state"));
         Assertions.assertTrue(names.contains("update_chart_configuration"));
         Assertions.assertTrue(names.contains("update_chart_data_source"));
+        Assertions.assertTrue(names.contains("get_plot_options_schema"));
     }
 
     @Nested
@@ -333,6 +334,99 @@ class ChartAIToolsTest {
         void execute_withMalformedJson_returnsError() {
             var result = tool.execute("not json at all");
             Assertions.assertTrue(result.contains("Error"));
+        }
+    }
+
+    @Nested
+    class GetPlotOptionsSchema {
+
+        private LLMProvider.ToolSpec tool;
+
+        @BeforeEach
+        void setUp() {
+            tool = ChartAITools.getPlotOptionsSchema();
+        }
+
+        @Test
+        void name() {
+            Assertions.assertEquals("get_plot_options_schema", tool.getName());
+        }
+
+        @Test
+        void knownType_returnsSchemaWithProperties() {
+            String result = tool.execute("{\"chartType\":\"column\"}");
+            Assertions.assertFalse(result.contains("Error"), result);
+            Assertions.assertTrue(result.contains("\"properties\""));
+            Assertions.assertTrue(result.contains("stacking"));
+            Assertions.assertTrue(result.contains("borderRadius"));
+        }
+
+        @Test
+        void seriesType_returnsBaseProperties() {
+            String result = tool.execute("{\"chartType\":\"series\"}");
+            Assertions.assertFalse(result.contains("Error"), result);
+            Assertions.assertTrue(result.contains("stacking"));
+            Assertions.assertTrue(result.contains("dataLabels"));
+            Assertions.assertTrue(result.contains("marker"));
+        }
+
+        @Test
+        void unknownType_returnsError() {
+            String result = tool.execute("{\"chartType\":\"nonexistent\"}");
+            Assertions.assertTrue(result.contains("Error"));
+            Assertions.assertTrue(result.contains("unknown chart type"));
+        }
+
+        @Test
+        void missingParameter_returnsError() {
+            String result = tool.execute("{}");
+            Assertions.assertTrue(result.contains("Error"));
+            Assertions.assertTrue(result.contains("chartType"));
+        }
+
+        @Test
+        void caseInsensitive() {
+            String result = tool.execute("{\"chartType\":\"COLUMN\"}");
+            Assertions.assertFalse(result.contains("Error"), result);
+            Assertions.assertTrue(result.contains("\"properties\""));
+        }
+
+        @Test
+        void lineType_containsLineWidthAndMarker() {
+            String result = tool.execute("{\"chartType\":\"line\"}");
+            Assertions.assertFalse(result.contains("Error"), result);
+            Assertions.assertTrue(result.contains("lineWidth"));
+            Assertions.assertTrue(result.contains("marker"));
+        }
+
+        @Test
+        void pieType_containsInnerSize() {
+            String result = tool.execute("{\"chartType\":\"pie\"}");
+            Assertions.assertFalse(result.contains("Error"), result);
+            Assertions.assertTrue(result.contains("innerSize"));
+        }
+
+        @Test
+        void schemaContainsNestedObjectForDataLabels() {
+            String result = tool.execute("{\"chartType\":\"column\"}");
+            // dataLabels should be expanded with its own properties
+            Assertions.assertTrue(result.contains("dataLabels"));
+            Assertions.assertTrue(result.contains("enabled"));
+            Assertions.assertTrue(result.contains("format"));
+        }
+
+        @Test
+        void enumFieldsHaveEnumValues() {
+            String result = tool.execute("{\"chartType\":\"column\"}");
+            // stacking should include enum values
+            Assertions.assertTrue(result.contains("\"enum\""));
+        }
+
+        @Test
+        void colorFieldsMappedAsString() {
+            String result = tool.execute("{\"chartType\":\"column\"}");
+            // color field should be a string type
+            Assertions.assertTrue(result.contains("CSS color"));
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
@@ -500,6 +500,22 @@ class ChartConfigurationParserTest {
             Assertions.assertEquals(Stacking.NORMAL, column.getStacking());
         }
 
+        @Test
+        void nonObjectValue_isSkipped() {
+            var config = parse(
+                    "{\"plotOptions\":{\"column\":\"not an object\"}}");
+            Assertions.assertTrue(config.getPlotOptions().isEmpty());
+        }
+
+        @Test
+        void colorField_deserializedFromString() {
+            var config = parse("{\"plotOptions\":{\"column\":"
+                    + "{\"color\":\"#ff0000\"}}}");
+            var column = getPlotOption(config, PlotOptionsColumn.class);
+            Assertions.assertNotNull(column.getColor());
+            Assertions.assertEquals("#ff0000", column.getColor().toString());
+        }
+
         @SuppressWarnings("unchecked")
         private <T> T getPlotOption(Configuration config, Class<T> type) {
             return (T) config.getPlotOptions().stream().filter(type::isInstance)

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
@@ -27,8 +27,10 @@ import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.Dimension;
 import com.vaadin.flow.component.charts.model.HorizontalAlign;
 import com.vaadin.flow.component.charts.model.LayoutDirection;
+import com.vaadin.flow.component.charts.model.PlotOptionsArea;
 import com.vaadin.flow.component.charts.model.PlotOptionsBar;
 import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
+import com.vaadin.flow.component.charts.model.PlotOptionsLine;
 import com.vaadin.flow.component.charts.model.PlotOptionsPie;
 import com.vaadin.flow.component.charts.model.PlotOptionsSeries;
 import com.vaadin.flow.component.charts.model.Stacking;
@@ -454,6 +456,48 @@ class ChartConfigurationParserTest {
             parse("{\"plotOptions\":{\"series\":"
                     + "{\"stacking\":\"invalid_value\"}}}");
             // Should not throw
+        }
+
+        @Test
+        void lineLineWidth() {
+            var config = parse(
+                    "{\"plotOptions\":{\"line\":{\"lineWidth\":3}}}");
+            var line = getPlotOption(config, PlotOptionsLine.class);
+            Assertions.assertEquals(3, line.getLineWidth());
+        }
+
+        @Test
+        void areaFillOpacity() {
+            var config = parse(
+                    "{\"plotOptions\":{\"area\":{\"fillOpacity\":0.5}}}");
+            var area = getPlotOption(config, PlotOptionsArea.class);
+            Assertions.assertEquals(0.5, area.getFillOpacity());
+        }
+
+        @Test
+        void unknownChartType_isIgnored() {
+            var config = parse(
+                    "{\"plotOptions\":{\"nonexistent\":{\"foo\":true}}}");
+            Assertions.assertTrue(config.getPlotOptions().isEmpty());
+        }
+
+        @Test
+        void multipleTypes_inSamePlotOptions() {
+            var config = parse(
+                    "{\"plotOptions\":{" + "\"column\":{\"borderRadius\":5},"
+                            + "\"line\":{\"lineWidth\":2}}}");
+            var column = getPlotOption(config, PlotOptionsColumn.class);
+            Assertions.assertEquals(5, column.getBorderRadius());
+            var line = getPlotOption(config, PlotOptionsLine.class);
+            Assertions.assertEquals(2, line.getLineWidth());
+        }
+
+        @Test
+        void caseInsensitiveEnumValues() {
+            var config = parse(
+                    "{\"plotOptions\":{\"column\":{\"stacking\":\"Normal\"}}}");
+            var column = getPlotOption(config, PlotOptionsColumn.class);
+            Assertions.assertEquals(Stacking.NORMAL, column.getStacking());
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Add `PlotOptionsSchemaGenerator` that builds JSON schemas for each chart type's plot options at build time, with property descriptions parsed from JavaDoc
- Add `PlotOptionsSchema` runtime loader and `get_plot_options_schema` tool for LLMs to discover available styling properties
- Replace hardcoded plot options in `update_chart_configuration` schema with `additionalProperties` and dynamic schema lookup
- Refactor `ChartConfigurationParser` to use Jackson-based `PlotOptions` deserialization with Color support, lenient enums, and field-based access

Part of https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=173099386
Related to https://github.com/vaadin/flow-components/pull/9071

🤖 Generated with [Claude Code](https://claude.com/claude-code)