### PR TITLE
refactor!: add "Decimal" prefix to decimal slider variants

### DIFF
--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicPage.java
@@ -18,20 +18,20 @@ package com.vaadin.flow.component.slider.tests;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.slider.RangeSlider;
-import com.vaadin.flow.component.slider.RangeSliderValue;
+import com.vaadin.flow.component.slider.DecimalRangeSlider;
+import com.vaadin.flow.component.slider.DecimalRangeSliderValue;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-range-slider/basic")
-public class RangeSliderBasicPage extends Div {
+public class DecimalRangeSliderBasicPage extends Div {
 
-    public RangeSliderBasicPage() {
-        RangeSlider rangeSlider = new RangeSlider();
+    public DecimalRangeSliderBasicPage() {
+        DecimalRangeSlider rangeSlider = new DecimalRangeSlider();
         rangeSlider.setMin(10.0);
         rangeSlider.setMax(200.0);
         rangeSlider.setStep(5.0);
-        rangeSlider.setValue(new RangeSliderValue(25.0, 150.0));
+        rangeSlider.setValue(new DecimalRangeSliderValue(25.0, 150.0));
         rangeSlider.setWidth("200px");
 
         Span serverValue = new Span();

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicPage.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.slider.DecimalRangeSliderValue;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-range-slider/basic")
+@Route("vaadin-slider/decimal-range-slider-basic")
 public class DecimalRangeSliderBasicPage extends Div {
 
     public DecimalRangeSliderBasicPage() {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicPage.java
@@ -18,15 +18,15 @@ package com.vaadin.flow.component.slider.tests;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.slider.Slider;
+import com.vaadin.flow.component.slider.DecimalSlider;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-slider/basic")
-public class SliderBasicPage extends Div {
+public class DecimalSliderBasicPage extends Div {
 
-    public SliderBasicPage() {
-        Slider slider = new Slider();
+    public DecimalSliderBasicPage() {
+        DecimalSlider slider = new DecimalSlider();
         slider.setMin(10.0);
         slider.setMax(200.0);
         slider.setStep(5.0);

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicPage.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.component.slider.DecimalSlider;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-slider/basic")
+@Route("vaadin-slider/decimal-slider-basic")
 public class DecimalSliderBasicPage extends Div {
 
     public DecimalSliderBasicPage() {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/IntegerRangeSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/IntegerRangeSliderBasicPage.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.component.slider.IntegerRangeSlider;
 import com.vaadin.flow.component.slider.IntegerRangeSliderValue;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-integer-range-slider/basic")
+@Route("vaadin-slider/integer-range-slider-basic")
 public class IntegerRangeSliderBasicPage extends Div {
 
     public IntegerRangeSliderBasicPage() {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/IntegerSliderBasicPage.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/main/java/com/vaadin/flow/component/slider/tests/IntegerSliderBasicPage.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.slider.IntegerSlider;
 import com.vaadin.flow.router.Route;
 
-@Route("vaadin-integer-slider/basic")
+@Route("vaadin-slider/integer-slider-basic")
 public class IntegerSliderBasicPage extends Div {
 
     public IntegerSliderBasicPage() {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicIT.java
@@ -20,21 +20,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.interactions.Actions;
 
-import com.vaadin.flow.component.slider.testbench.RangeSliderElement;
+import com.vaadin.flow.component.slider.testbench.DecimalRangeSliderElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-range-slider/basic")
-public class RangeSliderBasicIT extends AbstractComponentIT {
+public class DecimalRangeSliderBasicIT extends AbstractComponentIT {
 
-    private RangeSliderElement rangeSlider;
+    private DecimalRangeSliderElement rangeSlider;
     private TestBenchElement serverValue;
 
     @Before
     public void init() {
         open();
-        rangeSlider = $(RangeSliderElement.class).first();
+        rangeSlider = $(DecimalRangeSliderElement.class).first();
         serverValue = $("span").id("server-value");
     }
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalRangeSliderBasicIT.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
-@TestPath("vaadin-range-slider/basic")
+@TestPath("vaadin-slider/decimal-range-slider-basic")
 public class DecimalRangeSliderBasicIT extends AbstractComponentIT {
 
     private DecimalRangeSliderElement rangeSlider;

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicIT.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
-@TestPath("vaadin-slider/basic")
+@TestPath("vaadin-slider/decimal-slider-basic")
 public class DecimalSliderBasicIT extends AbstractComponentIT {
 
     private DecimalSliderElement slider;

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/DecimalSliderBasicIT.java
@@ -20,21 +20,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.interactions.Actions;
 
-import com.vaadin.flow.component.slider.testbench.SliderElement;
+import com.vaadin.flow.component.slider.testbench.DecimalSliderElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-slider/basic")
-public class SliderBasicIT extends AbstractComponentIT {
+public class DecimalSliderBasicIT extends AbstractComponentIT {
 
-    private SliderElement slider;
+    private DecimalSliderElement slider;
     private TestBenchElement serverValue;
 
     @Before
     public void init() {
         open();
-        slider = $(SliderElement.class).first();
+        slider = $(DecimalSliderElement.class).first();
         serverValue = $("span").id("server-value");
     }
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerRangeSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerRangeSliderBasicIT.java
@@ -27,7 +27,7 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-slider/integer-range-slider-basic")
 public class IntegerRangeSliderBasicIT extends AbstractComponentIT {
     // Only covers basic functionality for setting and retrieving properties via
-    // the TestBench element. DecimalRangeSliderIT has more comprehensive
+    // the TestBench element. DecimalRangeSliderBasicIT has more comprehensive
     // coverage.
 
     private IntegerRangeSliderElement rangeSlider;

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerRangeSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerRangeSliderBasicIT.java
@@ -24,10 +24,11 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
-@TestPath("vaadin-integer-range-slider/basic")
+@TestPath("vaadin-slider/integer-range-slider-basic")
 public class IntegerRangeSliderBasicIT extends AbstractComponentIT {
     // Only covers basic functionality for setting and retrieving properties via
-    // the TestBench element. RangeSliderIT has more comprehensive coverage.
+    // the TestBench element. DecimalRangeSliderIT has more comprehensive
+    // coverage.
 
     private IntegerRangeSliderElement rangeSlider;
     private TestBenchElement serverValue;

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerSliderBasicIT.java
@@ -24,10 +24,10 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
-@TestPath("vaadin-integer-slider/basic")
+@TestPath("vaadin-slider/integer-slider-basic")
 public class IntegerSliderBasicIT extends AbstractComponentIT {
     // Only covers basic functionality for setting and retrieving properties via
-    // the TestBench element. SliderIT has more comprehensive coverage.
+    // the TestBench element. DecimalSliderIT has more comprehensive coverage.
 
     private IntegerSliderElement slider;
     private TestBenchElement serverValue;

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerSliderBasicIT.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/src/test/java/com/vaadin/flow/component/slider/tests/IntegerSliderBasicIT.java
@@ -27,7 +27,8 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-slider/integer-slider-basic")
 public class IntegerSliderBasicIT extends AbstractComponentIT {
     // Only covers basic functionality for setting and retrieving properties via
-    // the TestBench element. DecimalSliderIT has more comprehensive coverage.
+    // the TestBench element. DecimalSliderBasicIT has more comprehensive
+    // coverage.
 
     private IntegerSliderElement slider;
     private TestBenchElement serverValue;

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/DecimalRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/DecimalRangeSlider.java
@@ -20,35 +20,35 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**
- * RangeSlider is an input field that allows the user to select a numeric range
- * within bounds by dragging two thumbs along a track or using arrow keys for
- * precise input.
+ * DecimalRangeSlider is an input field that allows the user to select a decimal
+ * range within bounds by dragging two thumbs along a track or using arrow keys
+ * for precise input.
  * <p>
- * RangeSlider uses {@link Double} as the value type for its start and end
- * values, see {@link IntegerRangeSlider} for a version of the component that
- * supports integer values.
+ * DecimalRangeSlider uses {@link Double} as the value type for its start and
+ * end values, see {@link IntegerRangeSlider} for a version of the component
+ * that supports integer values.
  *
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-range-slider")
 @NpmPackage(value = "@vaadin/slider", version = "25.2.0-alpha8")
 @JsModule("@vaadin/slider/src/vaadin-range-slider.js")
-public class RangeSlider
-        extends NumberRangeSlider<RangeSlider, RangeSliderValue, Double> {
+public class DecimalRangeSlider extends
+        NumberRangeSlider<DecimalRangeSlider, DecimalRangeSliderValue, Double> {
 
     /**
-     * Constructs a {@code RangeSlider} with min 0 and max 100. The initial
-     * value is [0, 100].
+     * Constructs a {@code DecimalRangeSlider} with min 0 and max 100. The
+     * initial value is [0, 100].
      * <p>
      * The step defaults to 1.
      */
-    public RangeSlider() {
+    public DecimalRangeSlider() {
         this(DEFAULT_MIN, DEFAULT_MAX);
     }
 
     /**
-     * Constructs a {@code RangeSlider} with the given min and max. The initial
-     * value is set to [min, max].
+     * Constructs a {@code DecimalRangeSlider} with the given min and max. The
+     * initial value is set to [min, max].
      * <p>
      * The step defaults to 1.
      *
@@ -57,27 +57,27 @@ public class RangeSlider
      * @param max
      *            the maximum value
      */
-    public RangeSlider(double min, double max) {
-        super(min, max, RangeSliderValue::new, v -> v, v -> v);
+    public DecimalRangeSlider(double min, double max) {
+        super(min, max, DecimalRangeSliderValue::new, v -> v, v -> v);
     }
 
     /**
-     * Constructs a {@code RangeSlider} with the given label, min 0, and max
-     * 100. The initial value is [0, 100].
+     * Constructs a {@code DecimalRangeSlider} with the given label, min 0, and
+     * max 100. The initial value is [0, 100].
      * <p>
      * The step defaults to 1.
      *
      * @param label
      *            the text to set as the label
      */
-    public RangeSlider(String label) {
+    public DecimalRangeSlider(String label) {
         this();
         setLabel(label);
     }
 
     /**
-     * Constructs a {@code RangeSlider} with the given label, min and max. The
-     * initial value is set to [min, max].
+     * Constructs a {@code DecimalRangeSlider} with the given label, min and
+     * max. The initial value is set to [min, max].
      * <p>
      * The step defaults to 1.
      *
@@ -88,7 +88,7 @@ public class RangeSlider
      * @param max
      *            the maximum value
      */
-    public RangeSlider(String label, double min, double max) {
+    public DecimalRangeSlider(String label, double min, double max) {
         this(min, max);
         setLabel(label);
     }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/DecimalRangeSliderValue.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/DecimalRangeSliderValue.java
@@ -18,8 +18,8 @@ package com.vaadin.flow.component.slider;
 import java.util.Objects;
 
 /**
- * Represents the value of a {@link RangeSlider}, consisting of decimal start
- * and end values.
+ * Represents the value of a {@link DecimalRangeSlider}, consisting of decimal
+ * start and end values.
  *
  * @param start
  *            the start value of the range
@@ -28,11 +28,12 @@ import java.util.Objects;
  *
  * @author Vaadin Ltd
  */
-public record RangeSliderValue(Double start,
+public record DecimalRangeSliderValue(Double start,
         Double end) implements Range<Double> {
 
     /**
-     * Creates a new RangeSliderValue with the given start and end values.
+     * Creates a new DecimalRangeSliderValue with the given start and end
+     * values.
      *
      * @param start
      *            the start value of the range
@@ -41,7 +42,7 @@ public record RangeSliderValue(Double start,
      * @throws IllegalArgumentException
      *             if start is greater than end
      */
-    public RangeSliderValue {
+    public DecimalRangeSliderValue {
         Objects.requireNonNull(start, "Start value cannot be null");
         Objects.requireNonNull(end, "End value cannot be null");
         if (start > end) {

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/DecimalSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/DecimalSlider.java
@@ -20,32 +20,33 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**
- * Slider is an input field that allows the user to select a numeric value
- * within a range by dragging a handle along a track or using arrow keys for
- * precise input.
+ * DecimalSlider is an input field that allows the user to select a decimal
+ * value within a range by dragging a handle along a track or using arrow keys
+ * for precise input.
  * <p>
- * Slider uses {@link Double} as the value type, see {@link IntegerSlider} for a
- * version of the component that supports integer values.
+ * DecimalSlider uses {@link Double} as the value type, see
+ * {@link IntegerSlider} for a version of the component that supports integer
+ * values.
  *
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-slider")
 @NpmPackage(value = "@vaadin/slider", version = "25.2.0-alpha8")
 @JsModule("@vaadin/slider/src/vaadin-slider.js")
-public class Slider extends NumberSlider<Slider, Double> {
+public class DecimalSlider extends NumberSlider<DecimalSlider, Double> {
     /**
-     * Constructs a {@code Slider} with min 0 and max 100. The initial value is
-     * 0.
+     * Constructs a {@code DecimalSlider} with min 0 and max 100. The initial
+     * value is 0.
      * <p>
      * The step defaults to 1.
      */
-    public Slider() {
+    public DecimalSlider() {
         this(DEFAULT_MIN, DEFAULT_MAX);
     }
 
     /**
-     * Constructs a {@code Slider} with the given min and max. The initial value
-     * is set to the minimum value.
+     * Constructs a {@code DecimalSlider} with the given min and max. The
+     * initial value is set to the minimum value.
      * <p>
      * The step defaults to 1.
      *
@@ -54,26 +55,26 @@ public class Slider extends NumberSlider<Slider, Double> {
      * @param max
      *            the maximum value
      */
-    public Slider(double min, double max) {
+    public DecimalSlider(double min, double max) {
         super(min, max, (v) -> v, (v) -> v);
     }
 
     /**
-     * Constructs a {@code Slider} with the given label, min 0, and max 100. The
-     * initial value is 0.
+     * Constructs a {@code DecimalSlider} with the given label, min 0, and max
+     * 100. The initial value is 0.
      * <p>
      * The step defaults to 1.
      *
      * @param label
      *            the text to set as the label
      */
-    public Slider(String label) {
+    public DecimalSlider(String label) {
         this();
         setLabel(label);
     }
 
     /**
-     * Constructs a {@code Slider} with the given label, min and max. The
+     * Constructs a {@code DecimalSlider} with the given label, min and max. The
      * initial value is set to the minimum value.
      * <p>
      * The step defaults to 1.
@@ -85,7 +86,7 @@ public class Slider extends NumberSlider<Slider, Double> {
      * @param max
      *            the maximum value
      */
-    public Slider(String label, double min, double max) {
+    public DecimalSlider(String label, double min, double max) {
         this(min, max);
         setLabel(label);
     }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/ExperimentalFeatureException.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/ExperimentalFeatureException.java
@@ -23,10 +23,11 @@ package com.vaadin.flow.component.slider;
  */
 public class ExperimentalFeatureException extends RuntimeException {
     public ExperimentalFeatureException() {
-        super("The slider components are currently an experimental feature and needs to be "
-                + "explicitly enabled. The component can be enabled using Copilot, in the "
-                + "experimental features tab, or by adding a "
-                + "`src/main/resources/vaadin-featureflags.properties` file with the following content: "
-                + "`com.vaadin.experimental.sliderComponent=true`");
+        super("""
+                The slider components are currently experimental and need to be \
+                explicitly enabled. The components can be enabled using Copilot, in the \
+                experimental features tab, or by adding a \
+                `src/main/resources/vaadin-featureflags.properties` file with the following content: \
+                `com.vaadin.experimental.sliderComponent=true`.""");
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/ExperimentalFeatureException.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/ExperimentalFeatureException.java
@@ -16,14 +16,14 @@
 package com.vaadin.flow.component.slider;
 
 /**
- * An exception which is thrown when somebody attempts to use the {@link Slider}
+ * An exception which is thrown when somebody attempts to use any slider
  * component without activating the associated feature flag first.
  *
  * @author Vaadin Ltd
  */
 public class ExperimentalFeatureException extends RuntimeException {
     public ExperimentalFeatureException() {
-        super("The Slider component is currently an experimental feature and needs to be "
+        super("The slider components are currently an experimental feature and needs to be "
                 + "explicitly enabled. The component can be enabled using Copilot, in the "
                 + "experimental features tab, or by adding a "
                 + "`src/main/resources/vaadin-featureflags.properties` file with the following content: "

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/IntegerRangeSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/IntegerRangeSlider.java
@@ -20,13 +20,13 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**
- * IntegerRangeSlider is an input field that allows the user to select a numeric
- * range within bounds by dragging two thumbs along a track or using arrow keys
- * for precise input.
+ * IntegerRangeSlider is an input field that allows the user to select an
+ * integer range within bounds by dragging two thumbs along a track or using
+ * arrow keys for precise input.
  * <p>
  * IntegerRangeSlider uses {@link Integer} as the value type for its start and
- * end values, see {@link RangeSlider} for a version of the component that
- * supports decimal values.
+ * end values, see {@link DecimalRangeSlider} for a version of the component
+ * that supports decimal values.
  *
  * @author Vaadin Ltd.
  */

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/IntegerSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/IntegerSlider.java
@@ -20,12 +20,13 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**
- * IntegerSlider is an input field that allows the user to select a numeric
+ * IntegerSlider is an input field that allows the user to select an integer
  * value within a range by dragging a handle along a track or using arrow keys
  * for precise input.
  * <p>
- * IntegerSlider uses {@link Integer} as the value type, see {@link Slider} for
- * a version of the component that supports decimal values.
+ * IntegerSlider uses {@link Integer} as the value type, see
+ * {@link DecimalSlider} for a version of the component that supports decimal
+ * values.
  *
  * @author Vaadin Ltd.
  */

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/DecimalRangeSliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/DecimalRangeSliderTest.java
@@ -20,64 +20,64 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.internal.JacksonUtils;
 
-class RangeSliderTest
-        extends AbstractRangeSliderTest<RangeSlider, RangeSliderValue, Double> {
+class DecimalRangeSliderTest extends
+        AbstractRangeSliderTest<DecimalRangeSlider, DecimalRangeSliderValue, Double> {
 
     @Override
-    RangeSlider createSlider() {
-        return new RangeSlider();
+    DecimalRangeSlider createSlider() {
+        return new DecimalRangeSlider();
     }
 
     @Test
     void defaultConstructor() {
-        RangeSlider slider = new RangeSlider();
+        DecimalRangeSlider slider = new DecimalRangeSlider();
         Assertions.assertEquals(0, slider.getMin(), 0);
         Assertions.assertEquals(100, slider.getMax(), 0);
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void minMaxConstructor() {
-        RangeSlider slider = new RangeSlider(10, 50);
+        DecimalRangeSlider slider = new DecimalRangeSlider(10, 50);
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(50, slider.getMax(), 0);
         Assertions.assertEquals(1, slider.getStep(), 0);
-        Assertions.assertEquals(new RangeSliderValue(10.0, 50.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(10.0, 50.0),
                 slider.getValue());
     }
 
     @Test
     void labelConstructor() {
-        RangeSlider slider = new RangeSlider("Label");
+        DecimalRangeSlider slider = new DecimalRangeSlider("Label");
         Assertions.assertEquals("Label", slider.getLabel());
         Assertions.assertEquals(0, slider.getMin(), 0);
         Assertions.assertEquals(100, slider.getMax(), 0);
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void labelMinMaxConstructor() {
-        RangeSlider slider = new RangeSlider("Label", 10, 50);
+        DecimalRangeSlider slider = new DecimalRangeSlider("Label", 10, 50);
         Assertions.assertEquals("Label", slider.getLabel());
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(50, slider.getMax(), 0);
         Assertions.assertEquals(1, slider.getStep(), 0);
-        Assertions.assertEquals(new RangeSliderValue(10.0, 50.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(10.0, 50.0),
                 slider.getValue());
     }
 
     @Test
-    void rangeSliderValue_nullStart_throws() {
+    void decimalRangeSliderValue_nullStart_throws() {
         Assertions.assertThrows(NullPointerException.class,
-                () -> new RangeSliderValue(null, 100.0));
+                () -> new DecimalRangeSliderValue(null, 100.0));
     }
 
     @Test
-    void rangeSliderValue_nullEnd_throws() {
+    void decimalRangeSliderValue_nullEnd_throws() {
         Assertions.assertThrows(NullPointerException.class,
-                () -> new RangeSliderValue(0.0, null));
+                () -> new DecimalRangeSliderValue(0.0, null));
     }
 
     @Test
@@ -111,7 +111,7 @@ class RangeSliderTest
     void setValueFromClient_null_ignored() {
         slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", JacksonUtils.nullNode());
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
@@ -119,7 +119,7 @@ class RangeSliderTest
     void setValueFromClient_startNotAlignedWithStep_ignored() {
         slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(15, 80));
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
@@ -127,28 +127,28 @@ class RangeSliderTest
     void setValueFromClient_endNotAlignedWithStep_ignored() {
         slider.setStep(10.0);
         slider.getElement().setPropertyJson("value", createValueArray(20, 85));
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_startBelowMin_ignored() {
         slider.getElement().setPropertyJson("value", createValueArray(-10, 50));
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_endAboveMax_ignored() {
         slider.getElement().setPropertyJson("value", createValueArray(50, 110));
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 
     @Test
     void setValueFromClient_startGreaterThanEnd_ignored() {
         slider.getElement().setPropertyJson("value", createValueArray(80, 20));
-        Assertions.assertEquals(new RangeSliderValue(0.0, 100.0),
+        Assertions.assertEquals(new DecimalRangeSliderValue(0.0, 100.0),
                 slider.getValue());
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/DecimalSliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/DecimalSliderTest.java
@@ -18,16 +18,16 @@ package com.vaadin.flow.component.slider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class SliderTest extends AbstractSliderTest<Slider, Double> {
+class DecimalSliderTest extends AbstractSliderTest<DecimalSlider, Double> {
 
     @Override
-    Slider createSlider() {
-        return new Slider();
+    DecimalSlider createSlider() {
+        return new DecimalSlider();
     }
 
     @Test
     void defaultConstructor() {
-        Slider slider = new Slider();
+        DecimalSlider slider = new DecimalSlider();
         Assertions.assertEquals(0, slider.getMin(), 0);
         Assertions.assertEquals(100, slider.getMax(), 0);
         Assertions.assertEquals(0, slider.getValue(), 0);
@@ -35,7 +35,7 @@ class SliderTest extends AbstractSliderTest<Slider, Double> {
 
     @Test
     void minMaxConstructor() {
-        Slider slider = new Slider(10, 50);
+        DecimalSlider slider = new DecimalSlider(10, 50);
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(50, slider.getMax(), 0);
         Assertions.assertEquals(1, slider.getStep(), 0);
@@ -44,7 +44,7 @@ class SliderTest extends AbstractSliderTest<Slider, Double> {
 
     @Test
     void labelConstructor() {
-        Slider slider = new Slider("Label");
+        DecimalSlider slider = new DecimalSlider("Label");
         Assertions.assertEquals("Label", slider.getLabel());
         Assertions.assertEquals(0, slider.getMin(), 0);
         Assertions.assertEquals(100, slider.getMax(), 0);
@@ -53,7 +53,7 @@ class SliderTest extends AbstractSliderTest<Slider, Double> {
 
     @Test
     void labelMinMaxConstructor() {
-        Slider slider = new Slider("Label", 10, 50);
+        DecimalSlider slider = new DecimalSlider("Label", 10, 50);
         Assertions.assertEquals("Label", slider.getLabel());
         Assertions.assertEquals(10, slider.getMin(), 0);
         Assertions.assertEquals(50, slider.getMax(), 0);

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/RangeSliderWarningsTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/RangeSliderWarningsTest.java
@@ -44,7 +44,7 @@ class RangeSliderWarningsTest {
 
         mockLoggerFactoryStatic = Mockito.mockStatic(LoggerFactory.class);
         mockLoggerFactoryStatic
-                .when(() -> LoggerFactory.getLogger(RangeSlider.class))
+                .when(() -> LoggerFactory.getLogger(DecimalRangeSlider.class))
                 .thenReturn(mockedLogger);
     }
 
@@ -55,7 +55,7 @@ class RangeSliderWarningsTest {
 
     @Test
     void setMinGreaterThanMax_warnsMinGreaterThanMax() {
-        RangeSlider slider = new RangeSlider();
+        DecimalRangeSlider slider = new DecimalRangeSlider();
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -69,7 +69,7 @@ class RangeSliderWarningsTest {
 
     @Test
     void setMaxLessThanMin_warnsMinGreaterThanMax() {
-        RangeSlider slider = new RangeSlider();
+        DecimalRangeSlider slider = new DecimalRangeSlider();
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -83,46 +83,46 @@ class RangeSliderWarningsTest {
 
     @Test
     void setValueOutOfRange_warnsValueOutOfRange() {
-        RangeSlider slider = new RangeSlider(0, 100);
+        DecimalRangeSlider slider = new DecimalRangeSlider(0, 100);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setValue(new RangeSliderValue(0.0, 150.0));
+        slider.setValue(new DecimalRangeSliderValue(0.0, 150.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(
                 Mockito.contains("outside the configured range"),
-                Mockito.eq(new RangeSliderValue(0.0, 150.0)), Mockito.eq(0.0),
-                Mockito.eq(100.0));
+                Mockito.eq(new DecimalRangeSliderValue(0.0, 150.0)),
+                Mockito.eq(0.0), Mockito.eq(100.0));
     }
 
     @Test
     void setValueNotAlignedWithStep_warnsValueNotAligned() {
-        RangeSlider slider = new RangeSlider(0, 100);
+        DecimalRangeSlider slider = new DecimalRangeSlider(0, 100);
         slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setValue(new RangeSliderValue(0.0, 15.0));
+        slider.setValue(new DecimalRangeSliderValue(0.0, 15.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger).warn(
                 Mockito.contains("not aligned with step"),
-                Mockito.eq(new RangeSliderValue(0.0, 15.0)), Mockito.eq(0.0),
-                Mockito.eq(100.0), Mockito.eq(10.0));
+                Mockito.eq(new DecimalRangeSliderValue(0.0, 15.0)),
+                Mockito.eq(0.0), Mockito.eq(100.0), Mockito.eq(10.0));
     }
 
     @Test
     void setConsistentProperties_noWarnings() {
-        RangeSlider slider = new RangeSlider(0, 100);
+        DecimalRangeSlider slider = new DecimalRangeSlider(0, 100);
         slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
 
-        slider.setValue(new RangeSliderValue(20.0, 80.0));
+        slider.setValue(new DecimalRangeSliderValue(20.0, 80.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger, Mockito.never()).warn(Mockito.anyString(),
@@ -131,7 +131,7 @@ class RangeSliderWarningsTest {
 
     @Test
     void setMultipleProperties_onlyOneCheckPerResponseCycle() {
-        RangeSlider slider = new RangeSlider(0, 100);
+        DecimalRangeSlider slider = new DecimalRangeSlider(0, 100);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -139,7 +139,7 @@ class RangeSliderWarningsTest {
         slider.setMin(10.0);
         slider.setMax(50.0);
         slider.setStep(5.0);
-        slider.setValue(new RangeSliderValue(15.0, 45.0));
+        slider.setValue(new DecimalRangeSliderValue(15.0, 45.0));
         ui.fakeClientCommunication();
 
         Mockito.verify(mockedLogger, Mockito.never()).warn(Mockito.anyString(),

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/SliderSignalTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/SliderSignalTest.java
@@ -31,14 +31,14 @@ class SliderSignalTest extends AbstractSignalsTest {
     EnableFeatureFlagExtension featureFlagExtension = new EnableFeatureFlagExtension(
             SliderFeatureFlagProvider.SLIDER_COMPONENT);
 
-    private Slider slider;
+    private DecimalSlider slider;
     private ValueSignal<Double> minSignal;
     private ValueSignal<Double> maxSignal;
     private ValueSignal<Double> stepSignal;
 
     @BeforeEach
     void setup() {
-        slider = new Slider();
+        slider = new DecimalSlider();
         minSignal = new ValueSignal<>(0.0);
         maxSignal = new ValueSignal<>(100.0);
         stepSignal = new ValueSignal<>(1.0);

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/SliderWarningsTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/SliderWarningsTest.java
@@ -44,7 +44,7 @@ class SliderWarningsTest {
 
         mockLoggerFactoryStatic = Mockito.mockStatic(LoggerFactory.class);
         mockLoggerFactoryStatic
-                .when(() -> LoggerFactory.getLogger(Slider.class))
+                .when(() -> LoggerFactory.getLogger(DecimalSlider.class))
                 .thenReturn(mockedLogger);
     }
 
@@ -55,7 +55,7 @@ class SliderWarningsTest {
 
     @Test
     void setMinGreaterThanMax_warnsMinGreaterThanMax() {
-        Slider slider = new Slider();
+        DecimalSlider slider = new DecimalSlider();
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -69,7 +69,7 @@ class SliderWarningsTest {
 
     @Test
     void setMaxLessThanMin_warnsMinGreaterThanMax() {
-        Slider slider = new Slider();
+        DecimalSlider slider = new DecimalSlider();
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -83,7 +83,7 @@ class SliderWarningsTest {
 
     @Test
     void setValueOutOfRange_warnsValueOutOfRange() {
-        Slider slider = new Slider(0, 100);
+        DecimalSlider slider = new DecimalSlider(0, 100);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);
@@ -98,7 +98,7 @@ class SliderWarningsTest {
 
     @Test
     void setValueNotAlignedWithStep_warnsValueNotAligned() {
-        Slider slider = new Slider(0, 100);
+        DecimalSlider slider = new DecimalSlider(0, 100);
         slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
@@ -114,7 +114,7 @@ class SliderWarningsTest {
 
     @Test
     void setConsistentProperties_noWarnings() {
-        Slider slider = new Slider(0, 100);
+        DecimalSlider slider = new DecimalSlider(0, 100);
         slider.setStep(10.0);
         ui.add(slider);
         ui.fakeClientCommunication();
@@ -129,7 +129,7 @@ class SliderWarningsTest {
 
     @Test
     void setMultipleProperties_onlyOneCheckPerResponseCycle() {
-        Slider slider = new Slider(0, 100);
+        DecimalSlider slider = new DecimalSlider(0, 100);
         ui.add(slider);
         ui.fakeClientCommunication();
         Mockito.clearInvocations(mockedLogger);

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/RangeSliderBasicValidationTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/RangeSliderBasicValidationTest.java
@@ -15,15 +15,15 @@
  */
 package com.vaadin.flow.component.slider.validation;
 
-import com.vaadin.flow.component.slider.RangeSlider;
-import com.vaadin.flow.component.slider.RangeSliderValue;
+import com.vaadin.flow.component.slider.DecimalRangeSlider;
+import com.vaadin.flow.component.slider.DecimalRangeSliderValue;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
-class RangeSliderBasicValidationTest
-        extends AbstractBasicValidationTest<RangeSlider, RangeSliderValue> {
+class RangeSliderBasicValidationTest extends
+        AbstractBasicValidationTest<DecimalRangeSlider, DecimalRangeSliderValue> {
 
     @Override
-    protected RangeSlider createTestField() {
-        return new RangeSlider();
+    protected DecimalRangeSlider createTestField() {
+        return new DecimalRangeSlider();
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/RangeSliderBinderValidationTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/RangeSliderBinderValidationTest.java
@@ -19,32 +19,33 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.flow.component.slider.RangeSlider;
-import com.vaadin.flow.component.slider.RangeSliderValue;
+import com.vaadin.flow.component.slider.DecimalRangeSlider;
+import com.vaadin.flow.component.slider.DecimalRangeSliderValue;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.BindingValidationStatus;
 
 class RangeSliderBinderValidationTest {
     private static final String VALIDATION_ERROR_MESSAGE = "End value must be at least 50";
 
-    private RangeSlider rangeSlider;
+    private DecimalRangeSlider rangeSlider;
     private Binder<Bean> binder;
 
     public static class Bean {
-        private RangeSliderValue value = new RangeSliderValue(0.0, 100.0);
+        private DecimalRangeSliderValue value = new DecimalRangeSliderValue(0.0,
+                100.0);
 
-        public RangeSliderValue getValue() {
+        public DecimalRangeSliderValue getValue() {
             return value;
         }
 
-        public void setValue(RangeSliderValue value) {
+        public void setValue(DecimalRangeSliderValue value) {
             this.value = value;
         }
     }
 
     @BeforeEach
     void setup() {
-        rangeSlider = new RangeSlider();
+        rangeSlider = new DecimalRangeSlider();
         binder = new Binder<>(Bean.class);
         binder.forField(rangeSlider)
                 .withValidator(value -> value.end() >= 50,
@@ -54,7 +55,7 @@ class RangeSliderBinderValidationTest {
 
     @Test
     void setValue_validatorPasses_noValidationError() {
-        rangeSlider.setValue(new RangeSliderValue(0.0, 50.0));
+        rangeSlider.setValue(new DecimalRangeSliderValue(0.0, 50.0));
 
         BindingValidationStatus<?> status = binder.validate()
                 .getFieldValidationStatuses().get(0);
@@ -64,7 +65,7 @@ class RangeSliderBinderValidationTest {
 
     @Test
     void setValue_validatorFails_hasValidationError() {
-        rangeSlider.setValue(new RangeSliderValue(0.0, 49.0));
+        rangeSlider.setValue(new DecimalRangeSliderValue(0.0, 49.0));
 
         BindingValidationStatus<?> status = binder.validate()
                 .getFieldValidationStatuses().get(0);
@@ -76,10 +77,11 @@ class RangeSliderBinderValidationTest {
 
     @Test
     void readBean_null_setsEmptyValue() {
-        rangeSlider.setValue(new RangeSliderValue(25.0, 75.0));
+        rangeSlider.setValue(new DecimalRangeSliderValue(25.0, 75.0));
         binder.readBean(null);
 
-        Assertions.assertEquals(new RangeSliderValue(rangeSlider.getMin(),
-                rangeSlider.getMax()), rangeSlider.getValue());
+        Assertions
+                .assertEquals(new DecimalRangeSliderValue(rangeSlider.getMin(),
+                        rangeSlider.getMax()), rangeSlider.getValue());
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/SliderBasicValidationTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/SliderBasicValidationTest.java
@@ -15,14 +15,14 @@
  */
 package com.vaadin.flow.component.slider.validation;
 
-import com.vaadin.flow.component.slider.Slider;
+import com.vaadin.flow.component.slider.DecimalSlider;
 import com.vaadin.tests.validation.AbstractBasicValidationTest;
 
 class SliderBasicValidationTest
-        extends AbstractBasicValidationTest<Slider, Double> {
+        extends AbstractBasicValidationTest<DecimalSlider, Double> {
 
     @Override
-    protected Slider createTestField() {
-        return new Slider();
+    protected DecimalSlider createTestField() {
+        return new DecimalSlider();
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/SliderBinderValidationTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/validation/SliderBinderValidationTest.java
@@ -19,14 +19,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.flow.component.slider.Slider;
+import com.vaadin.flow.component.slider.DecimalSlider;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.BindingValidationStatus;
 
 class SliderBinderValidationTest {
     private static final String VALIDATION_ERROR_MESSAGE = "Value must be at least 50";
 
-    private Slider slider;
+    private DecimalSlider slider;
     private Binder<Bean> binder;
 
     public static class Bean {
@@ -43,7 +43,7 @@ class SliderBinderValidationTest {
 
     @BeforeEach
     void setup() {
-        slider = new Slider();
+        slider = new DecimalSlider();
         binder = new Binder<>(Bean.class);
         binder.forField(slider)
                 .withValidator(value -> value >= 50, VALIDATION_ERROR_MESSAGE)

--- a/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/DecimalRangeSliderElement.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/DecimalRangeSliderElement.java
@@ -18,11 +18,15 @@ package com.vaadin.flow.component.slider.testbench;
 import com.vaadin.testbench.elementsbase.Element;
 
 /**
- * A TestBench element for testing a {@code RangeSlider} component.
+ * A TestBench element for testing a {@code DecimalRangeSlider} component.
+ * <p>
+ * See {@link IntegerRangeSliderElement} for testing {@code IntegerRangeSlider}
+ * components.
  */
 @Element("vaadin-range-slider")
-public class RangeSliderElement extends NumberRangeSliderElement<Double> {
-    public RangeSliderElement() {
+public class DecimalRangeSliderElement
+        extends NumberRangeSliderElement<Double> {
+    public DecimalRangeSliderElement() {
         super(v -> v, v -> v);
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/DecimalSliderElement.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/DecimalSliderElement.java
@@ -18,11 +18,14 @@ package com.vaadin.flow.component.slider.testbench;
 import com.vaadin.testbench.elementsbase.Element;
 
 /**
- * A TestBench element for testing a {@code Slider} component.
+ * A TestBench element for testing a {@code DecimalSlider} component.
+ * <p>
+ * See {@link IntegerSliderElement} for testing {@code IntegerSlider}
+ * components.
  */
 @Element("vaadin-slider")
-public class SliderElement extends NumberSliderElement<Double> {
-    public SliderElement() {
+public class DecimalSliderElement extends NumberSliderElement<Double> {
+    public DecimalSliderElement() {
         super(v -> v, v -> v);
     }
 }

--- a/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/IntegerRangeSliderElement.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/IntegerRangeSliderElement.java
@@ -19,6 +19,9 @@ import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element for testing an {@code IntegerRangeSlider} component.
+ * <p>
+ * See {@link DecimalRangeSliderElement} for testing {@code DecimalRangeSlider}
+ * components.
  */
 @Element("vaadin-range-slider")
 public class IntegerRangeSliderElement

--- a/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/IntegerSliderElement.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-testbench/src/main/java/com/vaadin/flow/component/slider/testbench/IntegerSliderElement.java
@@ -19,6 +19,9 @@ import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element for testing an {@code IntegerSlider} component.
+ * <p>
+ * See {@link DecimalSliderElement} for testing {@code DecimalSlider}
+ * components.
  */
 @Element("vaadin-slider")
 public class IntegerSliderElement extends NumberSliderElement<Integer> {


### PR DESCRIPTION
## Description

Rename decimal slider variants and related classes to use a "Decimal" prefix, similar to integer variants:
- `Slider` -> `DecimalSlider`
- `RangeSlider` -> `DecimalRangeSlider`
- `RangeSliderValue` -> `DecimalRangeSliderValue`
- `SliderElement` -> `DecimalSliderElement`
- `RangeSliderElement` -> `DecimalSliderElement`

Part of https://github.com/vaadin/flow-components/issues/8863

## Type of change

- Refactoring / Breaking change
