### PR TITLE
refactor!: replace ExpandingArea with expandMaster and expandDetail

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -76,40 +76,26 @@ public class MasterDetailLayout extends Component
     }
 
     /**
-     * Supported expand values for {@link MasterDetailLayout}. Controls which
-     * area(s) expand to fill available space.
-     */
-    public enum ExpandingArea {
-        MASTER, DETAIL, BOTH
-    }
-
-    /**
      * Creates an empty Master Detail Layout.
      */
     public MasterDetailLayout() {
     }
 
     /**
-     * Creates a Master Detail Layout with the given master size, detail size,
-     * and expanding side.
+     * Creates a Master Detail Layout with the given master and detail sizes.
      *
      * @param masterSize
      *            the size of the master area in CSS length units
      * @param detailSize
      *            the size of the detail area in CSS length units
-     * @param expandingArea
-     *            which area(s) expand to fill available space
      */
-    public MasterDetailLayout(String masterSize, String detailSize,
-            ExpandingArea expandingArea) {
+    public MasterDetailLayout(String masterSize, String detailSize) {
         setMasterSize(masterSize);
         setDetailSize(detailSize);
-        setExpandingArea(expandingArea);
     }
 
     /**
-     * Creates a Master Detail Layout with the given master size, detail size,
-     * and expanding area.
+     * Creates a Master Detail Layout with the given master and detail sizes.
      *
      * @param masterSize
      *            the size of the master area
@@ -119,14 +105,11 @@ public class MasterDetailLayout extends Component
      *            the size of the detail area
      * @param detailUnit
      *            the unit for the detail size
-     * @param expandingArea
-     *            which area(s) expand to fill available space
      */
     public MasterDetailLayout(float masterSize, Unit masterUnit,
-            float detailSize, Unit detailUnit, ExpandingArea expandingArea) {
+            float detailSize, Unit detailUnit) {
         setMasterSize(masterSize, masterUnit);
         setDetailSize(detailSize, detailUnit);
-        setExpandingArea(expandingArea);
     }
 
     /**
@@ -429,31 +412,51 @@ public class MasterDetailLayout extends Component
     }
 
     /**
-     * Gets which area(s) expand to fill available space. Defaults to
-     * {@link ExpandingArea#MASTER}.
+     * Gets whether the master area expands to fill available space. Defaults to
+     * {@code false}.
      *
-     * @return the expanding area
+     * @return {@code true} if the master area expands, {@code false} otherwise
      */
-    public ExpandingArea getExpandingArea() {
-        String expand = getElement().getProperty("expand");
-        if (expand != null) {
-            return ExpandingArea.valueOf(expand.toUpperCase());
-        }
-        return ExpandingArea.MASTER;
+    public boolean isExpandMaster() {
+        return getElement().getProperty("expandMaster", false);
     }
 
     /**
-     * Controls which area(s) expand to fill available space. Possible values
-     * are {@link ExpandingArea#MASTER}, {@link ExpandingArea#DETAIL}, and
-     * {@link ExpandingArea#BOTH}. Defaults to {@link ExpandingArea#MASTER}.
+     * Sets whether the master area expands to fill available space. When both
+     * {@link #setExpandMaster(boolean)} and {@link #setExpandDetail(boolean)}
+     * are set to {@code true}, the master and detail areas share the available
+     * space equally.
      *
-     * @param expandingArea
-     *            the expanding area
+     * @param expandMaster
+     *            {@code true} to expand the master area, {@code false}
+     *            otherwise
      */
-    public void setExpandingArea(ExpandingArea expandingArea) {
-        Objects.requireNonNull(expandingArea, "ExpandingArea cannot be null");
-        getElement().setProperty("expand",
-                expandingArea.name().toLowerCase(Locale.ENGLISH));
+    public void setExpandMaster(boolean expandMaster) {
+        getElement().setProperty("expandMaster", expandMaster);
+    }
+
+    /**
+     * Gets whether the detail area expands to fill available space. Defaults to
+     * {@code false}.
+     *
+     * @return {@code true} if the detail area expands, {@code false} otherwise
+     */
+    public boolean isExpandDetail() {
+        return getElement().getProperty("expandDetail", false);
+    }
+
+    /**
+     * Sets whether the detail area expands to fill available space. When both
+     * {@link #setExpandMaster(boolean)} and {@link #setExpandDetail(boolean)}
+     * are set to {@code true}, the master and detail areas share the available
+     * space equally.
+     *
+     * @param expandDetail
+     *            {@code true} to expand the detail area, {@code false}
+     *            otherwise
+     */
+    public void setExpandDetail(boolean expandDetail) {
+        getElement().setProperty("expandDetail", expandDetail);
     }
 
     /**

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -46,27 +46,21 @@ class MasterDetailLayoutTest {
     }
 
     @Test
-    void constructorWithSizesAndExpand() {
-        var customLayout = new MasterDetailLayout("400px", "200px",
-                MasterDetailLayout.ExpandingArea.MASTER);
+    void constructorWithSizes() {
+        var customLayout = new MasterDetailLayout("400px", "200px");
         ui.add(customLayout);
 
         Assertions.assertEquals("400px", customLayout.getMasterSize());
         Assertions.assertEquals("200px", customLayout.getDetailSize());
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.MASTER,
-                customLayout.getExpandingArea());
     }
 
     @Test
-    void constructorWithSizesUnitsAndExpandingArea() {
-        var customLayout = new MasterDetailLayout(30, Unit.EM, 15, Unit.EM,
-                MasterDetailLayout.ExpandingArea.DETAIL);
+    void constructorWithSizesAndUnits() {
+        var customLayout = new MasterDetailLayout(30, Unit.EM, 15, Unit.EM);
         ui.add(customLayout);
 
         Assertions.assertEquals("30.0em", customLayout.getMasterSize());
         Assertions.assertEquals("15.0em", customLayout.getDetailSize());
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.DETAIL,
-                customLayout.getExpandingArea());
     }
 
     @Test
@@ -360,29 +354,29 @@ class MasterDetailLayoutTest {
     }
 
     @Test
-    void setExpandingArea_getExpandingArea() {
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.MASTER,
-                layout.getExpandingArea());
+    void setExpandMaster_isExpandMaster() {
+        Assertions.assertFalse(layout.isExpandMaster());
+        Assertions.assertFalse(
+                layout.getElement().getProperty("expandMaster", false));
 
-        layout.setExpandingArea(MasterDetailLayout.ExpandingArea.BOTH);
+        layout.setExpandMaster(true);
 
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.BOTH,
-                layout.getExpandingArea());
-        Assertions.assertEquals("both",
-                layout.getElement().getProperty("expand"));
-
-        layout.setExpandingArea(MasterDetailLayout.ExpandingArea.DETAIL);
-
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.DETAIL,
-                layout.getExpandingArea());
-        Assertions.assertEquals("detail",
-                layout.getElement().getProperty("expand"));
+        Assertions.assertTrue(layout.isExpandMaster());
+        Assertions.assertTrue(
+                layout.getElement().getProperty("expandMaster", false));
     }
 
     @Test
-    void setExpandingAreaNull_throws() {
-        Assertions.assertThrows(NullPointerException.class,
-                () -> layout.setExpandingArea(null));
+    void setExpandDetail_isExpandDetail() {
+        Assertions.assertFalse(layout.isExpandDetail());
+        Assertions.assertFalse(
+                layout.getElement().getProperty("expandDetail", false));
+
+        layout.setExpandDetail(true);
+
+        Assertions.assertTrue(layout.isExpandDetail());
+        Assertions.assertTrue(
+                layout.getElement().getProperty("expandDetail", false));
     }
 
     @Test


### PR DESCRIPTION
## Description

Follow-up to the web component change https://github.com/vaadin/web-components/pull/11521

Replaces the `expand` enum-valued attribute on `MasterDetailLayout` with two independent boolean properties:

- Removes the `ExpandingArea` enum and `get/setExpandingArea` methods
- Adds `isExpandMaster` / `setExpandMaster(boolean)` (defaults to `false`)
- Adds `isExpandDetail` / `setExpandDetail(boolean)` (defaults to `false`)
- Drops the `ExpandingArea` parameter from the two convenience constructors; callers configure expansion via the new setters

Part of https://github.com/vaadin/web-components/issues/11519

## Type of change

- Refactor