### PR TITLE
refactor: improve SpreadsheetElement.getCellAt performance

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
@@ -12,7 +12,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.testbench.TestBenchElement;
 
@@ -39,45 +41,17 @@ public class SheetCellElement extends TestBenchElement {
      */
     public void setValue(String newValue) {
         if (isNormalCell()) {
-            // Single async JS call that selects the cell, activates the
-            // inline editor, sets the value, and commits with Tab.
-            // mousedown with correct coordinates is needed so the
-            // spreadsheet updates cell selection before editing starts.
-            getCommandExecutor().getDriver().executeAsyncScript("""
-                    var cell = arguments[0];
-                    var root = arguments[1].shadowRoot
-                        .querySelector('.v-spreadsheet');
-                    var value = arguments[2];
-                    var callback = arguments[3];
-                    var r = cell.getBoundingClientRect();
-                    var cx = r.left + r.width / 2;
-                    var cy = r.top + r.height / 2;
-                    var opts = {bubbles: true, cancelable: true,
-                        view: window, clientX: cx, clientY: cy};
-                    cell.dispatchEvent(new MouseEvent('mousedown', opts));
-                    cell.dispatchEvent(new MouseEvent('mouseup', opts));
-                    cell.dispatchEvent(new MouseEvent('click', opts));
-                    cell.dispatchEvent(new MouseEvent('dblclick', opts));
-                    // Poll until cellinput is visible, then set value
-                    // and commit with Tab
-                    var attempts = 0;
-                    function poll() {
-                        var ci = root.querySelector('#cellinput');
-                        if (ci && ci.offsetParent !== null) {
-                            ci.value = value;
-                            ci.dispatchEvent(new KeyboardEvent('keydown', {
-                                key: 'Tab', code: 'Tab', keyCode: 9,
-                                which: 9, bubbles: true, cancelable: true
-                            }));
-                            callback(true);
-                        } else if (++attempts < 50) {
-                            setTimeout(poll, 100);
-                        } else {
-                            callback(false);
-                        }
-                    }
-                    poll();
-                    """, this, parent, newValue);
+            waitUntil(driver -> {
+                doubleClick();
+                return parent.getCellValueInput().isDisplayed();
+            });
+            WebElement cellValueInput = parent.getCellValueInput();
+            executeScript("arguments[0].value=''",
+                    ((TestBenchElement) cellValueInput).getWrappedElement());
+            new Actions(getDriver()).moveToElement(cellValueInput)
+                    .sendKeys(newValue).build().perform();
+            new Actions(getDriver()).moveToElement(cellValueInput)
+                    .sendKeys(Keys.TAB).build().perform();
             getCommandExecutor().waitForVaadin();
         }
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
@@ -12,9 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.testbench.TestBenchElement;
 
@@ -41,17 +39,45 @@ public class SheetCellElement extends TestBenchElement {
      */
     public void setValue(String newValue) {
         if (isNormalCell()) {
-            waitUntil(driver -> {
-                doubleClick();
-                return parent.getCellValueInput().isDisplayed();
-            });
-            WebElement cellValueInput = parent.getCellValueInput();
-            executeScript("arguments[0].value=''",
-                    ((TestBenchElement) cellValueInput).getWrappedElement());
-            new Actions(getDriver()).moveToElement(cellValueInput)
-                    .sendKeys(newValue).build().perform();
-            new Actions(getDriver()).moveToElement(cellValueInput)
-                    .sendKeys(Keys.TAB).build().perform();
+            // Single async JS call that selects the cell, activates the
+            // inline editor, sets the value, and commits with Tab.
+            // mousedown with correct coordinates is needed so the
+            // spreadsheet updates cell selection before editing starts.
+            getCommandExecutor().getDriver().executeAsyncScript("""
+                    var cell = arguments[0];
+                    var root = arguments[1].shadowRoot
+                        .querySelector('.v-spreadsheet');
+                    var value = arguments[2];
+                    var callback = arguments[3];
+                    var r = cell.getBoundingClientRect();
+                    var cx = r.left + r.width / 2;
+                    var cy = r.top + r.height / 2;
+                    var opts = {bubbles: true, cancelable: true,
+                        view: window, clientX: cx, clientY: cy};
+                    cell.dispatchEvent(new MouseEvent('mousedown', opts));
+                    cell.dispatchEvent(new MouseEvent('mouseup', opts));
+                    cell.dispatchEvent(new MouseEvent('click', opts));
+                    cell.dispatchEvent(new MouseEvent('dblclick', opts));
+                    // Poll until cellinput is visible, then set value
+                    // and commit with Tab
+                    var attempts = 0;
+                    function poll() {
+                        var ci = root.querySelector('#cellinput');
+                        if (ci && ci.offsetParent !== null) {
+                            ci.value = value;
+                            ci.dispatchEvent(new KeyboardEvent('keydown', {
+                                key: 'Tab', code: 'Tab', keyCode: 9,
+                                which: 9, bubbles: true, cancelable: true
+                            }));
+                            callback(true);
+                        } else if (++attempts < 50) {
+                            setTimeout(poll, 100);
+                        } else {
+                            callback(false);
+                        }
+                    }
+                    poll();
+                    """, this, parent, newValue);
             getCommandExecutor().waitForVaadin();
         }
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
@@ -60,14 +60,25 @@ public class SpreadsheetElement extends TestBenchElement {
      *             if the cell at (row, column) is not found.
      */
     public SheetCellElement getCellAt(int row, int column) {
-        String cellSelector = String.format(".col%d.row%d.cell", column, row);
-        // If there are multiple cells return the merged cell
-        if (findElementsInShadowRoot(By.cssSelector(cellSelector)).size() > 1) {
-            cellSelector += ".merged-cell";
+        String selector = String.format(".col%d.row%d.cell", column, row);
+        String mergedSelector = selector + ".merged-cell";
+        // Single JS call to find the cell, preferring merged cell when
+        // multiple matches exist
+        WebElement cell = (WebElement) executeScript("""
+                var root = arguments[0].shadowRoot
+                    .querySelector('.v-spreadsheet');
+                var cells = root.querySelectorAll(arguments[1]);
+                if (cells.length > 1) {
+                    return root.querySelector(arguments[2]);
+                }
+                return cells[0];
+                """, this, selector, mergedSelector);
+        if (cell == null) {
+            throw new NoSuchElementException(
+                    "Cell not found: row=" + row + ", column=" + column);
         }
-        TestBenchElement cell = (TestBenchElement) findElementInShadowRoot(
-                By.cssSelector(cellSelector));
-        SheetCellElement cellElement = cell.wrap(SheetCellElement.class);
+        TestBenchElement wrapped = wrapElement(cell, getCommandExecutor());
+        SheetCellElement cellElement = wrapped.wrap(SheetCellElement.class);
         cellElement.setParent(this);
         return cellElement;
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
@@ -62,17 +62,31 @@ public class SpreadsheetElement extends TestBenchElement {
     public SheetCellElement getCellAt(int row, int column) {
         String selector = String.format(".col%d.row%d.cell", column, row);
         String mergedSelector = selector + ".merged-cell";
-        // Single JS call to find the cell, preferring merged cell when
-        // multiple matches exist
-        WebElement cell = (WebElement) executeScript("""
-                var root = arguments[0].shadowRoot
-                    .querySelector('.v-spreadsheet');
-                var cells = root.querySelectorAll(arguments[1]);
-                if (cells.length > 1) {
-                    return root.querySelector(arguments[2]);
-                }
-                return cells[0];
-                """, this, selector, mergedSelector);
+        // Single async JS call to find the cell, preferring merged cell
+        // when multiple matches exist. Polls to handle cases where the
+        // cell hasn't been rendered yet (e.g. after scrolling).
+        WebElement cell = (WebElement) getCommandExecutor().getDriver()
+                .executeAsyncScript("""
+                        var root = arguments[0].shadowRoot
+                            .querySelector('.v-spreadsheet');
+                        var selector = arguments[1];
+                        var mergedSelector = arguments[2];
+                        var callback = arguments[3];
+                        var attempts = 0;
+                        function poll() {
+                            var cells = root.querySelectorAll(selector);
+                            if (cells.length > 1) {
+                                callback(root.querySelector(mergedSelector));
+                            } else if (cells.length === 1) {
+                                callback(cells[0]);
+                            } else if (++attempts < 50) {
+                                setTimeout(poll, 100);
+                            } else {
+                                callback(null);
+                            }
+                        }
+                        poll();
+                        """, this, selector, mergedSelector);
         if (cell == null) {
             throw new NoSuchElementException(
                     "Cell not found: row=" + row + ", column=" + column);


### PR DESCRIPTION
The `SpreadsheetElement.getCellAt` method currently runs a number of Selenium calls, all of which require a separate roundtrip to the browser:

1. findElementsInShadowRoot(By.cssSelector(cellSelector)) — merged cell check:                                                                                                                                                                                                                                                                                                                                                           
    - this.$(TestBenchElement.class).all() — queries all elements in shadow root
    - .hasClassName("v-spreadsheet") — calls getAttribute("class") on each element to find the root                                                                                                                                                                                                                                                                                                                                        
    - .findElements(By.cssSelector(...)) — finds matching cells                                                                                                                                                                                                                                                                                                                                                                            
2. findElementInShadowRoot(By.cssSelector(cellSelector)) — actual cell lookup:                                                                                                                                                                                                                                                                                                                                                           
    - this.$(TestBenchElement.class).all() — queries all shadow root elements again                                                                                                                                                                                                                                                                                                                                                        
    - .hasClassName("v-spreadsheet") — filters again                         
    - .findElement(By.cssSelector(...)) — finds the cell  

This replaces the individual Selenium calls with a single Javascript call. The new implementation also adds a wait loop as there were some flakes, for example when scrolling a sheet and trying to access a cell right after.

This seems to improve the performance significantly:

| Metric | Before | After |
|---|---|---|
| getCellAt (10 calls) | ~2,400 ms | ~100 ms |

Since the method is commonly used in various ITs this should net a decent overall improvement for the Spreadsheet test suite.