### PR TITLE
fix: prevent AIOrchestrator instances from sharing resources

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -30,6 +30,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -152,6 +153,12 @@ public class AIOrchestrator implements Serializable {
                     + " is already in use by another AIOrchestrator. "
                     + "Each instance can only be used by a single "
                     + "orchestrator.");
+        }
+    }
+
+    private static void unclaim(Object instance) {
+        if (instance != null) {
+            CLAIMED_INSTANCES.remove(instance);
         }
     }
 
@@ -991,19 +998,7 @@ public class AIOrchestrator implements Serializable {
          * @return the configured orchestrator
          */
         public AIOrchestrator build() {
-            claim(provider);
-            claim(messageList instanceof MessageListWrapper w ? w.messageList
-                    : messageList);
-            claim(input instanceof MessageInputWrapper w ? w.messageInput()
-                    : input);
-            if (fileReceiver instanceof UploadManagerWrapper w) {
-                claim(w.uploadManager);
-            } else if (fileReceiver instanceof UploadWrapper w) {
-                claim(w.upload);
-            } else {
-                claim(fileReceiver);
-            }
-            claim(controller);
+            forEachClaimable(AIOrchestrator::claim);
 
             var orchestrator = new AIOrchestrator(provider, systemPrompt);
             orchestrator.messageList = messageList;
@@ -1017,22 +1012,31 @@ public class AIOrchestrator implements Serializable {
             orchestrator.attachmentSubmitListener = attachmentSubmitListener;
             orchestrator.attachmentClickListener = attachmentClickListener;
             orchestrator.responseCompleteListener = responseCompleteListener;
-            if (input != null) {
-                input.addSubmitListener(orchestrator::doPrompt);
-            }
+            try {
+                if (input != null) {
+                    input.addSubmitListener(orchestrator::doPrompt);
+                }
 
-            if (attachmentClickListener != null && messageList != null) {
-                messageList.addAttachmentClickListener((message, attIndex) -> {
-                    var messageId = orchestrator.itemToMessageId.get(message);
-                    if (messageId != null) {
-                        orchestrator.attachmentClickListener.onAttachmentClick(
-                                new AttachmentClickListener.AttachmentClickEvent(
-                                        messageId, attIndex));
-                    }
-                });
-            }
-            if (history != null) {
-                orchestrator.restoreHistory(history, historyAttachments);
+                if (attachmentClickListener != null && messageList != null) {
+                    messageList
+                            .addAttachmentClickListener((message, attIndex) -> {
+                                var messageId = orchestrator.itemToMessageId
+                                        .get(message);
+                                if (messageId != null) {
+                                    orchestrator.attachmentClickListener
+                                            .onAttachmentClick(
+                                                    new AttachmentClickListener.AttachmentClickEvent(
+                                                            messageId,
+                                                            attIndex));
+                                }
+                            });
+                }
+                if (history != null) {
+                    orchestrator.restoreHistory(history, historyAttachments);
+                }
+            } catch (RuntimeException e) {
+                forEachClaimable(AIOrchestrator::unclaim);
+                throw e;
             }
 
             LOGGER.debug(
@@ -1047,6 +1051,24 @@ public class AIOrchestrator implements Serializable {
                     orchestrator.assistantName);
 
             return orchestrator;
+        }
+
+        private void forEachClaimable(Consumer<Object> action) {
+            action.accept(provider);
+            action.accept(
+                    messageList instanceof MessageListWrapper w ? w.messageList
+                            : messageList);
+            action.accept(
+                    input instanceof MessageInputWrapper w ? w.messageInput()
+                            : input);
+            if (fileReceiver instanceof UploadManagerWrapper w) {
+                action.accept(w.uploadManager);
+            } else if (fileReceiver instanceof UploadWrapper w) {
+                action.accept(w.upload);
+            } else {
+                action.accept(fileReceiver);
+            }
+            action.accept(controller);
         }
 
         private static AIMessageList wrapMessageList(MessageList messageList) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -24,7 +24,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -137,6 +139,21 @@ public class AIOrchestrator implements Serializable {
      */
     private static final Pattern VALID_TOOL_NAME_PATTERN = Pattern
             .compile("^[a-zA-Z0-9_-]{1,64}$");
+
+    private static final Set<Object> CLAIMED_INSTANCES = Collections
+            .synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+
+    private static void claim(Object instance) {
+        if (instance == null) {
+            return;
+        }
+        if (!CLAIMED_INSTANCES.add(instance)) {
+            throw new IllegalStateException(instance.getClass().getSimpleName()
+                    + " is already in use by another AIOrchestrator. "
+                    + "Each instance can only be used by a single "
+                    + "orchestrator.");
+        }
+    }
 
     private transient LLMProvider provider;
     private final String systemPrompt;
@@ -974,6 +991,20 @@ public class AIOrchestrator implements Serializable {
          * @return the configured orchestrator
          */
         public AIOrchestrator build() {
+            claim(provider);
+            claim(messageList instanceof MessageListWrapper w ? w.messageList
+                    : messageList);
+            claim(input instanceof MessageInputWrapper w ? w.messageInput()
+                    : input);
+            if (fileReceiver instanceof UploadManagerWrapper w) {
+                claim(w.uploadManager);
+            } else if (fileReceiver instanceof UploadWrapper w) {
+                claim(w.upload);
+            } else {
+                claim(fileReceiver);
+            }
+            claim(controller);
+
             var orchestrator = new AIOrchestrator(provider, systemPrompt);
             orchestrator.messageList = messageList;
             orchestrator.input = input;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/MessageListWrapper.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/MessageListWrapper.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.component.messages.MessageListItem;
  */
 class MessageListWrapper implements AIMessageList {
 
-    private final MessageList messageList;
+    final MessageList messageList;
     private final Map<MessageListItem, AIMessage> itemToMessage = new HashMap<>();
 
     MessageListWrapper(MessageList messageList) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/UploadManagerWrapper.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/UploadManagerWrapper.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.server.streams.UploadHandler;
  */
 class UploadManagerWrapper implements AIFileReceiver {
 
-    private final UploadManager uploadManager;
+    final UploadManager uploadManager;
     private final List<AIAttachment> pendingAttachments = new CopyOnWriteArrayList<>();
 
     UploadManagerWrapper(UploadManager uploadManager) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/UploadWrapper.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/UploadWrapper.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.server.streams.UploadHandler;
  */
 class UploadWrapper implements AIFileReceiver {
 
-    private final Upload upload;
+    final Upload upload;
     private final List<AIAttachment> pendingAttachments = new CopyOnWriteArrayList<>();
 
     UploadWrapper(Upload upload) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2056,6 +2056,37 @@ class AIOrchestratorTest {
         Assertions.assertThrows(IllegalStateException.class, builder::build);
     }
 
+    @Test
+    void builder_buildFailsAfterClaim_resourceCanBeReused() {
+        var input = Mockito.mock(AIInput.class);
+        Mockito.doThrow(new RuntimeException("simulated build failure"))
+                .doNothing().when(input).addSubmitListener(Mockito.any());
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> AIOrchestrator
+                        .builder(Mockito.mock(LLMProvider.class), null)
+                        .withInput(input).build());
+
+        Assertions.assertDoesNotThrow(() -> AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null).withInput(input)
+                .build());
+    }
+
+    @Test
+    void builder_withAlreadyClaimedResource_doesNotApplySideEffects() {
+        var sharedInput = Mockito.mock(AIInput.class);
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withInput(sharedInput).build();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> AIOrchestrator
+                        .builder(Mockito.mock(LLMProvider.class), null)
+                        .withInput(sharedInput).build());
+
+        Mockito.verify(sharedInput, Mockito.times(1))
+                .addSubmitListener(Mockito.any());
+    }
+
     private static byte[] createTestImage(int width, int height)
             throws IOException {
         var image = new BufferedImage(width, height,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1975,6 +1975,87 @@ class AIOrchestratorTest {
         assertBuilderWarning("responseCompleteListener");
     }
 
+    @Test
+    void builder_withProviderAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedProvider = Mockito.mock(LLMProvider.class);
+        AIOrchestrator.builder(sharedProvider, null).build();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> AIOrchestrator.builder(sharedProvider, null).build());
+    }
+
+    @Test
+    void builder_withMessageListAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedMessageList = Mockito.mock(AIMessageList.class);
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withMessageList(sharedMessageList).build();
+
+        var builder = AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null)
+                .withMessageList(sharedMessageList);
+        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    void builder_withFlowMessageListAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedFlowMessageList = Mockito.mock(MessageList.class);
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withMessageList(sharedFlowMessageList).build();
+
+        var builder = AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null)
+                .withMessageList(sharedFlowMessageList);
+        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    void builder_withInputAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedInput = Mockito.mock(AIInput.class);
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withInput(sharedInput).build();
+
+        var builder = AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null)
+                .withInput(sharedInput);
+        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    void builder_withFlowMessageInputAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedFlowInput = Mockito.mock(MessageInput.class);
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withInput(sharedFlowInput).build();
+
+        var builder = AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null)
+                .withInput(sharedFlowInput);
+        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    void builder_withFileReceiverAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedFileReceiver = Mockito.mock(AIFileReceiver.class);
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withFileReceiver(sharedFileReceiver).build();
+
+        var builder = AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null)
+                .withFileReceiver(sharedFileReceiver);
+        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    void builder_withControllerAlreadyUsedByAnotherOrchestrator_throws() {
+        var sharedController = createController();
+        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
+                .withController(sharedController).build();
+
+        var builder = AIOrchestrator
+                .builder(Mockito.mock(LLMProvider.class), null)
+                .withController(sharedController);
+        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    }
+
     private static byte[] createTestImage(int width, int height)
             throws IOException {
         var image = new BufferedImage(width, height,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -20,12 +20,15 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -1976,84 +1979,55 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withProviderAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedProvider = Mockito.mock(LLMProvider.class);
-        AIOrchestrator.builder(sharedProvider, null).build();
+    void builder_claimsAllResources_toPreventSharing() throws Exception {
+        // Builder with-methods that do NOT configure a shareable resource —
+        // value types, listeners, tools, and restored conversation state. Any
+        // other with-method is treated as configuring a resource that build()
+        // must claim. If you add a new resource with-method (component,
+        // controller, ...), do not add it here — ensure build() claims it.
+        Set<String> nonResourceSetters = Set.of("withTools", "withUserName",
+                "withAssistantName", "withAttachmentSubmitListener",
+                "withAttachmentClickListener", "withResponseCompleteListener",
+                "withHistory");
 
+        // Provider is set via the factory method, not a with-method.
+        assertClaimed(null, LLMProvider.class);
+
+        for (Method method : AIOrchestrator.Builder.class
+                .getDeclaredMethods()) {
+            if (!Modifier.isPublic(method.getModifiers())
+                    || !method.getName().startsWith("with")
+                    || nonResourceSetters.contains(method.getName())) {
+                continue;
+            }
+            Assertions.assertEquals(1, method.getParameterCount(),
+                    "Resource with-method must take a single argument: "
+                            + method.getName());
+            assertClaimed(method, method.getParameterTypes()[0]);
+        }
+    }
+
+    private static void assertClaimed(Method setter, Class<?> resourceType)
+            throws Exception {
+        var shared = Mockito.mock(resourceType);
+        buildWith(setter, shared);
         Assertions.assertThrows(IllegalStateException.class,
-                () -> AIOrchestrator.builder(sharedProvider, null).build());
+                () -> buildWith(setter, shared),
+                "Builder must claim the " + resourceType.getSimpleName()
+                        + " passed to "
+                        + (setter == null ? "builder()" : setter.getName())
+                        + " to prevent sharing between orchestrators");
     }
 
-    @Test
-    void builder_withMessageListAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedMessageList = Mockito.mock(AIMessageList.class);
-        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
-                .withMessageList(sharedMessageList).build();
-
-        var builder = AIOrchestrator
-                .builder(Mockito.mock(LLMProvider.class), null)
-                .withMessageList(sharedMessageList);
-        Assertions.assertThrows(IllegalStateException.class, builder::build);
-    }
-
-    @Test
-    void builder_withFlowMessageListAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedFlowMessageList = Mockito.mock(MessageList.class);
-        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
-                .withMessageList(sharedFlowMessageList).build();
-
-        var builder = AIOrchestrator
-                .builder(Mockito.mock(LLMProvider.class), null)
-                .withMessageList(sharedFlowMessageList);
-        Assertions.assertThrows(IllegalStateException.class, builder::build);
-    }
-
-    @Test
-    void builder_withInputAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedInput = Mockito.mock(AIInput.class);
-        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
-                .withInput(sharedInput).build();
-
-        var builder = AIOrchestrator
-                .builder(Mockito.mock(LLMProvider.class), null)
-                .withInput(sharedInput);
-        Assertions.assertThrows(IllegalStateException.class, builder::build);
-    }
-
-    @Test
-    void builder_withFlowMessageInputAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedFlowInput = Mockito.mock(MessageInput.class);
-        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
-                .withInput(sharedFlowInput).build();
-
-        var builder = AIOrchestrator
-                .builder(Mockito.mock(LLMProvider.class), null)
-                .withInput(sharedFlowInput);
-        Assertions.assertThrows(IllegalStateException.class, builder::build);
-    }
-
-    @Test
-    void builder_withFileReceiverAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedFileReceiver = Mockito.mock(AIFileReceiver.class);
-        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
-                .withFileReceiver(sharedFileReceiver).build();
-
-        var builder = AIOrchestrator
-                .builder(Mockito.mock(LLMProvider.class), null)
-                .withFileReceiver(sharedFileReceiver);
-        Assertions.assertThrows(IllegalStateException.class, builder::build);
-    }
-
-    @Test
-    void builder_withControllerAlreadyUsedByAnotherOrchestrator_throws() {
-        var sharedController = createController();
-        AIOrchestrator.builder(Mockito.mock(LLMProvider.class), null)
-                .withController(sharedController).build();
-
-        var builder = AIOrchestrator
-                .builder(Mockito.mock(LLMProvider.class), null)
-                .withController(sharedController);
-        Assertions.assertThrows(IllegalStateException.class, builder::build);
+    private static AIOrchestrator buildWith(Method setter, Object shared)
+            throws Exception {
+        if (setter == null) {
+            return AIOrchestrator.builder((LLMProvider) shared, null).build();
+        }
+        var builder = AIOrchestrator.builder(Mockito.mock(LLMProvider.class),
+                null);
+        setter.invoke(builder, shared);
+        return builder.build();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Each `LLMProvider`, message list, input, file receiver, and controller passed to an `AIOrchestrator` must be used by at most one orchestrator
- Reusing an instance now throws `IllegalStateException`

Fixes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=178098791

🤖 Generated with [Claude Code](https://claude.com/claude-code)