### PR TITLE
docs: note chart tool schema provider compatibility

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -85,14 +85,13 @@ import com.vaadin.flow.shared.Registration;
  * {@link #getState()} after each successful AI request.
  * </p>
  * <p>
- * <b>Provider compatibility:</b> The chart tools use {@code anyOf} unions and
- * optional properties in their parameter schemas, and are therefore
- * incompatible with OpenAI's strict tool-calling mode (used when the OpenAI
- * tool definition is sent with {@code "strict": true}). Strict tool calling is
- * off by default in both LangChain4J and Spring AI, so no action is required
- * for typical setups; just avoid opting in (e.g. do not pass
- * {@code strictTools(true)} to LangChain4J's {@code OpenAiStreamingChatModel}
- * builder).
+ * <b>Provider compatibility:</b> The chart tools use optional properties in
+ * their parameter schemas, which are incompatible with OpenAI's strict
+ * tool-calling mode (strict mode requires every property listed under
+ * {@code properties} to also appear in {@code required}). Strict tool calling
+ * is off by default in both LangChain4J and Spring AI; only users who
+ * explicitly opt in (e.g. {@code strictTools(true)} on LangChain4J's
+ * {@code OpenAiStreamingChatModel} builder) are affected.
  * </p>
  *
  * @author Vaadin Ltd

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -84,6 +84,16 @@ import com.vaadin.flow.shared.Registration;
  * to be notified when the chart state changes, for example to persist
  * {@link #getState()} after each successful AI request.
  * </p>
+ * <p>
+ * <b>Provider compatibility:</b> The chart tools use {@code anyOf} unions and
+ * optional properties in their parameter schemas, and are therefore
+ * incompatible with OpenAI's strict tool-calling mode (used when the OpenAI
+ * tool definition is sent with {@code "strict": true}). Strict tool calling is
+ * off by default in both LangChain4J and Spring AI, so no action is required
+ * for typical setups; just avoid opting in (e.g. do not pass
+ * {@code strictTools(true)} to LangChain4J's {@code OpenAiStreamingChatModel}
+ * builder).
+ * </p>
  *
  * @author Vaadin Ltd
  * @see ChartAITools

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -322,7 +322,7 @@ public final class ChartAITools {
                                     "{c:BORDER_WIDTH}": { "type": "number", "description": "Pixel width of the outer chart border" },
                                     "{c:BORDER_RADIUS}": { "type": "number", "description": "Corner radius of the outer chart border" },
                                     "{c:WIDTH}": { "type": "number", "description": "Chart width in pixels" },
-                                    "{c:HEIGHT}": { "oneOf": [{ "type": "number", "description": "Height in pixels" }, { "type": "string", "description": "Height as string (e.g., '400px', '100%')" }] },
+                                    "{c:HEIGHT}": { "anyOf": [{ "type": "number", "description": "Height in pixels" }, { "type": "string", "description": "Height as string (e.g., '400px', '100%')" }] },
                                     "{c:MARGIN_TOP}": { "type": "number", "description": "Fixed pixel margin between the top outer edge of the chart and the plot area" },
                                     "{c:MARGIN_RIGHT}": { "type": "number", "description": "Fixed pixel margin between the right outer edge of the chart and the plot area" },
                                     "{c:MARGIN_BOTTOM}": { "type": "number", "description": "Fixed pixel margin between the bottom outer edge of the chart and the plot area" },
@@ -363,13 +363,13 @@ public final class ChartAITools {
                                   }
                                 },
                                 "{c:TITLE}": {
-                                  "oneOf": [
+                                  "anyOf": [
                                     { "type": "string", "description": "Title text" },
                                     { "type": "object", "properties": { "{c:TEXT}": { "type": "string", "description": "The title text" } } }
                                   ]
                                 },
                                 "{c:SUBTITLE}": {
-                                  "oneOf": [
+                                  "anyOf": [
                                     { "type": "string", "description": "Subtitle text" },
                                     { "type": "object", "properties": { "{c:TEXT}": { "type": "string", "description": "The subtitle text" } } }
                                   ]
@@ -386,7 +386,7 @@ public final class ChartAITools {
                                   }
                                 },
                                 "{c:Y_AXIS}": {
-                                  "oneOf": [
+                                  "anyOf": [
                                     {
                                       "type": "object",
                                       "description": "Single Y-axis configuration",

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsSchemaTest.java
@@ -734,7 +734,7 @@ class ChartAIToolsSchemaTest {
     /**
      * Recursively walks the JSON node and checks that every object property at
      * each level is declared in the corresponding schema's "properties".
-     * Handles "oneOf" by checking if at least one alternative covers all
+     * Handles "anyOf" by checking if at least one alternative covers all
      * properties.
      */
     private static void assertAllPropertiesCovered(JsonNode jsonNode,
@@ -743,9 +743,9 @@ class ChartAIToolsSchemaTest {
             return;
         }
 
-        // Handle oneOf: at least one alternative must cover all properties
-        if (schemaNode.has("oneOf")) {
-            for (JsonNode option : schemaNode.get("oneOf")) {
+        // Handle anyOf: at least one alternative must cover all properties
+        if (schemaNode.has("anyOf")) {
+            for (JsonNode option : schemaNode.get("anyOf")) {
                 List<String> optionUncovered = new ArrayList<>();
                 assertAllPropertiesCovered(jsonNode, option, path,
                         optionUncovered);
@@ -754,7 +754,7 @@ class ChartAIToolsSchemaTest {
                 }
             }
             uncovered
-                    .add(path + ": no oneOf alternative covers all properties");
+                    .add(path + ": no anyOf alternative covers all properties");
             return;
         }
 


### PR DESCRIPTION
## Summary

- Replace `oneOf` with `anyOf` in chart tool schemas (`{c:HEIGHT}`, `{c:TITLE}`, `{c:SUBTITLE}`, `{c:Y_AXIS}`). The alternatives differ only by `type` in every site, so the two are semantically equivalent here — but `anyOf` is more portable form
- Add a *Provider compatibility* paragraph to `ChartAIController`'s Javadoc noting the chart tools remain incompatible with OpenAI's strict tool-calling mode (schemas use optional properties, which strict mode disallows). Strict mode is off by default in LangChain4J and Spring AI, so only users who explicitly opt in with `strictTools(true)` are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)