### PR TITLE
fix: add exception handling around SpreadsheetComponentFactory callbacks

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -3764,14 +3764,19 @@ public class Spreadsheet extends Component
             final int row = selectedCellReference.getRow();
             final String key = SpreadsheetUtil.toKey(col + 1, row + 1);
             var currentCellKeysToEditorIdMap = getCellKeysToEditorIdMap();
-            if (currentCellKeysToEditorIdMap.containsKey(key)
-                    && customComponents != null) {
+            if (currentCellKeysToEditorIdMap.containsKey(key)) {
                 String componentId = currentCellKeysToEditorIdMap.get(key);
                 for (Component c : customComponents) {
                     if (getComponentNodeId(c).equals(componentId)) {
-                        customComponentFactory.onCustomEditorDisplayed(
-                                getCell(row, col), row, col, this,
-                                getActiveSheet(), c);
+                        try {
+                            customComponentFactory.onCustomEditorDisplayed(
+                                    getCell(row, col), row, col, this,
+                                    getActiveSheet(), c);
+                        } catch (Exception e) {
+                            LOGGER.warn(
+                                    "Error in onCustomEditorDisplayed for cell ({}, {})",
+                                    col + 1, row + 1, e);
+                        }
                         return;
                     }
                 }
@@ -4602,9 +4607,6 @@ public class Spreadsheet extends Component
             HashMap<String, String> _cellKeysToEditorIdMap = new HashMap<>(
                     getCellKeysToEditorIdMap());
             HashMap<String, String> _componentIDtoCellKeysMap = new HashMap<>();
-            if (customComponents == null) {
-                customComponents = new HashSet<Component>();
-            }
             HashSet<Component> newCustomComponents = new HashSet<Component>();
             Set<Integer> rowsWithComponents = new HashSet<Integer>();
             // iteration indexes 0-based
@@ -4659,7 +4661,7 @@ public class Spreadsheet extends Component
         } else {
             setCellKeysToEditorIdMap(null);
             setComponentIDtoCellKeysMap(null);
-            if (customComponents != null && !customComponents.isEmpty()) {
+            if (!customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);
                 }
@@ -4686,38 +4688,45 @@ public class Spreadsheet extends Component
                     if (row != null) {
                         cell = row.getCell(c);
                     }
-                    // check if the cell has a custom component
-                    Component customComponent = customComponentFactory
-                            .getCustomComponentForCell(cell, r, c, this,
-                                    getActiveSheet());
-                    if (customComponent != null) {
-                        final String key = SpreadsheetUtil.toKey(c + 1, r + 1);
-                        if (!customComponents.contains(customComponent)) {
-                            registerCustomComponent(customComponent);
-                        }
-                        componentIDtoCellKeysMap
-                                .put(getComponentNodeId(customComponent), key);
-                        newCustomComponents.add(customComponent);
-                        rowsWithComponents.add(r);
-                    } else if (!isCellLocked(new CellAddress(r, c))) {
-                        // no custom component and not locked, check if
-                        // the cell has a custom editor
-                        Component customEditor = customComponentFactory
-                                .getCustomEditorForCell(cell, r, c, this,
+                    try {
+                        // check if the cell has a custom component
+                        Component customComponent = customComponentFactory
+                                .getCustomComponentForCell(cell, r, c, this,
                                         getActiveSheet());
-                        if (customEditor != null) {
+                        if (customComponent != null) {
                             final String key = SpreadsheetUtil.toKey(c + 1,
                                     r + 1);
-                            if (!newCustomComponents.contains(customEditor)
-                                    && !customComponents
-                                            .contains(customEditor)) {
-                                registerCustomComponent(customEditor);
+                            if (!customComponents.contains(customComponent)) {
+                                registerCustomComponent(customComponent);
                             }
-                            cellKeysToEditorIdMap.put(key,
-                                    getComponentNodeId(customEditor));
-                            newCustomComponents.add(customEditor);
+                            componentIDtoCellKeysMap.put(
+                                    getComponentNodeId(customComponent), key);
+                            newCustomComponents.add(customComponent);
                             rowsWithComponents.add(r);
+                        } else if (!isCellLocked(new CellAddress(r, c))) {
+                            // no custom component and not locked, check if
+                            // the cell has a custom editor
+                            Component customEditor = customComponentFactory
+                                    .getCustomEditorForCell(cell, r, c, this,
+                                            getActiveSheet());
+                            if (customEditor != null) {
+                                final String key = SpreadsheetUtil.toKey(c + 1,
+                                        r + 1);
+                                if (!newCustomComponents.contains(customEditor)
+                                        && !customComponents
+                                                .contains(customEditor)) {
+                                    registerCustomComponent(customEditor);
+                                }
+                                cellKeysToEditorIdMap.put(key,
+                                        getComponentNodeId(customEditor));
+                                newCustomComponents.add(customEditor);
+                                rowsWithComponents.add(r);
+                            }
                         }
+                    } catch (Exception e) {
+                        LOGGER.warn(
+                                "Error loading custom component/editor for cell ({}, {})",
+                                c + 1, r + 1, e);
                     }
                 }
                 if (region != null) {
@@ -4846,7 +4855,7 @@ public class Spreadsheet extends Component
             loadCustomEditorOnSelectedCell();
         } else {
             setCellKeysToEditorIdMap(null);
-            if (customComponents != null && !customComponents.isEmpty()) {
+            if (!customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);
                 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
@@ -41,7 +41,10 @@ import com.vaadin.flow.component.Component;
  * editor value to correspond to the cell's value.
  * <p>
  * The {@link #getCustomComponentForCell(Cell, int, int, Spreadsheet, Sheet)} is
- * called first
+ * called first.
+ * <p>
+ * Exceptions thrown by any method in this interface are caught and logged at
+ * WARN level. A failing cell will not prevent other cells from loading.
  *
  * @author Vaadin Ltd.
  */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/CustomComponentsTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/CustomComponentsTest.java
@@ -77,4 +77,101 @@ class CustomComponentsTest {
         Assertions.assertFalse(customComponent.getParent().isPresent());
     }
 
+    @Test
+    void factoryThrowsForOneCell_otherCellsStillLoad() {
+        var goodComponent = new Span("Good component");
+
+        var throwingSpreadsheet = new Spreadsheet();
+        throwingSpreadsheet.setSpreadsheetComponentFactory(
+                new SpreadsheetComponentFactory() {
+
+                    @Override
+                    public Component getCustomComponentForCell(Cell cell,
+                            int rowIndex, int columnIndex,
+                            Spreadsheet spreadsheet, Sheet sheet) {
+                        // Throw for cell (0, 0)
+                        if (rowIndex == 0 && columnIndex == 0) {
+                            throw new RuntimeException(
+                                    "Simulated factory error");
+                        }
+                        // Return valid component for cell (1, 1)
+                        if (rowIndex == 1 && columnIndex == 1) {
+                            return goodComponent;
+                        }
+                        return null;
+                    }
+
+                    @Override
+                    public Component getCustomEditorForCell(Cell cell,
+                            int rowIndex, int columnIndex,
+                            Spreadsheet spreadsheet, Sheet sheet) {
+                        return null;
+                    }
+
+                    @Override
+                    public void onCustomEditorDisplayed(Cell cell, int rowIndex,
+                            int columnIndex, Spreadsheet spreadsheet,
+                            Sheet sheet, Component customEditor) {
+                    }
+                });
+
+        // Simulate viewport covering both cells
+        TestHelper.fireClientEvent(throwingSpreadsheet, "onSheetScroll",
+                "[1, 1, 10, 10]");
+
+        // The good component should still be attached despite the factory
+        // throwing for another cell.
+        Assertions.assertEquals(throwingSpreadsheet,
+                goodComponent.getParent().get());
+    }
+
+    @Test
+    void onCustomEditorDisplayedThrows_doesNotPropagate() {
+        var editor = new Span("Editor");
+
+        var throwingSpreadsheet = new Spreadsheet();
+        throwingSpreadsheet.setSpreadsheetComponentFactory(
+                new SpreadsheetComponentFactory() {
+
+                    @Override
+                    public Component getCustomComponentForCell(Cell cell,
+                            int rowIndex, int columnIndex,
+                            Spreadsheet spreadsheet, Sheet sheet) {
+                        return null;
+                    }
+
+                    @Override
+                    public Component getCustomEditorForCell(Cell cell,
+                            int rowIndex, int columnIndex,
+                            Spreadsheet spreadsheet, Sheet sheet) {
+                        // Return editor for A1
+                        if (rowIndex == 0 && columnIndex == 0) {
+                            return editor;
+                        }
+                        return null;
+                    }
+
+                    @Override
+                    public void onCustomEditorDisplayed(Cell cell, int rowIndex,
+                            int columnIndex, Spreadsheet spreadsheet,
+                            Sheet sheet, Component customEditor) {
+                        throw new RuntimeException(
+                                "Simulated onCustomEditorDisplayed error");
+                    }
+                });
+
+        // First scroll registers the editor in the map via
+        // loadCustomComponents().
+        TestHelper.fireClientEvent(throwingSpreadsheet, "onSheetScroll",
+                "[1, 1, 10, 10]");
+
+        // cellSelected triggers onCellSelected() ->
+        // loadCustomEditorOnSelectedCell() which calls
+        // onCustomEditorDisplayed() for A1. This call site has no
+        // surrounding try-catch, so the exception must be caught inside
+        // loadCustomEditorOnSelectedCell() itself.
+        Assertions.assertDoesNotThrow(() -> TestHelper.fireClientEvent(
+                throwingSpreadsheet, "cellSelected", "[1, 1, true]"));
+    }
+
 }


### PR DESCRIPTION
## Description

Wrap factory method calls in loadRangeComponents() and loadCustomEditorOnSelectedCell() with try-catch blocks so that a bug in a user-implemented SpreadsheetComponentFactory does not crash the entire spreadsheet. Exceptions are logged at WARN level with the cell address for debugging.

Also removes stale null checks on the customComponents set, which is always initialized to an empty HashSet since https://github.com/vaadin/flow-components/pull/9080.