### PR TITLE
feat: add 3D chart support with options3d and frame configuration

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -338,7 +338,28 @@ public final class ChartAITools {
                                     "{c:POLAR}": { "type": "boolean", "description": "When true, cartesian charts are transformed into the polar coordinate system" },
                                     "{c:ANIMATION}": { "type": "boolean", "description": "Overall animation for all chart updating. Does not affect initial series animation." },
                                     "{c:STYLED_MODE}": { "type": "boolean", "description": "Whether to apply styled mode. When enabled, no presentational attributes or CSS are applied to the chart SVG." },
-                                    "{c:ZOOM_TYPE}": { "type": "string", "description": "Decides in what dimensions the user can zoom by dragging the mouse", "enum": ["x", "y", "xy"] }
+                                    "{c:ZOOM_TYPE}": { "type": "string", "description": "Decides in what dimensions the user can zoom by dragging the mouse", "enum": ["x", "y", "xy"] },
+                                    "{c:OPTIONS_3D}": {
+                                      "type": "object",
+                                      "description": "Options to render the chart in 3D. Required for 3D charts and for the zAxis to take effect.",
+                                      "properties": {
+                                        "{c:ENABLED}": { "type": "boolean", "description": "Whether to render the chart using 3D functionality" },
+                                        "{c:ALPHA}": { "type": "number", "description": "One of the two rotation angles for the chart" },
+                                        "{c:BETA}": { "type": "number", "description": "One of the two rotation angles for the chart" },
+                                        "{c:DEPTH}": { "type": "number", "description": "The total depth of the chart" },
+                                        "{c:VIEW_DISTANCE}": { "type": "number", "description": "The distance the viewer is standing in front of the chart, used for perspective effect" },
+                                        "{c:FRAME}": {
+                                          "type": "object",
+                                          "description": "Defines the 3D frame panels around the chart",
+                                          "properties": {
+                                            "{c:BACK}": { "type": "object", "description": "Back panel of the frame", "properties": { "{c:COLOR}": { "type": "string", "description": "The color of the panel" }, "{c:SIZE}": { "type": "number", "description": "Thickness of the panel" } } },
+                                            "{c:BOTTOM}": { "type": "object", "description": "Bottom panel of the frame", "properties": { "{c:COLOR}": { "type": "string", "description": "The color of the panel" }, "{c:SIZE}": { "type": "number", "description": "Thickness of the panel" } } },
+                                            "{c:SIDE}": { "type": "object", "description": "Side panel of the frame", "properties": { "{c:COLOR}": { "type": "string", "description": "The color of the panel" }, "{c:SIZE}": { "type": "number", "description": "Thickness of the panel" } } },
+                                            "{c:TOP}": { "type": "object", "description": "Top panel of the frame", "properties": { "{c:COLOR}": { "type": "string", "description": "The color of the panel" }, "{c:SIZE}": { "type": "number", "description": "Thickness of the panel" } } }
+                                          }
+                                        }
+                                      }
+                                    }
                                   }
                                 },
                                 "{c:TITLE}": {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParser.java
@@ -32,6 +32,8 @@ import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
 import com.vaadin.flow.component.charts.model.Axis;
 import com.vaadin.flow.component.charts.model.AxisTitle;
 import com.vaadin.flow.component.charts.model.AxisType;
+import com.vaadin.flow.component.charts.model.Back;
+import com.vaadin.flow.component.charts.model.Bottom;
 import com.vaadin.flow.component.charts.model.ChartModel;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.ColorAxis;
@@ -39,12 +41,16 @@ import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.Credits;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.Dimension;
+import com.vaadin.flow.component.charts.model.Frame;
 import com.vaadin.flow.component.charts.model.HorizontalAlign;
 import com.vaadin.flow.component.charts.model.LayoutDirection;
 import com.vaadin.flow.component.charts.model.Legend;
+import com.vaadin.flow.component.charts.model.Options3d;
 import com.vaadin.flow.component.charts.model.Pane;
 import com.vaadin.flow.component.charts.model.PlotOptionsSeries;
+import com.vaadin.flow.component.charts.model.Side;
 import com.vaadin.flow.component.charts.model.Tooltip;
+import com.vaadin.flow.component.charts.model.Top;
 import com.vaadin.flow.component.charts.model.VerticalAlign;
 import com.vaadin.flow.component.charts.model.YAxis;
 import com.vaadin.flow.component.charts.model.style.Color;
@@ -302,6 +308,75 @@ public final class ChartConfigurationParser implements Serializable {
                 chartModel.setZoomType(Dimension.valueOf(zoomType));
             } catch (IllegalArgumentException e) {
                 // Invalid zoom type, skip
+            }
+        }
+        if (chartNode.has(OPTIONS_3D) && chartNode.get(OPTIONS_3D).isObject()) {
+            applyOptions3dConfig(chartModel.getOptions3d(),
+                    chartNode.get(OPTIONS_3D));
+        }
+    }
+
+    private static void applyOptions3dConfig(Options3d options3d,
+            JsonNode node) {
+        if (node.has(ENABLED) && node.get(ENABLED).isBoolean()) {
+            options3d.setEnabled(node.get(ENABLED).asBoolean());
+        }
+        if (node.has(ALPHA) && node.get(ALPHA).isNumber()) {
+            options3d.setAlpha(node.get(ALPHA).asInt());
+        }
+        if (node.has(BETA) && node.get(BETA).isNumber()) {
+            options3d.setBeta(node.get(BETA).asInt());
+        }
+        if (node.has(DEPTH) && node.get(DEPTH).isNumber()) {
+            options3d.setDepth(node.get(DEPTH).asInt());
+        }
+        if (node.has(VIEW_DISTANCE) && node.get(VIEW_DISTANCE).isNumber()) {
+            options3d.setViewDistance(node.get(VIEW_DISTANCE).asInt());
+        }
+        if (node.has(FRAME) && node.get(FRAME).isObject()) {
+            applyFrameConfig(options3d.getFrame(), node.get(FRAME));
+        }
+    }
+
+    private static void applyFrameConfig(Frame frame, JsonNode frameNode) {
+        if (frameNode.has(BACK) && frameNode.get(BACK).isObject()) {
+            JsonNode n = frameNode.get(BACK);
+            Back back = frame.getBack();
+            if (n.has(COLOR) && n.get(COLOR).isString()) {
+                back.setColor(new SolidColor(n.get(COLOR).asString()));
+            }
+            if (n.has(SIZE) && n.get(SIZE).isNumber()) {
+                back.setSize(n.get(SIZE).asInt());
+            }
+        }
+        if (frameNode.has(BOTTOM) && frameNode.get(BOTTOM).isObject()) {
+            JsonNode n = frameNode.get(BOTTOM);
+            Bottom bottom = frame.getBottom();
+            if (n.has(COLOR) && n.get(COLOR).isString()) {
+                bottom.setColor(new SolidColor(n.get(COLOR).asString()));
+            }
+            if (n.has(SIZE) && n.get(SIZE).isNumber()) {
+                bottom.setSize(n.get(SIZE).asInt());
+            }
+        }
+        if (frameNode.has(SIDE) && frameNode.get(SIDE).isObject()) {
+            JsonNode n = frameNode.get(SIDE);
+            Side side = frame.getSide();
+            if (n.has(COLOR) && n.get(COLOR).isString()) {
+                side.setColor(new SolidColor(n.get(COLOR).asString()));
+            }
+            if (n.has(SIZE) && n.get(SIZE).isNumber()) {
+                side.setSize(n.get(SIZE).asInt());
+            }
+        }
+        if (frameNode.has(TOP) && frameNode.get(TOP).isObject()) {
+            JsonNode n = frameNode.get(TOP);
+            Top top = frame.getTop();
+            if (n.has(COLOR) && n.get(COLOR).isString()) {
+                top.setColor(new SolidColor(n.get(COLOR).asString()));
+            }
+            if (n.has(SIZE) && n.get(SIZE).isNumber()) {
+                top.setSize(n.get(SIZE).asInt());
             }
         }
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ConfigurationKeys.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ConfigurationKeys.java
@@ -81,6 +81,17 @@ public final class ConfigurationKeys implements Serializable {
     public static final String ANIMATION = "animation";
     public static final String STYLED_MODE = "styledMode";
     public static final String ZOOM_TYPE = "zoomType";
+    public static final String OPTIONS_3D = "options3d";
+    public static final String ALPHA = "alpha";
+    public static final String BETA = "beta";
+    public static final String DEPTH = "depth";
+    public static final String VIEW_DISTANCE = "viewDistance";
+    public static final String FRAME = "frame";
+    public static final String BACK = "back";
+    public static final String BOTTOM = "bottom";
+    public static final String SIDE = "side";
+    public static final String TOP = "top";
+    public static final String COLOR = "color";
 
     // --- Tooltip ---
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartConfigurationParserTest.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.Dimension;
+import com.vaadin.flow.component.charts.model.Frame;
 import com.vaadin.flow.component.charts.model.HorizontalAlign;
 import com.vaadin.flow.component.charts.model.LayoutDirection;
 import com.vaadin.flow.component.charts.model.PlotOptionsArea;
@@ -559,6 +560,114 @@ class ChartConfigurationParserTest {
             return (T) config.getPlotOptions().stream().filter(type::isInstance)
                     .findFirst().orElseThrow(() -> new RuntimeException(
                             "No PlotOptions of type " + type.getSimpleName()));
+        }
+    }
+
+    @Nested
+    class Options3dConfig {
+
+        @Test
+        void allOptions3dProperties() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"enabled\":true,\"alpha\":15,\"beta\":25,"
+                    + "\"depth\":200,\"viewDistance\":150}}}");
+            var options3d = config.getChart().getOptions3d();
+            Assertions.assertTrue(options3d.getEnabled());
+            Assertions.assertEquals(15, options3d.getAlpha());
+            Assertions.assertEquals(25, options3d.getBeta());
+            Assertions.assertEquals(200, options3d.getDepth());
+            Assertions.assertEquals(150, options3d.getViewDistance());
+        }
+
+        @Test
+        void partialOptions3d_onlyEnabled() {
+            var config = parse(
+                    "{\"chart\":{\"options3d\":{\"enabled\":true}}}");
+            var options3d = config.getChart().getOptions3d();
+            Assertions.assertTrue(options3d.getEnabled());
+            Assertions.assertNull(options3d.getAlpha());
+            Assertions.assertNull(options3d.getBeta());
+        }
+
+        @Test
+        void nonObjectOptions3d_isIgnored() {
+            var config = parse("{\"chart\":{\"options3d\":\"not_an_object\"}}");
+            // Should not throw, options3d stays at defaults
+            Assertions.assertNull(config.getChart().getOptions3d().getAlpha());
+        }
+
+        @Test
+        void frameWithAllPanels() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"enabled\":true," + "\"frame\":{"
+                    + "\"back\":{\"color\":\"#f5f5dc\",\"size\":2},"
+                    + "\"bottom\":{\"color\":\"#cccccc\",\"size\":3},"
+                    + "\"side\":{\"color\":\"#dddddd\",\"size\":4},"
+                    + "\"top\":{\"color\":\"#eeeeee\",\"size\":5}" + "}}}}");
+            Frame frame = config.getChart().getOptions3d().getFrame();
+            Assertions.assertNotNull(frame.getBack().getColor());
+            Assertions.assertEquals(2, frame.getBack().getSize());
+            Assertions.assertNotNull(frame.getBottom().getColor());
+            Assertions.assertEquals(3, frame.getBottom().getSize());
+            Assertions.assertNotNull(frame.getSide().getColor());
+            Assertions.assertEquals(4, frame.getSide().getSize());
+            Assertions.assertNotNull(frame.getTop().getColor());
+            Assertions.assertEquals(5, frame.getTop().getSize());
+        }
+
+        @Test
+        void frameWithOnlyBack() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"frame\":{\"back\":{\"color\":\"#ff0000\",\"size\":1}}"
+                    + "}}}");
+            Frame frame = config.getChart().getOptions3d().getFrame();
+            Assertions.assertNotNull(frame.getBack().getColor());
+            Assertions.assertEquals(1, frame.getBack().getSize());
+            // Other panels should have no color set
+            Assertions.assertNull(frame.getBottom().getColor());
+            Assertions.assertNull(frame.getSide().getColor());
+            Assertions.assertNull(frame.getTop().getColor());
+        }
+
+        @Test
+        void framePanelWithOnlyColor() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"frame\":{\"bottom\":{\"color\":\"#aabbcc\"}}" + "}}}");
+            var bottom = config.getChart().getOptions3d().getFrame()
+                    .getBottom();
+            Assertions.assertNotNull(bottom.getColor());
+            Assertions.assertNull(bottom.getSize());
+        }
+
+        @Test
+        void framePanelWithOnlySize() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"frame\":{\"side\":{\"size\":10}}" + "}}}");
+            var side = config.getChart().getOptions3d().getFrame().getSide();
+            Assertions.assertNull(side.getColor());
+            Assertions.assertEquals(10, side.getSize());
+        }
+
+        @Test
+        void nonObjectFrame_isIgnored() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"enabled\":true,\"frame\":\"not_an_object\"}}}");
+            // Should not throw
+            Assertions
+                    .assertTrue(config.getChart().getOptions3d().getEnabled());
+        }
+
+        @Test
+        void nonObjectPanelEntry_isIgnored() {
+            var config = parse("{\"chart\":{\"options3d\":{"
+                    + "\"frame\":{\"back\":42,\"bottom\":\"str\","
+                    + "\"side\":true,\"top\":null}}}}");
+            // Should not throw, panels remain at defaults
+            Frame frame = config.getChart().getOptions3d().getFrame();
+            Assertions.assertNull(frame.getBack().getColor());
+            Assertions.assertNull(frame.getBottom().getColor());
+            Assertions.assertNull(frame.getSide().getColor());
+            Assertions.assertNull(frame.getTop().getColor());
         }
     }
 


### PR DESCRIPTION
## Summary
- Add 3D chart support (`options3d` and `frame` configuration) to the chart AI tools schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)