### PR TITLE
chore: allow customizing Chrome binary

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -30,6 +30,11 @@ public abstract class AbstractComponentIT
         if (extraArgs != null && !extraArgs.isBlank()) {
             chromeOptions.addArguments(extraArgs.split("\\s+"));
         }
+
+        String chromeBinary = System.getenv("TESTBENCH_CHROME_BINARY");
+        if (chromeBinary != null && !chromeBinary.isBlank()) {
+            chromeOptions.setBinary(chromeBinary);
+        }
     }
 
     @Override


### PR DESCRIPTION
When running integration tests, especially for larger test suites, I usually have the issue that one or two Chrome instances become unresponsive and cause individual tests to stall for about a minute. While this doesn't resolve in test failures, as the underlying ChromeBrowserTest includes a retry mechanism, it still takes additional time and also makes timing test suites locally challenging. OTOH I have not experienced this issue when using Chromium instead of Chrome.

This adds an optional env variable to configure a custom Chrome binary, which would allow running tests with Chromium if so desired.