### PR TITLE
fix: match config series to data by name, fall back to position

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -263,29 +263,46 @@ public final class ChartRenderer implements Serializable {
     }
 
     /**
-     * Applies previously extracted series configuration to the data series,
-     * matching by name.
+     * Applies previously extracted series configuration to the data series.
+     * Matches by name first, then falls back to positional matching for
+     * unmatched series — copying the template's name, plot options, and
+     * y-axis binding.
      */
     private static void applySeriesConfig(List<Series> allSeries,
             Map<String, AbstractSeries> seriesConfig) {
-        if (seriesConfig.isEmpty()) {
-            return;
-        }
+        // Pass 1: match by name
+        var matched = new java.util.HashSet<String>();
         for (var series : allSeries) {
-            if (!(series instanceof AbstractSeries as)
-                    || as.getName() == null) {
-                continue;
+            if (series instanceof AbstractSeries as
+                    && as.getName() != null) {
+                var tpl = seriesConfig.get(as.getName());
+                if (tpl != null) {
+                    applyTemplate(as, tpl);
+                    matched.add(as.getName());
+                }
             }
-            var template = seriesConfig.get(as.getName());
-            if (template == null) {
-                continue;
-            }
-            if (template.getPlotOptions() != null) {
-                as.setPlotOptions(template.getPlotOptions());
-            }
-            if (template.getyAxis() != null) {
-                as.setyAxis(template.getyAxis());
-            }
+        }
+
+        // Pass 2: positional fallback for unmatched series
+        var templates = seriesConfig.values().stream()
+                .filter(t -> !matched.contains(t.getName())).toList();
+        var data = allSeries.stream()
+                .filter(AbstractSeries.class::isInstance)
+                .map(AbstractSeries.class::cast)
+                .filter(as -> !matched.contains(as.getName())).toList();
+        for (int i = 0; i < Math.min(data.size(), templates.size()); i++) {
+            data.get(i).setName(templates.get(i).getName());
+            applyTemplate(data.get(i), templates.get(i));
+        }
+    }
+
+    private static void applyTemplate(AbstractSeries target,
+            AbstractSeries template) {
+        if (template.getPlotOptions() != null) {
+            target.setPlotOptions(template.getPlotOptions());
+        }
+        if (template.getyAxis() != null) {
+            target.setyAxis(template.getyAxis());
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.ai.chart;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -264,48 +263,30 @@ public final class ChartRenderer implements Serializable {
     }
 
     /**
-     * Applies previously extracted series configuration to the data series.
-     * Matches by name first, then falls back to positional matching for
-     * unmatched series — copying the template's name, plot options, and
-     * y-axis binding.
+     * Applies series configuration templates to data series by position.
+     * Templates and data series are assumed to be in the same order (both
+     * produced by the LLM in a single request). If a template has a name, it
+     * overrides the data series name so the legend shows the LLM-specified
+     * label.
      */
-    private static void applySeriesConfig(List<Series> allSeries,
-            Map<String, AbstractSeries> seriesConfig) {
-        // Pre-scan: which template names have a matching data series?
-        var nameMatched = new HashSet<String>();
-        for (var s : allSeries) {
-            if (s instanceof AbstractSeries as
-                    && seriesConfig.containsKey(as.getName())) {
-                nameMatched.add(as.getName());
-            }
-        }
-
-        // Templates without a name match feed the positional fallback.
-        var positional = seriesConfig.values().stream()
-                .filter(t -> !nameMatched.contains(t.getName())).iterator();
-
-        for (var s : allSeries) {
-            if (!(s instanceof AbstractSeries as)) {
+    private static void applySeriesConfig(List<Series> dataSeries,
+            Map<String, AbstractSeries> templates) {
+        var templateList = new ArrayList<>(templates.values());
+        for (int i = 0; i < Math.min(dataSeries.size(),
+                templateList.size()); i++) {
+            if (!(dataSeries.get(i) instanceof AbstractSeries as)) {
                 continue;
             }
-            var tpl = seriesConfig.get(as.getName());
-            if (tpl == null && positional.hasNext()) {
-                tpl = positional.next();
-                as.setName(tpl.getName());
+            var template = templateList.get(i);
+            if (template.getName() != null) {
+                as.setName(template.getName());
             }
-            if (tpl != null) {
-                applyTemplate(as, tpl);
+            if (template.getPlotOptions() != null) {
+                as.setPlotOptions(template.getPlotOptions());
             }
-        }
-    }
-
-    private static void applyTemplate(AbstractSeries target,
-            AbstractSeries template) {
-        if (template.getPlotOptions() != null) {
-            target.setPlotOptions(template.getPlotOptions());
-        }
-        if (template.getyAxis() != null) {
-            target.setyAxis(template.getyAxis());
+            if (template.getyAxis() != null) {
+                as.setyAxis(template.getyAxis());
+            }
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.ai.chart;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -263,30 +264,48 @@ public final class ChartRenderer implements Serializable {
     }
 
     /**
-     * Applies series configuration templates to data series by position.
-     * Templates and data series are assumed to be in the same order (both
-     * produced by the LLM in a single request). If a template has a name, it
-     * overrides the data series name so the legend shows the LLM-specified
-     * label.
+     * Applies previously extracted series configuration to the data series.
+     * Matches by name first, then falls back to positional matching for
+     * unmatched series — copying the template's name, plot options, and y-axis
+     * binding.
      */
-    private static void applySeriesConfig(List<Series> dataSeries,
-            Map<String, AbstractSeries> templates) {
-        var templateList = new ArrayList<>(templates.values());
-        for (int i = 0; i < Math.min(dataSeries.size(),
-                templateList.size()); i++) {
-            if (!(dataSeries.get(i) instanceof AbstractSeries as)) {
+    private static void applySeriesConfig(List<Series> allSeries,
+            Map<String, AbstractSeries> seriesConfig) {
+        // Pre-scan: which template names have a matching data series?
+        var nameMatched = new HashSet<String>();
+        for (var s : allSeries) {
+            if (s instanceof AbstractSeries as
+                    && seriesConfig.containsKey(as.getName())) {
+                nameMatched.add(as.getName());
+            }
+        }
+
+        // Templates without a name match feed the positional fallback.
+        var positional = seriesConfig.values().stream()
+                .filter(t -> !nameMatched.contains(t.getName())).iterator();
+
+        for (var s : allSeries) {
+            if (!(s instanceof AbstractSeries as)) {
                 continue;
             }
-            var template = templateList.get(i);
-            if (template.getName() != null) {
-                as.setName(template.getName());
+            var tpl = seriesConfig.get(as.getName());
+            if (tpl == null && positional.hasNext()) {
+                tpl = positional.next();
+                as.setName(tpl.getName());
             }
-            if (template.getPlotOptions() != null) {
-                as.setPlotOptions(template.getPlotOptions());
+            if (tpl != null) {
+                applyTemplate(as, tpl);
             }
-            if (template.getyAxis() != null) {
-                as.setyAxis(template.getyAxis());
-            }
+        }
+    }
+
+    private static void applyTemplate(AbstractSeries target,
+            AbstractSeries template) {
+        if (template.getPlotOptions() != null) {
+            target.setPlotOptions(template.getPlotOptions());
+        }
+        if (template.getyAxis() != null) {
+            target.setyAxis(template.getyAxis());
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartRenderer.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.ai.chart;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -270,29 +271,31 @@ public final class ChartRenderer implements Serializable {
      */
     private static void applySeriesConfig(List<Series> allSeries,
             Map<String, AbstractSeries> seriesConfig) {
-        // Pass 1: match by name
-        var matched = new java.util.HashSet<String>();
-        for (var series : allSeries) {
-            if (series instanceof AbstractSeries as
-                    && as.getName() != null) {
-                var tpl = seriesConfig.get(as.getName());
-                if (tpl != null) {
-                    applyTemplate(as, tpl);
-                    matched.add(as.getName());
-                }
+        // Pre-scan: which template names have a matching data series?
+        var nameMatched = new HashSet<String>();
+        for (var s : allSeries) {
+            if (s instanceof AbstractSeries as
+                    && seriesConfig.containsKey(as.getName())) {
+                nameMatched.add(as.getName());
             }
         }
 
-        // Pass 2: positional fallback for unmatched series
-        var templates = seriesConfig.values().stream()
-                .filter(t -> !matched.contains(t.getName())).toList();
-        var data = allSeries.stream()
-                .filter(AbstractSeries.class::isInstance)
-                .map(AbstractSeries.class::cast)
-                .filter(as -> !matched.contains(as.getName())).toList();
-        for (int i = 0; i < Math.min(data.size(), templates.size()); i++) {
-            data.get(i).setName(templates.get(i).getName());
-            applyTemplate(data.get(i), templates.get(i));
+        // Templates without a name match feed the positional fallback.
+        var positional = seriesConfig.values().stream()
+                .filter(t -> !nameMatched.contains(t.getName())).iterator();
+
+        for (var s : allSeries) {
+            if (!(s instanceof AbstractSeries as)) {
+                continue;
+            }
+            var tpl = seriesConfig.get(as.getName());
+            if (tpl == null && positional.hasNext()) {
+                tpl = positional.next();
+                as.setName(tpl.getName());
+            }
+            if (tpl != null) {
+                applyTemplate(as, tpl);
+            }
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -641,6 +641,40 @@ class ChartRenderingTest {
         }
 
         @Test
+        void nameMatchedSeriesNotOverwrittenByPositionalFallback() {
+            // When one data series matches a config template by name and
+            // another doesn't, the name-matched series must not be
+            // re-processed by positional fallback. The name-matched
+            // series ("Revenue") is deliberately second in data order so
+            // that positional fallback — if it ignored matched tracking —
+            // would assign it the wrong template.
+            databaseProvider.results = List.of(
+                    row(ColumnNames.SERIES, "Other", "category", "Jan", "value",
+                            38000),
+                    row(ColumnNames.SERIES, "Revenue", "category", "Jan",
+                            "value", 45000));
+
+            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
+                    + "\"series\":[" + "{\"name\":\"Revenue\",\"yAxis\":0},"
+                    + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
+            updateData("SELECT s, c, v FROM t");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(2, series.size());
+            // "Other" did not match — positional fallback renames to "Costs"
+            Assertions.assertEquals("Costs", series.get(0).getName());
+            Assertions.assertEquals(1,
+                    ((AbstractSeries) series.get(0)).getyAxis(),
+                    "Positionally matched series should get template yAxis");
+            // "Revenue" matched by name — must keep its name and yAxis
+            Assertions.assertEquals("Revenue", series.get(1).getName());
+            Assertions.assertEquals(0,
+                    ((AbstractSeries) series.get(1)).getyAxis(),
+                    "Name-matched series should keep its yAxis");
+        }
+
+        @Test
         void positionalMatchAppliesPlotOptionsAndYAxis() {
             // Positional fallback must apply plotOptions and yAxis from
             // the config template, not just the name.
@@ -675,6 +709,53 @@ class ChartRenderingTest {
             Assertions.assertInstanceOf(PlotOptionsLine.class,
                     countSeries.getPlotOptions(),
                     "Positional match should apply plotOptions from template");
+        }
+
+        @Test
+        void dataOrderDifferentFromConfigOrderPreservesDataLabels() {
+            // The LLM writes the config series[] array without any
+            // guarantee that the SQL data will come back in that order
+            // (GROUP BY without ORDER BY, DB-side hash ordering, etc.).
+            // When data order differs from config order, matching by
+            // position renames data series to the WRONG labels —
+            // effectively swapping data points under their legend
+            // labels. Matching by name (the prior behavior) avoids this.
+            controller.setDataConverter(data -> {
+                // Simulate DB returning "South" before "North"
+                DataSeries south = new DataSeries("South");
+                south.add(new DataSeriesItem("Jan", 38000));
+                DataSeries north = new DataSeries("North");
+                north.add(new DataSeriesItem("Jan", 45000));
+                return List.of(south, north);
+            });
+
+            updateConfiguration("""
+                    {"chart":{"type":"column"},
+                     "yAxis":[{"title":{"text":"Primary"}},
+                              {"title":{"text":"Secondary"},"opposite":true}],
+                     "series":[{"name":"North","yAxis":0},
+                               {"name":"South","yAxis":1}]}
+                    """);
+            updateData("SELECT s, c, v FROM t");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(2, series.size());
+            // The first data series is South (value 38000); its label
+            // must remain "South", not be overwritten to "North".
+            Assertions.assertEquals("South", series.get(0).getName(),
+                    "Data series labels must not be swapped when data "
+                            + "order differs from config order");
+            Assertions.assertEquals("North", series.get(1).getName());
+            // Similarly the yAxis assignment should follow the name,
+            // so that "South" sits on the Secondary axis (yAxis=1).
+            Assertions.assertEquals(1,
+                    ((AbstractSeries) series.get(0)).getyAxis(),
+                    "South should end up on Secondary y-axis (yAxis=1), "
+                            + "not Primary");
+            Assertions.assertEquals(0,
+                    ((AbstractSeries) series.get(1)).getyAxis(),
+                    "North should end up on Primary y-axis (yAxis=0)");
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -638,43 +638,6 @@ class ChartRenderingTest {
         }
 
         @Test
-        void nameMatchedSeriesNotOverwrittenByPositionalFallback() {
-            // When one data series matches a config template by name and
-            // another doesn't, the name-matched series must not be
-            // re-processed by positional fallback. The name-matched
-            // series ("Revenue") is deliberately second in data order so
-            // that positional fallback — if it ignored matched tracking —
-            // would assign it the wrong template.
-            databaseProvider.results = List.of(
-                    row(ColumnNames.SERIES, "Other", "category", "Jan",
-                            "value", 38000),
-                    row(ColumnNames.SERIES, "Revenue", "category", "Jan",
-                            "value", 45000));
-
-            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
-                    + "\"series\":["
-                    + "{\"name\":\"Revenue\",\"yAxis\":0},"
-                    + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
-            updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
-
-            var series = chart.getConfiguration().getSeries();
-            Assertions.assertEquals(2, series.size());
-            // "Other" did not match — positional fallback renames to "Costs"
-            Assertions.assertEquals("Costs", series.get(0).getName());
-            Assertions.assertEquals(1,
-                    ((com.vaadin.flow.component.charts.model.AbstractSeries) series
-                            .get(0)).getyAxis(),
-                    "Positionally matched series should get template yAxis");
-            // "Revenue" matched by name — must keep its name and yAxis
-            Assertions.assertEquals("Revenue", series.get(1).getName());
-            Assertions.assertEquals(0,
-                    ((com.vaadin.flow.component.charts.model.AbstractSeries) series
-                            .get(1)).getyAxis(),
-                    "Name-matched series should keep its yAxis");
-        }
-
-        @Test
         void positionalMatchAppliesPlotOptionsAndYAxis() {
             // Positional fallback must apply plotOptions and yAxis from
             // the config template, not just the name.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.charts.model.AbstractSeries;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;
@@ -36,6 +37,7 @@ import com.vaadin.flow.component.charts.model.DataSeries;
 import com.vaadin.flow.component.charts.model.DataSeriesItem;
 import com.vaadin.flow.component.charts.model.OhlcItem;
 import com.vaadin.flow.component.charts.model.PlotOptionsFlags;
+import com.vaadin.flow.component.charts.model.PlotOptionsLine;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
 import com.vaadin.tests.MockUIExtension;
 
@@ -566,8 +568,7 @@ class ChartRenderingTest {
             Assertions.assertEquals(1, series.size());
             // Series should be named from title AND have plotOptions applied
             Assertions.assertEquals("Revenue", series.get(0).getName());
-            var plotOptions = ((com.vaadin.flow.component.charts.model.AbstractSeries) series
-                    .get(0)).getPlotOptions();
+            var plotOptions = ((AbstractSeries) series.get(0)).getPlotOptions();
             Assertions.assertNotNull(plotOptions,
                     "Per-series plotOptions should be applied to "
                             + "single unnamed series after title-based naming");
@@ -594,13 +595,13 @@ class ChartRenderingTest {
                 }
             });
 
-            updateConfiguration("{\"chart\":{\"type\":\"candlestick\"},"
-                    + "\"yAxis\":[{\"title\":{\"text\":\"Price\"}},"
-                    + "{\"title\":{\"text\":\"Volume\"},\"opposite\":true}],"
-                    + "\"series\":["
-                    + "{\"name\":\"Prices\",\"type\":\"candlestick\"},"
-                    + "{\"name\":\"Vol\",\"type\":\"column\",\"yAxis\":1}"
-                    + "]}");
+            updateConfiguration("""
+                    {"chart":{"type":"candlestick"},
+                     "yAxis":[{"title":{"text":"Price"}},
+                              {"title":{"text":"Volume"},"opposite":true}],
+                     "series":[{"name":"Prices","type":"candlestick"},
+                               {"name":"Vol","type":"column","yAxis":1}]}
+                    """);
             updateData("SELECT 1", "SELECT 2");
             controller.onRequestCompleted();
 
@@ -623,9 +624,11 @@ class ChartRenderingTest {
                     row(ColumnNames.SERIES, "South", "category", "Jan", "value",
                             38000));
 
-            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
-                    + "\"series\":[" + "{\"name\":\"Revenue\",\"yAxis\":0},"
-                    + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
+            updateConfiguration("""
+                    {"chart":{"type":"column"},
+                     "series":[{"name":"Revenue","yAxis":0},
+                               {"name":"Costs","yAxis":1}]}
+                    """);
             updateData("SELECT s, c, v FROM t");
             controller.onRequestCompleted();
 
@@ -655,23 +658,21 @@ class ChartRenderingTest {
                 }
             });
 
-            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
-                    + "\"series\":["
-                    + "{\"name\":\"Revenue\",\"type\":\"column\",\"yAxis\":0},"
-                    + "{\"name\":\"Count\",\"type\":\"line\",\"yAxis\":1}"
-                    + "]}");
+            updateConfiguration("""
+                    {"chart":{"type":"column"},
+                     "series":[{"name":"Revenue","type":"column","yAxis":0},
+                               {"name":"Count","type":"line","yAxis":1}]}
+                    """);
             updateData("SELECT 1", "SELECT 2");
             controller.onRequestCompleted();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
-            var countSeries = (com.vaadin.flow.component.charts.model.AbstractSeries) series
-                    .get(1);
+            var countSeries = (AbstractSeries) series.get(1);
             Assertions.assertEquals("Count", countSeries.getName());
             Assertions.assertEquals(1, countSeries.getyAxis(),
                     "Positional match should apply yAxis from template");
-            Assertions.assertInstanceOf(
-                    com.vaadin.flow.component.charts.model.PlotOptionsLine.class,
+            Assertions.assertInstanceOf(PlotOptionsLine.class,
                     countSeries.getPlotOptions(),
                     "Positional match should apply plotOptions from template");
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -574,6 +574,146 @@ class ChartRenderingTest {
         }
 
         @Test
+        void multiQueryUnnamedSeriesReceiveNamesFromConfig() {
+            // When two separate queries produce unnamed series (e.g.
+            // candlestick OHLC + volume) and the LLM config provides a
+            // series array with names, the names should be applied
+            // positionally to the unnamed data series.
+            int[] callCount = { 0 };
+            controller.setDataConverter(data -> {
+                callCount[0]++;
+                if (callCount[0] == 1) {
+                    DataSeries ohlcSeries = new DataSeries();
+                    ohlcSeries.add(new OhlcItem(1704067200000L, 142.5, 148.2,
+                            141.0, 147.8));
+                    return List.of(ohlcSeries);
+                } else {
+                    DataSeries volumeSeries = new DataSeries();
+                    volumeSeries.add(new DataSeriesItem(1704067200000L, 52000));
+                    return List.of(volumeSeries);
+                }
+            });
+
+            updateConfiguration("{\"chart\":{\"type\":\"candlestick\"},"
+                    + "\"yAxis\":[{\"title\":{\"text\":\"Price\"}},"
+                    + "{\"title\":{\"text\":\"Volume\"},\"opposite\":true}],"
+                    + "\"series\":["
+                    + "{\"name\":\"Prices\",\"type\":\"candlestick\"},"
+                    + "{\"name\":\"Vol\",\"type\":\"column\",\"yAxis\":1}"
+                    + "]}");
+            updateData("SELECT 1", "SELECT 2");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(2, series.size());
+            Assertions.assertEquals("Prices", series.get(0).getName(),
+                    "First unnamed series should receive name from config");
+            Assertions.assertEquals("Vol", series.get(1).getName(),
+                    "Second unnamed series should receive name from config");
+        }
+
+        @Test
+        void configSeriesNamesOverrideSeriesColumnNames() {
+            // When _SERIES column produces named series but the config
+            // also provides explicit series names, the config names
+            // should win (the user asked for specific legend labels).
+            databaseProvider.results = List.of(
+                    row(ColumnNames.SERIES, "North", "category", "Jan", "value",
+                            45000),
+                    row(ColumnNames.SERIES, "South", "category", "Jan", "value",
+                            38000));
+
+            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
+                    + "\"series\":[" + "{\"name\":\"Revenue\",\"yAxis\":0},"
+                    + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
+            updateData("SELECT s, c, v FROM t");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(2, series.size());
+            Assertions.assertEquals("Revenue", series.get(0).getName(),
+                    "Config name should override _SERIES name");
+            Assertions.assertEquals("Costs", series.get(1).getName(),
+                    "Config name should override _SERIES name");
+        }
+
+        @Test
+        void nameMatchedSeriesNotOverwrittenByPositionalFallback() {
+            // When one data series matches a config template by name and
+            // another doesn't, the name-matched series must not be
+            // re-processed by positional fallback. The name-matched
+            // series ("Revenue") is deliberately second in data order so
+            // that positional fallback — if it ignored matched tracking —
+            // would assign it the wrong template.
+            databaseProvider.results = List.of(
+                    row(ColumnNames.SERIES, "Other", "category", "Jan",
+                            "value", 38000),
+                    row(ColumnNames.SERIES, "Revenue", "category", "Jan",
+                            "value", 45000));
+
+            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
+                    + "\"series\":["
+                    + "{\"name\":\"Revenue\",\"yAxis\":0},"
+                    + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
+            updateData("SELECT s, c, v FROM t");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(2, series.size());
+            // "Other" did not match — positional fallback renames to "Costs"
+            Assertions.assertEquals("Costs", series.get(0).getName());
+            Assertions.assertEquals(1,
+                    ((com.vaadin.flow.component.charts.model.AbstractSeries) series
+                            .get(0)).getyAxis(),
+                    "Positionally matched series should get template yAxis");
+            // "Revenue" matched by name — must keep its name and yAxis
+            Assertions.assertEquals("Revenue", series.get(1).getName());
+            Assertions.assertEquals(0,
+                    ((com.vaadin.flow.component.charts.model.AbstractSeries) series
+                            .get(1)).getyAxis(),
+                    "Name-matched series should keep its yAxis");
+        }
+
+        @Test
+        void positionalMatchAppliesPlotOptionsAndYAxis() {
+            // Positional fallback must apply plotOptions and yAxis from
+            // the config template, not just the name.
+            int[] callCount = { 0 };
+            controller.setDataConverter(data -> {
+                callCount[0]++;
+                if (callCount[0] == 1) {
+                    DataSeries s = new DataSeries();
+                    s.add(new DataSeriesItem("Jan", 100));
+                    return List.of(s);
+                } else {
+                    DataSeries s = new DataSeries();
+                    s.add(new DataSeriesItem("Jan", 200));
+                    return List.of(s);
+                }
+            });
+
+            updateConfiguration("{\"chart\":{\"type\":\"column\"},"
+                    + "\"series\":["
+                    + "{\"name\":\"Revenue\",\"type\":\"column\",\"yAxis\":0},"
+                    + "{\"name\":\"Count\",\"type\":\"line\",\"yAxis\":1}"
+                    + "]}");
+            updateData("SELECT 1", "SELECT 2");
+            controller.onRequestCompleted();
+
+            var series = chart.getConfiguration().getSeries();
+            Assertions.assertEquals(2, series.size());
+            var countSeries = (com.vaadin.flow.component.charts.model.AbstractSeries) series
+                    .get(1);
+            Assertions.assertEquals("Count", countSeries.getName());
+            Assertions.assertEquals(1, countSeries.getyAxis(),
+                    "Positional match should apply yAxis from template");
+            Assertions.assertInstanceOf(
+                    com.vaadin.flow.component.charts.model.PlotOptionsLine.class,
+                    countSeries.getPlotOptions(),
+                    "Positional match should apply plotOptions from template");
+        }
+
+        @Test
         void multipleSeriesWithSeriesColumnKeepsOriginalNames() {
             databaseProvider.results = List.of(
                     row(ColumnNames.SERIES, "Series A", "category", "Jan",


### PR DESCRIPTION
## Summary
- Series configuration templates (names, `plotOptions`, `yAxis`) are matched to data series by name first, with positional fallback for unmatched ones, so LLM-specified legend labels always take effect without swapping data under the wrong labels when SQL returns series in a different order than the config
- Previously, `applySeriesConfig` only matched by name, which failed for unnamed multi-query series (e.g., candlestick + volume) and for `_SERIES`-named series where the config used different labels

Before:
<img width="1003" height="687" alt="Screenshot 2026-04-16 at 17 10 46" src="https://github.com/user-attachments/assets/63151d1c-9a18-47de-809f-312e41c2f241" />

After:
<img width="1005" height="686" alt="Screenshot 2026-04-16 at 17 12 45" src="https://github.com/user-attachments/assets/3ab5ac09-cc8c-4aee-a8c0-fd8b104a5343" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)