### PR TITLE
fix: do not leak exception messages to the LLM

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -269,6 +269,7 @@ public final class ChartAITools {
                     String chartId = resolveChartId(arguments, callbacks);
                     return callbacks.getState(chartId);
                 } catch (ValidationException e) {
+                    LOGGER.warn("get_chart_state validation failed", e);
                     return "Error getting chart state: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("get_chart_state failed", e);
@@ -530,6 +531,8 @@ public final class ChartAITools {
                     return "Chart '" + chartId
                             + "' configuration updated. Changes will be applied when the request completes.";
                 } catch (ValidationException e) {
+                    LOGGER.warn("update_chart_configuration validation failed",
+                            e);
                     return "Error updating chart configuration: "
                             + e.getMessage();
                 } catch (Exception e) {
@@ -680,6 +683,8 @@ public final class ChartAITools {
                     return "Chart '" + chartId
                             + "' data source updated. Changes will be applied when the request completes.";
                 } catch (ValidationException e) {
+                    LOGGER.warn("update_chart_data_source validation failed",
+                            e);
                     return "Error updating chart data: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_chart_data_source failed", e);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -185,6 +185,18 @@ public final class ChartAITools {
     }
 
     /**
+     * Signals a validation failure whose message is safe to pass back to the
+     * LLM. Unexpected runtime exceptions, by contrast, may carry internal
+     * detail (SQL fragments, schema names, file paths) and must be replaced
+     * with a generic message before being returned.
+     */
+    private static final class ValidationException extends RuntimeException {
+        ValidationException(String message) {
+            super(message);
+        }
+    }
+
+    /**
      * Resolves the chart ID from the tool arguments. If {@code chartId} is not
      * provided and there is exactly one chart, that chart's ID is used as the
      * default.
@@ -192,7 +204,7 @@ public final class ChartAITools {
     private static String resolveChartId(JsonNode args, Callbacks callbacks) {
         var ids = callbacks.getChartIds();
         if (ids.isEmpty()) {
-            throw new IllegalArgumentException("No charts available.");
+            throw new ValidationException("No charts available.");
         }
         if (ids.size() == 1) {
             return ids.iterator().next();
@@ -201,7 +213,7 @@ public final class ChartAITools {
         if (idNode != null && ids.contains(idNode.asString())) {
             return idNode.asString();
         }
-        throw new IllegalArgumentException(
+        throw new ValidationException(
                 "chartId is required when multiple charts exist. "
                         + "Available chart IDs: " + ids);
     }
@@ -256,9 +268,11 @@ public final class ChartAITools {
                     LOGGER.info("get_chart_state called");
                     String chartId = resolveChartId(arguments, callbacks);
                     return callbacks.getState(chartId);
+                } catch (ValidationException e) {
+                    return "Error getting chart state: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("get_chart_state failed", e);
-                    return "Error getting chart state: " + e.getMessage();
+                    return "Error getting chart state.";
                 }
             }
         };
@@ -515,10 +529,12 @@ public final class ChartAITools {
 
                     return "Chart '" + chartId
                             + "' configuration updated. Changes will be applied when the request completes.";
-                } catch (Exception e) {
-                    LOGGER.error("update_chart_configuration failed", e);
+                } catch (ValidationException e) {
                     return "Error updating chart configuration: "
                             + e.getMessage();
+                } catch (Exception e) {
+                    LOGGER.error("update_chart_configuration failed", e);
+                    return "Error updating chart configuration.";
                 }
             }
         };
@@ -663,9 +679,11 @@ public final class ChartAITools {
 
                     return "Chart '" + chartId
                             + "' data source updated. Changes will be applied when the request completes.";
+                } catch (ValidationException e) {
+                    return "Error updating chart data: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_chart_data_source failed", e);
-                    return "Error updating chart data: " + e.getMessage();
+                    return "Error updating chart data.";
                 }
             }
         };
@@ -725,7 +743,7 @@ public final class ChartAITools {
                     return schema;
                 } catch (Exception e) {
                     LOGGER.error("get_plot_options_schema failed", e);
-                    return "Error: " + e.getMessage();
+                    return "Error getting plot options schema.";
                 }
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -156,6 +156,7 @@ public final class GridAITools {
                     var gridId = resolveGridId(arguments, callbacks);
                     return callbacks.getState(gridId);
                 } catch (ValidationException e) {
+                    LOGGER.warn("get_grid_state validation failed", e);
                     return "Error getting grid state: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("get_grid_state failed", e);
@@ -237,6 +238,7 @@ public final class GridAITools {
                     return "Grid '" + gridId
                             + "' data update queued successfully";
                 } catch (ValidationException e) {
+                    LOGGER.warn("update_grid_data validation failed", e);
                     return "Error updating grid data: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_grid_data failed", e);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -47,6 +47,18 @@ public final class GridAITools {
     }
 
     /**
+     * Signals a validation failure whose message is safe to pass back to the
+     * LLM. Unexpected runtime exceptions, by contrast, may carry internal
+     * detail (SQL fragments, schema names, file paths) and must be replaced
+     * with a generic message before being returned.
+     */
+    private static final class ValidationException extends RuntimeException {
+        ValidationException(String message) {
+            super(message);
+        }
+    }
+
+    /**
      * Callback interface for grid state access and mutation.
      */
     public interface Callbacks extends Serializable {
@@ -95,9 +107,9 @@ public final class GridAITools {
             return ids.iterator().next();
         }
         if (ids.isEmpty()) {
-            throw new IllegalArgumentException("No grids available.");
+            throw new ValidationException("No grids available.");
         }
-        throw new IllegalArgumentException(
+        throw new ValidationException(
                 "gridId is required when multiple grids exist. "
                         + "Available grid IDs: " + ids);
     }
@@ -143,9 +155,11 @@ public final class GridAITools {
                     LOGGER.info("get_grid_state called");
                     var gridId = resolveGridId(arguments, callbacks);
                     return callbacks.getState(gridId);
+                } catch (ValidationException e) {
+                    return "Error getting grid state: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("get_grid_state failed", e);
-                    return "Error getting grid state: " + e.getMessage();
+                    return "Error getting grid state.";
                 }
             }
         };
@@ -222,9 +236,11 @@ public final class GridAITools {
                     callbacks.updateData(gridId, query);
                     return "Grid '" + gridId
                             + "' data update queued successfully";
+                } catch (ValidationException e) {
+                    return "Error updating grid data: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_grid_data failed", e);
-                    return "Error updating grid data: " + e.getMessage();
+                    return "Error updating grid data.";
                 }
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -186,7 +186,6 @@ class ChartAIControllerTest {
             String result = tool
                     .execute(json("{\"queries\": [\"SELECT invalid\"]}"));
             Assertions.assertTrue(result.contains("Error"));
-            Assertions.assertTrue(result.contains("Bad SQL"));
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIToolsTest.java
@@ -163,7 +163,20 @@ class ChartAIToolsTest {
                     "Chart not found");
             var result = tool.execute(json("{\"chartId\": \"chart-1\"}"));
             Assertions.assertTrue(result.contains("Error"));
-            Assertions.assertTrue(result.contains("Chart not found"));
+        }
+
+        @Test
+        void execute_whenCallbackThrows_doesNotLeakExceptionMessage() {
+            // Exception messages can carry sensitive internal detail (SQL
+            // fragments, schema names, file paths, credentials). The tool
+            // result is fed to the LLM, which a user can prompt to repeat
+            // it verbatim — so raw exception messages must not be included.
+            callbacks.getStateException = new RuntimeException(
+                    "SENSITIVE_INTERNAL_DETAIL_XYZ");
+            var result = tool.execute(json("{\"chartId\": \"chart-1\"}"));
+            Assertions.assertFalse(
+                    result.contains("SENSITIVE_INTERNAL_DETAIL_XYZ"),
+                    "Tool result leaks exception message to LLM: " + result);
         }
     }
 
