### PR TITLE
proto: use custom aidatarow instead of map in grid controller

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/AIDataRow.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/AIDataRow.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.grid;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents a single row of data in an AI-managed grid. Row instances are
+ * created internally by the framework when rendering query results and should
+ * not be constructed or modified by application code.
+ * <p>
+ * This type exists to make the {@link GridAIController}'s grid type parameter
+ * explicit ({@code Grid<AIDataRow>}) and to signal that row data is
+ * framework-owned. Application code should interact with the grid's columns and
+ * state through the controller API, not through individual row values.
+ * </p>
+ *
+ * @author Vaadin Ltd
+ * @see GridAIController
+ * @see GridRenderer
+ */
+public final class AIDataRow implements Serializable {
+
+    private final Map<String, Object> values;
+
+    /**
+     * Creates a new row from the given column-value map.
+     *
+     * @param values
+     *            the column values keyed by column name, not {@code null}
+     */
+    AIDataRow(Map<String, Object> values) {
+        this.values = values;
+    }
+
+    /**
+     * Returns the value for the given column.
+     *
+     * @param column
+     *            the column name
+     * @return the value, or {@code null} if the column is not present
+     */
+    Object get(String column) {
+        return values.get(column);
+    }
+
+    /**
+     * Returns the set of column names in this row.
+     *
+     * @return the column names, never {@code null}
+     */
+    Set<Map.Entry<String, Object>> entries() {
+        return values.entrySet();
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.ai.grid;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -34,18 +33,24 @@ import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * AI controller for populating a {@link Grid} with database data via LLM tool
- * calls. Attach it to an {@link AIOrchestrator} via
+ * AI controller for populating a {@link Grid Grid&lt;AIDataRow&gt;} with
+ * database data via LLM tool calls. Attach it to an {@link AIOrchestrator} via
  * {@link AIOrchestrator.Builder#withController(AIController)} to expose its
  * tools to the LLM. The recommended system prompt is available from
  * {@link #getSystemPrompt()}.
  *
  * <pre>
+ * var grid = new Grid&lt;AIDataRow&gt;();
  * var controller = new GridAIController(grid, databaseProvider);
  * AIOrchestrator orchestrator = AIOrchestrator
  *         .builder(llmProvider, GridAIController.getSystemPrompt())
  *         .withController(controller).withMessageList(messageList).build();
  * </pre>
+ * <p>
+ * The grid uses {@link AIDataRow} as its item type. Row instances are created
+ * internally when query results are rendered and should not be constructed or
+ * accessed by application code.
+ * </p>
  * <p>
  * The grid automatically creates columns from query results with:
  * </p>
@@ -85,6 +90,7 @@ import com.vaadin.flow.shared.Registration;
  * </p>
  *
  * @author Vaadin Ltd
+ * @see AIDataRow
  * @see GridAITools
  * @see GridRenderer
  * @see GridState
@@ -97,7 +103,7 @@ public class GridAIController implements AIController {
 
     private static final String GRID_ID = "grid";
 
-    private final Grid<Map<String, Object>> grid;
+    private final Grid<AIDataRow> grid;
     private final DatabaseProvider databaseProvider;
     private final List<SerializableConsumer<GridState>> stateChangeListeners = new ArrayList<>();
 
@@ -110,7 +116,7 @@ public class GridAIController implements AIController {
      *            the database provider for schema and query execution, not
      *            {@code null}
      */
-    public GridAIController(Grid<Map<String, Object>> grid,
+    public GridAIController(Grid<AIDataRow> grid,
             DatabaseProvider databaseProvider) {
         this.grid = Objects.requireNonNull(grid, "Grid must not be null");
         this.databaseProvider = Objects.requireNonNull(databaseProvider,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridRenderer.java
@@ -22,7 +22,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -72,7 +71,7 @@ public final class GridRenderer implements Serializable {
      * @param query
      *            the SQL SELECT query, not {@code null}
      */
-    public static void renderGrid(Grid<Map<String, Object>> grid,
+    public static void renderGrid(Grid<AIDataRow> grid,
             DatabaseProvider databaseProvider, String query) {
         var sampleRows = databaseProvider.executeQuery(wrapWithLimit(query, 1));
         removeExtraHeaderRows(grid);
@@ -85,8 +84,9 @@ public final class GridRenderer implements Serializable {
             grid.setItems(List.of());
             return;
         }
-        var firstRow = sampleRows.getFirst();
-        var sortedColumns = new ArrayList<>(firstRow.entrySet());
+
+        var firstRow = new AIDataRow(sampleRows.getFirst());
+        var sortedColumns = new ArrayList<>(firstRow.entries());
         sortedColumns.sort((a, b) -> {
             var prefixA = GridFormatting.groupPrefix(a.getKey());
             var prefixB = GridFormatting.groupPrefix(b.getKey());
@@ -98,15 +98,16 @@ public final class GridRenderer implements Serializable {
         applyColumnGrouping(grid);
         var dataProvider = createDataProvider(databaseProvider, query);
         grid.setItems(dataProvider);
-        LOGGER.info("Grid configured with {} columns", firstRow.size());
+        LOGGER.info("Grid configured with {} columns",
+                firstRow.entries().size());
     }
 
-    private static void addColumn(Grid<Map<String, Object>> grid,
-            String columnName, Object sampleValue) {
+    private static void addColumn(Grid<AIDataRow> grid, String columnName,
+            Object sampleValue) {
         var header = GridFormatting
                 .formatHeader(GridFormatting.stripGroupPrefix(columnName));
 
-        Grid.Column<Map<String, Object>> column;
+        Grid.Column<AIDataRow> column;
 
         if (sampleValue instanceof LocalDate
                 || sampleValue instanceof java.sql.Date) {
@@ -132,8 +133,8 @@ public final class GridRenderer implements Serializable {
                 .setAutoWidth(true).setResizable(true);
     }
 
-    private static void applyColumnGrouping(Grid<Map<String, Object>> grid) {
-        var groups = new LinkedHashMap<String, List<Grid.Column<Map<String, Object>>>>();
+    private static void applyColumnGrouping(Grid<AIDataRow> grid) {
+        var groups = new LinkedHashMap<String, List<Grid.Column<AIDataRow>>>();
         for (var column : grid.getColumns()) {
             var key = column.getKey();
             var dotIndex = key.indexOf('.');
@@ -159,7 +160,7 @@ public final class GridRenderer implements Serializable {
         }
     }
 
-    private static void removeExtraHeaderRows(Grid<Map<String, Object>> grid) {
+    private static void removeExtraHeaderRows(Grid<AIDataRow> grid) {
         var headerRows = grid.getHeaderRows();
         while (headerRows.size() > 1) {
             grid.removeHeaderRow(headerRows.getFirst());
@@ -167,14 +168,15 @@ public final class GridRenderer implements Serializable {
         }
     }
 
-    private static DataProvider<Map<String, Object>, Void> createDataProvider(
+    private static DataProvider<AIDataRow, Void> createDataProvider(
             DatabaseProvider databaseProvider, String query) {
         var countQuery = wrapWithCount(query);
         return new CallbackDataProvider<>(fetchQuery -> {
             var sql = enrichQuery(query, fetchQuery.getOffset(),
                     fetchQuery.getLimit(), fetchQuery.getSortOrders());
             LOGGER.debug("Fetching rows: {}", sql);
-            return databaseProvider.executeQuery(sql).stream();
+            return databaseProvider.executeQuery(sql).stream()
+                    .map(AIDataRow::new);
         }, countFetchQuery -> {
             LOGGER.debug("Counting rows: {}", countQuery);
             var countResult = databaseProvider.executeQuery(countQuery);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -50,7 +50,7 @@ class GridAIControllerTest {
     @RegisterExtension
     MockUIExtension ui = new MockUIExtension();
 
-    private Grid<Map<String, Object>> grid;
+    private Grid<AIDataRow> grid;
     private StubDatabaseProvider dbProvider;
     private GridAIController controller;
 


### PR DESCRIPTION
## Description

This PR updates the grid in `GridAIController` to use a custom `AIDataRow` to represent a row instead of a map:
`Grid<Map<String, Object>>` -> `Grid<AIDataRow>` 

Prototype based on DX test findings

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.