### PR TITLE
fix: register Map resources on the Map element

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/serialization/MapSerializer.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/serialization/MapSerializer.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.map.MapBase;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
@@ -35,14 +36,14 @@ public class MapSerializer {
     private final ObjectMapper mapper;
     private final Map<Object, StreamRegistration> streamRegistrationCache = new HashMap<>();
 
-    public MapSerializer(com.vaadin.flow.component.map.MapBase map) {
+    public MapSerializer(MapBase map) {
         // Create mapper that automatically registers stream resources and
         // download handlers in the current UI's stream resource registry
         SimpleModule mapModule = new SimpleModule()
                 .addSerializer(StreamResource.class,
                         new StreamResourceSerializer())
                 .addSerializer(DownloadHandler.class,
-                        new DownloadHandlerSerializer());
+                        new DownloadHandlerSerializer(map));
         this.mapper = JsonMapper.builder().addModule(mapModule).build();
 
         // Unregister stream registrations when the map is detached
@@ -118,8 +119,11 @@ public class MapSerializer {
     private class DownloadHandlerSerializer
             extends StdSerializer<DownloadHandler> {
 
-        public DownloadHandlerSerializer() {
+        private final MapBase map;
+
+        public DownloadHandlerSerializer(MapBase map) {
             super(DownloadHandler.class);
+            this.map = map;
         }
 
         @Override
@@ -139,7 +143,8 @@ public class MapSerializer {
             if (registration == null) {
                 StreamResourceRegistry resourceRegistry = UI.getCurrentOrThrow()
                         .getSession().getResourceRegistry();
-                registration = resourceRegistry.registerResource(resource);
+                registration = resourceRegistry.registerResource(resource,
+                        map.getElement());
                 streamRegistrationCache.put(resource, registration);
             }
             return registration.getResourceUri();

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapSerializationTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapSerializationTest.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.map.configuration.layer.TileLayer;
 import com.vaadin.flow.component.map.configuration.source.OSMSource;
 import com.vaadin.flow.component.map.configuration.style.Icon;
 import com.vaadin.flow.component.map.configuration.style.Style;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamRegistration;
@@ -56,8 +57,9 @@ class MapSerializationTest {
                 .registerResource((AbstractStreamResource) Mockito.any()))
                 .thenReturn(streamRegistrationMock);
 
-        Mockito.when(streamResourceRegistryMock
-                .registerResource((ElementRequestHandler) Mockito.any()))
+        Mockito.when(streamResourceRegistryMock.registerResource(
+                (ElementRequestHandler) Mockito.any(),
+                Mockito.any(Element.class)))
                 .thenReturn(streamRegistrationMock, streamRegistrationMock);
 
         map = new Map();
@@ -117,7 +119,7 @@ class MapSerializationTest {
         ui.fakeClientCommunication();
 
         Mockito.verify(streamResourceRegistryMock, Mockito.times(1))
-                .registerResource(Assets.PIN.getHandler());
+                .registerResource(Assets.PIN.getHandler(), map.getElement());
         Mockito.clearInvocations(streamResourceRegistryMock);
 
         // Force another sync of the same icon
@@ -125,14 +127,14 @@ class MapSerializationTest {
         ui.fakeClientCommunication();
 
         Mockito.verify(streamResourceRegistryMock, Mockito.never())
-                .registerResource(Assets.PIN.getHandler());
+                .registerResource(Assets.PIN.getHandler(), map.getElement());
 
         // Sync a different icon with the same resource
         setupMarker();
         ui.fakeClientCommunication();
 
         Mockito.verify(streamResourceRegistryMock, Mockito.never())
-                .registerResource(Assets.PIN.getHandler());
+                .registerResource(Assets.PIN.getHandler(), map.getElement());
     }
 
     @Test
@@ -160,7 +162,7 @@ class MapSerializationTest {
         ui.fakeClientCommunication();
 
         Mockito.verify(streamResourceRegistryMock, Mockito.times(1))
-                .registerResource(Assets.PIN.getHandler());
+                .registerResource(Assets.PIN.getHandler(), map.getElement());
     }
 
     private MarkerFeature setupMarker() {


### PR DESCRIPTION
## Description

Map uses a custom JSON serializer to automatically register stream resources in the UI when it encounters those during serialization. Currently, those are registered on the UI itself and not on the Map element. This results in access to those resources being denied from the server while a server-side modal is opened.

This fixes the serializer to register the stream resources on the map. Thus clients are allowed to access these resources when the map is within a strict modal dialog for example.

Fixes https://github.com/vaadin/flow-components/issues/9129

## Type of change

- Bugfix
