### PR TITLE
refactor: make toolspec execute accept jsonnode

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerPage.java
@@ -32,10 +32,12 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.messages.MessageInput;
 import com.vaadin.flow.component.messages.MessageList;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Test page for ChartAIController with Dashboard. Uses an async LLM provider
@@ -98,12 +100,19 @@ public class DashboardChartControllerPage extends Div {
             if ("/render-bar".equals(message)) {
                 return Flux.<String> create(sink -> {
                     new Thread(() -> {
+                        var dataArgs = JacksonUtils.createObjectNode();
+                        dataArgs.putArray("queries").add("SELECT * FROM sales");
                         executeTool(tools, "update_chart_data_source",
-                                "{\"queries\":[\"SELECT * FROM sales\"]}");
+                                dataArgs);
+
+                        var configArgs = JacksonUtils.createObjectNode();
+                        var configObj = configArgs.putObject("configuration");
+                        configObj.putObject("chart").put("type", "bar");
+                        configObj.putObject("title").put("text",
+                                "Monthly Revenue");
                         executeTool(tools, "update_chart_configuration",
-                                "{\"configuration\":{\"chart\":"
-                                        + "{\"type\":\"bar\"},\"title\":"
-                                        + "{\"text\":\"Monthly Revenue\"}}}");
+                                configArgs);
+
                         sink.next("Rendered bar chart.");
                         sink.complete();
                     }).start();
@@ -119,7 +128,7 @@ public class DashboardChartControllerPage extends Div {
         }
 
         private static void executeTool(List<ToolSpec> tools, String name,
-                String args) {
+                JsonNode args) {
             tools.stream().filter(t -> t.getName().equals(name)).findFirst()
                     .orElseThrow().execute(args);
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerPage.java
@@ -37,7 +37,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import reactor.core.publisher.Flux;
-import tools.jackson.databind.JsonNode;
 
 /**
  * Test page for ChartAIController with Dashboard. Uses an async LLM provider
@@ -100,19 +99,12 @@ public class DashboardChartControllerPage extends Div {
             if ("/render-bar".equals(message)) {
                 return Flux.<String> create(sink -> {
                     new Thread(() -> {
-                        var dataArgs = JacksonUtils.createObjectNode();
-                        dataArgs.putArray("queries").add("SELECT * FROM sales");
                         executeTool(tools, "update_chart_data_source",
-                                dataArgs);
-
-                        var configArgs = JacksonUtils.createObjectNode();
-                        var configObj = configArgs.putObject("configuration");
-                        configObj.putObject("chart").put("type", "bar");
-                        configObj.putObject("title").put("text",
-                                "Monthly Revenue");
+                                "{\"queries\":[\"SELECT * FROM sales\"]}");
                         executeTool(tools, "update_chart_configuration",
-                                configArgs);
-
+                                "{\"configuration\":{\"chart\":"
+                                        + "{\"type\":\"bar\"},\"title\":"
+                                        + "{\"text\":\"Monthly Revenue\"}}}");
                         sink.next("Rendered bar chart.");
                         sink.complete();
                     }).start();
@@ -128,9 +120,9 @@ public class DashboardChartControllerPage extends Div {
         }
 
         private static void executeTool(List<ToolSpec> tools, String name,
-                JsonNode args) {
+                String args) {
             tools.stream().filter(t -> t.getName().equals(name)).findFirst()
-                    .orElseThrow().execute(args);
+                    .orElseThrow().execute(JacksonUtils.readTree(args));
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ai.provider.LLMProvider;
-import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.JsonNode;
 
@@ -252,11 +251,10 @@ public final class ChartAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 try {
                     LOGGER.info("get_chart_state called");
-                    JsonNode args = JacksonUtils.readTree(arguments);
-                    String chartId = resolveChartId(args, callbacks);
+                    String chartId = resolveChartId(arguments, callbacks);
                     return callbacks.getState(chartId);
                 } catch (Exception e) {
                     LOGGER.error("get_chart_state failed", e);
@@ -502,14 +500,13 @@ public final class ChartAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 try {
                     LOGGER.info("update_chart_configuration called with: {}",
                             arguments);
-                    JsonNode args = JacksonUtils.readTree(arguments);
-                    String chartId = resolveChartId(args, callbacks);
+                    String chartId = resolveChartId(arguments, callbacks);
 
-                    JsonNode configNode = args.get("configuration");
+                    JsonNode configNode = arguments.get("configuration");
                     if (configNode == null || configNode.isNull()) {
                         return "Error updating chart configuration: 'configuration' parameter is required.";
                     }
@@ -646,16 +643,15 @@ public final class ChartAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 try {
                     LOGGER.info("update_chart_data_source called with: {}",
                             arguments);
-                    JsonNode args = JacksonUtils.readTree(arguments);
-                    String chartId = resolveChartId(args, callbacks);
+                    String chartId = resolveChartId(arguments, callbacks);
 
                     List<String> queries = new ArrayList<>();
                     String validationError = validateQueries(
-                            args.get("queries"), queries);
+                            arguments.get("queries"), queries);
                     if (validationError != null) {
                         return validationError;
                     }
@@ -711,12 +707,11 @@ public final class ChartAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 try {
                     LOGGER.info("get_plot_options_schema called with: {}",
                             arguments);
-                    JsonNode args = JacksonUtils.readTree(arguments);
-                    JsonNode typeNode = args.get("chartType");
+                    JsonNode typeNode = arguments.get("chartType");
                     if (typeNode == null || typeNode.isNull()) {
                         return "Error: 'chartType' parameter is required.";
                     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ai.provider.LLMProvider;
-import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.JsonNode;
 
@@ -139,11 +138,10 @@ public final class GridAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 try {
                     LOGGER.info("get_grid_state called");
-                    var args = JacksonUtils.readTree(arguments);
-                    var gridId = resolveGridId(args, callbacks);
+                    var gridId = resolveGridId(arguments, callbacks);
                     return callbacks.getState(gridId);
                 } catch (Exception e) {
                     LOGGER.error("get_grid_state failed", e);
@@ -214,12 +212,11 @@ public final class GridAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 try {
                     LOGGER.info("update_grid_data called with: {}", arguments);
-                    var args = JacksonUtils.readTree(arguments);
-                    var gridId = resolveGridId(args, callbacks);
-                    var query = args.get("query").asString();
+                    var gridId = resolveGridId(arguments, callbacks);
+                    var query = arguments.get("query").asString();
                     LOGGER.info("update_grid_data gridId={} query={}", gridId,
                             query);
                     callbacks.updateData(gridId, query);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAITools.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.ai.provider;
 import java.util.List;
 import java.util.Objects;
 
+import tools.jackson.databind.JsonNode;
+
 /**
  * Factory for creating reusable database {@link LLMProvider.ToolSpec}
  * instances. These tools can be used by any controller that works with a
@@ -59,7 +61,7 @@ public final class DatabaseProviderAITools {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return provider.getSchema();
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
 
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Framework-agnostic interface for Large Language Model (LLM) providers. This
@@ -185,10 +186,7 @@ public interface LLMProvider {
 
         /**
          * Gets the JSON Schema describing the parameters this tool accepts. The
-         * schema should follow the JSON Schema specification.
-         * <p>
-         * Example:
-         * </p>
+         * top-level schema must be an object:
          *
          * <pre>
          * {
@@ -199,6 +197,28 @@ public interface LLMProvider {
          *   "required": ["query"]
          * }
          * </pre>
+         * <p>
+         * To stay portable across LLM providers, prefer the following JSON
+         * Schema subset, which is supported by both OpenAI (including strict
+         * mode) and Anthropic:
+         * </p>
+         * <ul>
+         * <li>Top-level {@code "type": "object"} with {@code "properties"} and
+         * {@code "required"}</li>
+         * <li>Per-property {@code type} (one of {@code string},
+         * {@code integer}, {@code number}, {@code boolean}, {@code array},
+         * {@code object}), {@code description}, and {@code enum}</li>
+         * <li>{@code items} for arrays; nested {@code object} with its own
+         * {@code properties}/{@code required}</li>
+         * <li>{@code anyOf} for nullable / union types</li>
+         * </ul>
+         * <p>
+         * The following keywords are <b>not</b> portable across providers and
+         * should be avoided unless you target a specific provider:
+         * {@code $ref}, {@code oneOf}, {@code allOf}, {@code not},
+         * {@code pattern}, {@code format}, {@code minimum}, {@code maximum},
+         * {@code minItems}, {@code maxItems}.
+         * </p>
          *
          * @return the JSON Schema string, or {@code null} if the tool takes no
          *         parameters
@@ -215,12 +235,12 @@ public interface LLMProvider {
          * </p>
          *
          * @param arguments
-         *            the tool arguments as a JSON string matching the
-         *            parameters schema, or {@code null} if the tool takes no
-         *            parameters
+         *            the tool arguments as a {@link JsonNode} matching the
+         *            parameters schema, never {@code null}. Tools that take no
+         *            parameters receive an empty object node.
          * @return the result of the tool execution as a string, never
          *         {@code null}
          */
-        String execute(String arguments);
+        String execute(JsonNode arguments);
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -186,7 +186,10 @@ public interface LLMProvider {
 
         /**
          * Gets the JSON Schema describing the parameters this tool accepts. The
-         * top-level schema must be an object:
+         * schema should follow the JSON Schema specification.
+         * <p>
+         * Example:
+         * </p>
          *
          * <pre>
          * {
@@ -197,28 +200,6 @@ public interface LLMProvider {
          *   "required": ["query"]
          * }
          * </pre>
-         * <p>
-         * To stay portable across LLM providers, prefer the following JSON
-         * Schema subset, which is supported by both OpenAI (including strict
-         * mode) and Anthropic:
-         * </p>
-         * <ul>
-         * <li>Top-level {@code "type": "object"} with {@code "properties"} and
-         * {@code "required"}</li>
-         * <li>Per-property {@code type} (one of {@code string},
-         * {@code integer}, {@code number}, {@code boolean}, {@code array},
-         * {@code object}), {@code description}, and {@code enum}</li>
-         * <li>{@code items} for arrays; nested {@code object} with its own
-         * {@code properties}/{@code required}</li>
-         * <li>{@code anyOf} for nullable / union types</li>
-         * </ul>
-         * <p>
-         * The following keywords are <b>not</b> portable across providers and
-         * should be avoided unless you target a specific provider:
-         * {@code $ref}, {@code oneOf}, {@code allOf}, {@code not},
-         * {@code pattern}, {@code format}, {@code minimum}, {@code maximum},
-         * {@code minItems}, {@code maxItems}.
-         * </p>
          *
          * @return the JSON Schema string, or {@code null} if the tool takes no
          *         parameters
@@ -229,15 +210,12 @@ public interface LLMProvider {
          * Executes the tool with the given arguments.
          * <p>
          * Implementations should return a human-readable result string on
-         * success. On failure, implementations may throw any runtime exception;
-         * the provider will catch it and report the error message back to the
-         * LLM so it can recover gracefully.
+         * success. On failure, they may throw any runtime exception.
          * </p>
          *
          * @param arguments
          *            the tool arguments as a {@link JsonNode} matching the
-         *            parameters schema, never {@code null}. Tools that take no
-         *            parameters receive an empty object node.
+         *            parameters schema
          * @return the result of the tool execution as a string, never
          *         {@code null}
          */

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.AttachmentContentType;
 import com.vaadin.flow.component.ai.common.ChatMessage;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import dev.langchain4j.agent.tool.Tool;
@@ -62,7 +63,6 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 /**
  * LangChain4j implementation of {@link LLMProvider}.
@@ -99,7 +99,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
             .getLogger(LangChain4JLLMProvider.class);
 
     private static final int MAX_MESSAGES = 30;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final transient StreamingChatModel streamingChatModel;
     private final transient ChatModel nonStreamingChatModel;
@@ -216,8 +215,8 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
         // Add explicit (framework-agnostic) tools
         for (var tool : explicitTools) {
-            toolExecutors.put(tool.getName(),
-                    (execReq, memoryId) -> tool.execute(execReq.arguments()));
+            toolExecutors.put(tool.getName(), (execReq, memoryId) -> tool
+                    .execute(parseArguments(execReq.arguments())));
         }
         return toolExecutors;
     }
@@ -252,9 +251,16 @@ public class LangChain4JLLMProvider implements LLMProvider {
         return builder.build();
     }
 
+    private static JsonNode parseArguments(String arguments) {
+        if (arguments == null || arguments.isBlank()) {
+            return JacksonUtils.createObjectNode();
+        }
+        return JacksonUtils.readTree(arguments);
+    }
+
     private static JsonObjectSchema parseParametersSchema(String schemaJson) {
         try {
-            JsonNode root = OBJECT_MAPPER.readTree(schemaJson);
+            JsonNode root = JacksonUtils.readTree(schemaJson);
             var schemaBuilder = JsonObjectSchema.builder();
             if (root.has("properties")) {
                 JsonNode props = root.get("properties");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -41,9 +41,11 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.AttachmentContentType;
 import com.vaadin.flow.component.ai.common.ChatMessage;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Spring AI implementation of {@link LLMProvider}.
@@ -285,12 +287,19 @@ public class SpringAILLMProvider implements LLMProvider {
             @Override
             public String call(String arguments) {
                 try {
-                    return tool.execute(arguments);
+                    return tool.execute(parseArguments(arguments));
                 } catch (Exception e) {
                     return "Error executing tool: " + e.getMessage();
                 }
             }
         };
+    }
+
+    private static JsonNode parseArguments(String arguments) {
+        if (arguments == null || arguments.isBlank()) {
+            return JacksonUtils.createObjectNode();
+        }
+        return JacksonUtils.readTree(arguments);
     }
 
     private static void checkPushConfiguration() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -38,6 +38,7 @@ import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
 
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 class AIComponentsSerializableTest extends ClassesSerializableTest {
 
@@ -369,7 +370,7 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return "result";
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -43,6 +43,8 @@ import com.vaadin.flow.component.charts.util.ChartSerialization;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
 
+import tools.jackson.databind.JsonNode;
+
 class ChartAIControllerTest {
 
     @RegisterExtension
@@ -115,17 +117,14 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "column");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"column\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             String state = findTool(tools, "get_chart_state")
-                    .execute(JacksonUtils.createObjectNode());
+                    .execute(json("{}"));
             Assertions.assertTrue(state.contains("\"configuration\""));
             Assertions.assertTrue(state.contains("\"series\""),
                     "State should include series configuration");
@@ -139,13 +138,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             ChartEntry entry = ChartEntry.get(chart);
@@ -160,8 +156,8 @@ class ChartAIControllerTest {
             var tool = findTool(controller.getTools(),
                     "update_chart_configuration");
 
-            String result = tool.execute(JacksonUtils.createObjectNode()
-                    .put("configuration", "not a json object"));
+            String result = tool.execute(
+                    json("{\"configuration\": \"not a json object\"}"));
             Assertions.assertTrue(result.contains("Error"),
                     "Invalid config should return error: " + result);
         }
@@ -174,9 +170,8 @@ class ChartAIControllerTest {
                     .filter(t -> t.getName().equals("update_chart_data_source"))
                     .findFirst().get();
 
-            String result = tool.execute(JacksonUtils.createObjectNode().set(
-                    "queries",
-                    JacksonUtils.createArrayNode().add("SELECT invalid")));
+            String result = tool
+                    .execute(json("{\"queries\": [\"SELECT invalid\"]}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Bad SQL"));
         }
@@ -188,8 +183,7 @@ class ChartAIControllerTest {
 
             var tools = controller.getTools();
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
@@ -213,13 +207,11 @@ class ChartAIControllerTest {
             configuration.setPlotOptions(plotOptions);
 
             // Apply and render
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.set("configuration", JacksonUtils
-                    .readTree(ChartSerialization.toJSON(configuration)));
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration")
+                    .execute(json("{\"configuration\":"
+                            + ChartSerialization.toJSON(configuration) + "}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             // Verify plot options were applied to the chart
@@ -242,15 +234,14 @@ class ChartAIControllerTest {
                     .findFirst().get();
 
             String result = dataTool
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             Assertions.assertTrue(result.contains("updated"));
 
             // Verify queries are stored via get_chart_state
             var stateTool = tools.stream()
                     .filter(t -> t.getName().equals("get_chart_state"))
                     .findFirst().get();
-            String state = stateTool.execute(JacksonUtils.createObjectNode());
+            String state = stateTool.execute(json("{}"));
             Assertions.assertTrue(state.contains("SELECT 1"));
         }
     }
@@ -270,19 +261,16 @@ class ChartAIControllerTest {
 
             var tools = controller.getTools();
 
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
             tools.stream()
                     .filter(t -> t.getName()
                             .equals("update_chart_configuration"))
-                    .findFirst().get().execute(configArgs);
+                    .findFirst().get().execute(json(
+                            "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
 
             tools.stream()
                     .filter(t -> t.getName().equals("update_chart_data_source"))
                     .findFirst().get()
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             controller.onRequestCompleted();
 
@@ -310,13 +298,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "column");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"column\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             ChartState state = controller.getState();
@@ -336,14 +321,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            var configObj = configArgs.putObject("configuration");
-            configObj.putObject("chart").put("type", "column");
-            configObj.putObject("title").put("text", "Original");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"column\"}, \"title\": {\"text\": \"Original\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             ChartState savedState = controller.getState();
@@ -467,13 +448,10 @@ class ChartAIControllerTest {
 
             // Create pending state via tool calls
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             ChartEntry entry = ChartEntry.get(chart);
             Assertions.assertTrue(entry.hasPendingState(),
@@ -502,13 +480,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             Assertions.assertNotNull(captured.get());
@@ -532,8 +507,7 @@ class ChartAIControllerTest {
 
             var tools = controller.getTools();
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
@@ -552,13 +526,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             Assertions.assertNull(captured.get());
@@ -570,13 +541,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             List<ChartState> states = new ArrayList<>();
@@ -602,13 +570,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             Assertions.assertNotNull(secondListenerState.get(),
@@ -622,10 +587,8 @@ class ChartAIControllerTest {
             controller.addStateChangeListener(captured::set);
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "pie");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
             controller.onRequestCompleted();
 
             Assertions.assertNull(captured.get());
@@ -646,13 +609,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             // Render is deferred (chart detached), so pending state
@@ -671,13 +631,10 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             // Listener should not fire while chart is detached
@@ -699,25 +656,19 @@ class ChartAIControllerTest {
             // First request while detached
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
             // Second request while still detached
             databaseProvider.results = List
                     .of(Map.of("category", "B", "value", 20));
-            var configArgs2 = JacksonUtils.createObjectNode();
-            configArgs2.putObject("configuration").putObject("chart")
-                    .put("type", "pie");
-            findTool(tools, "update_chart_configuration").execute(configArgs2);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 2")));
+                    .execute(json("{\"queries\": [\"SELECT 2\"]}"));
             controller.onRequestCompleted();
 
             ui.add(chart);
@@ -750,13 +701,10 @@ class ChartAIControllerTest {
 
             // Create pending state via tools
             var tools = controller.getTools();
-            var configArgs = JacksonUtils.createObjectNode();
-            configArgs.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            findTool(tools, "update_chart_configuration").execute(configArgs);
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
-                    .execute(JacksonUtils.createObjectNode().set("queries",
-                            JacksonUtils.createArrayNode().add("SELECT 1")));
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             Configuration config = new Configuration();
             config.getChart().setType(ChartType.COLUMN);
@@ -787,6 +735,10 @@ class ChartAIControllerTest {
             List<LLMProvider.ToolSpec> tools, String name) {
         return tools.stream().filter(t -> t.getName().equals(name)).findFirst()
                 .orElseThrow();
+    }
+
+    private static JsonNode json(String json) {
+        return JacksonUtils.readTree(json);
     }
 
     private static class TestDatabaseProvider implements DatabaseProvider {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.charts.model.DataSeriesItem;
 import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
 import com.vaadin.flow.component.charts.model.Stacking;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
 
 class ChartAIControllerTest {
@@ -114,13 +115,17 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"column\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "column");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
-            String state = findTool(tools, "get_chart_state").execute("{}");
+            String state = findTool(tools, "get_chart_state")
+                    .execute(JacksonUtils.createObjectNode());
             Assertions.assertTrue(state.contains("\"configuration\""));
             Assertions.assertTrue(state.contains("\"series\""),
                     "State should include series configuration");
@@ -134,10 +139,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             ChartEntry entry = ChartEntry.get(chart);
@@ -152,8 +160,8 @@ class ChartAIControllerTest {
             var tool = findTool(controller.getTools(),
                     "update_chart_configuration");
 
-            String result = tool
-                    .execute("{\"configuration\": \"not a json object\"}");
+            String result = tool.execute(JacksonUtils.createObjectNode()
+                    .put("configuration", "not a json object"));
             Assertions.assertTrue(result.contains("Error"),
                     "Invalid config should return error: " + result);
         }
@@ -166,7 +174,9 @@ class ChartAIControllerTest {
                     .filter(t -> t.getName().equals("update_chart_data_source"))
                     .findFirst().get();
 
-            String result = tool.execute("{\"queries\":[\"SELECT invalid\"]}");
+            String result = tool.execute(JacksonUtils.createObjectNode().set(
+                    "queries",
+                    JacksonUtils.createArrayNode().add("SELECT invalid")));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Bad SQL"));
         }
@@ -178,7 +188,8 @@ class ChartAIControllerTest {
 
             var tools = controller.getTools();
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
 
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
@@ -202,11 +213,13 @@ class ChartAIControllerTest {
             configuration.setPlotOptions(plotOptions);
 
             // Apply and render
-            findTool(tools, "update_chart_configuration")
-                    .execute("{\"configuration\":"
-                            + ChartSerialization.toJSON(configuration) + "}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.set("configuration", JacksonUtils
+                    .readTree(ChartSerialization.toJSON(configuration)));
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             // Verify plot options were applied to the chart
@@ -228,14 +241,16 @@ class ChartAIControllerTest {
                     .filter(t -> t.getName().equals("update_chart_data_source"))
                     .findFirst().get();
 
-            String result = dataTool.execute("{\"queries\":[\"SELECT 1\"]}");
+            String result = dataTool
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             Assertions.assertTrue(result.contains("updated"));
 
             // Verify queries are stored via get_chart_state
             var stateTool = tools.stream()
                     .filter(t -> t.getName().equals("get_chart_state"))
                     .findFirst().get();
-            String state = stateTool.execute("{}");
+            String state = stateTool.execute(JacksonUtils.createObjectNode());
             Assertions.assertTrue(state.contains("SELECT 1"));
         }
     }
@@ -255,15 +270,19 @@ class ChartAIControllerTest {
 
             var tools = controller.getTools();
 
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
             tools.stream()
                     .filter(t -> t.getName()
                             .equals("update_chart_configuration"))
-                    .findFirst().get().execute(
-                            "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+                    .findFirst().get().execute(configArgs);
 
             tools.stream()
                     .filter(t -> t.getName().equals("update_chart_data_source"))
-                    .findFirst().get().execute("{\"queries\":[\"SELECT 1\"]}");
+                    .findFirst().get()
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
 
             controller.onRequestCompleted();
 
@@ -291,10 +310,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"column\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "column");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             ChartState state = controller.getState();
@@ -314,10 +336,14 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Original\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            var configObj = configArgs.putObject("configuration");
+            configObj.putObject("chart").put("type", "column");
+            configObj.putObject("title").put("text", "Original");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             ChartState savedState = controller.getState();
@@ -441,10 +467,13 @@ class ChartAIControllerTest {
 
             // Create pending state via tool calls
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
 
             ChartEntry entry = ChartEntry.get(chart);
             Assertions.assertTrue(entry.hasPendingState(),
@@ -473,10 +502,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             Assertions.assertNotNull(captured.get());
@@ -500,7 +532,8 @@ class ChartAIControllerTest {
 
             var tools = controller.getTools();
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
 
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
@@ -519,10 +552,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             Assertions.assertNull(captured.get());
@@ -534,10 +570,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             List<ChartState> states = new ArrayList<>();
@@ -563,10 +602,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             Assertions.assertNotNull(secondListenerState.get(),
@@ -580,8 +622,10 @@ class ChartAIControllerTest {
             controller.addStateChangeListener(captured::set);
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"pie\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "pie");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             controller.onRequestCompleted();
 
             Assertions.assertNull(captured.get());
@@ -602,10 +646,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             // Render is deferred (chart detached), so pending state
@@ -624,10 +671,13 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
 
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             // Listener should not fire while chart is detached
@@ -649,19 +699,25 @@ class ChartAIControllerTest {
             // First request while detached
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
             controller.onRequestCompleted();
 
             // Second request while still detached
             databaseProvider.results = List
                     .of(Map.of("category", "B", "value", 20));
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"pie\"}}}");
+            var configArgs2 = JacksonUtils.createObjectNode();
+            configArgs2.putObject("configuration").putObject("chart")
+                    .put("type", "pie");
+            findTool(tools, "update_chart_configuration").execute(configArgs2);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 2\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 2")));
             controller.onRequestCompleted();
 
             ui.add(chart);
@@ -694,10 +750,13 @@ class ChartAIControllerTest {
 
             // Create pending state via tools
             var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(
-                    "{\"configuration\":{\"chart\":{\"type\":\"bar\"}}}");
+            var configArgs = JacksonUtils.createObjectNode();
+            configArgs.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            findTool(tools, "update_chart_configuration").execute(configArgs);
             findTool(tools, "update_chart_data_source")
-                    .execute("{\"queries\":[\"SELECT 1\"]}");
+                    .execute(JacksonUtils.createObjectNode().set("queries",
+                            JacksonUtils.createArrayNode().add("SELECT 1")));
 
             Configuration config = new Configuration();
             config.getChart().setType(ChartType.COLUMN);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -59,6 +59,7 @@ import com.vaadin.flow.component.charts.model.Stacking;
 import com.vaadin.flow.component.charts.model.Tooltip;
 import com.vaadin.flow.component.charts.model.VerticalAlign;
 import com.vaadin.flow.component.charts.model.style.SolidColor;
+import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -659,16 +660,16 @@ class ChartAIToolsSchemaTest {
                     "sankey", "scatter", "solidgauge", "spline", "timeline",
                     "treemap", "waterfall", "xrange" };
             for (String type : expectedTypes) {
-                String result = schemaTool
-                        .execute("{\"chartType\":\"" + type + "\"}");
+                String result = schemaTool.execute(
+                        JacksonUtils.createObjectNode().put("chartType", type));
                 Assertions.assertFalse(result.startsWith("Error"),
                         "Missing schema for type '" + type + "': " + result);
             }
         }
 
         private JsonNode getSchemaNode(String chartType) {
-            String json = schemaTool
-                    .execute("{\"chartType\":\"" + chartType + "\"}");
+            String json = schemaTool.execute(JacksonUtils.createObjectNode()
+                    .put("chartType", chartType));
             Assertions.assertFalse(json.startsWith("Error"),
                     "Schema lookup failed: " + json);
             return MAPPER.readTree(json);
@@ -676,8 +677,8 @@ class ChartAIToolsSchemaTest {
 
         private void assertPlotOptionsMatchSchema(String chartType,
                 AbstractPlotOptions plotOptions) {
-            String schemaJson = schemaTool
-                    .execute("{\"chartType\":\"" + chartType + "\"}");
+            String schemaJson = schemaTool.execute(JacksonUtils
+                    .createObjectNode().put("chartType", chartType));
             Assertions.assertFalse(schemaJson.startsWith("Error"),
                     "Schema lookup failed: " + schemaJson);
             var schema = SchemaRegistry

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.internal.JacksonUtils;
 
 class ChartAIToolsTest {
 
@@ -86,7 +87,8 @@ class ChartAIToolsTest {
         @Test
         void execute_withExplicitChartId_returnsState() {
             callbacks.stateToReturn = "{\"chart\":{\"type\":\"line\"}}";
-            var result = tool.execute("{\"chartId\": \"chart-1\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
             Assertions.assertEquals("{\"chart\":{\"type\":\"line\"}}", result);
             Assertions.assertEquals("chart-1", callbacks.lastGetStateId);
         }
@@ -95,7 +97,7 @@ class ChartAIToolsTest {
         void execute_withSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("only-chart");
             callbacks.stateToReturn = "state";
-            var result = tool.execute("{}");
+            var result = tool.execute(JacksonUtils.createObjectNode());
             Assertions.assertEquals("state", result);
             Assertions.assertEquals("only-chart", callbacks.lastGetStateId);
         }
@@ -104,7 +106,8 @@ class ChartAIToolsTest {
         void execute_withMultipleCharts_andExplicitChartId_resolvesCorrectChart() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
             callbacks.stateToReturn = "state-of-chart-2";
-            var result = tool.execute("{\"chartId\": \"chart-2\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "chart-2"));
             Assertions.assertEquals("state-of-chart-2", result);
             Assertions.assertEquals("chart-2", callbacks.lastGetStateId);
         }
@@ -112,7 +115,8 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_andUnrecognizedChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var result = tool.execute("{\"chartId\": \"bogus\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "bogus"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("chartId is required"));
         }
@@ -120,14 +124,14 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var result = tool.execute("{}");
+            var result = tool.execute(JacksonUtils.createObjectNode());
             Assertions.assertTrue(result.contains("Error"));
         }
 
         @Test
         void execute_withNoCharts_returnsError() {
             callbacks.chartIds = Set.of();
-            var result = tool.execute("{}");
+            var result = tool.execute(JacksonUtils.createObjectNode());
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("No charts available"));
         }
@@ -136,7 +140,8 @@ class ChartAIToolsTest {
         void execute_withNullChartId_andSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("only-chart");
             callbacks.stateToReturn = "state";
-            var result = tool.execute("{\"chartId\": null}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().putNull("chartId"));
             Assertions.assertEquals("state", result);
             Assertions.assertEquals("only-chart", callbacks.lastGetStateId);
         }
@@ -145,7 +150,8 @@ class ChartAIToolsTest {
         void execute_withUnrecognizedChartId_andSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("chart");
             callbacks.stateToReturn = "state";
-            var result = tool.execute("{\"chartId\": \"1\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "1"));
             Assertions.assertEquals("state", result);
             Assertions.assertEquals("chart", callbacks.lastGetStateId);
         }
@@ -154,15 +160,10 @@ class ChartAIToolsTest {
         void execute_whenCallbackThrows_returnsError() {
             callbacks.getStateException = new RuntimeException(
                     "Chart not found");
-            var result = tool.execute("{\"chartId\": \"chart-1\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Chart not found"));
-        }
-
-        @Test
-        void execute_withMalformedJson_returnsError() {
-            var result = tool.execute("not json at all");
-            Assertions.assertTrue(result.contains("Error"));
         }
     }
 
@@ -195,8 +196,11 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withExplicitChartId_updatesConfiguration() {
-            var result = tool.execute(
-                    "{\"chartId\": \"chart-1\", \"configuration\": {\"chart\": {\"type\": \"bar\"}}}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            var result = tool.execute(argsNode);
 
             Assertions.assertEquals("chart-1", callbacks.lastUpdateConfigId);
             Assertions.assertEquals("{\"chart\":{\"type\":\"bar\"}}",
@@ -208,7 +212,9 @@ class ChartAIToolsTest {
         @Test
         void execute_withSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("my-chart");
-            tool.execute("{\"configuration\": {\"title\": \"Test\"}}");
+            var argsNode = JacksonUtils.createObjectNode();
+            argsNode.putObject("configuration").put("title", "Test");
+            tool.execute(argsNode);
 
             Assertions.assertEquals("my-chart", callbacks.lastUpdateConfigId);
         }
@@ -216,14 +222,16 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var result = tool
-                    .execute("{\"configuration\": {\"title\": \"Test\"}}");
+            var argsNode = JacksonUtils.createObjectNode();
+            argsNode.putObject("configuration").put("title", "Test");
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
         }
 
         @Test
         void execute_withMissingConfiguration_returnsError() {
-            var result = tool.execute("{\"chartId\": \"chart-1\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("'configuration' parameter is required"));
@@ -233,16 +241,13 @@ class ChartAIToolsTest {
         void execute_whenCallbackThrows_returnsError() {
             callbacks.updateConfigException = new RuntimeException(
                     "Config rejected");
-            var result = tool.execute(
-                    "{\"chartId\": \"chart-1\", \"configuration\": {\"chart\": {\"type\": \"bar\"}}}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putObject("configuration").putObject("chart").put("type",
+                    "bar");
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Config rejected"));
-        }
-
-        @Test
-        void execute_withMalformedJson_returnsError() {
-            var result = tool.execute("not json at all");
-            Assertions.assertTrue(result.contains("Error"));
         }
     }
 
@@ -278,8 +283,11 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withExplicitChartId_updatesData() {
-            var result = tool.execute(
-                    "{\"chartId\": \"chart-1\", \"queries\": [\"SELECT * FROM t1\", \"SELECT * FROM t2\"]}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putArray("queries").add("SELECT * FROM t1")
+                    .add("SELECT * FROM t2");
+            var result = tool.execute(argsNode);
 
             Assertions.assertEquals("chart-1", callbacks.lastUpdateDataId);
             Assertions.assertEquals(
@@ -292,7 +300,9 @@ class ChartAIToolsTest {
         @Test
         void execute_withSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("my-chart");
-            tool.execute("{\"queries\": [\"SELECT 1\"]}");
+            var argsNode = JacksonUtils.createObjectNode();
+            argsNode.putArray("queries").add("SELECT 1");
+            tool.execute(argsNode);
 
             Assertions.assertEquals("my-chart", callbacks.lastUpdateDataId);
             Assertions.assertEquals(List.of("SELECT 1"),
@@ -302,7 +312,9 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var result = tool.execute("{\"queries\": [\"SELECT 1\"]}");
+            var argsNode = JacksonUtils.createObjectNode();
+            argsNode.putArray("queries").add("SELECT 1");
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
         }
 
@@ -310,21 +322,27 @@ class ChartAIToolsTest {
         void execute_whenCallbackThrows_returnsError() {
             callbacks.updateDataException = new RuntimeException(
                     "Invalid query");
-            var result = tool.execute(
-                    "{\"chartId\": \"chart-1\", \"queries\": [\"SELECT invalid\"]}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putArray("queries").add("SELECT invalid");
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Invalid query"));
         }
 
         @Test
         void execute_withEmptyQueries_updatesData() {
-            tool.execute("{\"chartId\": \"chart-1\", \"queries\": []}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putArray("queries");
+            tool.execute(argsNode);
             Assertions.assertEquals(List.of(), callbacks.lastUpdateDataQueries);
         }
 
         @Test
         void execute_withMissingQueries_returnsError() {
-            var result = tool.execute("{\"chartId\": \"chart-1\"}");
+            var result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("'queries' parameter is required"));
@@ -332,16 +350,19 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withNonArrayQueries_returnsError() {
-            var result = tool.execute(
-                    "{\"chartId\": \"chart-1\", \"queries\": \"SELECT 1\"}");
+            var argsNode = JacksonUtils.createObjectNode()
+                    .put("chartId", "chart-1").put("queries", "SELECT 1");
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("must be an array"));
         }
 
         @Test
         void execute_withNullQueryElement_returnsError() {
-            var result = tool
-                    .execute("{\"chartId\": \"chart-1\", \"queries\": [null]}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putArray("queries").addNull();
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("must not contain null elements"));
@@ -349,18 +370,15 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withEmptyQueryString_returnsError() {
-            var result = tool
-                    .execute("{\"chartId\": \"chart-1\", \"queries\": [\"\"]}");
+            var argsNode = JacksonUtils.createObjectNode().put("chartId",
+                    "chart-1");
+            argsNode.putArray("queries").add("");
+            var result = tool.execute(argsNode);
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("must not contain empty strings"));
         }
 
-        @Test
-        void execute_withMalformedJson_returnsError() {
-            var result = tool.execute("not json at all");
-            Assertions.assertTrue(result.contains("Error"));
-        }
     }
 
     @Nested
@@ -380,7 +398,8 @@ class ChartAIToolsTest {
 
         @Test
         void unknownType_returnsError() {
-            String result = tool.execute("{\"chartType\":\"nonexistent\"}");
+            String result = tool.execute(JacksonUtils.createObjectNode()
+                    .put("chartType", "nonexistent"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("unknown chart type"));
             Assertions.assertTrue(result.contains("Supported types:"),
@@ -391,14 +410,15 @@ class ChartAIToolsTest {
 
         @Test
         void missingParameter_returnsError() {
-            String result = tool.execute("{}");
+            String result = tool.execute(JacksonUtils.createObjectNode());
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("chartType"));
         }
 
         @Test
         void caseInsensitive() {
-            String result = tool.execute("{\"chartType\":\"COLUMN\"}");
+            String result = tool.execute(
+                    JacksonUtils.createObjectNode().put("chartType", "COLUMN"));
             Assertions.assertFalse(result.contains("Error"), result);
             Assertions.assertTrue(result.contains("\"properties\""));
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.internal.JacksonUtils;
 
+import tools.jackson.databind.JsonNode;
+
 class ChartAIToolsTest {
 
     private TestCallbacks callbacks;
@@ -58,6 +60,10 @@ class ChartAIToolsTest {
         Assertions.assertTrue(names.contains("get_plot_options_schema"));
     }
 
+    private static JsonNode json(String json) {
+        return JacksonUtils.readTree(json);
+    }
+
     @Nested
     class GetChartState {
 
@@ -87,8 +93,7 @@ class ChartAIToolsTest {
         @Test
         void execute_withExplicitChartId_returnsState() {
             callbacks.stateToReturn = "{\"chart\":{\"type\":\"line\"}}";
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
+            var result = tool.execute(json("{\"chartId\": \"chart-1\"}"));
             Assertions.assertEquals("{\"chart\":{\"type\":\"line\"}}", result);
             Assertions.assertEquals("chart-1", callbacks.lastGetStateId);
         }
@@ -97,7 +102,7 @@ class ChartAIToolsTest {
         void execute_withSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("only-chart");
             callbacks.stateToReturn = "state";
-            var result = tool.execute(JacksonUtils.createObjectNode());
+            var result = tool.execute(json("{}"));
             Assertions.assertEquals("state", result);
             Assertions.assertEquals("only-chart", callbacks.lastGetStateId);
         }
@@ -106,8 +111,7 @@ class ChartAIToolsTest {
         void execute_withMultipleCharts_andExplicitChartId_resolvesCorrectChart() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
             callbacks.stateToReturn = "state-of-chart-2";
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "chart-2"));
+            var result = tool.execute(json("{\"chartId\": \"chart-2\"}"));
             Assertions.assertEquals("state-of-chart-2", result);
             Assertions.assertEquals("chart-2", callbacks.lastGetStateId);
         }
@@ -115,8 +119,7 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_andUnrecognizedChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "bogus"));
+            var result = tool.execute(json("{\"chartId\": \"bogus\"}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("chartId is required"));
         }
@@ -124,14 +127,14 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var result = tool.execute(JacksonUtils.createObjectNode());
+            var result = tool.execute(json("{}"));
             Assertions.assertTrue(result.contains("Error"));
         }
 
         @Test
         void execute_withNoCharts_returnsError() {
             callbacks.chartIds = Set.of();
-            var result = tool.execute(JacksonUtils.createObjectNode());
+            var result = tool.execute(json("{}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("No charts available"));
         }
@@ -140,8 +143,7 @@ class ChartAIToolsTest {
         void execute_withNullChartId_andSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("only-chart");
             callbacks.stateToReturn = "state";
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().putNull("chartId"));
+            var result = tool.execute(json("{\"chartId\": null}"));
             Assertions.assertEquals("state", result);
             Assertions.assertEquals("only-chart", callbacks.lastGetStateId);
         }
@@ -150,8 +152,7 @@ class ChartAIToolsTest {
         void execute_withUnrecognizedChartId_andSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("chart");
             callbacks.stateToReturn = "state";
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "1"));
+            var result = tool.execute(json("{\"chartId\": \"1\"}"));
             Assertions.assertEquals("state", result);
             Assertions.assertEquals("chart", callbacks.lastGetStateId);
         }
@@ -160,8 +161,7 @@ class ChartAIToolsTest {
         void execute_whenCallbackThrows_returnsError() {
             callbacks.getStateException = new RuntimeException(
                     "Chart not found");
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
+            var result = tool.execute(json("{\"chartId\": \"chart-1\"}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Chart not found"));
         }
@@ -196,11 +196,8 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withExplicitChartId_updatesConfiguration() {
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
 
             Assertions.assertEquals("chart-1", callbacks.lastUpdateConfigId);
             Assertions.assertEquals("{\"chart\":{\"type\":\"bar\"}}",
@@ -212,9 +209,7 @@ class ChartAIToolsTest {
         @Test
         void execute_withSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("my-chart");
-            var argsNode = JacksonUtils.createObjectNode();
-            argsNode.putObject("configuration").put("title", "Test");
-            tool.execute(argsNode);
+            tool.execute(json("{\"configuration\": {\"title\": \"Test\"}}"));
 
             Assertions.assertEquals("my-chart", callbacks.lastUpdateConfigId);
         }
@@ -222,16 +217,14 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var argsNode = JacksonUtils.createObjectNode();
-            argsNode.putObject("configuration").put("title", "Test");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(
+                    json("{\"configuration\": {\"title\": \"Test\"}}"));
             Assertions.assertTrue(result.contains("Error"));
         }
 
         @Test
         void execute_withMissingConfiguration_returnsError() {
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
+            var result = tool.execute(json("{\"chartId\": \"chart-1\"}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("'configuration' parameter is required"));
@@ -241,11 +234,8 @@ class ChartAIToolsTest {
         void execute_whenCallbackThrows_returnsError() {
             callbacks.updateConfigException = new RuntimeException(
                     "Config rejected");
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putObject("configuration").putObject("chart").put("type",
-                    "bar");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Config rejected"));
         }
@@ -283,11 +273,8 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withExplicitChartId_updatesData() {
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putArray("queries").add("SELECT * FROM t1")
-                    .add("SELECT * FROM t2");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"queries\": [\"SELECT * FROM t1\", \"SELECT * FROM t2\"]}"));
 
             Assertions.assertEquals("chart-1", callbacks.lastUpdateDataId);
             Assertions.assertEquals(
@@ -300,9 +287,7 @@ class ChartAIToolsTest {
         @Test
         void execute_withSingleChart_defaultsToThatChart() {
             callbacks.chartIds = Set.of("my-chart");
-            var argsNode = JacksonUtils.createObjectNode();
-            argsNode.putArray("queries").add("SELECT 1");
-            tool.execute(argsNode);
+            tool.execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             Assertions.assertEquals("my-chart", callbacks.lastUpdateDataId);
             Assertions.assertEquals(List.of("SELECT 1"),
@@ -312,9 +297,7 @@ class ChartAIToolsTest {
         @Test
         void execute_withMultipleCharts_noChartId_returnsError() {
             callbacks.chartIds = Set.of("chart-1", "chart-2");
-            var argsNode = JacksonUtils.createObjectNode();
-            argsNode.putArray("queries").add("SELECT 1");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(json("{\"queries\": [\"SELECT 1\"]}"));
             Assertions.assertTrue(result.contains("Error"));
         }
 
@@ -322,27 +305,21 @@ class ChartAIToolsTest {
         void execute_whenCallbackThrows_returnsError() {
             callbacks.updateDataException = new RuntimeException(
                     "Invalid query");
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putArray("queries").add("SELECT invalid");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"queries\": [\"SELECT invalid\"]}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("Invalid query"));
         }
 
         @Test
         void execute_withEmptyQueries_updatesData() {
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putArray("queries");
-            tool.execute(argsNode);
+            tool.execute(json("{\"chartId\": \"chart-1\", \"queries\": []}"));
             Assertions.assertEquals(List.of(), callbacks.lastUpdateDataQueries);
         }
 
         @Test
         void execute_withMissingQueries_returnsError() {
-            var result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartId", "chart-1"));
+            var result = tool.execute(json("{\"chartId\": \"chart-1\"}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("'queries' parameter is required"));
@@ -350,19 +327,16 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withNonArrayQueries_returnsError() {
-            var argsNode = JacksonUtils.createObjectNode()
-                    .put("chartId", "chart-1").put("queries", "SELECT 1");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"queries\": \"SELECT 1\"}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("must be an array"));
         }
 
         @Test
         void execute_withNullQueryElement_returnsError() {
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putArray("queries").addNull();
-            var result = tool.execute(argsNode);
+            var result = tool.execute(
+                    json("{\"chartId\": \"chart-1\", \"queries\": [null]}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("must not contain null elements"));
@@ -370,10 +344,8 @@ class ChartAIToolsTest {
 
         @Test
         void execute_withEmptyQueryString_returnsError() {
-            var argsNode = JacksonUtils.createObjectNode().put("chartId",
-                    "chart-1");
-            argsNode.putArray("queries").add("");
-            var result = tool.execute(argsNode);
+            var result = tool.execute(
+                    json("{\"chartId\": \"chart-1\", \"queries\": [\"\"]}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(
                     result.contains("must not contain empty strings"));
@@ -398,8 +370,8 @@ class ChartAIToolsTest {
 
         @Test
         void unknownType_returnsError() {
-            String result = tool.execute(JacksonUtils.createObjectNode()
-                    .put("chartType", "nonexistent"));
+            String result = tool
+                    .execute(json("{\"chartType\":\"nonexistent\"}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("unknown chart type"));
             Assertions.assertTrue(result.contains("Supported types:"),
@@ -410,15 +382,14 @@ class ChartAIToolsTest {
 
         @Test
         void missingParameter_returnsError() {
-            String result = tool.execute(JacksonUtils.createObjectNode());
+            String result = tool.execute(json("{}"));
             Assertions.assertTrue(result.contains("Error"));
             Assertions.assertTrue(result.contains("chartType"));
         }
 
         @Test
         void caseInsensitive() {
-            String result = tool.execute(
-                    JacksonUtils.createObjectNode().put("chartType", "COLUMN"));
+            String result = tool.execute(json("{\"chartType\":\"COLUMN\"}"));
             Assertions.assertFalse(result.contains("Error"), result);
             Assertions.assertTrue(result.contains("\"properties\""));
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -72,18 +72,21 @@ class ChartRenderingTest {
     }
 
     private void updateConfiguration(String configJson) {
-        var argsNode = JacksonUtils.createObjectNode();
-        argsNode.set("configuration", JacksonUtils.readTree(configJson));
-        findTool("update_chart_configuration").execute(argsNode);
+        findTool("update_chart_configuration").execute(JacksonUtils
+                .readTree("{\"configuration\":" + configJson + "}"));
     }
 
     private void updateData(String... queries) {
-        var argsNode = JacksonUtils.createObjectNode();
-        var array = argsNode.putArray("queries");
-        for (var query : queries) {
-            array.add(query);
+        var sb = new StringBuilder("{\"queries\":[");
+        for (int i = 0; i < queries.length; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("\"").append(queries[i]).append("\"");
         }
-        findTool("update_chart_data_source").execute(argsNode);
+        sb.append("]}");
+        findTool("update_chart_data_source")
+                .execute(JacksonUtils.readTree(sb.toString()));
     }
 
     @Nested

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -39,6 +39,7 @@ import com.vaadin.flow.component.charts.model.OhlcItem;
 import com.vaadin.flow.component.charts.model.PlotOptionsFlags;
 import com.vaadin.flow.component.charts.model.PlotOptionsLine;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
 
 /**
@@ -71,20 +72,18 @@ class ChartRenderingTest {
     }
 
     private void updateConfiguration(String configJson) {
-        findTool("update_chart_configuration")
-                .execute("{\"configuration\":" + configJson + "}");
+        var argsNode = JacksonUtils.createObjectNode();
+        argsNode.set("configuration", JacksonUtils.readTree(configJson));
+        findTool("update_chart_configuration").execute(argsNode);
     }
 
     private void updateData(String... queries) {
-        StringBuilder sb = new StringBuilder("{\"queries\":[");
-        for (int i = 0; i < queries.length; i++) {
-            if (i > 0) {
-                sb.append(",");
-            }
-            sb.append("\"").append(queries[i]).append("\"");
+        var argsNode = JacksonUtils.createObjectNode();
+        var array = argsNode.putArray("queries");
+        for (var query : queries) {
+            array.add(query);
         }
-        sb.append("]}");
-        findTool("update_chart_data_source").execute(sb.toString());
+        findTool("update_chart_data_source").execute(argsNode);
     }
 
     @Nested

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -46,6 +46,8 @@ import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
 
+import tools.jackson.databind.JsonNode;
+
 class GridAIControllerTest {
 
     @RegisterExtension
@@ -100,8 +102,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("get_database_schema"))
                 .findFirst().orElseThrow();
-        Assertions.assertEquals("test schema",
-                tool.execute(JacksonUtils.createObjectNode()));
+        Assertions.assertEquals("test schema", tool.execute(json("{}")));
     }
 
     @Test
@@ -109,7 +110,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("get_grid_state")).findFirst()
                 .orElseThrow();
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("empty"));
     }
 
@@ -119,8 +120,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("update_grid_data")).findFirst()
                 .orElseThrow();
-        var result = tool.execute(
-                JacksonUtils.createObjectNode().put("query", "SELECT 1"));
+        var result = tool.execute(json("{\"query\": \"SELECT 1\"}"));
         Assertions.assertTrue(result.contains("queued successfully"));
     }
 
@@ -130,8 +130,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("update_grid_data")).findFirst()
                 .orElseThrow();
-        var result = tool.execute(
-                JacksonUtils.createObjectNode().put("query", "INVALID"));
+        var result = tool.execute(json("{\"query\": \"INVALID\"}"));
         Assertions.assertTrue(result.contains("Error"));
     }
 
@@ -140,7 +139,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("update_grid_data")).findFirst()
                 .orElseThrow();
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("Error"));
     }
 
@@ -173,8 +172,8 @@ class GridAIControllerTest {
     @Test
     void getState_afterFailedRender_returnsNull() {
         dbProvider.queryResults = List.of(row("a", 1));
-        findTool("update_grid_data").execute(JacksonUtils.createObjectNode()
-                .put("query", "SELECT a FROM t"));
+        findTool("update_grid_data")
+                .execute(json("{\"query\": \"SELECT a FROM t\"}"));
 
         dbProvider.throwOnExecute = true;
         controller.onRequestCompleted();
@@ -190,7 +189,7 @@ class GridAIControllerTest {
         simulateUpdate("SELECT a FROM t");
 
         var stateTool = findTool("get_grid_state");
-        var result = stateTool.execute(JacksonUtils.createObjectNode());
+        var result = stateTool.execute(json("{}"));
         Assertions.assertTrue(result.contains("SELECT a FROM t"));
     }
 
@@ -213,8 +212,8 @@ class GridAIControllerTest {
 
         // State should still reflect the first update
         var stateTool = findTool("get_grid_state");
-        Assertions.assertTrue(stateTool.execute(JacksonUtils.createObjectNode())
-                .contains("SELECT a FROM t"));
+        Assertions.assertTrue(
+                stateTool.execute(json("{}")).contains("SELECT a FROM t"));
     }
 
     // --- GridState serialization ---
@@ -312,8 +311,8 @@ class GridAIControllerTest {
 
         // LLM tries a bad query
         dbProvider.queryResults = List.of(row("a", 1));
-        findTool("update_grid_data").execute(JacksonUtils.createObjectNode()
-                .put("query", "SELECT a FROM bad"));
+        findTool("update_grid_data")
+                .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
         dbProvider.throwOnExecute = true;
         controller.onRequestCompleted();
 
@@ -327,8 +326,7 @@ class GridAIControllerTest {
         dbProvider.queryResults = List.of(row("a", 1));
         controller.restoreState(new GridState("SELECT a FROM t"));
 
-        var result = findTool("get_grid_state")
-                .execute(JacksonUtils.createObjectNode());
+        var result = findTool("get_grid_state").execute(json("{}"));
         Assertions.assertTrue(result.contains("SELECT a FROM t"));
     }
 
@@ -352,8 +350,8 @@ class GridAIControllerTest {
         controller.addStateChangeListener(captured::set);
 
         dbProvider.queryResults = List.of(row("a", 1));
-        findTool("update_grid_data").execute(JacksonUtils.createObjectNode()
-                .put("query", "SELECT a FROM t"));
+        findTool("update_grid_data")
+                .execute(json("{\"query\": \"SELECT a FROM t\"}"));
 
         dbProvider.throwOnExecute = true;
         controller.onRequestCompleted();
@@ -912,12 +910,16 @@ class GridAIControllerTest {
                 .orElseThrow();
     }
 
+    private static JsonNode json(String json) {
+        return JacksonUtils.readTree(json);
+    }
+
     /**
      * Simulates a full LLM update cycle: tool call + onRequestCompleted.
      */
     private void simulateUpdate(String query) {
         findTool("update_grid_data")
-                .execute(JacksonUtils.createObjectNode().put("query", query));
+                .execute(json("{\"query\": \"" + query + "\"}"));
         controller.onRequestCompleted();
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.provider.QuerySortOrder;
 import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
 
 class GridAIControllerTest {
@@ -99,7 +100,8 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("get_database_schema"))
                 .findFirst().orElseThrow();
-        Assertions.assertEquals("test schema", tool.execute("{}"));
+        Assertions.assertEquals("test schema",
+                tool.execute(JacksonUtils.createObjectNode()));
     }
 
     @Test
@@ -107,7 +109,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("get_grid_state")).findFirst()
                 .orElseThrow();
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("empty"));
     }
 
@@ -117,7 +119,8 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("update_grid_data")).findFirst()
                 .orElseThrow();
