### PR TITLE
feat: add OHLC volume series guidance to chart AI tools

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -574,6 +574,10 @@ public final class ChartAITools {
                                 OHLC/Candlestick:
                                 - Columns: {X}, {OPEN}, {HIGH}, {LOW}, {CLOSE} ({X} is required for proper date axis)
                                 - Example: SELECT date AS {X}, open AS {OPEN}, high AS {HIGH}, low AS {LOW}, close AS {CLOSE} FROM stock_prices
+                                - When adding a volume series alongside OHLC/candlestick data, use a separate query \
+                                with {X}, {Y}, and {SERIES} aliases (e.g. SELECT date AS {X}, volume AS {Y}, 'Volume' AS {SERIES} \
+                                FROM stock_prices). The {SERIES} alias names the series so it can be configured via \
+                                update_chart_configuration() with type "column" and yAxis 1 on a dual y-axis setup.
 
                                 Sankey diagram:
                                 - 3 columns: {FROM}, {TO}, {WEIGHT}


### PR DESCRIPTION
## Summary
- Adds LLM guidance for the OHLC/candlestick + volume series pattern to the `update_chart_data_source` tool description
- Instructs the LLM to use `_x`, `_y`, and `_series` aliases for the volume query so the series gets proper datetime X values and a name for per-series config matching

### Testing

- The fix can be tested using branch `fix/chart-ai-controller-candlestick-volume-test`

Before:
<img width="888" height="631" alt="candlestick-before" src="https://github.com/user-attachments/assets/7f22c7ad-efbe-45f0-aede-94bb24af46bf" />

After:
<img width="889" height="632" alt="candlestick-after" src="https://github.com/user-attachments/assets/4d669be5-29df-41ab-b5ba-31748f2217ef" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)