### PR TITLE
refactor: warn when orchestrator has no system prompt

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -690,6 +690,12 @@ public class AIOrchestrator implements Serializable {
 
         private Builder(LLMProvider provider, String systemPrompt) {
             Objects.requireNonNull(provider, "Provider cannot be null");
+            if (systemPrompt == null || systemPrompt.isBlank()) {
+                LOGGER.warn("No system prompt was provided to the "
+                        + "AIOrchestrator. Pass a system prompt to "
+                        + "AIOrchestrator.builder(provider, systemPrompt) "
+                        + "to guide the LLM's behaviour.");
+            }
             this.provider = provider;
             this.systemPrompt = systemPrompt;
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -196,11 +196,15 @@ public class AIOrchestrator implements Serializable {
 
     /**
      * Creates a new builder for AIOrchestrator with a system prompt.
+     * <p>
+     * A system prompt is strongly recommended — without one, the LLM has no
+     * guidance beyond tool descriptions and may behave inconsistently.
+     * </p>
      *
      * @param provider
      *            the LLM provider
      * @param systemPrompt
-     *            the system prompt for the LLM
+     *            the system prompt for the LLM, or {@code null} to omit
      * @return a new builder
      */
     public static Builder builder(LLMProvider provider, String systemPrompt) {
@@ -999,7 +1003,6 @@ public class AIOrchestrator implements Serializable {
          */
         public AIOrchestrator build() {
             forEachClaimable(AIOrchestrator::claim);
-
             var orchestrator = new AIOrchestrator(provider, systemPrompt);
             orchestrator.messageList = messageList;
             orchestrator.input = input;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2062,6 +2062,31 @@ class AIOrchestratorTest {
                 .addSubmitListener(Mockito.any());
     }
 
+    @Test
+    void builder_withNullSystemPrompt_logsWarning() {
+        AIOrchestrator.builder(mockProvider, null).build();
+        assertSystemPromptWarning(true);
+    }
+
+    @Test
+    void builder_withBlankSystemPrompt_logsWarning() {
+        AIOrchestrator.builder(mockProvider, "   ").build();
+        assertSystemPromptWarning(true);
+    }
+
+    @Test
+    void builder_withEmptySystemPrompt_logsWarning() {
+        AIOrchestrator.builder(mockProvider, "").build();
+        assertSystemPromptWarning(true);
+    }
+
+    @Test
+    void builder_withNonBlankSystemPrompt_doesNotLogWarning() {
+        AIOrchestrator.builder(mockProvider, "You are a helpful assistant")
+                .build();
+        assertSystemPromptWarning(false);
+    }
+
     private static byte[] createTestImage(int width, int height)
             throws IOException {
         var image = new BufferedImage(width, height,
@@ -2088,6 +2113,13 @@ class AIOrchestratorTest {
                 .findFirst();
         Assertions.assertTrue(warning.isPresent(),
                 "Expected warning for " + fieldName);
+    }
+
+    private void assertSystemPromptWarning(boolean warningExpected) {
+        var warning = logger.getLoggingEvents().stream().filter(
+                e -> e.getMessage().contains("No system prompt was provided"))
+                .findAny();
+        Assertions.assertEquals(warningExpected, warning.isPresent());
     }
 
     private void assertNoBuilderWarning() {


### PR DESCRIPTION
## Description

Makes orchestrator builder log a warning if no system prompt is provided.

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=178095922

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.