### PR TITLE
feat: add setMasterSize/setDetailSize overloads with expand parameter

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -76,40 +76,26 @@ public class MasterDetailLayout extends Component
     }
 
     /**
-     * Supported expand values for {@link MasterDetailLayout}. Controls which
-     * area(s) expand to fill available space.
-     */
-    public enum ExpandingArea {
-        MASTER, DETAIL, BOTH
-    }
-
-    /**
      * Creates an empty Master Detail Layout.
      */
     public MasterDetailLayout() {
     }
 
     /**
-     * Creates a Master Detail Layout with the given master size, detail size,
-     * and expanding side.
+     * Creates a Master Detail Layout with the given master and detail sizes.
      *
      * @param masterSize
      *            the size of the master area in CSS length units
      * @param detailSize
      *            the size of the detail area in CSS length units
-     * @param expandingArea
-     *            which area(s) expand to fill available space
      */
-    public MasterDetailLayout(String masterSize, String detailSize,
-            ExpandingArea expandingArea) {
+    public MasterDetailLayout(String masterSize, String detailSize) {
         setMasterSize(masterSize);
         setDetailSize(detailSize);
-        setExpandingArea(expandingArea);
     }
 
     /**
-     * Creates a Master Detail Layout with the given master size, detail size,
-     * and expanding area.
+     * Creates a Master Detail Layout with the given master and detail sizes.
      *
      * @param masterSize
      *            the size of the master area
@@ -119,14 +105,11 @@ public class MasterDetailLayout extends Component
      *            the size of the detail area
      * @param detailUnit
      *            the unit for the detail size
-     * @param expandingArea
-     *            which area(s) expand to fill available space
      */
     public MasterDetailLayout(float masterSize, Unit masterUnit,
-            float detailSize, Unit detailUnit, ExpandingArea expandingArea) {
+            float detailSize, Unit detailUnit) {
         setMasterSize(masterSize, masterUnit);
         setDetailSize(detailSize, detailUnit);
-        setExpandingArea(expandingArea);
     }
 
     /**
@@ -429,31 +412,51 @@ public class MasterDetailLayout extends Component
     }
 
     /**
-     * Gets which area(s) expand to fill available space. Defaults to
-     * {@link ExpandingArea#MASTER}.
+     * Gets whether the master area expands to fill available space. Defaults to
+     * {@code false}.
      *
-     * @return the expanding area
+     * @return {@code true} if the master area expands, {@code false} otherwise
      */
-    public ExpandingArea getExpandingArea() {
-        String expand = getElement().getProperty("expand");
-        if (expand != null) {
-            return ExpandingArea.valueOf(expand.toUpperCase());
-        }
-        return ExpandingArea.MASTER;
+    public boolean isExpandMaster() {
+        return getElement().getProperty("expandMaster", false);
     }
 
     /**
-     * Controls which area(s) expand to fill available space. Possible values
-     * are {@link ExpandingArea#MASTER}, {@link ExpandingArea#DETAIL}, and
-     * {@link ExpandingArea#BOTH}. Defaults to {@link ExpandingArea#MASTER}.
+     * Sets whether the master area expands to fill available space. When both
+     * {@link #setExpandMaster(boolean)} and {@link #setExpandDetail(boolean)}
+     * are set to {@code true}, the master and detail areas share the available
+     * space equally.
      *
-     * @param expandingArea
-     *            the expanding area
+     * @param expandMaster
+     *            {@code true} to expand the master area, {@code false}
+     *            otherwise
      */
-    public void setExpandingArea(ExpandingArea expandingArea) {
-        Objects.requireNonNull(expandingArea, "ExpandingArea cannot be null");
-        getElement().setProperty("expand",
-                expandingArea.name().toLowerCase(Locale.ENGLISH));
+    public void setExpandMaster(boolean expandMaster) {
+        getElement().setProperty("expandMaster", expandMaster);
+    }
+
+    /**
+     * Gets whether the detail area expands to fill available space. Defaults to
+     * {@code false}.
+     *
+     * @return {@code true} if the detail area expands, {@code false} otherwise
+     */
+    public boolean isExpandDetail() {
+        return getElement().getProperty("expandDetail", false);
+    }
+
+    /**
+     * Sets whether the detail area expands to fill available space. When both
+     * {@link #setExpandMaster(boolean)} and {@link #setExpandDetail(boolean)}
+     * are set to {@code true}, the master and detail areas share the available
+     * space equally.
+     *
+     * @param expandDetail
+     *            {@code true} to expand the detail area, {@code false}
+     *            otherwise
+     */
+    public void setExpandDetail(boolean expandDetail) {
+        getElement().setProperty("expandDetail", expandDetail);
     }
 
     /**

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -532,6 +532,31 @@ public class MasterDetailLayout extends Component
     }
 
     /**
+     * Gets whether the layout forces the detail area to be shown as an overlay,
+     * even if there is enough space for master and detail to be shown next to
+     * each other using the default (split) mode.
+     *
+     * @return {@code true} if the overlay mode is enforced, {@code false}
+     *         otherwise
+     */
+    public boolean isForceOverlay() {
+        return getElement().getProperty("forceOverlay", false);
+    }
+
+    /**
+     * Sets whether the layout forces the detail area to be shown as an overlay,
+     * even if there is enough space for master and detail to be shown next to
+     * each other using the default (split) mode.
+     *
+     * @param forceOverlay
+     *            {@code true} if the overlay mode is enforced, {@code false}
+     *            otherwise
+     */
+    public void setForceOverlay(boolean forceOverlay) {
+        getElement().setProperty("forceOverlay", forceOverlay);
+    }
+
+    /**
      * Gets whether the layout animation is enabled.
      *
      * @return {@code true} if the animation is enabled, {@code false} otherwise

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.java
@@ -268,6 +268,42 @@ public class MasterDetailLayout extends Component
     }
 
     /**
+     * Sets the size of the master area in CSS length units and whether the
+     * master area expands to fill available space.
+     *
+     * @param size
+     *            the size of the master area in CSS length units
+     * @param expand
+     *            {@code true} to expand the master area, {@code false}
+     *            otherwise
+     * @see #setMasterSize(String)
+     * @see #setExpandMaster(boolean)
+     */
+    public void setMasterSize(String size, boolean expand) {
+        setMasterSize(size);
+        setExpandMaster(expand);
+    }
+
+    /**
+     * Sets the size of the master area in CSS length units and whether the
+     * master area expands to fill available space.
+     *
+     * @param size
+     *            the size of the master area
+     * @param unit
+     *            the unit
+     * @param expand
+     *            {@code true} to expand the master area, {@code false}
+     *            otherwise
+     * @see #setMasterSize(float, Unit)
+     * @see #setExpandMaster(boolean)
+     */
+    public void setMasterSize(float size, Unit unit, boolean expand) {
+        setMasterSize(size, unit);
+        setExpandMaster(expand);
+    }
+
+    /**
      * Gets the size of the detail area.
      *
      * @return the size of the detail area in CSS length units, or {@code null}
@@ -312,6 +348,42 @@ public class MasterDetailLayout extends Component
     public void setDetailSize(float size, Unit unit) {
         Objects.requireNonNull(unit, "Unit cannot be null");
         getElement().setProperty("detailSize", HasSize.getCssSize(size, unit));
+    }
+
+    /**
+     * Sets the size of the detail area in CSS length units and whether the
+     * detail area expands to fill available space.
+     *
+     * @param size
+     *            the size of the detail area in CSS length units
+     * @param expand
+     *            {@code true} to expand the detail area, {@code false}
+     *            otherwise
+     * @see #setDetailSize(String)
+     * @see #setExpandDetail(boolean)
+     */
+    public void setDetailSize(String size, boolean expand) {
+        setDetailSize(size);
+        setExpandDetail(expand);
+    }
+
+    /**
+     * Sets the size of the detail area in CSS length units and whether the
+     * detail area expands to fill available space.
+     *
+     * @param size
+     *            the size of the detail area
+     * @param unit
+     *            the unit
+     * @param expand
+     *            {@code true} to expand the detail area, {@code false}
+     *            otherwise
+     * @see #setDetailSize(float, Unit)
+     * @see #setExpandDetail(boolean)
+     */
+    public void setDetailSize(float size, Unit unit, boolean expand) {
+        setDetailSize(size, unit);
+        setExpandDetail(expand);
     }
 
     /**

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -46,27 +46,21 @@ class MasterDetailLayoutTest {
     }
 
     @Test
-    void constructorWithSizesAndExpand() {
-        var customLayout = new MasterDetailLayout("400px", "200px",
-                MasterDetailLayout.ExpandingArea.MASTER);
+    void constructorWithSizes() {
+        var customLayout = new MasterDetailLayout("400px", "200px");
         ui.add(customLayout);
 
         Assertions.assertEquals("400px", customLayout.getMasterSize());
         Assertions.assertEquals("200px", customLayout.getDetailSize());
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.MASTER,
-                customLayout.getExpandingArea());
     }
 
     @Test
-    void constructorWithSizesUnitsAndExpandingArea() {
-        var customLayout = new MasterDetailLayout(30, Unit.EM, 15, Unit.EM,
-                MasterDetailLayout.ExpandingArea.DETAIL);
+    void constructorWithSizesAndUnits() {
+        var customLayout = new MasterDetailLayout(30, Unit.EM, 15, Unit.EM);
         ui.add(customLayout);
 
         Assertions.assertEquals("30.0em", customLayout.getMasterSize());
         Assertions.assertEquals("15.0em", customLayout.getDetailSize());
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.DETAIL,
-                customLayout.getExpandingArea());
     }
 
     @Test
@@ -360,29 +354,29 @@ class MasterDetailLayoutTest {
     }
 
     @Test
-    void setExpandingArea_getExpandingArea() {
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.MASTER,
-                layout.getExpandingArea());
+    void setExpandMaster_isExpandMaster() {
+        Assertions.assertFalse(layout.isExpandMaster());
+        Assertions.assertFalse(
+                layout.getElement().getProperty("expandMaster", false));
 
-        layout.setExpandingArea(MasterDetailLayout.ExpandingArea.BOTH);
+        layout.setExpandMaster(true);
 
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.BOTH,
-                layout.getExpandingArea());
-        Assertions.assertEquals("both",
-                layout.getElement().getProperty("expand"));
-
-        layout.setExpandingArea(MasterDetailLayout.ExpandingArea.DETAIL);
-
-        Assertions.assertEquals(MasterDetailLayout.ExpandingArea.DETAIL,
-                layout.getExpandingArea());
-        Assertions.assertEquals("detail",
-                layout.getElement().getProperty("expand"));
+        Assertions.assertTrue(layout.isExpandMaster());
+        Assertions.assertTrue(
+                layout.getElement().getProperty("expandMaster", false));
     }
 
     @Test
-    void setExpandingAreaNull_throws() {
-        Assertions.assertThrows(NullPointerException.class,
-                () -> layout.setExpandingArea(null));
+    void setExpandDetail_isExpandDetail() {
+        Assertions.assertFalse(layout.isExpandDetail());
+        Assertions.assertFalse(
+                layout.getElement().getProperty("expandDetail", false));
+
+        layout.setExpandDetail(true);
+
+        Assertions.assertTrue(layout.isExpandDetail());
+        Assertions.assertTrue(
+                layout.getElement().getProperty("expandDetail", false));
     }
 
     @Test

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -408,6 +408,19 @@ class MasterDetailLayoutTest {
     }
 
     @Test
+    public void setForceOverlay_isForceOverlay() {
+        Assertions.assertFalse(layout.isForceOverlay());
+        Assertions.assertFalse(
+                layout.getElement().getProperty("forceOverlay", false));
+
+        layout.setForceOverlay(true);
+
+        Assertions.assertTrue(layout.isForceOverlay());
+        Assertions.assertTrue(
+                layout.getElement().getProperty("forceOverlay", false));
+    }
+
+    @Test
     void setAnimationEnabled_isAnimationEnabled() {
         Assertions.assertTrue(layout.isAnimationEnabled());
         Assertions.assertFalse(

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/src/test/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTest.java
@@ -274,6 +274,20 @@ class MasterDetailLayoutTest {
     }
 
     @Test
+    void setMasterSizeWithExpand_getMasterSize_isExpandMaster() {
+        layout.setMasterSize("300px", true);
+        Assertions.assertEquals("300px", layout.getMasterSize());
+        Assertions.assertTrue(layout.isExpandMaster());
+    }
+
+    @Test
+    void setMasterSizeWithUnitAndExpand_getMasterSize_isExpandMaster() {
+        layout.setMasterSize(30, Unit.EM, true);
+        Assertions.assertEquals("30.0em", layout.getMasterSize());
+        Assertions.assertTrue(layout.isExpandMaster());
+    }
+
+    @Test
     void setDetailSize_getDetailSize() {
         String size = "400px";
         layout.setDetailSize(size);
@@ -288,6 +302,20 @@ class MasterDetailLayoutTest {
         Assertions.assertEquals("30.0em", layout.getDetailSize());
         Assertions.assertEquals("30.0em",
                 layout.getElement().getProperty("detailSize"));
+    }
+
+    @Test
+    void setDetailSizeWithExpand_getDetailSize_isExpandDetail() {
+        layout.setDetailSize("300px", true);
+        Assertions.assertEquals("300px", layout.getDetailSize());
+        Assertions.assertTrue(layout.isExpandDetail());
+    }
+
+    @Test
+    void setDetailSizeWithUnitAndExpand_getDetailSize_isExpandDetail() {
+        layout.setDetailSize(30, Unit.EM, true);
+        Assertions.assertEquals("30.0em", layout.getDetailSize());
+        Assertions.assertTrue(layout.isExpandDetail());
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds overloads to `setMasterSize` and `setDetailSize` that accept an additional `expand` boolean, so size and expand can be configured in a single call:

```java
layout.setMasterSize("300px", true);
layout.setDetailSize("300px", true);
```

Both `String` and `float`/`Unit` variants are added for parity with the existing setters. Each overload delegates to the existing size setter and `setExpandMaster`/`setExpandDetail`.

Part of https://github.com/vaadin/web-components/issues/11519

## Type of change

- Feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)