### PR TITLE
refactor: replace controller system prompts with instructions tools

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -42,14 +42,14 @@ import com.vaadin.flow.shared.Registration;
  * and create or update chart visualizations based on natural language requests.
  * Attach it to an {@link AIOrchestrator} via
  * {@link AIOrchestrator.Builder#withController(AIController)} to expose its
- * tools to the LLM. The recommended system prompt is available from
- * {@link #getSystemPrompt()}.
+ * tools to the LLM. Workflow instructions are delivered through the description
+ * of the {@code get_chart_instructions} tool, which the LLM reads as part of
+ * the tool manifest.
  * </p>
  *
  * <pre>
  * var controller = new ChartAIController(chart, databaseProvider);
- * AIOrchestrator orchestrator = AIOrchestrator
- *         .builder(llmProvider, ChartAIController.getSystemPrompt())
+ * AIOrchestrator orchestrator = AIOrchestrator.builder(llmProvider, systemPrompt)
  *         .withController(controller).withMessageList(messageList).build();
  * </pre>
  * <p>
@@ -99,10 +99,12 @@ public class ChartAIController implements AIController {
 
     private static final String CHART_ID = "chart";
 
-    private static final String SYSTEM_PROMPT = """
-            You have chart visualization tools. Follow this workflow when working with Charts:
+    private static final String INSTRUCTIONS_TOOL_NAME = "get_chart_instructions";
 
-            1. ALWAYS call get_chart_state() FIRST before making changes
+    private static final String INSTRUCTIONS_TEXT = """
+            Chart visualization workflow. Follow this for every chart request:
+
+            1. Call get_chart_state() to see the current chart state
             2. Call get_database_schema() to understand available data
             3. Call update_chart_data_source() and update_chart_configuration() \
             as needed — they can be called independently
@@ -154,21 +156,10 @@ public class ChartAIController implements AIController {
                 "Data converter cannot be null");
     }
 
-    /**
-     * Returns the recommended system prompt for chart visualization
-     * capabilities. Pass this to
-     * {@link AIOrchestrator#builder(LLMProvider, String)} so the LLM follows
-     * the intended tool-calling workflow.
-     *
-     * @return the system prompt text
-     */
-    public static String getSystemPrompt() {
-        return SYSTEM_PROMPT;
-    }
-
     @Override
     public List<LLMProvider.ToolSpec> getTools() {
         List<LLMProvider.ToolSpec> tools = new ArrayList<>();
+        tools.add(createInstructionsTool());
         tools.addAll(DatabaseProviderAITools.createAll(databaseProvider));
         tools.addAll(ChartAITools.createAll(new ChartAITools.Callbacks() {
             @Override
@@ -207,6 +198,36 @@ public class ChartAIController implements AIController {
             }
         }));
         return tools;
+    }
+
+    private LLMProvider.ToolSpec createInstructionsTool() {
+        return new LLMProvider.ToolSpec() {
+            @Override
+            public String getName() {
+                return INSTRUCTIONS_TOOL_NAME;
+            }
+
+            @Override
+            public String getDescription() {
+                return """
+                        Read this before using any chart or database tool.
+                        Calling this tool returns these same instructions —
+                        normally unnecessary since you are already reading them here.
+
+                        """
+                        + INSTRUCTIONS_TEXT;
+            }
+
+            @Override
+            public String getParametersSchema() {
+                return null;
+            }
+
+            @Override
+            public String execute(String arguments) {
+                return INSTRUCTIONS_TEXT;
+            }
+        };
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -34,6 +34,8 @@ import com.vaadin.flow.component.charts.util.ChartSerialization;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 
+import tools.jackson.databind.JsonNode;
+
 /**
  * AI controller for creating interactive chart visualizations from database
  * data.
@@ -225,7 +227,7 @@ public class ChartAIController implements AIController {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return INSTRUCTIONS_TEXT;
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -49,8 +49,9 @@ import com.vaadin.flow.shared.Registration;
  *
  * <pre>
  * var controller = new ChartAIController(chart, databaseProvider);
- * AIOrchestrator orchestrator = AIOrchestrator.builder(llmProvider, systemPrompt)
- *         .withController(controller).withMessageList(messageList).build();
+ * AIOrchestrator orchestrator = AIOrchestrator
+ *         .builder(llmProvider, systemPrompt).withController(controller)
+ *         .withMessageList(messageList).build();
  * </pre>
  * <p>
  * State changes requested by the LLM are deferred and applied in

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -43,8 +43,9 @@ import com.vaadin.flow.shared.Registration;
  *
  * <pre>
  * var controller = new GridAIController(grid, databaseProvider);
- * AIOrchestrator orchestrator = AIOrchestrator.builder(llmProvider, systemPrompt)
- *         .withController(controller).withMessageList(messageList).build();
+ * AIOrchestrator orchestrator = AIOrchestrator
+ *         .builder(llmProvider, systemPrompt).withController(controller)
+ *         .withMessageList(messageList).build();
  * </pre>
  * <p>
  * The grid automatically creates columns from query results with:

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -37,13 +37,13 @@ import com.vaadin.flow.shared.Registration;
  * AI controller for populating a {@link Grid} with database data via LLM tool
  * calls. Attach it to an {@link AIOrchestrator} via
  * {@link AIOrchestrator.Builder#withController(AIController)} to expose its
- * tools to the LLM. The recommended system prompt is available from
- * {@link #getSystemPrompt()}.
+ * tools to the LLM. Workflow instructions are delivered through the description
+ * of the {@code get_grid_instructions} tool, which the LLM reads as part of the
+ * tool manifest.
  *
  * <pre>
  * var controller = new GridAIController(grid, databaseProvider);
- * AIOrchestrator orchestrator = AIOrchestrator
- *         .builder(llmProvider, GridAIController.getSystemPrompt())
+ * AIOrchestrator orchestrator = AIOrchestrator.builder(llmProvider, systemPrompt)
  *         .withController(controller).withMessageList(messageList).build();
  * </pre>
  * <p>
@@ -97,6 +97,27 @@ public class GridAIController implements AIController {
 
     private static final String GRID_ID = "grid";
 
+    private static final String INSTRUCTIONS_TOOL_NAME = "get_grid_instructions";
+
+    private static final String INSTRUCTIONS_TEXT = """
+            Grid data display workflow. Follow this for every grid request:
+
+            TOOLS:
+            1. get_database_schema() - Retrieves database schema (tables, columns, types)
+            2. get_grid_state() - Returns current grid state (query)
+            3. update_grid_data(query) - Updates grid data with SQL SELECT query
+
+            WORKFLOW:
+            Complete the user's request in a SINGLE response by calling all needed tools.
+            1. Call get_grid_state() to see what's already configured
+            2. Call get_database_schema() to learn the exact table and column names
+            3. Call update_grid_data() with a SQL SELECT query using only columns from the schema
+
+            IMPORTANT:
+            - Call get_grid_state() and update_grid_data() in the SAME response
+            - Do NOT stop after get_grid_state()
+            """;
+
     private final Grid<Map<String, Object>> grid;
     private final DatabaseProvider databaseProvider;
     private final List<SerializableConsumer<GridState>> stateChangeListeners = new ArrayList<>();
@@ -117,37 +138,10 @@ public class GridAIController implements AIController {
                 "DatabaseProvider must not be null");
     }
 
-    /**
-     * Returns the recommended system prompt for grid data display capabilities.
-     * Pass this to {@link AIOrchestrator#builder(LLMProvider, String)} so the
-     * LLM follows the intended tool-calling workflow.
-     *
-     * @return the system prompt text
-     */
-    public static String getSystemPrompt() {
-        return """
-                You have access to grid data display capabilities:
-
-                TOOLS:
-                1. get_database_schema() - Retrieves database schema (tables, columns, types)
-                2. get_grid_state() - Returns current grid state (query)
-                3. update_grid_data(query) - Updates grid data with SQL SELECT query
-
-                WORKFLOW:
-                Complete the user's request in a SINGLE response by calling all needed tools.
-                1. Call get_grid_state() to see what's already configured
-                2. Call get_database_schema() to learn the exact table and column names
-                3. Call update_grid_data() with a SQL SELECT query using only columns from the schema
-
-                IMPORTANT:
-                - Call get_grid_state() and update_grid_data() in the SAME response
-                - Do NOT stop after get_grid_state()
-                """;
-    }
-
     @Override
     public List<LLMProvider.ToolSpec> getTools() {
         var tools = new ArrayList<LLMProvider.ToolSpec>();
+        tools.add(createInstructionsTool());
         tools.addAll(DatabaseProviderAITools.createAll(databaseProvider));
         tools.addAll(GridAITools.createAll(new GridAITools.Callbacks() {
             @Override
@@ -170,6 +164,36 @@ public class GridAIController implements AIController {
             }
         }));
         return tools;
+    }
+
+    private LLMProvider.ToolSpec createInstructionsTool() {
+        return new LLMProvider.ToolSpec() {
+            @Override
+            public String getName() {
+                return INSTRUCTIONS_TOOL_NAME;
+            }
+
+            @Override
+            public String getDescription() {
+                return """
+                        Read this before using any grid or database tool.
+                        Calling this tool returns these same instructions —
+                        normally unnecessary since you are already reading them here.
+
+                        """
+                        + INSTRUCTIONS_TEXT;
+            }
+
+            @Override
+            public String getParametersSchema() {
+                return null;
+            }
+
+            @Override
+            public String execute(String arguments) {
+                return INSTRUCTIONS_TEXT;
+            }
+        };
     }
 
     @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -33,6 +33,8 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 
+import tools.jackson.databind.JsonNode;
+
 /**
  * AI controller for populating a {@link Grid} with database data via LLM tool
  * calls. Attach it to an {@link AIOrchestrator} via
@@ -191,7 +193,7 @@ public class GridAIController implements AIController {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return INSTRUCTIONS_TEXT;
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -60,7 +60,7 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.component\\.ai\\.provider\\..*",
                 // GridAIController — intentionally not serializable; restored
                 // via reconnect()
-                "com\\.vaadin\\.flow\\.component\\.ai\\.grid\\.GridAIController",
+                "com\\.vaadin\\.flow\\.component\\.ai\\.grid\\.GridAIController(\\$\\d+)?",
                 "com\\.vaadin\\.flow\\.component\\.ai\\.grid\\.GridAITools.*",
                 // AIController — intentionally not serializable; restored
                 // via reconnect()
@@ -73,7 +73,7 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAITools(\\$\\d+)?",
                 // ChartAIController — intentionally not serializable;
                 // restored via reconnect()
-                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAIController",
+                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAIController(\\$\\d+)?",
                 // Build-time generator — not a runtime component
                 "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.PlotOptionsSchemaGenerator"));
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -82,26 +82,39 @@ class ChartAIControllerTest {
         void toolNamesIncludeExpected() {
             var names = controller.getTools().stream().map(t -> t.getName())
                     .toList();
+            Assertions.assertTrue(names.contains("get_chart_instructions"));
             Assertions.assertTrue(names.contains("get_database_schema"));
             Assertions.assertTrue(names.contains("get_chart_state"));
             Assertions.assertTrue(names.contains("update_chart_configuration"));
             Assertions.assertTrue(names.contains("update_chart_data_source"));
         }
+
+        @Test
+        void instructionsToolIsFirst() {
+            Assertions.assertEquals("get_chart_instructions",
+                    controller.getTools().get(0).getName());
+        }
     }
 
     @Nested
-    class GetSystemPrompt {
+    class GetChartInstructions {
 
         @Test
-        void isNotEmpty() {
-            Assertions
-                    .assertFalse(ChartAIController.getSystemPrompt().isEmpty());
+        void descriptionContainsWorkflow() {
+            var tool = findTool(controller.getTools(),
+                    "get_chart_instructions");
+            Assertions.assertTrue(
+                    tool.getDescription().contains("get_chart_state"));
+            Assertions.assertTrue(
+                    tool.getDescription().contains("get_database_schema"));
         }
 
         @Test
-        void mentionsWorkflow() {
-            Assertions.assertTrue(ChartAIController.getSystemPrompt()
-                    .contains("get_chart_state"));
+        void executeReturnsWorkflow() {
+            var result = findTool(controller.getTools(),
+                    "get_chart_instructions").execute(null);
+            Assertions.assertFalse(result.isEmpty());
+            Assertions.assertTrue(result.contains("get_chart_state"));
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -79,18 +79,25 @@ class GridAIControllerTest {
     // --- Tools ---
 
     @Test
-    void getTools_returnsThreeTools() {
+    void getTools_returnsFourTools() {
         var tools = controller.getTools();
-        Assertions.assertEquals(3, tools.size());
+        Assertions.assertEquals(4, tools.size());
     }
 
     @Test
     void getTools_containsSchemaStatAndUpdateTools() {
         var tools = controller.getTools();
         var names = tools.stream().map(LLMProvider.ToolSpec::getName).toList();
+        Assertions.assertTrue(names.contains("get_grid_instructions"));
         Assertions.assertTrue(names.contains("get_database_schema"));
         Assertions.assertTrue(names.contains("get_grid_state"));
         Assertions.assertTrue(names.contains("update_grid_data"));
+    }
+
+    @Test
+    void getTools_instructionsToolIsFirst() {
+        Assertions.assertEquals("get_grid_instructions",
+                controller.getTools().get(0).getName());
     }
 
     @Test
@@ -468,21 +475,23 @@ class GridAIControllerTest {
         Assertions.assertNull(grid.getEmptyStateText());
     }
 
-    // --- System prompt ---
+    // --- Instructions tool ---
 
     @Test
-    void getSystemPrompt_notNullOrEmpty() {
-        var prompt = GridAIController.getSystemPrompt();
-        Assertions.assertNotNull(prompt);
-        Assertions.assertFalse(prompt.isBlank());
+    void instructionsTool_descriptionContainsWorkflow() {
+        var tool = findTool("get_grid_instructions");
+        Assertions.assertTrue(tool.getDescription().contains("get_grid_state"));
+        Assertions.assertTrue(
+                tool.getDescription().contains("get_database_schema"));
+        Assertions
+                .assertTrue(tool.getDescription().contains("update_grid_data"));
     }
 
     @Test
-    void getSystemPrompt_containsToolNames() {
-        var prompt = GridAIController.getSystemPrompt();
-        Assertions.assertTrue(prompt.contains("get_database_schema"));
-        Assertions.assertTrue(prompt.contains("get_grid_state"));
-        Assertions.assertTrue(prompt.contains("update_grid_data"));
+    void instructionsTool_executeReturnsWorkflow() {
+        var result = findTool("get_grid_instructions").execute(null);
+        Assertions.assertFalse(result.isBlank());
+        Assertions.assertTrue(result.contains("get_grid_state"));
     }
 
     // --- stripGroupPrefix ---


### PR DESCRIPTION
## Summary
- Replaces `ChartAIController.getSystemPrompt()` and `GridAIController.getSystemPrompt()` with dedicated `get_chart_instructions` / `get_grid_instructions` tools whose descriptions carry the workflow.
- Users no longer pass a controller-specific system prompt to `AIOrchestrator.builder`; the LLM picks up the workflow from the tool manifest, so adding a controller is now enough.
- `execute()` on the instructions tools returns the same workflow text as a graceful fallback if the model calls them.

Fixes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=178096129

🤖 Generated with [Claude Code](https://claude.com/claude-code)