-        var result = tool.execute("{\"query\": \"SELECT 1\"}");
+        var result = tool.execute(
+                JacksonUtils.createObjectNode().put("query", "SELECT 1"));
         Assertions.assertTrue(result.contains("queued successfully"));
     }
 
@@ -127,7 +130,8 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("update_grid_data")).findFirst()
                 .orElseThrow();
-        var result = tool.execute("{\"query\": \"INVALID\"}");
+        var result = tool.execute(
+                JacksonUtils.createObjectNode().put("query", "INVALID"));
         Assertions.assertTrue(result.contains("Error"));
     }
 
@@ -136,7 +140,7 @@ class GridAIControllerTest {
         var tool = controller.getTools().stream()
                 .filter(t -> t.getName().equals("update_grid_data")).findFirst()
                 .orElseThrow();
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("Error"));
     }
 
@@ -169,8 +173,8 @@ class GridAIControllerTest {
     @Test
     void getState_afterFailedRender_returnsNull() {
         dbProvider.queryResults = List.of(row("a", 1));
-        findTool("update_grid_data")
-                .execute("{\"query\": \"SELECT a FROM t\"}");
+        findTool("update_grid_data").execute(JacksonUtils.createObjectNode()
+                .put("query", "SELECT a FROM t"));
 
         dbProvider.throwOnExecute = true;
         controller.onRequestCompleted();
@@ -186,7 +190,7 @@ class GridAIControllerTest {
         simulateUpdate("SELECT a FROM t");
 
         var stateTool = findTool("get_grid_state");
-        var result = stateTool.execute("{}");
+        var result = stateTool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("SELECT a FROM t"));
     }
 
@@ -209,8 +213,8 @@ class GridAIControllerTest {
 
         // State should still reflect the first update
         var stateTool = findTool("get_grid_state");
-        Assertions.assertTrue(
-                stateTool.execute("{}").contains("SELECT a FROM t"));
+        Assertions.assertTrue(stateTool.execute(JacksonUtils.createObjectNode())
+                .contains("SELECT a FROM t"));
     }
 
     // --- GridState serialization ---
@@ -308,8 +312,8 @@ class GridAIControllerTest {
 
         // LLM tries a bad query
         dbProvider.queryResults = List.of(row("a", 1));
-        findTool("update_grid_data")
-                .execute("{\"query\": \"SELECT a FROM bad\"}");
+        findTool("update_grid_data").execute(JacksonUtils.createObjectNode()
+                .put("query", "SELECT a FROM bad"));
         dbProvider.throwOnExecute = true;
         controller.onRequestCompleted();
 
@@ -323,7 +327,8 @@ class GridAIControllerTest {
         dbProvider.queryResults = List.of(row("a", 1));
         controller.restoreState(new GridState("SELECT a FROM t"));
 
-        var result = findTool("get_grid_state").execute("{}");
+        var result = findTool("get_grid_state")
+                .execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("SELECT a FROM t"));
     }
 
@@ -347,8 +352,8 @@ class GridAIControllerTest {
         controller.addStateChangeListener(captured::set);
 
         dbProvider.queryResults = List.of(row("a", 1));
-        findTool("update_grid_data")
-                .execute("{\"query\": \"SELECT a FROM t\"}");
+        findTool("update_grid_data").execute(JacksonUtils.createObjectNode()
+                .put("query", "SELECT a FROM t"));
 
         dbProvider.throwOnExecute = true;
         controller.onRequestCompleted();
@@ -911,8 +916,8 @@ class GridAIControllerTest {
      * Simulates a full LLM update cycle: tool call + onRequestCompleted.
      */
     private void simulateUpdate(String query) {
-        findTool("update_grid_data").execute(
-                "{\"query\": \"" + query.replace("\"", "\\\"") + "\"}");
+        findTool("update_grid_data")
+                .execute(JacksonUtils.createObjectNode().put("query", query));
         controller.onRequestCompleted();
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.internal.JacksonUtils;
 
 class GridAIToolsTest {
 
@@ -77,7 +78,7 @@ class GridAIToolsTest {
     @Test
     void getGridState_noQuery_returnsEmpty() {
         var tool = GridAITools.getGridState(singleGridCallbacks(null, null));
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("empty"));
     }
 
@@ -85,7 +86,7 @@ class GridAIToolsTest {
     void getGridState_withQuery_returnsQuery() {
         var tool = GridAITools
                 .getGridState(singleGridCallbacks("SELECT * FROM t", null));
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("SELECT * FROM t"));
     }
 
@@ -106,14 +107,14 @@ class GridAIToolsTest {
     void getGridState_singleGrid_autoResolvesId() {
         var tool = GridAITools.getGridState(singleGridCallbacks(null, null));
         // No gridId in arguments — auto-resolves to the single grid
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("grid"));
     }
 
     @Test
     void getGridState_multipleGrids_requiresId() {
         var tool = GridAITools.getGridState(multiGridCallbacks());
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("Error"));
         Assertions.assertTrue(result.contains("gridId is required"));
     }
@@ -121,7 +122,8 @@ class GridAIToolsTest {
     @Test
     void getGridState_multipleGrids_withId_works() {
         var tool = GridAITools.getGridState(multiGridCallbacks());
-        var result = tool.execute("{\"gridId\": \"grid1\"}");
+        var result = tool.execute(
+                JacksonUtils.createObjectNode().put("gridId", "grid1"));
         Assertions.assertTrue(result.contains("grid1"));
     }
 
@@ -138,7 +140,8 @@ class GridAIToolsTest {
         var updated = new AtomicReference<String>();
         var tool = GridAITools
                 .updateGridData(singleGridCallbacks(null, updated));
-        var result = tool.execute("{\"query\": \"SELECT 1\"}");
+        var result = tool.execute(
+                JacksonUtils.createObjectNode().put("query", "SELECT 1"));
         Assertions.assertTrue(result.contains("queued successfully"));
         Assertions.assertEquals("SELECT 1", updated.get());
     }
@@ -161,7 +164,8 @@ class GridAIToolsTest {
                 return Set.of("grid");
             }
         });
-        var result = tool.execute("{\"query\": \"BAD\"}");
+        var result = tool
+                .execute(JacksonUtils.createObjectNode().put("query", "BAD"));
         Assertions.assertTrue(result.contains("Error"));
         Assertions.assertTrue(result.contains("bad query"));
     }
@@ -169,7 +173,7 @@ class GridAIToolsTest {
     @Test
     void updateGridData_missingQuery_returnsError() {
         var tool = GridAITools.updateGridData(singleGridCallbacks(null, null));
-        var result = tool.execute("{}");
+        var result = tool.execute(JacksonUtils.createObjectNode());
         Assertions.assertTrue(result.contains("Error"));
     }
 
@@ -206,8 +210,8 @@ class GridAIToolsTest {
                 return Set.of("g1", "g2");
             }
         });
-        var result = tool
-                .execute("{\"gridId\": \"g1\", \"query\": \"SELECT 1\"}");
+        var result = tool.execute(JacksonUtils.createObjectNode()
+                .put("gridId", "g1").put("query", "SELECT 1"));
         Assertions.assertTrue(result.contains("queued successfully"));
         Assertions.assertEquals("g1:SELECT 1", updated.get());
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
@@ -24,7 +24,13 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.internal.JacksonUtils;
 
+import tools.jackson.databind.JsonNode;
+
 class GridAIToolsTest {
+
+    private static JsonNode json(String json) {
+        return JacksonUtils.readTree(json);
+    }
 
     // --- Stub callbacks ---
 
@@ -78,7 +84,7 @@ class GridAIToolsTest {
     @Test
     void getGridState_noQuery_returnsEmpty() {
         var tool = GridAITools.getGridState(singleGridCallbacks(null, null));
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("empty"));
     }
 
@@ -86,7 +92,7 @@ class GridAIToolsTest {
     void getGridState_withQuery_returnsQuery() {
         var tool = GridAITools
                 .getGridState(singleGridCallbacks("SELECT * FROM t", null));
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("SELECT * FROM t"));
     }
 
@@ -107,14 +113,14 @@ class GridAIToolsTest {
     void getGridState_singleGrid_autoResolvesId() {
         var tool = GridAITools.getGridState(singleGridCallbacks(null, null));
         // No gridId in arguments — auto-resolves to the single grid
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("grid"));
     }
 
     @Test
     void getGridState_multipleGrids_requiresId() {
         var tool = GridAITools.getGridState(multiGridCallbacks());
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("Error"));
         Assertions.assertTrue(result.contains("gridId is required"));
     }
@@ -122,8 +128,7 @@ class GridAIToolsTest {
     @Test
     void getGridState_multipleGrids_withId_works() {
         var tool = GridAITools.getGridState(multiGridCallbacks());
-        var result = tool.execute(
-                JacksonUtils.createObjectNode().put("gridId", "grid1"));
+        var result = tool.execute(json("{\"gridId\": \"grid1\"}"));
         Assertions.assertTrue(result.contains("grid1"));
     }
 
@@ -140,8 +145,7 @@ class GridAIToolsTest {
         var updated = new AtomicReference<String>();
         var tool = GridAITools
                 .updateGridData(singleGridCallbacks(null, updated));
-        var result = tool.execute(
-                JacksonUtils.createObjectNode().put("query", "SELECT 1"));
+        var result = tool.execute(json("{\"query\": \"SELECT 1\"}"));
         Assertions.assertTrue(result.contains("queued successfully"));
         Assertions.assertEquals("SELECT 1", updated.get());
     }
@@ -164,8 +168,7 @@ class GridAIToolsTest {
                 return Set.of("grid");
             }
         });
