### PR TITLE
refactor!: extract `NumberSlider` / `NumberRangeSlider`

### DIFF
--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/RangeSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/RangeSliderBasicPage.java
@@ -28,10 +28,10 @@ public class RangeSliderBasicPage extends Div {
 
     public RangeSliderBasicPage() {
         RangeSlider rangeSlider = new RangeSlider();
-        rangeSlider.setMin(10);
-        rangeSlider.setMax(200);
-        rangeSlider.setStep(5);
-        rangeSlider.setValue(new RangeSliderValue(25, 150));
+        rangeSlider.setMin(10.0);
+        rangeSlider.setMax(200.0);
+        rangeSlider.setStep(5.0);
+        rangeSlider.setValue(new RangeSliderValue(25.0, 150.0));
         rangeSlider.setWidth("200px");
 
         Span serverValue = new Span();

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/SliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/SliderBasicPage.java
@@ -27,9 +27,9 @@ public class SliderBasicPage extends Div {
 
     public SliderBasicPage() {
         Slider slider = new Slider();
-        slider.setMin(10);
-        slider.setMax(200);
-        slider.setStep(5);
+        slider.setMin(10.0);
+        slider.setMax(200.0);
+        slider.setStep(5.0);
         slider.setValue(50.0);
         slider.setWidth("200px");
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
@@ -60,7 +60,7 @@ abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent
      *            a function to convert a value of the slider's numeric type to
      *            double
      */
-    protected NumberRangeSlider(TNumber min, TNumber max,
+    NumberRangeSlider(TNumber min, TNumber max,
             SerializableBiFunction<TNumber, TNumber, TValue> rangeFactory,
             SerializableFunction<Double, TNumber> fromDouble,
             SerializableFunction<TNumber, Double> toDouble) {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.util.Optional;
+
+import com.vaadin.flow.function.SerializableFunction;
+
+import tools.jackson.databind.node.ArrayNode;
+
+/**
+ * Base class for sliders that allow selecting a range of numeric values within
+ * configured bounds.
+ * 
+ * @param <TComponent>
+ *            the type of the slider component
+ * @param <TValue>
+ *            the type of the slider's value, which must extend {@link Range} of
+ *            a numeric type
+ * @param <TNumber>
+ *            the numeric type of the slider's start value, end value, min, max,
+ *            step properties, which must extend {@link Number}
+ */
+abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent, TValue, TNumber>, TValue extends Range<TNumber>, TNumber extends Number>
+        extends SliderBase<TComponent, TValue, TNumber, ArrayNode> {
+
+    /**
+     * Constructs a NumberRangeSlider with the given min and max values,
+     * functions to convert between the slider's range value type and
+     * client-side presentation, and functions to convert between the slider's
+     * numeric type and double.
+     * 
+     * @param min
+     *            the minimum value
+     * @param max
+     *            the maximum value
+     * @param presentationToModel
+     *            a function to convert a client-side presentation value to the
+     *            slider's range value type
+     * @param modelToPresentation
+     *            a function to convert a value of the slider's range value type
+     *            to client-side presentation
+     * @param fromDouble
+     *            a function to convert a double value to the slider's numeric
+     *            type
+     * @param toDouble
+     *            a function to convert a value of the slider's numeric type to
+     *            double
+     */
+    public NumberRangeSlider(TNumber min, TNumber max,
+            SerializableFunction<ArrayNode, TValue> presentationToModel,
+            SerializableFunction<TValue, ArrayNode> modelToPresentation,
+            SerializableFunction<Double, TNumber> fromDouble,
+            SerializableFunction<TNumber, Double> toDouble) {
+        super(min, max, ArrayNode.class, presentationToModel,
+                modelToPresentation, fromDouble, toDouble);
+    }
+
+    /**
+     * Sets an accessible name for the start range input element of the slider.
+     *
+     * @param accessibleName
+     *            the accessible name to set, or {@code null} to remove it
+     */
+    public void setAccessibleNameStart(String accessibleName) {
+        getElement().setProperty("accessibleNameStart", accessibleName);
+    }
+
+    /**
+     * Gets the accessible name for the start range input element of the slider.
+     *
+     * @return an optional accessible name, or an empty optional if no
+     *         accessible name has been set
+     */
+    public Optional<String> getAccessibleNameStart() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameStart"));
+    }
+
+    /**
+     * Sets an accessible name for the end range input element of the slider.
+     *
+     * @param accessibleName
+     *            the accessible name to set, or {@code null} to remove it
+     */
+    public void setAccessibleNameEnd(String accessibleName) {
+        getElement().setProperty("accessibleNameEnd", accessibleName);
+    }
+
+    /**
+     * Gets the accessible name for the end range input element of the slider.
+     *
+     * @return an optional accessible name, or an empty optional if no
+     *         accessible name has been set
+     */
+    public Optional<String> getAccessibleNameEnd() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameEnd"));
+    }
+
+    /**
+     * Clears the slider value, setting it to the full range from minimum to
+     * maximum.
+     *
+     * @see #getMin()
+     * @see #getMax()
+     */
+    @Override
+    public void clear() {
+        setValue(createRange(getMin(), getMax()));
+    }
+
+    @Override
+    protected boolean hasValidValue() {
+        try {
+            ArrayNode arrayValue = (ArrayNode) getElement()
+                    .getPropertyRaw("value");
+            TValue value = presentationToModel.apply(arrayValue);
+            return isValueWithinMinMax(value) && isValueAlignedWithStep(value);
+        } catch (IllegalArgumentException | ClassCastException e) {
+            return false;
+        }
+    }
+
+    @Override
+    protected boolean isValueWithinMinMax(TValue value) {
+        double min = toDouble.apply(getMin());
+        double max = toDouble.apply(getMax());
+        if (min > max) {
+            return false;
+        }
+
+        double valueStart = toDouble.apply(value.start());
+        double valueEnd = toDouble.apply(value.end());
+        double clampedStart = SliderUtil.clampToMinMax(valueStart, min, max);
+        double clampedEnd = SliderUtil.clampToMinMax(valueEnd, min, max);
+
+        return Double.compare(valueStart, clampedStart) == 0
+                && Double.compare(valueEnd, clampedEnd) == 0;
+    }
+
+    @Override
+    protected boolean isValueAlignedWithStep(TValue value) {
+        double min = toDouble.apply(getMin());
+        double max = toDouble.apply(getMax());
+        if (min > max) {
+            return false;
+        }
+
+        double step = toDouble.apply(getStep());
+        double valueStart = toDouble.apply(value.start());
+        double valueEnd = toDouble.apply(value.end());
+        double snappedStart = SliderUtil.snapToStep(valueStart, min, max, step);
+        double snappedEnd = SliderUtil.snapToStep(valueEnd, min, max, step);
+
+        return Double.compare(valueStart, snappedStart) == 0
+                && Double.compare(valueEnd, snappedEnd) == 0;
+    }
+
+    protected abstract TValue createRange(TNumber start, TNumber end);
+}

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
@@ -132,18 +132,6 @@ abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent
     }
 
     @Override
-    protected boolean hasValidValue() {
-        try {
-            ArrayNode arrayValue = (ArrayNode) getElement()
-                    .getPropertyRaw("value");
-            TValue value = presentationToModel.apply(arrayValue);
-            return isValueWithinMinMax(value) && isValueAlignedWithStep(value);
-        } catch (IllegalArgumentException | ClassCastException e) {
-            return false;
-        }
-    }
-
-    @Override
     protected boolean isValueWithinMinMax(TValue value) {
         double min = toDouble.apply(getMin());
         double max = toDouble.apply(getMax());

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
@@ -60,7 +60,7 @@ abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent
      *            a function to convert a value of the slider's numeric type to
      *            double
      */
-    public NumberRangeSlider(TNumber min, TNumber max,
+    protected NumberRangeSlider(TNumber min, TNumber max,
             SerializableBiFunction<TNumber, TNumber, TValue> rangeFactory,
             SerializableFunction<Double, TNumber> fromDouble,
             SerializableFunction<TNumber, Double> toDouble) {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberRangeSlider.java
@@ -15,9 +15,12 @@
  */
 package com.vaadin.flow.component.slider;
 
+import java.util.Arrays;
 import java.util.Optional;
 
+import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.node.ArrayNode;
 
@@ -37,22 +40,19 @@ import tools.jackson.databind.node.ArrayNode;
 abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent, TValue, TNumber>, TValue extends Range<TNumber>, TNumber extends Number>
         extends SliderBase<TComponent, TValue, TNumber, ArrayNode> {
 
+    private final SerializableBiFunction<TNumber, TNumber, TValue> rangeFactory;
+
     /**
-     * Constructs a NumberRangeSlider with the given min and max values,
-     * functions to convert between the slider's range value type and
-     * client-side presentation, and functions to convert between the slider's
-     * numeric type and double.
-     * 
+     * Constructs a NumberRangeSlider with the given min and max values, a
+     * factory function for creating range values, and functions to convert
+     * between the slider's numeric type and double.
+     *
      * @param min
      *            the minimum value
      * @param max
      *            the maximum value
-     * @param presentationToModel
-     *            a function to convert a client-side presentation value to the
-     *            slider's range value type
-     * @param modelToPresentation
-     *            a function to convert a value of the slider's range value type
-     *            to client-side presentation
+     * @param rangeFactory
+     *            a function to create range values from start and end values
      * @param fromDouble
      *            a function to convert a double value to the slider's numeric
      *            type
@@ -61,12 +61,20 @@ abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent
      *            double
      */
     public NumberRangeSlider(TNumber min, TNumber max,
-            SerializableFunction<ArrayNode, TValue> presentationToModel,
-            SerializableFunction<TValue, ArrayNode> modelToPresentation,
+            SerializableBiFunction<TNumber, TNumber, TValue> rangeFactory,
             SerializableFunction<Double, TNumber> fromDouble,
             SerializableFunction<TNumber, Double> toDouble) {
-        super(min, max, ArrayNode.class, presentationToModel,
-                modelToPresentation, fromDouble, toDouble);
+        super(min, max, ArrayNode.class,
+                arrayValue -> rangeFactory.apply(
+                        fromDouble.apply(arrayValue.get(0).asDouble()),
+                        fromDouble.apply(arrayValue.get(1).asDouble())),
+                value -> JacksonUtils
+                        .listToJson(Arrays.asList(toDouble.apply(value.start()),
+                                toDouble.apply(value.end()))),
+                fromDouble, toDouble);
+        this.rangeFactory = rangeFactory;
+
+        setValue(rangeFactory.apply(min, max));
     }
 
     /**
@@ -120,7 +128,7 @@ abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent
      */
     @Override
     public void clear() {
-        setValue(createRange(getMin(), getMax()));
+        setValue(rangeFactory.apply(getMin(), getMax()));
     }
 
     @Override
@@ -169,6 +177,4 @@ abstract class NumberRangeSlider<TComponent extends NumberRangeSlider<TComponent
         return Double.compare(valueStart, snappedStart) == 0
                 && Double.compare(valueEnd, snappedEnd) == 0;
     }
-
-    protected abstract TValue createRange(TNumber start, TNumber end);
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
@@ -117,12 +117,6 @@ abstract class NumberSlider<TComponent extends NumberSlider<TComponent, TValue>,
     }
 
     @Override
-    protected boolean hasValidValue() {
-        TValue value = fromDouble.apply(getElement().getProperty("value", 0.0));
-        return isValueWithinMinMax(value) && isValueAlignedWithStep(value);
-    }
-
-    @Override
     protected boolean isValueWithinMinMax(TValue value) {
         double min = toDouble.apply(getMin());
         double max = toDouble.apply(getMax());

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
@@ -54,6 +54,8 @@ abstract class NumberSlider<TComponent extends NumberSlider<TComponent, TValue>,
             SerializableFunction<TValue, Double> toDouble) {
         super(min, max, Double.class, fromDouble, toDouble, fromDouble,
                 toDouble);
+
+        setValue(min);
     }
 
     /**

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
@@ -49,7 +49,7 @@ abstract class NumberSlider<TComponent extends NumberSlider<TComponent, TValue>,
      *            a function to convert a value of the slider's value type to
      *            double
      */
-    protected NumberSlider(TValue min, TValue max,
+    NumberSlider(TValue min, TValue max,
             SerializableFunction<Double, TValue> fromDouble,
             SerializableFunction<TValue, Double> toDouble) {
         super(min, max, Double.class, fromDouble, toDouble, fromDouble,

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.util.Optional;
+
+import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.function.SerializableFunction;
+
+/**
+ * Base class for sliders that allow selecting a single numeric value within a
+ * range.
+ * 
+ * @param <TComponent>
+ *            the type of the slider component
+ * @param <TValue>
+ *            the type of the slider's value, min, max, step properties, which
+ *            must extend {@link Number}
+ */
+abstract class NumberSlider<TComponent extends NumberSlider<TComponent, TValue>, TValue extends Number>
+        extends SliderBase<TComponent, TValue, TValue, Double>
+        implements HasAriaLabel {
+
+    /**
+     * Constructs a NumberSlider with the given min and max values, and
+     * functions to convert between the slider's value type and double.
+     * 
+     * @param min
+     *            the minimum value
+     * @param max
+     *            the maximum value
+     * @param fromDouble
+     *            a function to convert a double value to the slider's value
+     *            type
+     * @param toDouble
+     *            a function to convert a value of the slider's value type to
+     *            double
+     */
+    protected NumberSlider(TValue min, TValue max,
+            SerializableFunction<Double, TValue> fromDouble,
+            SerializableFunction<TValue, Double> toDouble) {
+        super(min, max, Double.class, fromDouble, toDouble, fromDouble,
+                toDouble);
+    }
+
+    /**
+     * Sets an accessible name for the range input element of the slider.
+     *
+     * @param ariaLabel
+     *            the accessible name to set, or {@code null} to remove it
+     */
+    @Override
+    public void setAriaLabel(String ariaLabel) {
+        getElement().setProperty("accessibleName", ariaLabel);
+    }
+
+    /**
+     * Gets the accessible name for the range input element of the slider.
+     *
+     * @return an optional accessible name, or an empty optional if no
+     *         accessible name has been set
+     */
+    @Override
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    /**
+     * Sets the id of an element to be used as the accessible name for the range
+     * input element of the slider.
+     *
+     * @param ariaLabelledBy
+     *            the id of the element to be used as the label, or {@code null}
+     *            to remove it
+     */
+    @Override
+    public void setAriaLabelledBy(String ariaLabelledBy) {
+        getElement().setProperty("accessibleNameRef", ariaLabelledBy);
+    }
+
+    /**
+     * Gets the id of the element used as the accessible name for the range
+     * input element of the slider.
+     *
+     * @return an optional id of the element used as the label, or an empty
+     *         optional if no id has been set
+     */
+    @Override
+    public Optional<String> getAriaLabelledBy() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * Clears the slider value, setting it to the minimum value.
+     *
+     * @see #getMin()
+     */
+    @Override
+    public void clear() {
+        setValue(getMin());
+    }
+
+    @Override
+    protected boolean hasValidValue() {
+        TValue value = fromDouble.apply(getElement().getProperty("value", 0.0));
+        return isValueWithinMinMax(value) && isValueAlignedWithStep(value);
+    }
+
+    @Override
+    protected boolean isValueWithinMinMax(TValue value) {
+        double min = toDouble.apply(getMin());
+        double max = toDouble.apply(getMax());
+        if (min > max) {
+            return false;
+        }
+
+        double doubleValue = toDouble.apply(value);
+        double clampedValue = SliderUtil.clampToMinMax(doubleValue, min, max);
+
+        return Double.compare(doubleValue, clampedValue) == 0;
+    }
+
+    @Override
+    protected boolean isValueAlignedWithStep(TValue value) {
+        double min = toDouble.apply(getMin());
+        double max = toDouble.apply(getMax());
+        if (min > max) {
+            return false;
+        }
+
+        double step = toDouble.apply(getStep());
+        double doubleValue = toDouble.apply(value);
+        double snappedValue = SliderUtil.snapToStep(doubleValue, min, max,
+                step);
+
+        return Double.compare(doubleValue, snappedValue) == 0;
+    }
+}

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Range.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Range.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.io.Serializable;
+
+interface Range<TValue extends Number> extends Serializable {
+    TValue start();
+
+    TValue end();
+}

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Range.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Range.java
@@ -17,8 +17,8 @@ package com.vaadin.flow.component.slider;
 
 import java.io.Serializable;
 
-interface Range<TValue extends Number> extends Serializable {
-    TValue start();
+interface Range<TNumber extends Number> extends Serializable {
+    TNumber start();
 
-    TValue end();
+    TNumber end();
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Range.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Range.java
@@ -17,6 +17,16 @@ package com.vaadin.flow.component.slider;
 
 import java.io.Serializable;
 
+/**
+ * Represents a range of numeric values with a start and end. Package-private
+ * for now, as it is only used to facilitate internal logic in
+ * {@link NumberRangeSlider}.
+ * 
+ * @param <TNumber>
+ *            the numeric type of the range's start and end values, which must
+ *            extend {@link Number}
+ * @author Vaadin Ltd
+ */
 interface Range<TNumber extends Number> extends Serializable {
     TNumber start();
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSlider.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.slider;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -36,7 +35,9 @@ import tools.jackson.databind.node.ArrayNode;
 @Tag("vaadin-range-slider")
 @NpmPackage(value = "@vaadin/slider", version = "25.2.0-alpha6")
 @JsModule("@vaadin/slider/src/vaadin-range-slider.js")
-public class RangeSlider extends SliderBase<RangeSlider, RangeSliderValue> {
+public class RangeSlider
+        extends NumberRangeSlider<RangeSlider, RangeSliderValue, Double> {
+
     private static final SerializableFunction<ArrayNode, RangeSliderValue> PARSER = (
             arrayValue) -> {
         return new RangeSliderValue(arrayValue.get(0).asDouble(),
@@ -48,9 +49,6 @@ public class RangeSlider extends SliderBase<RangeSlider, RangeSliderValue> {
         return JacksonUtils
                 .listToJson(Arrays.asList(value.start(), value.end()));
     };
-
-    private static final double DEFAULT_MIN = 0.0;
-    private static final double DEFAULT_MAX = 100.0;
 
     /**
      * Constructs a {@code RangeSlider} with min 0 and max 100. The initial
@@ -74,7 +72,7 @@ public class RangeSlider extends SliderBase<RangeSlider, RangeSliderValue> {
      *            the maximum value
      */
     public RangeSlider(double min, double max) {
-        super(min, max, ArrayNode.class, PARSER, FORMATTER);
+        super(min, max, PARSER, FORMATTER, v -> v, v -> v);
     }
 
     /**
@@ -109,159 +107,8 @@ public class RangeSlider extends SliderBase<RangeSlider, RangeSliderValue> {
         setLabel(label);
     }
 
-    /**
-     * Sets an accessible name for the start range input element of the slider.
-     *
-     * @param accessibleName
-     *            the accessible name to set, or {@code null} to remove it
-     */
-    public void setAccessibleNameStart(String accessibleName) {
-        getElement().setProperty("accessibleNameStart", accessibleName);
-    }
-
-    /**
-     * Gets the accessible name for the start range input element of the slider.
-     *
-     * @return an optional accessible name, or an empty optional if no
-     *         accessible name has been set
-     */
-    public Optional<String> getAccessibleNameStart() {
-        return Optional
-                .ofNullable(getElement().getProperty("accessibleNameStart"));
-    }
-
-    /**
-     * Sets an accessible name for the end range input element of the slider.
-     *
-     * @param accessibleName
-     *            the accessible name to set, or {@code null} to remove it
-     */
-    public void setAccessibleNameEnd(String accessibleName) {
-        getElement().setProperty("accessibleNameEnd", accessibleName);
-    }
-
-    /**
-     * Gets the accessible name for the end range input element of the slider.
-     *
-     * @return an optional accessible name, or an empty optional if no
-     *         accessible name has been set
-     */
-    public Optional<String> getAccessibleNameEnd() {
-        return Optional
-                .ofNullable(getElement().getProperty("accessibleNameEnd"));
-    }
-
-    /**
-     * Gets the minimum value of the slider.
-     *
-     * @return the minimum value
-     */
-    public double getMin() {
-        return super.getMinDouble();
-    }
-
-    /**
-     * Sets the minimum value of the slider.
-     *
-     * @param min
-     *            the minimum value
-     */
-    public void setMin(double min) {
-        setMinDouble(min);
-    }
-
-    /**
-     * Gets the maximum value of the slider.
-     *
-     * @return the maximum value
-     */
-    public double getMax() {
-        return super.getMaxDouble();
-    }
-
-    /**
-     * Sets the maximum value of the slider.
-     *
-     * @param max
-     *            the maximum value
-     */
-    public void setMax(double max) {
-        setMaxDouble(max);
-    }
-
-    /**
-     * Gets the step value of the slider.
-     * <p>
-     * Valid slider values are calculated relative to the minimum value:
-     * {@code min}, {@code min + step}, {@code min + 2*step}, etc.
-     *
-     * @return the step value
-     */
-    public double getStep() {
-        return super.getStepDouble();
-    }
-
-    /**
-     * Sets the step value of the slider.
-     * <p>
-     * Valid slider values are calculated relative to the minimum value:
-     * {@code min}, {@code min + step}, {@code min + 2*step}, etc.
-     *
-     * @param step
-     *            the step value
-     */
-    public void setStep(double step) {
-        setStepDouble(step);
-    }
-
-    /**
-     * Clears the slider value, setting it to the full range from minimum to
-     * maximum.
-     *
-     * @see #getMin()
-     * @see #getMax()
-     */
     @Override
-    public void clear() {
-        setValue(new RangeSliderValue(getMin(), getMax()));
-    }
-
-    @Override
-    protected boolean hasValidValue() {
-        try {
-            ArrayNode arrayValue = (ArrayNode) getElement()
-                    .getPropertyRaw("value");
-            RangeSliderValue value = PARSER.apply(arrayValue);
-            return isValueWithinMinMax(value) && isValueAlignedWithStep(value);
-        } catch (IllegalArgumentException | ClassCastException e) {
-            return false;
-        }
-    }
-
-    @Override
-    protected boolean isValueWithinMinMax(RangeSliderValue value) {
-        double min = getMinDouble();
-        double max = getMaxDouble();
-        if (min > max) {
-            return false;
-        }
-
-        return value.equals(new RangeSliderValue(
-                SliderUtil.clampToMinMax(value.start(), min, max),
-                SliderUtil.clampToMinMax(value.end(), min, max)));
-    }
-
-    @Override
-    protected boolean isValueAlignedWithStep(RangeSliderValue value) {
-        double min = getMinDouble();
-        double max = getMaxDouble();
-        double step = getStepDouble();
-        if (min > max) {
-            return false;
-        }
-
-        return value.equals(new RangeSliderValue(
-                SliderUtil.snapToStep(value.start(), min, max, step),
-                SliderUtil.snapToStep(value.end(), min, max, step)));
+    protected RangeSliderValue createRange(Double start, Double end) {
+        return new RangeSliderValue(start, end);
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSlider.java
@@ -15,15 +15,9 @@
  */
 package com.vaadin.flow.component.slider;
 
-import java.util.Arrays;
-
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.function.SerializableFunction;
-import com.vaadin.flow.internal.JacksonUtils;
-
-import tools.jackson.databind.node.ArrayNode;
 
 /**
  * RangeSlider is an input field that allows the user to select a numeric range
@@ -37,18 +31,6 @@ import tools.jackson.databind.node.ArrayNode;
 @JsModule("@vaadin/slider/src/vaadin-range-slider.js")
 public class RangeSlider
         extends NumberRangeSlider<RangeSlider, RangeSliderValue, Double> {
-
-    private static final SerializableFunction<ArrayNode, RangeSliderValue> PARSER = (
-            arrayValue) -> {
-        return new RangeSliderValue(arrayValue.get(0).asDouble(),
-                arrayValue.get(1).asDouble());
-    };
-
-    private static final SerializableFunction<RangeSliderValue, ArrayNode> FORMATTER = (
-            value) -> {
-        return JacksonUtils
-                .listToJson(Arrays.asList(value.start(), value.end()));
-    };
 
     /**
      * Constructs a {@code RangeSlider} with min 0 and max 100. The initial
@@ -72,7 +54,7 @@ public class RangeSlider
      *            the maximum value
      */
     public RangeSlider(double min, double max) {
-        super(min, max, PARSER, FORMATTER, v -> v, v -> v);
+        super(min, max, RangeSliderValue::new, v -> v, v -> v);
     }
 
     /**
@@ -105,10 +87,5 @@ public class RangeSlider
     public RangeSlider(String label, double min, double max) {
         this(min, max);
         setLabel(label);
-    }
-
-    @Override
-    protected RangeSliderValue createRange(Double start, Double end) {
-        return new RangeSliderValue(start, end);
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSliderValue.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSliderValue.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.slider;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Represents the value of a {@link RangeSlider}, consisting of decimal start
@@ -42,6 +43,8 @@ public record RangeSliderValue(Double start,
      *             if start is greater than end
      */
     public RangeSliderValue {
+        Objects.requireNonNull(start, "Start value cannot be null");
+        Objects.requireNonNull(end, "End value cannot be null");
         if (start > end) {
             throw new IllegalArgumentException(
                     "Start value cannot be greater than end value");

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSliderValue.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSliderValue.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.slider;
 
-import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -30,7 +29,7 @@ import java.util.Objects;
  * @author Vaadin Ltd
  */
 public record RangeSliderValue(Double start,
-        Double end) implements Serializable, Range<Double> {
+        Double end) implements Range<Double> {
 
     /**
      * Creates a new RangeSliderValue with the given start and end values.

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSliderValue.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/RangeSliderValue.java
@@ -18,8 +18,8 @@ package com.vaadin.flow.component.slider;
 import java.io.Serializable;
 
 /**
- * Represents the value of a {@link RangeSlider}, consisting of a start and end
- * value.
+ * Represents the value of a {@link RangeSlider}, consisting of decimal start
+ * and end values.
  *
  * @param start
  *            the start value of the range
@@ -28,8 +28,8 @@ import java.io.Serializable;
  *
  * @author Vaadin Ltd
  */
-public record RangeSliderValue(double start,
-        double end) implements Serializable {
+public record RangeSliderValue(Double start,
+        Double end) implements Serializable, Range<Double> {
 
     /**
      * Creates a new RangeSliderValue with the given start and end values.

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Slider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/Slider.java
@@ -15,9 +15,6 @@
  */
 package com.vaadin.flow.component.slider;
 
-import java.util.Optional;
-
-import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -32,11 +29,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @Tag("vaadin-slider")
 @NpmPackage(value = "@vaadin/slider", version = "25.2.0-alpha6")
 @JsModule("@vaadin/slider/src/vaadin-slider.js")
-public class Slider extends SliderBase<Slider, Double> implements HasAriaLabel {
-
-    private static final double DEFAULT_MIN = 0.0;
-    private static final double DEFAULT_MAX = 100.0;
-
+public class Slider extends NumberSlider<Slider, Double> {
     /**
      * Constructs a {@code Slider} with min 0 and max 100. The initial value is
      * 0.
@@ -59,7 +52,7 @@ public class Slider extends SliderBase<Slider, Double> implements HasAriaLabel {
      *            the maximum value
      */
     public Slider(double min, double max) {
-        super(min, max, Double.class, (v) -> v, (v) -> v);
+        super(min, max, (v) -> v, (v) -> v);
     }
 
     /**
@@ -92,155 +85,5 @@ public class Slider extends SliderBase<Slider, Double> implements HasAriaLabel {
     public Slider(String label, double min, double max) {
         this(min, max);
         setLabel(label);
-    }
-
-    /**
-     * Sets an accessible name for the range input element of the slider.
-     *
-     * @param ariaLabel
-     *            the accessible name to set, or {@code null} to remove it
-     */
-    @Override
-    public void setAriaLabel(String ariaLabel) {
-        getElement().setProperty("accessibleName", ariaLabel);
-    }
-
-    /**
-     * Gets the accessible name for the range input element of the slider.
-     *
-     * @return an optional accessible name, or an empty optional if no
-     *         accessible name has been set
-     */
-    @Override
-    public Optional<String> getAriaLabel() {
-        return Optional.ofNullable(getElement().getProperty("accessibleName"));
-    }
-
-    /**
-     * Sets the id of an element to be used as the accessible name for the range
-     * input element of the slider.
-     *
-     * @param ariaLabelledBy
-     *            the id of the element to be used as the label, or {@code null}
-     *            to remove it
-     */
-    @Override
-    public void setAriaLabelledBy(String ariaLabelledBy) {
-        getElement().setProperty("accessibleNameRef", ariaLabelledBy);
-    }
-
-    /**
-     * Gets the id of the element used as the accessible name for the range
-     * input element of the slider.
-     *
-     * @return an optional id of the element used as the label, or an empty
-     *         optional if no id has been set
-     */
-    @Override
-    public Optional<String> getAriaLabelledBy() {
-        return Optional
-                .ofNullable(getElement().getProperty("accessibleNameRef"));
-    }
-
-    /**
-     * Gets the minimum value of the slider.
-     *
-     * @return the minimum value
-     */
-    public double getMin() {
-        return super.getMinDouble();
-    }
-
-    /**
-     * Sets the minimum value of the slider.
-     *
-     * @param min
-     *            the minimum value
-     */
-    public void setMin(double min) {
-        setMinDouble(min);
-    }
-
-    /**
-     * Gets the maximum value of the slider.
-     *
-     * @return the maximum value
-     */
-    public double getMax() {
-        return super.getMaxDouble();
-    }
-
-    /**
-     * Sets the maximum value of the slider.
-     *
-     * @param max
-     *            the maximum value
-     */
-    public void setMax(double max) {
-        setMaxDouble(max);
-    }
-
-    /**
-     * Gets the step value of the slider.
-     * <p>
-     * Valid slider values are calculated relative to the minimum value:
-     * {@code min}, {@code min + step}, {@code min + 2*step}, etc.
-     *
-     * @return the step value
-     */
-    public double getStep() {
-        return super.getStepDouble();
-    }
-
-    /**
-     * Sets the step value of the slider.
-     * <p>
-     * Valid slider values are calculated relative to the minimum value:
-     * {@code min}, {@code min + step}, {@code min + 2*step}, etc.
-     *
-     * @param step
-     *            the step value
-     */
-    public void setStep(double step) {
-        setStepDouble(step);
-    }
-
-    /**
-     * Clears the slider value, setting it to the minimum value.
-     *
-     * @see #getMin()
-     */
-    @Override
-    public void clear() {
-        setValue(getMin());
-    }
-
-    @Override
-    protected boolean hasValidValue() {
-        Double value = getElement().getProperty("value", 0.0);
-        return value != null && isValueWithinMinMax(value)
-                && isValueAlignedWithStep(value);
-    }
-
-    @Override
-    protected boolean isValueWithinMinMax(Double value) {
-        double min = getMinDouble();
-        double max = getMaxDouble();
-        if (min > max) {
-            return false;
-        }
-
-        return value.equals(SliderUtil.clampToMinMax(value, min, max));
-    }
-
-    @Override
-    protected boolean isValueAlignedWithStep(Double value) {
-        double min = getMinDouble();
-        double max = getMaxDouble();
-        if (min > max) {
-            return false;
-        }
-
-        return value.equals(SliderUtil.snapToStep(value, min, max, getStep()));
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -377,6 +377,7 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
 
     @Override
     public void setValue(TValue value) {
+        Objects.requireNonNull(value, "Value cannot be null");
         super.setValue(value);
         schedulePropertyConsistencyCheck();
     }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -424,6 +424,18 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
         }
     }
 
+    @Override
+    protected boolean hasValidValue() {
+        try {
+            TPresentation arrayValue = (TPresentation) getElement()
+                    .getPropertyRaw("value");
+            TValue value = presentationToModel.apply(arrayValue);
+            return isValueWithinMinMax(value) && isValueAlignedWithStep(value);
+        } catch (IllegalArgumentException | ClassCastException e) {
+            return false;
+        }
+    }
+
     abstract protected boolean isValueAlignedWithStep(TValue value);
 
     abstract protected boolean isValueWithinMinMax(TValue value);

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -55,14 +55,14 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
         HasValidationProperties, HasValueChangeMode, Focusable<TComponent>,
         KeyNotifier {
 
-    protected static final double DEFAULT_MIN = 0;
-    protected static final double DEFAULT_MAX = 100;
-    private static final double DEFAULT_STEP = 1;
+    static final double DEFAULT_MIN = 0;
+    static final double DEFAULT_MAX = 100;
+    static final double DEFAULT_STEP = 1;
 
-    protected final SerializableFunction<TPresentation, TValue> presentationToModel;
-    protected final SerializableFunction<TValue, TPresentation> modelToPresentation;
-    protected final SerializableFunction<Double, TNumber> fromDouble;
-    protected final SerializableFunction<TNumber, Double> toDouble;
+    final SerializableFunction<TPresentation, TValue> presentationToModel;
+    final SerializableFunction<TValue, TPresentation> modelToPresentation;
+    final SerializableFunction<Double, TNumber> fromDouble;
+    final SerializableFunction<TNumber, Double> toDouble;
 
     private ValueChangeMode currentMode;
 
@@ -94,8 +94,7 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      * @param toDouble
      *            a function to convert from the slider's number type to double
      */
-    protected SliderBase(TNumber min, TNumber max,
-            Class<TPresentation> presentationType,
+    SliderBase(TNumber min, TNumber max, Class<TPresentation> presentationType,
             SerializableFunction<TPresentation, TValue> presentationToModel,
             SerializableFunction<TValue, TPresentation> modelToPresentation,
             SerializableFunction<Double, TNumber> fromDouble,

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -85,10 +85,10 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      *            property
      * @param presentationToModel
      *            a function to convert a client-side presentation value to the
-     *            slider's range value type
+     *            slider's value type
      * @param modelToPresentation
-     *            a function to convert a value of the slider's range value type
-     *            to client-side presentation
+     *            a function to convert a value of the slider's value type to
+     *            client-side presentation
      * @param fromDouble
      *            a function to convert from double to the slider's number type
      * @param toDouble
@@ -202,12 +202,12 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      */
     public void setStep(TNumber step) {
         Objects.requireNonNull(step, "Step value cannot be null");
-        double stepValue = toDouble.apply(step);
-        if (stepValue <= 0) {
+        double stepDouble = toDouble.apply(step);
+        if (stepDouble <= 0) {
             throw new IllegalArgumentException(
                     "The step must be greater than 0.");
         }
-        getElement().setProperty("step", stepValue);
+        getElement().setProperty("step", stepDouble);
         schedulePropertyConsistencyCheck();
     }
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -115,8 +115,6 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
         setMin(min);
         setMax(max);
         setStep(fromDouble.apply(DEFAULT_STEP));
-        clear();
-
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
     }
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -395,9 +395,9 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
     }
 
     private void warnIfPropertiesInconsistent() {
-        Double min = toDouble.apply(getMin());
-        Double max = toDouble.apply(getMax());
-        Double step = toDouble.apply(getStep());
+        double min = toDouble.apply(getMin());
+        double max = toDouble.apply(getMax());
+        double step = toDouble.apply(getStep());
         TValue value = getValue();
 
         if (min > max) {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.slider;
 
+import java.util.Objects;
+
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.experimental.FeatureFlags;
@@ -39,17 +41,28 @@ import com.vaadin.flow.signals.Signal;
  * @param <TComponent>
  *            the component type
  * @param <TValue>
- *            the value type
+ *            the model value type
+ * @param <TNumber>
+ *            the number type used for min, max, and step properties
+ * @param <TPresentation>
+ *            the presentation type used by the element property
  *
  * @author Vaadin Ltd
  */
-abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TValue>
+abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNumber, TPresentation>, TValue, TNumber extends Number, TPresentation>
         extends AbstractSinglePropertyField<TComponent, TValue> implements
         InputField<ComponentValueChangeEvent<TComponent, TValue>, TValue>,
         HasValidationProperties, HasValueChangeMode, Focusable<TComponent>,
         KeyNotifier {
 
-    private static final double DEFAULT_STEP = 1.0;
+    protected static final double DEFAULT_MIN = 0;
+    protected static final double DEFAULT_MAX = 100;
+    private static final double DEFAULT_STEP = 1;
+
+    protected final SerializableFunction<TPresentation, TValue> presentationToModel;
+    protected final SerializableFunction<TValue, TPresentation> modelToPresentation;
+    protected final SerializableFunction<Double, TNumber> fromDouble;
+    protected final SerializableFunction<TNumber, Double> toDouble;
 
     private ValueChangeMode currentMode;
 
@@ -68,27 +81,40 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      * @param max
      *            the maximum value
      * @param presentationType
-     *            the class of the presentation type
+     *            the class of the presentation type used by the element
+     *            property
      * @param presentationToModel
-     *            a function to convert from presentation to model
+     *            a function to convert a client-side presentation value to the
+     *            slider's range value type
      * @param modelToPresentation
-     *            a function to convert from model to presentation
+     *            a function to convert a value of the slider's range value type
+     *            to client-side presentation
+     * @param fromDouble
+     *            a function to convert from double to the slider's number type
+     * @param toDouble
+     *            a function to convert from the slider's number type to double
      */
-    protected <TPresentation> SliderBase(double min, double max,
+    protected SliderBase(TNumber min, TNumber max,
             Class<TPresentation> presentationType,
             SerializableFunction<TPresentation, TValue> presentationToModel,
-            SerializableFunction<TValue, TPresentation> modelToPresentation) {
+            SerializableFunction<TValue, TPresentation> modelToPresentation,
+            SerializableFunction<Double, TNumber> fromDouble,
+            SerializableFunction<TNumber, Double> toDouble) {
         super("value", null, presentationType, presentationToModel,
                 modelToPresentation);
+        this.presentationToModel = presentationToModel;
+        this.modelToPresentation = modelToPresentation;
+        this.fromDouble = fromDouble;
+        this.toDouble = toDouble;
 
         getElement().setProperty("manualValidation", true);
 
         // workaround for https://github.com/vaadin/flow/issues/3496
         setInvalid(false);
 
-        setMinDouble(min);
-        setMaxDouble(max);
-        setStepDouble(DEFAULT_STEP);
+        setMin(min);
+        setMax(max);
+        setStep(fromDouble.apply(DEFAULT_STEP));
         clear();
 
         setValueChangeMode(ValueChangeMode.ON_CHANGE);
@@ -116,26 +142,8 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *
      * @return the minimum value
      */
-    double getMinDouble() {
-        return getElement().getProperty("min", 0.0);
-    }
-
-    /**
-     * Gets the maximum value of the slider.
-     *
-     * @return the maximum value
-     */
-    double getMaxDouble() {
-        return getElement().getProperty("max", 100.0);
-    }
-
-    /**
-     * Gets the step value of the slider.
-     *
-     * @return the step value
-     */
-    double getStepDouble() {
-        return getElement().getProperty("step", 1.0);
+    public TNumber getMin() {
+        return fromDouble.apply(getElement().getProperty("min", 0.0));
     }
 
     /**
@@ -144,9 +152,19 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      * @param min
      *            the minimum value
      */
-    void setMinDouble(double min) {
-        getElement().setProperty("min", min);
+    public void setMin(TNumber min) {
+        Objects.requireNonNull(min, "Min value cannot be null");
+        getElement().setProperty("min", toDouble.apply(min));
         schedulePropertyConsistencyCheck();
+    }
+
+    /**
+     * Gets the maximum value of the slider.
+     *
+     * @return the maximum value
+     */
+    public TNumber getMax() {
+        return fromDouble.apply(getElement().getProperty("max", 100.0));
     }
 
     /**
@@ -155,23 +173,41 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      * @param max
      *            the maximum value
      */
-    void setMaxDouble(double max) {
-        getElement().setProperty("max", max);
+    public void setMax(TNumber max) {
+        Objects.requireNonNull(max, "Max value cannot be null");
+        getElement().setProperty("max", toDouble.apply(max));
         schedulePropertyConsistencyCheck();
     }
 
     /**
+     * Gets the step value of the slider.
+     * <p>
+     * Valid slider values are calculated relative to the minimum value:
+     * {@code min}, {@code min + step}, {@code min + 2*step}, etc.
+     *
+     * @return the step value
+     */
+    public TNumber getStep() {
+        return fromDouble.apply(getElement().getProperty("step", 1.0));
+    }
+
+    /**
      * Sets the step value of the slider.
+     * <p>
+     * Valid slider values are calculated relative to the minimum value:
+     * {@code min}, {@code min + step}, {@code min + 2*step}, etc.
      *
      * @param step
      *            the step value
      */
-    void setStepDouble(double step) {
-        if (step <= 0) {
+    public void setStep(TNumber step) {
+        Objects.requireNonNull(step, "Step value cannot be null");
+        double stepValue = toDouble.apply(step);
+        if (stepValue <= 0) {
             throw new IllegalArgumentException(
                     "The step must be greater than 0.");
         }
-        getElement().setProperty("step", step);
+        getElement().setProperty("step", stepValue);
         schedulePropertyConsistencyCheck();
     }
 
@@ -198,8 +234,9 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *      SerializableConsumer)
      * @since 25.1
      */
-    public SignalBinding<Double> bindMin(Signal<Double> signal) {
-        return getElement().bindProperty("min", signal, null);
+    public SignalBinding<Double> bindMin(Signal<TNumber> signal) {
+        var doubleSignal = signal.map(v -> toDouble.apply(v));
+        return getElement().bindProperty("min", doubleSignal, null);
     }
 
     /**
@@ -225,8 +262,9 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *      SerializableConsumer)
      * @since 25.1
      */
-    public SignalBinding<Double> bindMax(Signal<Double> signal) {
-        return getElement().bindProperty("max", signal, null);
+    public SignalBinding<Double> bindMax(Signal<TNumber> signal) {
+        var doubleSignal = signal.map(v -> toDouble.apply(v));
+        return getElement().bindProperty("max", doubleSignal, null);
     }
 
     /**
@@ -252,8 +290,9 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
      *      SerializableConsumer)
      * @since 25.1
      */
-    public SignalBinding<Double> bindStep(Signal<Double> signal) {
-        return getElement().bindProperty("step", signal, null);
+    public SignalBinding<Double> bindStep(Signal<TNumber> signal) {
+        var doubleSignal = signal.map(v -> toDouble.apply(v));
+        return getElement().bindProperty("step", doubleSignal, null);
     }
 
     /**
@@ -356,9 +395,9 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue>, TVa
     }
 
     private void warnIfPropertiesInconsistent() {
-        double min = getMinDouble();
-        double max = getMaxDouble();
-        double step = getStepDouble();
+        Double min = toDouble.apply(getMin());
+        Double max = toDouble.apply(getMax());
+        Double step = toDouble.apply(getStep());
         TValue value = getValue();
 
         if (min > max) {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderBase.java
@@ -143,7 +143,7 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      * @return the minimum value
      */
     public TNumber getMin() {
-        return fromDouble.apply(getElement().getProperty("min", 0.0));
+        return fromDouble.apply(getElement().getProperty("min", DEFAULT_MIN));
     }
 
     /**
@@ -164,7 +164,7 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      * @return the maximum value
      */
     public TNumber getMax() {
-        return fromDouble.apply(getElement().getProperty("max", 100.0));
+        return fromDouble.apply(getElement().getProperty("max", DEFAULT_MAX));
     }
 
     /**
@@ -188,7 +188,7 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      * @return the step value
      */
     public TNumber getStep() {
-        return fromDouble.apply(getElement().getProperty("step", 1.0));
+        return fromDouble.apply(getElement().getProperty("step", DEFAULT_STEP));
     }
 
     /**
@@ -234,9 +234,8 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      *      SerializableConsumer)
      * @since 25.1
      */
-    public SignalBinding<Double> bindMin(Signal<TNumber> signal) {
-        var doubleSignal = signal.map(v -> toDouble.apply(v));
-        return getElement().bindProperty("min", doubleSignal, null);
+    public SignalBinding<TNumber> bindMin(Signal<TNumber> signal) {
+        return getElement().bindProperty("min", signal, null);
     }
 
     /**
@@ -262,9 +261,8 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      *      SerializableConsumer)
      * @since 25.1
      */
-    public SignalBinding<Double> bindMax(Signal<TNumber> signal) {
-        var doubleSignal = signal.map(v -> toDouble.apply(v));
-        return getElement().bindProperty("max", doubleSignal, null);
+    public SignalBinding<TNumber> bindMax(Signal<TNumber> signal) {
+        return getElement().bindProperty("max", signal, null);
     }
 
     /**
@@ -290,9 +288,8 @@ abstract class SliderBase<TComponent extends SliderBase<TComponent, TValue, TNum
      *      SerializableConsumer)
      * @since 25.1
      */
-    public SignalBinding<Double> bindStep(Signal<TNumber> signal) {
-        var doubleSignal = signal.map(v -> toDouble.apply(v));
-        return getElement().bindProperty("step", doubleSignal, null);
+    public SignalBinding<TNumber> bindStep(Signal<TNumber> signal) {
+        return getElement().bindProperty("step", signal, null);
     }
 
     /**

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/RangeSliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/RangeSliderTest.java
@@ -69,6 +69,18 @@ class RangeSliderTest {
     }
 
     @Test
+    void rangeSliderValue_nullStart_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new RangeSliderValue(null, 100.0));
+    }
+
+    @Test
+    void rangeSliderValue_nullEnd_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new RangeSliderValue(0.0, null));
+    }
+
+    @Test
     void setMin_updatesProperty() {
         RangeSlider slider = new RangeSlider();
         slider.setMin(10.0);
@@ -76,6 +88,13 @@ class RangeSliderTest {
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(10, slider.getElement().getProperty("min", 0),
                 0);
+    }
+
+    @Test
+    void setMin_null_throws() {
+        RangeSlider slider = new RangeSlider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setMin(null));
     }
 
     @Test
@@ -89,6 +108,13 @@ class RangeSliderTest {
     }
 
     @Test
+    void setMax_null_throws() {
+        RangeSlider slider = new RangeSlider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setMax(null));
+    }
+
+    @Test
     void setStep_updatesProperty() {
         RangeSlider slider = new RangeSlider();
         slider.setStep(0.1);
@@ -96,6 +122,13 @@ class RangeSliderTest {
         Assertions.assertEquals(0.1, slider.getStep(), 0);
         Assertions.assertEquals(0.1,
                 slider.getElement().getProperty("step", 0.0), 0);
+    }
+
+    @Test
+    void setStep_null_throws() {
+        RangeSlider slider = new RangeSlider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setStep(null));
     }
 
     @Test
@@ -220,6 +253,13 @@ class RangeSliderTest {
         slider.getElement().setPropertyJson("value", createValueArray(80, 20));
         Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
+    }
+
+    @Test
+    void setValue_null_throws() {
+        RangeSlider slider = new RangeSlider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setValue(null));
     }
 
     @Test

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/RangeSliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/RangeSliderTest.java
@@ -33,7 +33,7 @@ class RangeSliderTest {
         RangeSlider slider = new RangeSlider();
         Assertions.assertEquals(0, slider.getMin(), 0);
         Assertions.assertEquals(100, slider.getMax(), 0);
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
@@ -43,7 +43,7 @@ class RangeSliderTest {
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(50, slider.getMax(), 0);
         Assertions.assertEquals(1, slider.getStep(), 0);
-        Assertions.assertEquals(new RangeSliderValue(10, 50),
+        Assertions.assertEquals(new RangeSliderValue(10.0, 50.0),
                 slider.getValue());
     }
 
@@ -53,7 +53,7 @@ class RangeSliderTest {
         Assertions.assertEquals("Label", slider.getLabel());
         Assertions.assertEquals(0, slider.getMin(), 0);
         Assertions.assertEquals(100, slider.getMax(), 0);
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
@@ -64,14 +64,14 @@ class RangeSliderTest {
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(50, slider.getMax(), 0);
         Assertions.assertEquals(1, slider.getStep(), 0);
-        Assertions.assertEquals(new RangeSliderValue(10, 50),
+        Assertions.assertEquals(new RangeSliderValue(10.0, 50.0),
                 slider.getValue());
     }
 
     @Test
     void setMin_updatesProperty() {
         RangeSlider slider = new RangeSlider();
-        slider.setMin(10);
+        slider.setMin(10.0);
 
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(10, slider.getElement().getProperty("min", 0),
@@ -81,7 +81,7 @@ class RangeSliderTest {
     @Test
     void setMax_updatesProperty() {
         RangeSlider slider = new RangeSlider();
-        slider.setMax(200);
+        slider.setMax(200.0);
 
         Assertions.assertEquals(200, slider.getMax(), 0);
         Assertions.assertEquals(200, slider.getElement().getProperty("max", 0),
@@ -171,54 +171,54 @@ class RangeSliderTest {
     @Test
     void setValueFromClient_null_ignored() {
         RangeSlider slider = new RangeSlider();
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", JacksonUtils.nullNode());
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_startNotAlignedWithStep_ignored() {
         RangeSlider slider = new RangeSlider();
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(15, 80));
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_endNotAlignedWithStep_ignored() {
         RangeSlider slider = new RangeSlider();
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(20, 85));
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_startBelowMin_ignored() {
         RangeSlider slider = new RangeSlider();
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(-10, 50));
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_endAboveMax_ignored() {
         RangeSlider slider = new RangeSlider();
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(50, 110));
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_startGreaterThanEnd_ignored() {
         RangeSlider slider = new RangeSlider();
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(80, 20));
-        Assertions.assertEquals(new RangeSliderValue(0, 100),
+        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/RangeSliderWarningsTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/RangeSliderWarningsTest.java
@@ -63,7 +63,7 @@ class RangeSliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setMin(200);
+        slider.setMin(200.0);
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(Mockito.contains("min"),
@@ -77,7 +77,7 @@ class RangeSliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setMax(-10);
+        slider.setMax(-10.0);
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(Mockito.contains("min"),
@@ -91,41 +91,41 @@ class RangeSliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setValue(new RangeSliderValue(0, 150));
+        slider.setValue(new RangeSliderValue(0.0, 150.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(
                 Mockito.contains("outside the configured range"),
-                Mockito.eq(new RangeSliderValue(0, 150)), Mockito.eq(0.0),
+                Mockito.eq(new RangeSliderValue(0.0, 150.0)), Mockito.eq(0.0),
                 Mockito.eq(100.0));
     }
 
     @Test
     void setValueNotAlignedWithStep_warnsValueNotAligned() {
         RangeSlider slider = new RangeSlider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setValue(new RangeSliderValue(0, 15));
+        slider.setValue(new RangeSliderValue(0.0, 15.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(
                 Mockito.contains("not aligned with step"),
-                Mockito.eq(new RangeSliderValue(0, 15)), Mockito.eq(0.0),
+                Mockito.eq(new RangeSliderValue(0.0, 15.0)), Mockito.eq(0.0),
                 Mockito.eq(100.0), Mockito.eq(10.0));
     }
 
     @Test
     void setConsistentProperties_noWarnings() {
         RangeSlider slider = new RangeSlider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setValue(new RangeSliderValue(20, 80));
+        slider.setValue(new RangeSliderValue(20.0, 80.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger, Mockito.never()).warn(Mockito.anyString(),
@@ -139,10 +139,10 @@ class RangeSliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setMin(10);
-        slider.setMax(50);
-        slider.setStep(5);
-        slider.setValue(new RangeSliderValue(15, 45));
+        slider.setMin(10.0);
+        slider.setMax(50.0);
+        slider.setStep(5.0);
+        slider.setValue(new RangeSliderValue(15.0, 45.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger, Mockito.never()).warn(Mockito.anyString(),

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/SliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/SliderTest.java
@@ -71,6 +71,13 @@ class SliderTest {
     }
 
     @Test
+    void setMin_null_throws() {
+        Slider slider = new Slider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setMin(null));
+    }
+
+    @Test
     void setMax_updatesProperty() {
         Slider slider = new Slider();
         slider.setMax(200.0);
@@ -81,6 +88,13 @@ class SliderTest {
     }
 
     @Test
+    void setMax_null_throws() {
+        Slider slider = new Slider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setMax(null));
+    }
+
+    @Test
     void setStep_updatesProperty() {
         Slider slider = new Slider();
         slider.setStep(0.1);
@@ -88,6 +102,13 @@ class SliderTest {
         Assertions.assertEquals(0.1, slider.getStep(), 0);
         Assertions.assertEquals(0.1,
                 slider.getElement().getProperty("step", 0.0), 0);
+    }
+
+    @Test
+    void setStep_null_throws() {
+        Slider slider = new Slider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setStep(null));
     }
 
     @Test
@@ -170,6 +191,13 @@ class SliderTest {
         Assertions.assertFalse(slider.isMinMaxVisible());
         Assertions.assertFalse(
                 slider.getElement().getProperty("minMaxVisible", false));
+    }
+
+    @Test
+    void setValue_null_throws() {
+        Slider slider = new Slider();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> slider.setValue(null));
     }
 
     @Test

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/SliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/SliderTest.java
@@ -63,7 +63,7 @@ class SliderTest {
     @Test
     void setMin_updatesProperty() {
         Slider slider = new Slider();
-        slider.setMin(10);
+        slider.setMin(10.0);
 
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(10, slider.getElement().getProperty("min", 0),
@@ -73,7 +73,7 @@ class SliderTest {
     @Test
     void setMax_updatesProperty() {
         Slider slider = new Slider();
-        slider.setMax(200);
+        slider.setMax(200.0);
 
         Assertions.assertEquals(200, slider.getMax(), 0);
         Assertions.assertEquals(200, slider.getElement().getProperty("max", 0),
@@ -175,7 +175,7 @@ class SliderTest {
     @Test
     void setValueFromClient_valueNotAlignedWithStep_ignored() {
         Slider slider = new Slider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setProperty("value", 15.0);
         Assertions.assertEquals(0, slider.getValue(), 0);
     }
@@ -183,7 +183,7 @@ class SliderTest {
     @Test
     void setValueFromClient_valueBelowMin_ignored() {
         Slider slider = new Slider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setProperty("value", -10.0);
         Assertions.assertEquals(0, slider.getValue(), 0);
     }
@@ -191,7 +191,7 @@ class SliderTest {
     @Test
     void setValueFromClient_valueAboveMax_ignored() {
         Slider slider = new Slider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         slider.getElement().setProperty("value", 110.0);
         Assertions.assertEquals(0, slider.getValue(), 0);
     }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/SliderWarningsTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/tests/SliderWarningsTest.java
@@ -62,7 +62,7 @@ class SliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setMin(200);
+        slider.setMin(200.0);
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(Mockito.contains("min"),
@@ -76,7 +76,7 @@ class SliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setMax(-10);
+        slider.setMax(-10.0);
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(Mockito.contains("min"),
@@ -101,7 +101,7 @@ class SliderWarningsTest {
     @Test
     void setValueNotAlignedWithStep_warnsValueNotAligned() {
         Slider slider = new Slider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -117,7 +117,7 @@ class SliderWarningsTest {
     @Test
     void setConsistentProperties_noWarnings() {
         Slider slider = new Slider(0, 100);
-        slider.setStep(10);
+        slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -136,9 +136,9 @@ class SliderWarningsTest {
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setMin(10);
-        slider.setMax(50);
-        slider.setStep(5);
+        slider.setMin(10.0);
+        slider.setMax(50.0);
+        slider.setStep(5.0);
         slider.setValue(25.0);
         ui.fakeClientCommunication();
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/RangeSliderBinderValidationTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/RangeSliderBinderValidationTest.java
@@ -31,7 +31,7 @@ class RangeSliderBinderValidationTest {
     private Binder<Bean> binder;
 
     public static class Bean {
-        private RangeSliderValue value = new RangeSliderValue(0, 100);
+        private RangeSliderValue value = new RangeSliderValue(0.0, 100.0);
 
         public RangeSliderValue getValue() {
             return value;
@@ -54,7 +54,7 @@ class RangeSliderBinderValidationTest {
 
     @Test
     void setValue_validatorPasses_noValidationError() {
-        rangeSlider.setValue(new RangeSliderValue(0, 50));
+        rangeSlider.setValue(new RangeSliderValue(0.0, 50.0));
 
         BindingValidationStatus<?> status = binder.validate()
                 .getFieldValidationStatuses().get(0);
@@ -64,7 +64,7 @@ class RangeSliderBinderValidationTest {
 
     @Test
     void setValue_validatorFails_hasValidationError() {
-        rangeSlider.setValue(new RangeSliderValue(0, 49));
+        rangeSlider.setValue(new RangeSliderValue(0.0, 49.0));
 
         BindingValidationStatus<?> status = binder.validate()
                 .getFieldValidationStatuses().get(0);
@@ -76,7 +76,7 @@ class RangeSliderBinderValidationTest {
 
     @Test
     void readBean_null_setsEmptyValue() {
-        rangeSlider.setValue(new RangeSliderValue(25, 75));
+        rangeSlider.setValue(new RangeSliderValue(25.0, 75.0));
         binder.readBean(null);
 
         Assertions.assertEquals(new RangeSliderValue(rangeSlider.getMin(),


### PR DESCRIPTION
## Description

As a preparation for introducing an integer variant of Slider and Range Slider, this extracts common logic for single value / range value sliders into `NumberSlider` / `NumberRangeSlider`.

This moves the min, max and step properties to `SliderBase` using a generic number type. Likewise, the start and end values of range slider values now also use a generic type to facilitate internal logic. As a side effect, all of these now require passing a double literal (`10.0`, `10d`) as auto-converting from an integer literal to a boxed double is not supported by Java.

Part of https://github.com/vaadin/flow-components/issues/8863

## Type of change

- Breaking change