### PR TITLE
refactor: make AIController methods abstract

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -47,9 +47,7 @@ public interface AIController {
      *
      * @return list of tools, or empty list if controller provides no tools
      */
-    default List<LLMProvider.ToolSpec> getTools() {
-        return List.of();
-    }
+    List<LLMProvider.ToolSpec> getTools();
 
     /**
      * Called by the orchestrator when an LLM request cycle has completed.
@@ -61,6 +59,5 @@ public interface AIController {
      * </p>
      *
      */
-    default void onRequestCompleted() {
-    }
+    void onRequestCompleted();
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -342,6 +342,11 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
             public List<LLMProvider.ToolSpec> getTools() {
                 return List.of(tools);
             }
+
+            @Override
+            public void onRequestCompleted() {
+                // Test controller doesn't need to handle request completion
+            }
         };
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1638,6 +1638,11 @@ class AIOrchestratorTest {
         var callCount = new AtomicInteger();
         AIController controller = new AIController() {
             @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
+            @Override
             public void onRequestCompleted() {
                 callCount.incrementAndGet();
             }
@@ -1662,6 +1667,11 @@ class AIOrchestratorTest {
                 .thenReturn(Flux.just("Response"));
 
         AIController throwingController = new AIController() {
+            @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
             @Override
             public void onRequestCompleted() {
                 throw new RuntimeException("Controller error");
@@ -1693,6 +1703,11 @@ class AIOrchestratorTest {
         var callCount = new AtomicInteger();
         AIController controller = new AIController() {
             @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
+            @Override
             public void onRequestCompleted() {
                 callCount.incrementAndGet();
             }
@@ -1720,6 +1735,11 @@ class AIOrchestratorTest {
         var listenerCapture = new ArrayList<String>();
         var controllerCallCount = new AtomicInteger();
         AIController controller = new AIController() {
+            @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
             @Override
             public void onRequestCompleted() {
                 controllerCallCount.incrementAndGet();
@@ -1998,6 +2018,11 @@ class AIOrchestratorTest {
             @Override
             public List<LLMProvider.ToolSpec> getTools() {
                 return List.of(tools);
+            }
+
+            @Override
+            public void onRequestCompleted() {
+                // no-op
             }
         };
     }


### PR DESCRIPTION
## Summary
- Remove the default implementations from `AIController#getTools()` and `AIController#onRequestCompleted()`, making them abstract so implementers must provide their own behavior explicitly.

Fixes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=178096722 (non-visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)