### PR TITLE
refactor: improve SheetCellElement.setValue performance

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
@@ -12,9 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.testbench.TestBenchElement;
 
@@ -41,17 +39,76 @@ public class SheetCellElement extends TestBenchElement {
      */
     public void setValue(String newValue) {
         if (isNormalCell()) {
-            waitUntil(driver -> {
-                doubleClick();
-                return parent.getCellValueInput().isDisplayed();
-            });
-            WebElement cellValueInput = parent.getCellValueInput();
-            executeScript("arguments[0].value=''",
-                    ((TestBenchElement) cellValueInput).getWrappedElement());
-            new Actions(getDriver()).moveToElement(cellValueInput)
-                    .sendKeys(newValue).build().perform();
-            new Actions(getDriver()).moveToElement(cellValueInput)
-                    .sendKeys(Keys.TAB).build().perform();
+            // Single async JS call that selects the cell, activates the
+            // inline editor, sets the value, and commits with Tab.
+            // mousedown with correct coordinates is needed so the
+            // spreadsheet updates cell selection before editing starts.
+            getCommandExecutor().getDriver().executeAsyncScript("""
+                    var cell = arguments[0];
+                    var shadowRoot = arguments[1].shadowRoot;
+                    var root = shadowRoot
+                        .querySelector('.v-spreadsheet');
+                    var value = arguments[2];
+                    var callback = arguments[3];
+                    var r = cell.getBoundingClientRect();
+                    var cx = r.left + r.width / 2;
+                    var cy = r.top + r.height / 2;
+                    var opts = {bubbles: true, cancelable: true,
+                        view: window, clientX: cx, clientY: cy};
+                    cell.dispatchEvent(new MouseEvent('mousedown', opts));
+                    cell.dispatchEvent(new MouseEvent('mouseup', opts));
+                    cell.dispatchEvent(new MouseEvent('click', opts));
+                    cell.dispatchEvent(new MouseEvent('dblclick', opts));
+                    // Build expected class prefix to verify cellinput
+                    // is on the correct cell
+                    var cellClasses = cell.className.match(
+                        /col\\d+|row\\d+/g) || [];
+                    var expectedPrefix = cellClasses.join(' ');
+                    // Poll until cellinput is visible on the correct
+                    // cell AND has focus. Focus check is critical:
+                    // startEditingCell defers input.setFocus(true), and
+                    // dispatching Tab before that runs causes
+                    // onCellInputFocus to re-start editing on the next
+                    // cell after Tab moves the selection.
+                    var attempts = 0;
+                    function waitForInput() {
+                        var ci = root.querySelector('#cellinput');
+                        // className is non-empty when editing is active
+                        // (set by startEditingCell), and cleared by
+                        // stopEditingCell. activeElement check ensures
+                        // the deferred focus from startEditingCell has
+                        // completed.
+                        var ready = ci
+                            && ci.className.indexOf(expectedPrefix) === 0
+                            && shadowRoot.activeElement === ci;
+                        if (ready) {
+                            ci.value = value;
+                            ci.dispatchEvent(new KeyboardEvent('keydown', {
+                                key: 'Tab', code: 'Tab', keyCode: 9,
+                                which: 9, bubbles: true, cancelable: true
+                            }));
+                            // Wait for the cellinput to be closed after
+                            // the commit, so that the next setValue call
+                            // starts with a clean state.
+                            waitForClose();
+                        } else if (++attempts < 50) {
+                            setTimeout(waitForInput, 100);
+                        } else {
+                            callback(false);
+                        }
+                    }
+                    function waitForClose() {
+                        var ci = root.querySelector('#cellinput');
+                        if (!ci || ci.className === '') {
+                            callback(true);
+                        } else if (++attempts < 50) {
+                            setTimeout(waitForClose, 100);
+                        } else {
+                            callback(false);
+                        }
+                    }
+                    waitForInput();
+                    """, this, parent, newValue);
             getCommandExecutor().waitForVaadin();
         }
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
@@ -48,19 +48,19 @@ public class SheetCellElement extends TestBenchElement {
                                     const shadowRoot = arguments[1].shadowRoot;
                                     const root = shadowRoot.querySelector('.v-spreadsheet');
                                     const value = arguments[2];
-                                    const callback = arguments[3];
+                                    const callback = arguments[arguments.length - 1];
 
                                     const MAX_ATTEMPTS = 50;
                                     const delay = () => new Promise(r => setTimeout(r, 100));
 
                                     function startEditing() {
+                                        // Fire synthetic events to trigger selection and editor opening
                                         // Needs correct mouse coordinates
                                         const r = cell.getBoundingClientRect();
                                         const cx = r.left + r.width / 2;
                                         const cy = r.top + r.height / 2;
                                         const opts = {bubbles: true, cancelable: true,
                                             view: window, clientX: cx, clientY: cy};
-                                        // Fire synthetic events to trigger selection and editor opening
                                         cell.dispatchEvent(new MouseEvent('mousedown', opts));
                                         cell.dispatchEvent(new MouseEvent('mouseup', opts));
                                         cell.dispatchEvent(new MouseEvent('click', opts));
@@ -75,40 +75,45 @@ public class SheetCellElement extends TestBenchElement {
                                             }
                                             await delay();
                                         }
-                                        callback(false);
+                                        return null;
                                     }
 
                                     async function waitForClose() {
                                         for (let i = 0; i < MAX_ATTEMPTS; i++) {
                                             const input = root.querySelector('#cellinput');
                                             if (!input || shadowRoot.activeElement !== input) {
-                                                return;
+                                                return true;
                                             }
                                             await delay();
                                         }
-                                        callback(false);
+                                        return false;
                                     }
 
-                                    // Main function
-                                    (async () => {
-                                        // Select the cell and open the editor
-                                        startEditing();
+                                    // Select the cell and open the editor
+                                    startEditing();
 
-                                        // Wait for input to be visible and focused
-                                        const input = await waitForInput();
+                                    // Wait for input to be visible and focused
+                                    const input = await waitForInput();
+                                    if (!input) {
+                                        callback(false);
+                                        return;
+                                    }
 
-                                        // Set the value, commit with Tab key
-                                        input.value = value;
-                                        input.dispatchEvent(new KeyboardEvent('keydown', {
-                                            key: 'Tab', code: 'Tab', keyCode: 9,
-                                            which: 9, bubbles: true, cancelable: true
-                                        }));
+                                    // Set the value, commit with Tab key
+                                    input.value = value;
+                                    input.dispatchEvent(new KeyboardEvent('keydown', {
+                                        key: 'Tab', code: 'Tab', keyCode: 9,
+                                        which: 9, bubbles: true, cancelable: true
+                                    }));
 
-                                        // Wait for the editor to close before finishing
-                                        // Allows next setValue call to start with a clean state
-                                        await waitForClose();
-                                        callback(true);
-                                    })();
+                                    // Wait for the editor to close before finishing
+                                    // Allows next setValue call to start with a clean state
+                                    const closed = await waitForClose();
+                                    if (!closed) {
+                                        callback(false);
+                                        return;
+                                    }
+                                    callback(true);
                                     """,
                             this, parent, newValue);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SheetCellElement.java
@@ -41,74 +41,83 @@ public class SheetCellElement extends TestBenchElement {
         if (isNormalCell()) {
             // Single async JS call that selects the cell, activates the
             // inline editor, sets the value, and commits with Tab.
-            // mousedown with correct coordinates is needed so the
-            // spreadsheet updates cell selection before editing starts.
-            getCommandExecutor().getDriver().executeAsyncScript("""
-                    var cell = arguments[0];
-                    var shadowRoot = arguments[1].shadowRoot;
-                    var root = shadowRoot
-                        .querySelector('.v-spreadsheet');
-                    var value = arguments[2];
-                    var callback = arguments[3];
-                    var r = cell.getBoundingClientRect();
-                    var cx = r.left + r.width / 2;
-                    var cy = r.top + r.height / 2;
-                    var opts = {bubbles: true, cancelable: true,
-                        view: window, clientX: cx, clientY: cy};
-                    cell.dispatchEvent(new MouseEvent('mousedown', opts));
-                    cell.dispatchEvent(new MouseEvent('mouseup', opts));
-                    cell.dispatchEvent(new MouseEvent('click', opts));
-                    cell.dispatchEvent(new MouseEvent('dblclick', opts));
-                    // Build expected class prefix to verify cellinput
-                    // is on the correct cell
-                    var cellClasses = cell.className.match(
-                        /col\\d+|row\\d+/g) || [];
-                    var expectedPrefix = cellClasses.join(' ');
-                    // Poll until cellinput is visible on the correct
-                    // cell AND has focus. Focus check is critical:
-                    // startEditingCell defers input.setFocus(true), and
-                    // dispatching Tab before that runs causes
-                    // onCellInputFocus to re-start editing on the next
-                    // cell after Tab moves the selection.
-                    var attempts = 0;
-                    function waitForInput() {
-                        var ci = root.querySelector('#cellinput');
-                        // className is non-empty when editing is active
-                        // (set by startEditingCell), and cleared by
-                        // stopEditingCell. activeElement check ensures
-                        // the deferred focus from startEditingCell has
-                        // completed.
-                        var ready = ci
-                            && ci.className.indexOf(expectedPrefix) === 0
-                            && shadowRoot.activeElement === ci;
-                        if (ready) {
-                            ci.value = value;
-                            ci.dispatchEvent(new KeyboardEvent('keydown', {
-                                key: 'Tab', code: 'Tab', keyCode: 9,
-                                which: 9, bubbles: true, cancelable: true
-                            }));
-                            // Wait for the cellinput to be closed after
-                            // the commit, so that the next setValue call
-                            // starts with a clean state.
-                            waitForClose();
-                        } else if (++attempts < 50) {
-                            setTimeout(waitForInput, 100);
-                        } else {
-                            callback(false);
-                        }
-                    }
-                    function waitForClose() {
-                        var ci = root.querySelector('#cellinput');
-                        if (!ci || ci.className === '') {
-                            callback(true);
-                        } else if (++attempts < 50) {
-                            setTimeout(waitForClose, 100);
-                        } else {
-                            callback(false);
-                        }
-                    }
-                    waitForInput();
-                    """, this, parent, newValue);
+            Boolean result = (Boolean) getCommandExecutor().getDriver()
+                    .executeAsyncScript(
+                            """
+                                    const cell = arguments[0];
+                                    const shadowRoot = arguments[1].shadowRoot;
+                                    const root = shadowRoot.querySelector('.v-spreadsheet');
+                                    const value = arguments[2];
+                                    const callback = arguments[3];
+
+                                    const MAX_ATTEMPTS = 50;
+                                    const delay = () => new Promise(r => setTimeout(r, 100));
+
+                                    function startEditing() {
+                                        // Needs correct mouse coordinates
+                                        const r = cell.getBoundingClientRect();
+                                        const cx = r.left + r.width / 2;
+                                        const cy = r.top + r.height / 2;
+                                        const opts = {bubbles: true, cancelable: true,
+                                            view: window, clientX: cx, clientY: cy};
+                                        // Fire synthetic events to trigger selection and editor opening
+                                        cell.dispatchEvent(new MouseEvent('mousedown', opts));
+                                        cell.dispatchEvent(new MouseEvent('mouseup', opts));
+                                        cell.dispatchEvent(new MouseEvent('click', opts));
+                                        cell.dispatchEvent(new MouseEvent('dblclick', opts));
+                                    }
+
+                                    async function waitForInput() {
+                                        for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                                            const input = root.querySelector('#cellinput');
+                                            if (input && shadowRoot.activeElement === input) {
+                                                return input;
+                                            }
+                                            await delay();
+                                        }
+                                        callback(false);
+                                    }
+
+                                    async function waitForClose() {
+                                        for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                                            const input = root.querySelector('#cellinput');
+                                            if (!input || shadowRoot.activeElement !== input) {
+                                                return;
+                                            }
+                                            await delay();
+                                        }
+                                        callback(false);
+                                    }
+
+                                    // Main function
+                                    (async () => {
+                                        // Select the cell and open the editor
+                                        startEditing();
+
+                                        // Wait for input to be visible and focused
+                                        const input = await waitForInput();
+
+                                        // Set the value, commit with Tab key
+                                        input.value = value;
+                                        input.dispatchEvent(new KeyboardEvent('keydown', {
+                                            key: 'Tab', code: 'Tab', keyCode: 9,
+                                            which: 9, bubbles: true, cancelable: true
+                                        }));
+
+                                        // Wait for the editor to close before finishing
+                                        // Allows next setValue call to start with a clean state
+                                        await waitForClose();
+                                        callback(true);
+                                    })();
+                                    """,
+                            this, parent, newValue);
+
+            if (Boolean.FALSE.equals(result)) {
+                throw new org.openqa.selenium.TimeoutException(
+                        "setValue timed out for cell "
+                                + getDomAttribute("class") + " with value '"
+                                + newValue + "'");
+            }
             getCommandExecutor().waitForVaadin();
         }
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/src/main/java/com/vaadin/flow/component/spreadsheet/testbench/SpreadsheetElement.java
@@ -66,27 +66,31 @@ public class SpreadsheetElement extends TestBenchElement {
         // when multiple matches exist. Polls to handle cases where the
         // cell hasn't been rendered yet (e.g. after scrolling).
         WebElement cell = (WebElement) getCommandExecutor().getDriver()
-                .executeAsyncScript("""
-                        var root = arguments[0].shadowRoot
-                            .querySelector('.v-spreadsheet');
-                        var selector = arguments[1];
-                        var mergedSelector = arguments[2];
-                        var callback = arguments[3];
-                        var attempts = 0;
-                        function poll() {
-                            var cells = root.querySelectorAll(selector);
-                            if (cells.length > 1) {
-                                callback(root.querySelector(mergedSelector));
-                            } else if (cells.length === 1) {
-                                callback(cells[0]);
-                            } else if (++attempts < 50) {
-                                setTimeout(poll, 100);
-                            } else {
+                .executeAsyncScript(
+                        """
+                                const root = arguments[0].shadowRoot
+                                    .querySelector('.v-spreadsheet');
+                                const selector = arguments[1];
+                                const mergedSelector = arguments[2];
+                                const callback = arguments[arguments.length - 1];
+
+                                const MAX_ATTEMPTS = 50;
+                                const delay = () => new Promise(r => setTimeout(r, 100));
+
+                                for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                                    const cells = root.querySelectorAll(selector);
+                                    if (cells.length > 1) {
+                                        callback(root.querySelector(mergedSelector));
+                                        return;
+                                    } else if (cells.length === 1) {
+                                        callback(cells[0]);
+                                        return;
+                                    }
+                                    await delay();
+                                }
                                 callback(null);
-                            }
-                        }
-                        poll();
-                        """, this, selector, mergedSelector);
+                                """,
+                        this, selector, mergedSelector);
         if (cell == null) {
             throw new NoSuchElementException(
                     "Cell not found: row=" + row + ", column=" + column);


### PR DESCRIPTION
Similar to https://github.com/vaadin/flow-components/pull/9096, this improves the performance of `SheetCellElement.setValue` by moving the respective logic into Javascript:

| Metric | Before | After |
|---|---|---|
| setValue (avg. 10 calls) | ~681 ms | ~138 ms |