@@ -237,7 +250,17 @@ class ChartAIToolsTest {
             var result = tool.execute(json(
                     "{\"chartId\": \"chart-1\", \"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             Assertions.assertTrue(result.contains("Error"));
-            Assertions.assertTrue(result.contains("Config rejected"));
+        }
+
+        @Test
+        void execute_whenCallbackThrows_doesNotLeakExceptionMessage() {
+            callbacks.updateConfigException = new RuntimeException(
+                    "SENSITIVE_INTERNAL_DETAIL_XYZ");
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
+            Assertions.assertFalse(
+                    result.contains("SENSITIVE_INTERNAL_DETAIL_XYZ"),
+                    "Tool result leaks exception message to LLM: " + result);
         }
     }
 
@@ -308,7 +331,17 @@ class ChartAIToolsTest {
             var result = tool.execute(json(
                     "{\"chartId\": \"chart-1\", \"queries\": [\"SELECT invalid\"]}"));
             Assertions.assertTrue(result.contains("Error"));
-            Assertions.assertTrue(result.contains("Invalid query"));
+        }
+
+        @Test
+        void execute_whenCallbackThrows_doesNotLeakExceptionMessage() {
+            callbacks.updateDataException = new RuntimeException(
+                    "SENSITIVE_INTERNAL_DETAIL_XYZ");
+            var result = tool.execute(json(
+                    "{\"chartId\": \"chart-1\", \"queries\": [\"SELECT invalid\"]}"));
+            Assertions.assertFalse(
+                    result.contains("SENSITIVE_INTERNAL_DETAIL_XYZ"),
+                    "Tool result leaks exception message to LLM: " + result);
         }
 
         @Test
@@ -392,6 +425,19 @@ class ChartAIToolsTest {
             String result = tool.execute(json("{\"chartType\":\"COLUMN\"}"));
             Assertions.assertFalse(result.contains("Error"), result);
             Assertions.assertTrue(result.contains("\"properties\""));
+        }
+
+        @Test
+        void execute_whenExceptionThrown_doesNotLeakExceptionMessage() {
+            // Calling asString() on a container node throws
+            // JsonNodeException with a message that embeds the raw
+            // node value — exactly the kind of detail the catch-all
+            // handler must not pass through to the LLM.
+            var result = tool.execute(json("{\"chartType\":[1,2,3]}"));
+            Assertions.assertFalse(result.contains("coerce"),
+                    "Tool result leaks exception message to LLM: " + result);
+            Assertions.assertFalse(result.contains("ArrayNode"),
+                    "Tool result leaks exception message to LLM: " + result);
         }
 
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
@@ -152,6 +152,8 @@ class GridAIToolsTest {
 
             @Override
             public void updateData(String gridId, String query) {
+                throw new UnsupportedOperationException(
+                        "updateData not expected in getState leak test");
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
@@ -138,6 +138,32 @@ class GridAIToolsTest {
                 () -> GridAITools.getGridState(null));
     }
 
+    @Test
+    void getGridState_handlerThrows_doesNotLeakExceptionMessage() {
+        // Exception messages can carry sensitive internal detail (SQL
+        // fragments, schema names, file paths, credentials). The tool
+        // result is fed to the LLM, which a user can prompt to repeat
+        // it verbatim — so raw exception messages must not be included.
+        var tool = GridAITools.getGridState(new GridAITools.Callbacks() {
+            @Override
+            public String getState(String gridId) {
+                throw new RuntimeException("SENSITIVE_INTERNAL_DETAIL_XYZ");
+            }
+
+            @Override
+            public void updateData(String gridId, String query) {
+            }
+
+            @Override
+            public Set<String> getGridIds() {
+                return Set.of("grid");
+            }
+        });
+        var result = tool.execute(json("{}"));
+        Assertions.assertFalse(result.contains("SENSITIVE_INTERNAL_DETAIL_XYZ"),
+                "Tool result leaks exception message to LLM: " + result);
+    }
+
     // --- updateGridData ---
 
     @Test
@@ -170,7 +196,29 @@ class GridAIToolsTest {
         });
         var result = tool.execute(json("{\"query\": \"BAD\"}"));
         Assertions.assertTrue(result.contains("Error"));
-        Assertions.assertTrue(result.contains("bad query"));
+    }
+
+    @Test
+    void updateGridData_handlerThrows_doesNotLeakExceptionMessage() {
+        var tool = GridAITools.updateGridData(new GridAITools.Callbacks() {
+            @Override
+            public String getState(String gridId) {
+                return "{}";
+            }
+
+            @Override
+            public void updateData(String gridId, String query) {
+                throw new RuntimeException("SENSITIVE_INTERNAL_DETAIL_XYZ");
+            }
+
+            @Override
+            public Set<String> getGridIds() {
+                return Set.of("grid");
+            }
+        });
+        var result = tool.execute(json("{\"query\": \"BAD\"}"));
+        Assertions.assertFalse(result.contains("SENSITIVE_INTERNAL_DETAIL_XYZ"),
+                "Tool result leaks exception message to LLM: " + result);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Tool error responses in `ChartAITools` and `GridAITools` appended raw `e.getMessage()` to the string returned to the LLM, so any detail carried by an exception from a callback, JDBC driver, filesystem, or Jackson coercion could be repeated back to the end user via the model.
- Introduced a private `ValidationException` in each class. Only our own curated messages (e.g. `"chartId is required when multiple charts exist. Available chart IDs: [...]"`) pass through to the LLM; all other throwables are logged and replaced with a generic `"Error ..."` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)