### PR TITLE
fix: resolve unrecognized chart ID to single available chart

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -192,16 +192,11 @@ public final class ChartAITools {
      */
     private static String resolveChartId(JsonNode args, Callbacks callbacks) {
         var ids = callbacks.getChartIds();
-        JsonNode idNode = args.get("chartId");
+        var idNode = args.get("chartId");
         if (idNode != null && !idNode.isNull()) {
-            String chartId = idNode.asString();
+            var chartId = idNode.asString();
             if (ids.contains(chartId)) {
                 return chartId;
-            }
-            // LLM provided an unrecognized ID; fall back to the single
-            // chart if there is exactly one, otherwise report the error.
-            if (ids.size() == 1) {
-                return ids.iterator().next();
             }
         }
         if (ids.size() == 1) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -191,11 +191,19 @@ public final class ChartAITools {
      * default.
      */
     private static String resolveChartId(JsonNode args, Callbacks callbacks) {
+        var ids = callbacks.getChartIds();
         JsonNode idNode = args.get("chartId");
         if (idNode != null && !idNode.isNull()) {
-            return idNode.asString();
+            String chartId = idNode.asString();
+            if (ids.contains(chartId)) {
+                return chartId;
+            }
+            // LLM provided an unrecognized ID; fall back to the single
+            // chart if there is exactly one, otherwise report the error.
+            if (ids.size() == 1) {
+                return ids.iterator().next();
+            }
         }
-        var ids = callbacks.getChartIds();
         if (ids.size() == 1) {
             return ids.iterator().next();
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -192,18 +192,15 @@ public final class ChartAITools {
      */
     private static String resolveChartId(JsonNode args, Callbacks callbacks) {
         var ids = callbacks.getChartIds();
-        var idNode = args.get("chartId");
-        if (idNode != null && !idNode.isNull()) {
-            var chartId = idNode.asString();
-            if (ids.contains(chartId)) {
-                return chartId;
-            }
+        if (ids.isEmpty()) {
+            throw new IllegalArgumentException("No charts available.");
         }
         if (ids.size() == 1) {
             return ids.iterator().next();
         }
-        if (ids.isEmpty()) {
-            throw new IllegalArgumentException("No charts available.");
+        var idNode = args.get("chartId");
+        if (idNode != null && ids.contains(idNode.asString())) {
+            return idNode.asString();
         }
         throw new IllegalArgumentException(
                 "chartId is required when multiple charts exist. "

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -125,6 +125,15 @@ class ChartAIToolsTest {
         }
 
         @Test
+        void execute_withUnrecognizedChartId_andSingleChart_defaultsToThatChart() {
+            callbacks.chartIds = Set.of("chart");
+            callbacks.stateToReturn = "state";
+            var result = tool.execute("{\"chartId\": \"1\"}");
+            Assertions.assertEquals("state", result);
+            Assertions.assertEquals("chart", callbacks.lastGetStateId);
+        }
+
+        @Test
         void execute_whenCallbackThrows_returnsError() {
             callbacks.getStateException = new RuntimeException(
                     "Chart not found");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -101,6 +101,23 @@ class ChartAIToolsTest {
         }
 
         @Test
+        void execute_withMultipleCharts_andExplicitChartId_resolvesCorrectChart() {
+            callbacks.chartIds = Set.of("chart-1", "chart-2");
+            callbacks.stateToReturn = "state-of-chart-2";
+            var result = tool.execute("{\"chartId\": \"chart-2\"}");
+            Assertions.assertEquals("state-of-chart-2", result);
+            Assertions.assertEquals("chart-2", callbacks.lastGetStateId);
+        }
+
+        @Test
+        void execute_withMultipleCharts_andUnrecognizedChartId_returnsError() {
+            callbacks.chartIds = Set.of("chart-1", "chart-2");
+            var result = tool.execute("{\"chartId\": \"bogus\"}");
+            Assertions.assertTrue(result.contains("Error"));
+            Assertions.assertTrue(result.contains("chartId is required"));
+        }
+
+        @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
             var result = tool.execute("{}");


### PR DESCRIPTION
## Summary
- Fixes `IllegalStateException` in `ChartEntry.getOrCreate` when the LLM provides an unrecognized `chartId` (e.g. `"1"` instead of `"chart"`). `resolveChartId` now validates the provided ID against available charts and falls back to the single available chart when there is exactly one.
- Found during a DX test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)