### PR TITLE
chore: wait after page refresh

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipDefaultsIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/TooltipDefaultsIT.java
@@ -46,7 +46,7 @@ public class TooltipDefaultsIT extends AbstractComponentIT {
     public void changeDefaults_refreshPage_checkTooltipConfig() {
         $("button").id("set-default-delays-to-5000").click();
         getDriver().navigate().refresh();
-        buttonWithTooltip = $(ButtonElement.class).first();
+        buttonWithTooltip = $(ButtonElement.class).waitForFirst();
         Assert.assertEquals(5000, getActiveHideDelay(buttonWithTooltip));
         Assert.assertEquals(5000, getActiveFocusDelay(buttonWithTooltip));
         Assert.assertEquals(5000, getActiveHoverDelay(buttonWithTooltip));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/PreserveOnRefreshIT.java
@@ -64,6 +64,7 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
     public void refresh_editorOpen() {
         findElement(By.id("edit-button")).click();
         getDriver().navigate().refresh();
+        waitForElementPresent(By.id("closed"));
         WebElement closed = findElement(By.id("closed"));
         Assert.assertEquals("Closed", closed.getText());
 
@@ -74,7 +75,7 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
     }
 
     private GridElement getGrid() {
-        return $(GridElement.class).first();
+        return $(GridElement.class).waitForFirst();
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
@@ -71,7 +71,7 @@ public class TreeGridDetachAttachIT extends AbstractComponentIT {
 
         getDriver().navigate().refresh();
 
-        grid = $(TreeGridElement.class).first();
+        grid = $(TreeGridElement.class).waitForFirst();
         Assert.assertTrue(grid.isRowExpanded(2, 0));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandedAutoWidthPreserveOnRefreshIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandedAutoWidthPreserveOnRefreshIT.java
@@ -42,7 +42,7 @@ public class TreeGridExpandedAutoWidthPreserveOnRefreshIT
 
         getDriver().navigate().refresh();
 
-        grid = $(TreeGridElement.class).first();
+        grid = $(TreeGridElement.class).waitForFirst();
         Assert.assertEquals(columnOffsetWidth,
                 grid.getCell(0, 0).getPropertyInteger("offsetWidth"));
     }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/PreserveOnRefreshIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/PreserveOnRefreshIT.java
@@ -71,7 +71,7 @@ public class PreserveOnRefreshIT extends AbstractComponentIT {
         assertNotificationIsOpen();
 
         getDriver().navigate().refresh();
-        TestBenchElement notification = $(NOTIFICATION_TAG).first();
+        TestBenchElement notification = $(NOTIFICATION_TAG).waitForFirst();
         boolean containsComponentContent = notification.$("span")
                 .withAttribute("id", "component-content").exists();
         Assert.assertTrue(

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/PopoverDelayDefaultsIT.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/src/test/java/com/vaadin/flow/component/popover/tests/PopoverDelayDefaultsIT.java
@@ -46,7 +46,7 @@ public class PopoverDelayDefaultsIT extends AbstractComponentIT {
     public void changeDefaults_refreshPage_checkPopoverConfig() {
         $("button").id("set-default-delays-to-5000").click();
         getDriver().navigate().refresh();
-        popover = $(PopoverElement.class).first();
+        popover = $(PopoverElement.class).waitForFirst();
         Assert.assertEquals(5000, getActiveHideDelay(popover));
         Assert.assertEquals(5000, getActiveFocusDelay(popover));
         Assert.assertEquals(5000, getActiveHoverDelay(popover));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/PreserveOnRefreshIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/PreserveOnRefreshIT.java
@@ -107,6 +107,6 @@ public class PreserveOnRefreshIT extends AbstractSpreadsheetIT {
     }
 
     private SpreadsheetElement getSpreadsheetElement() {
-        return $(SpreadsheetElement.class).first();
+        return $(SpreadsheetElement.class).waitForFirst();
     }
 }


### PR DESCRIPTION
There are currently several flaky ITs, all of which seem to revolve around reloading the page and then trying to access some element that does not exist on the page yet. Other tests that use wait conditions for those elements to exist do not seem to be affected.

This adds wait conditions to all tests that do not have one yet.