### PR TITLE
docs: add examples on building parameter schemas

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -200,6 +200,50 @@ public interface LLMProvider {
          *   "required": ["query"]
          * }
          * </pre>
+         * <p>
+         * Hand-writing the JSON is fine for small schemas but becomes
+         * error-prone as they grow. For larger schemas, a schema builder from
+         * your provider's SDK catches keyword typos and structural mistakes at
+         * compile time:
+         * </p>
+         * <p>
+         * <b>1. Spring AI's {@code JsonSchemaGenerator}</b> (no extra
+         * dependency when using {@link SpringAILLMProvider}):
+         * </p>
+         *
+         * <pre>
+         * import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
+         *
+         * record UpdateGridArgs(String query) {}
+         *
+         * private static final String SCHEMA = JsonSchemaGenerator
+         *         .generateForType(UpdateGridArgs.class);
+         *
+         * // in execute(JsonNode arguments):
+         * UpdateGridArgs args = new ObjectMapper().treeToValue(arguments,
+         *         UpdateGridArgs.class);
+         * </pre>
+         * <p>
+         * <b>2. LangChain4J's {@code JsonObjectSchema} builder</b> (no extra
+         * dependency when using {@link LangChain4JLLMProvider}): a fluent
+         * builder whose result needs to be serialized to a {@code String}:
+         * </p>
+         *
+         * <pre>
+         * import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+         *
+         * var schema = JsonObjectSchema.builder()
+         *         .addStringProperty("query", "The SQL query")
+         *         .required("query").build();
+         * return new ObjectMapper().writeValueAsString(schema);
+         * </pre>
+         * <p>
+         * Whichever approach you pick, verify the output stays inside the
+         * portable JSON Schema subset (string, integer, number, boolean, array,
+         * object, plus {@code anyOf} and {@code enum}). Generators may emit
+         * keywords such as {@code format}, {@code pattern}, or {@code $ref}
+         * that not every LLM provider accepts.
+         * </p>
          *
          * @return the JSON Schema string, or {@code null} if the tool takes no
          *         parameters

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -202,19 +202,18 @@ public interface LLMProvider {
          * </pre>
          * <p>
          * Hand-writing the JSON is fine for small schemas but becomes
-         * error-prone as they grow. For larger schemas, a schema builder from
-         * your provider's SDK catches keyword typos and structural mistakes at
-         * compile time:
-         * </p>
-         * <p>
-         * <b>1. Spring AI's {@code JsonSchemaGenerator}</b> (no extra
-         * dependency when using {@link SpringAILLMProvider}):
+         * error-prone as they grow. For larger schemas, a schema generator
+         * catches keyword typos and structural mistakes at compile time. When
+         * using {@link SpringAILLMProvider}, Spring AI's
+         * {@code JsonSchemaGenerator} is available without an extra dependency:
          * </p>
          *
          * <pre>
+         * import com.fasterxml.jackson.annotation.JsonPropertyDescription;
          * import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
          *
-         * record UpdateGridArgs(String query) {}
+         * record UpdateGridArgs(
+         *         &#064;JsonPropertyDescription("The SQL query") String query) {}
          *
          * private static final String SCHEMA = JsonSchemaGenerator
          *         .generateForType(UpdateGridArgs.class);
@@ -224,19 +223,9 @@ public interface LLMProvider {
          *         UpdateGridArgs.class);
          * </pre>
          * <p>
-         * <b>2. LangChain4J's {@code JsonObjectSchema} builder</b> (no extra
-         * dependency when using {@link LangChain4JLLMProvider}): a fluent
-         * builder whose result needs to be serialized to a {@code String}:
+         * For other setups, any general-purpose JSON Schema generator that
+         * produces a schema string from a typed Java class works equivalently.
          * </p>
-         *
-         * <pre>
-         * import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-         *
-         * var schema = JsonObjectSchema.builder()
-         *         .addStringProperty("query", "The SQL query")
-         *         .required("query").build();
-         * return new ObjectMapper().writeValueAsString(schema);
-         * </pre>
          * <p>
          * Whichever approach you pick, verify the output stays inside the
          * portable JSON Schema subset (string, integer, number, boolean, array,


### PR DESCRIPTION
## Description

Adds examples on building parameter schemas using LangChain4J and Spring AI's built-in builders.

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=178097204

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Docs

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.