### PR TITLE
refactor: throw on invalid tool name and validate on controller set

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,6 +129,14 @@ public class AIOrchestrator implements Serializable {
      * The feature flag ID for AI components.
      */
     static final String FEATURE_FLAG_ID = AIComponentsFeatureFlagProvider.FEATURE_FLAG_ID;
+
+    /**
+     * Pattern for valid tool names. Popular LLM APIs (OpenAI, Anthropic, etc.)
+     * require tool names to contain only alphanumeric characters, underscores,
+     * and hyphens, with a maximum length of 64 characters.
+     */
+    private static final Pattern VALID_TOOL_NAME_PATTERN = Pattern
+            .compile("^[a-zA-Z0-9_-]{1,64}$");
 
     private transient LLMProvider provider;
     private final String systemPrompt;
@@ -389,7 +398,6 @@ public class AIOrchestrator implements Serializable {
         var controllerTools = controller != null
                 && controller.getTools() != null ? controller.getTools()
                         : List.<LLMProvider.ToolSpec> of();
-        warnDuplicateToolNames(controllerTools);
         var request = new LLMProvider.LLMRequest() {
 
             @Override
@@ -441,14 +449,27 @@ public class AIOrchestrator implements Serializable {
         }
     }
 
-    private static void warnDuplicateToolNames(
-            List<LLMProvider.ToolSpec> tools) {
+    private static void validateToolNames(List<LLMProvider.ToolSpec> tools) {
         var seen = new HashSet<String>();
         for (var tool : tools) {
-            if (!seen.add(tool.getName())) {
+            var name = tool.getName();
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Tool name must not be null or empty.");
+            }
+            if (!VALID_TOOL_NAME_PATTERN.matcher(name).matches()) {
+                throw new IllegalArgumentException(
+                        "Tool name '" + name + "' is not valid. "
+                                + "Tool names must contain only alphanumeric "
+                                + "characters, underscores, and hyphens, "
+                                + "with a maximum length of 64 characters "
+                                + "(pattern: "
+                                + VALID_TOOL_NAME_PATTERN.pattern() + ").");
+            }
+            if (!seen.add(name)) {
                 LOGGER.warn(
                         "Duplicate tool name '{}': previous tool will be replaced",
-                        tool.getName());
+                        name);
             }
         }
     }
@@ -516,9 +537,14 @@ public class AIOrchestrator implements Serializable {
          * @param controller
          *            the controller to use, not {@code null}
          * @return this reconnector
+         * @throws IllegalArgumentException
+         *             if any tool name is invalid
          */
         public Reconnector withController(AIController controller) {
             Objects.requireNonNull(controller, "Controller cannot be null");
+            if (controller.getTools() != null) {
+                validateToolNames(controller.getTools());
+            }
             this.controller = controller;
             return this;
         }
@@ -790,9 +816,14 @@ public class AIOrchestrator implements Serializable {
          * @return this builder
          * @throws NullPointerException
          *             if controller is {@code null}
+         * @throws IllegalArgumentException
+         *             if any tool name is invalid
          */
         public Builder withController(AIController controller) {
             Objects.requireNonNull(controller, "Controller cannot be null");
+            if (controller.getTools() != null) {
+                validateToolNames(controller.getTools());
+            }
             warnIfAlreadySet(this.controller, "controller");
             this.controller = controller;
             return this;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -162,10 +162,15 @@ public interface LLMProvider {
     interface ToolSpec {
 
         /**
-         * Gets the unique name of this tool. To avoid name collisions, use a
+         * Gets the unique name of this tool. The name must contain only
+         * alphanumeric characters, underscores, and hyphens, with a maximum
+         * length of 64 characters (matching the pattern
+         * {@code ^[a-zA-Z0-9_-]{1,64}$}), as required by popular LLM APIs.
+         * Names that do not match this pattern will be rejected by the
+         * orchestrator at request time. To avoid name collisions, use a
          * namespaced name such as {@code "MyController_updateConfig"}.
          *
-         * @return the tool name, never {@code null}
+         * @return the tool name, never {@code null} or empty
          */
         String getName();
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1787,6 +1787,110 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void builder_withNullToolName_throwsIllegalArgumentException() {
+        var controller = createController(createToolSpec(null, "A tool"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertEquals("Tool name must not be null or empty.",
+                exception.getMessage());
+    }
+
+    @Test
+    void builder_withEmptyToolName_throwsIllegalArgumentException() {
+        var controller = createController(createToolSpec("", "A tool"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertEquals("Tool name must not be null or empty.",
+                exception.getMessage());
+    }
+
+    @Test
+    void builder_withInvalidToolNameContainingSpaces_throwsIllegalArgumentException() {
+        var controller = createController(createToolSpec("my tool", "A tool"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'my tool'"),
+                "Exception should mention the invalid tool name");
+    }
+
+    @Test
+    void builder_withInvalidToolNameContainingSpecialChars_throwsIllegalArgumentException() {
+        var controller = createController(
+                createToolSpec("tool@name!", "A tool"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'tool@name!'"),
+                "Exception should mention the invalid tool name");
+    }
+
+    @Test
+    void builder_withToolNameExceeding64Characters_throwsIllegalArgumentException() {
+        var controller = createController(
+                createToolSpec("a".repeat(65), "A tool"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+    }
+
+    @Test
+    void builder_withToolNameExactly64Characters_doesNotThrow() {
+        var controller = createController(
+                createToolSpec("a".repeat(64), "A tool"));
+
+        Assertions.assertDoesNotThrow(() -> AIOrchestrator
+                .builder(mockProvider, null).withController(controller));
+    }
+
+    @Test
+    void builder_withValidToolNameContainingUnderscoresAndHyphens_doesNotThrow() {
+        var controller = createController(
+                createToolSpec("my_tool-Name123", "A tool"));
+
+        Assertions.assertDoesNotThrow(() -> AIOrchestrator
+                .builder(mockProvider, null).withController(controller));
+    }
+
+    @Test
+    void builder_withInvalidToolNameContainingDots_throwsIllegalArgumentException() {
+        var controller = createController(
+                createToolSpec("my.tool.name", "A tool"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'my.tool.name'"),
+                "Exception should mention the invalid tool name");
+    }
+
+    @Test
+    void reconnect_withInvalidToolName_throwsIllegalArgumentException()
+            throws Exception {
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).build();
+
+        // Simulate deserialization: null out the transient provider field
+        var providerField = AIOrchestrator.class.getDeclaredField("provider");
+        providerField.setAccessible(true);
+        providerField.set(orchestrator, null);
+
+        var controller = createController(
+                createToolSpec("invalid tool!", "A tool"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> orchestrator.reconnect(mockProvider)
+                        .withController(controller));
+    }
+
+    @Test
     void builder_withControllerCalledTwice_logsWarning() {
         var orchestratorBuilder = AIOrchestrator.builder(mockProvider, null)
                 .withController(createController());


### PR DESCRIPTION
## Description

It is common to set an invalid tool name in the controllers. This leads to bad request responses from the LLM.

This PR updates the validation so that
- On top of the current warning on duplicate tool name, it validates the tool names to be in line with what OpenAI and Anthropic APIs accept
- Validates on setting and reconnecting the controller instead of validating on every request.

Finding from the DX test sessions.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.