### PR TITLE
fix: set PlotOptionsFlags on flags data series

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -31,7 +31,9 @@ import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.FlagItem;
 import com.vaadin.flow.component.charts.model.GanttSeries;
+import com.vaadin.flow.component.charts.model.PlotOptionsFlags;
 import com.vaadin.flow.component.charts.model.Series;
 
 /**
@@ -94,6 +96,7 @@ public final class ChartRenderer implements Serializable {
         nameUnnamedSeries(config, allSeries);
 
         applySeriesConfig(allSeries, seriesConfig);
+        applyFlagsPlotOptions(allSeries);
 
         // Apply axis defaults from series data after LLM config,
         // so that data-driven axis type detection (e.g. datetime)
@@ -218,6 +221,27 @@ public final class ChartRenderer implements Serializable {
             var title = config.getTitle();
             if (title != null && title.getText() != null) {
                 abstractSeries.setName(title.getText());
+            }
+        }
+    }
+
+    /**
+     * Ensures any DataSeries containing FlagItem objects has PlotOptionsFlags
+     * set, so flags render correctly even when the chart-level type is
+     * different (e.g. column).
+     */
+    private static void applyFlagsPlotOptions(List<Series> allSeries) {
+        for (var series : allSeries) {
+            if (!(series instanceof DataSeries ds)) {
+                continue;
+            }
+            if (ds.getPlotOptions() instanceof PlotOptionsFlags) {
+                continue;
+            }
+            boolean hasFlags = ds.getData().stream()
+                    .anyMatch(FlagItem.class::isInstance);
+            if (hasFlags) {
+                ds.setPlotOptions(new PlotOptionsFlags());
             }
         }
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
 import com.vaadin.flow.component.charts.model.OhlcItem;
+import com.vaadin.flow.component.charts.model.PlotOptionsFlags;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
 import com.vaadin.tests.MockUIExtension;
 
@@ -1045,6 +1046,54 @@ class ChartRenderingTest {
     }
 
     // --- Helpers ---
+
+    @Nested
+    class FlagsChart {
+
+        @Test
+        void flagsSeriesRendersAsFlagsOnColumnChart() {
+            databaseProvider.results = List
+                    .of(row("_title", "Launch", "_text", "Product launch"));
+
+            updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
+            updateData("SELECT title AS _title, text AS _text FROM flags");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(1, series.size());
+
+            var flagsSeries = (DataSeries) series.getFirst();
+            Assertions.assertInstanceOf(PlotOptionsFlags.class,
+                    flagsSeries.getPlotOptions(),
+                    "Flags series should have PlotOptionsFlags "
+                            + "regardless of chart-level type");
+        }
+
+        @Test
+        void flagsSeriesPreservesExistingPlotOptionsFlags() {
+            databaseProvider.results = List
+                    .of(row("_title", "Launch", "_text", "Product launch"));
+
+            updateConfiguration("{\"chart\":{\"type\":\"line\"},"
+                    + "\"title\":{\"text\":\"Events\"},"
+                    + "\"series\":[{\"name\":\"Events\","
+                    + "\"type\":\"flags\","
+                    + "\"plotOptions\":{\"onSeries\":\"price\"}}]}");
+            updateData("SELECT title AS _title, text AS _text FROM flags");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(1, series.size());
+
+            var flagsSeries = (DataSeries) series.getFirst();
+            var plotOptions = flagsSeries.getPlotOptions();
+            Assertions.assertInstanceOf(PlotOptionsFlags.class, plotOptions,
+                    "Flags series should have PlotOptionsFlags");
+            Assertions.assertEquals("price",
+                    ((PlotOptionsFlags) plotOptions).getOnSeries(),
+                    "Pre-configured onSeries should be preserved");
+        }
+    }
 
     private static Map<String, Object> row(Object... kvPairs) {
         Map<String, Object> map = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary

- When the chart-level type differs from `flags` (e.g. `column`), a `DataSeries` containing `FlagItem` objects would not render as flags because it lacked `PlotOptionsFlags`
- Adds `applyFlagsPlotOptions()` to `ChartRenderer` that auto-detects flag series by their data items and sets `PlotOptionsFlags` when missing, while preserving any pre-configured plot options

🤖 Generated with [Claude Code](https://claude.com/claude-code)