-        var result = tool
-                .execute(JacksonUtils.createObjectNode().put("query", "BAD"));
+        var result = tool.execute(json("{\"query\": \"BAD\"}"));
         Assertions.assertTrue(result.contains("Error"));
         Assertions.assertTrue(result.contains("bad query"));
     }
@@ -173,7 +176,7 @@ class GridAIToolsTest {
     @Test
     void updateGridData_missingQuery_returnsError() {
         var tool = GridAITools.updateGridData(singleGridCallbacks(null, null));
-        var result = tool.execute(JacksonUtils.createObjectNode());
+        var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("Error"));
     }
 
@@ -210,8 +213,8 @@ class GridAIToolsTest {
                 return Set.of("g1", "g2");
             }
         });
-        var result = tool.execute(JacksonUtils.createObjectNode()
-                .put("gridId", "g1").put("query", "SELECT 1"));
+        var result = tool
+                .execute(json("{\"gridId\": \"g1\", \"query\": \"SELECT 1\"}"));
         Assertions.assertTrue(result.contains("queued successfully"));
         Assertions.assertEquals("g1:SELECT 1", updated.get());
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -60,6 +60,7 @@ import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
 
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 class AIOrchestratorTest {
     @RegisterExtension
@@ -2046,7 +2047,7 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return "result";
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAIToolsTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.internal.JacksonUtils;
+
 class DatabaseProviderAIToolsTest {
 
     private static final String SCHEMA = "Tables: users(id INT, name VARCHAR)";
@@ -71,7 +73,8 @@ class DatabaseProviderAIToolsTest {
     @Test
     void getDatabaseSchema_executeDelegatesToProvider() {
         var tool = DatabaseProviderAITools.getDatabaseSchema(provider);
-        Assertions.assertEquals(SCHEMA, tool.execute(null));
+        Assertions.assertEquals(SCHEMA,
+                tool.execute(JacksonUtils.createObjectNode()));
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -53,6 +53,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import tools.jackson.databind.JsonNode;
 
 class LangChain4JLLMProviderTest {
     @RegisterExtension
@@ -870,19 +871,19 @@ class LangChain4JLLMProviderTest {
 
     @Test
     void stream_withExplicitTool_passesArgumentsToExecutor() {
-        var receivedArgs = new ArrayList<String>();
+        var receivedArgs = new ArrayList<JsonNode>();
         var explicitTool = createExplicitTool("myTool", "A test tool",
                 "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> {
                     receivedArgs.add(args);
-                    return "result for " + args;
+                    return "result for " + args.get("city").asString();
                 });
 
         var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
                 Collections.emptyList(), new Object[0], List.of(explicitTool));
 
-        var toolArgs = "{\"city\":\"Helsinki\"}";
-        var response1 = mockSimpleResponseWithTool("myTool", toolArgs);
+        var response1 = mockSimpleResponseWithTool("myTool",
+                "{\"city\":\"Helsinki\"}");
         var response2 = mockSimpleResponse("Done");
         Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
                 .thenReturn(response1, response2);
@@ -891,13 +892,14 @@ class LangChain4JLLMProviderTest {
 
         Assertions.assertEquals(1, receivedArgs.size(),
                 "Tool executor should have been called once");
-        Assertions.assertEquals(toolArgs, receivedArgs.getFirst(),
-                "Tool executor should receive the arguments from the LLM response");
+        Assertions.assertEquals("Helsinki",
+                receivedArgs.getFirst().get("city").asString(),
+                "Tool executor should receive arguments as a JsonNode parsed from the LLM response");
 
         var captor = ArgumentCaptor.forClass(ChatRequest.class);
         Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
         var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
-        Assertions.assertEquals("result for " + toolArgs,
+        Assertions.assertEquals("result for Helsinki",
                 toolResults.getFirst().text());
     }
 
@@ -954,7 +956,7 @@ class LangChain4JLLMProviderTest {
 
     private static LLMProvider.ToolSpec createExplicitTool(String name,
             String description, String parametersSchema,
-            java.util.function.Function<String, String> executor) {
+            java.util.function.Function<JsonNode, String> executor) {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {
@@ -972,7 +974,7 @@ class LangChain4JLLMProviderTest {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return executor.apply(arguments);
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -904,6 +904,35 @@ class LangChain4JLLMProviderTest {
     }
 
     @Test
+    void stream_withExplicitTool_malformedJsonArguments_returnsError() {
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
+                args -> {
+                    receivedArgs.add(args);
+                    return "ok";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool", "not json");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        Assertions.assertEquals(0, receivedArgs.size());
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
+        Assertions.assertTrue(toolResults.getFirst().text()
+                .startsWith("Error executing tool:"));
+    }
+
+    @Test
     void stream_withExplicitToolNullSchema_createsToolWithoutParameters() {
         var explicitTool = createExplicitTool("simpleTool", "A simple tool",
                 null, args -> "done");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -50,6 +50,7 @@ import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.tests.MockUIExtension;
 
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 class SpringAILLMProviderTest {
     @RegisterExtension
@@ -847,12 +848,12 @@ class SpringAILLMProviderTest {
     @Test
     void stream_withExplicitTool_passesArgumentsToCallback() {
         provider.setStreaming(false);
-        var receivedArgs = new ArrayList<String>();
+        var receivedArgs = new ArrayList<JsonNode>();
         var explicitTool = createExplicitTool("myTool", "A test tool",
                 "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> {
                     receivedArgs.add(args);
-                    return "result for " + args;
+                    return "result for " + args.get("city").asString();
                 });
 
         var request = new TestLLMRequestWithExplicitTools("Call tool", null,
@@ -866,14 +867,15 @@ class SpringAILLMProviderTest {
                 .getToolCallbacks();
         Assertions.assertEquals(1, toolCallbacks.size());
 
-        // Call the callback directly to verify arguments are forwarded
-        var toolArgs = "{\"city\":\"Helsinki\"}";
-        var result = toolCallbacks.getFirst().call(toolArgs);
+        // Call the callback directly to verify arguments are parsed and
+        // forwarded as a JsonNode
+        var result = toolCallbacks.getFirst().call("{\"city\":\"Helsinki\"}");
         Assertions.assertEquals(1, receivedArgs.size(),
                 "Tool executor should have been called once");
-        Assertions.assertEquals(toolArgs, receivedArgs.getFirst(),
-                "Tool executor should receive the arguments passed to the callback");
-        Assertions.assertEquals("result for " + toolArgs, result);
+        Assertions.assertEquals("Helsinki",
+                receivedArgs.getFirst().get("city").asString(),
+                "Tool executor should receive arguments as a JsonNode matching the callback input");
+        Assertions.assertEquals("result for Helsinki", result);
     }
 
     @Test
@@ -925,7 +927,7 @@ class SpringAILLMProviderTest {
 
     private static LLMProvider.ToolSpec createExplicitTool(String name,
             String description, String parametersSchema,
-            java.util.function.Function<String, String> executor) {
+            java.util.function.Function<JsonNode, String> executor) {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {
@@ -943,7 +945,7 @@ class SpringAILLMProviderTest {
             }
 
             @Override
-            public String execute(String arguments) {
+            public String execute(JsonNode arguments) {
                 return executor.apply(arguments);
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -902,6 +902,31 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_withExplicitTool_malformedJsonArguments_returnsError() {
+        provider.setStreaming(false);
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
+                args -> {
+                    receivedArgs.add(args);
+                    return "ok";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        var result = toolCallbacks.getFirst().call("Not json");
+
+        Assertions.assertTrue(result.startsWith("Error executing tool:"));
+        Assertions.assertEquals(0, receivedArgs.size());
+    }
+
+    @Test
     void stream_withExplicitToolNullSchema_usesEmptySchema() {
         provider.setStreaming(false);
         var explicitTool = createExplicitTool("simpleTool", "A simple tool",


### PR DESCRIPTION
## Description

This PR makes `LLMProvider.ToolSpec.execute` accept `JsonNode` instead of `String`. This makes it easier for the developer to use the arguments to implement tool execution.

Based on the prototype https://github.com/vaadin/flow-components/pull/9131

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=178096959

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.