### PR TITLE
fix: avoid NPE in ChartRenderer when chart type is null

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -170,7 +170,7 @@ public final class ChartRenderer implements Serializable {
         // Collects from all series to handle multi-series with different
         // categories (e.g. stacked by region where each region has
         // different months).
-        if (!NO_CATEGORY_AXIS_TYPES.contains(chartType)) {
+        if (chartType == null || !NO_CATEGORY_AXIS_TYPES.contains(chartType)) {
             var categories = extractCategories(allItems);
             if (!categories.isEmpty()) {
                 xAxis.setCategories(categories.toArray(new String[0]));

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -483,6 +483,23 @@ class ChartRenderingTest {
         }
 
         @Test
+        void nullChartTypeSetsCategoriesFromNames() {
+            databaseProvider.results = List.of(
+                    row("category", "Jan", "value", 100),
+                    row("category", "Feb", "value", 200));
+
+            updateData("SELECT category, value FROM t");
+            controller.onRequestCompleted();
+
+            String[] categories = chart.getConfiguration().getxAxis()
+                    .getCategories();
+            Assertions.assertNotNull(categories,
+                    "Categories should be set when chart type is null");
+            Assertions.assertArrayEquals(new String[] { "Jan", "Feb" },
+                    categories);
+        }
+
+        @Test
         void mixedXValuesSmallAndLargeDoesNotSetDatetime() {
             // First value is a timestamp, second is small — should NOT be
             // detected as datetime since not all values qualify


### PR DESCRIPTION
## Summary
- Fixes NPE in `ChartRenderer.applyAxisDefaults` when chart type is not set (data-only update without configuration). `Set.of().contains(null)` throws NPE; added null guard to treat unset type as default (line chart with category axis).
- Found during a DX test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)