### PR TITLE
chore: improve Jetty setup [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ mvn package jetty:run -Dvaadin.pnpm.enable -Dvaadin.frontend.hotdeploy=true -am 
 - Server needs to be restarted after code changes
 - Integration tests can fail if the 8080 port is already in use. At that point stop and ask the user whether to kill the process using that port. If you started the server yourself and want to run tests against it, add `-DskipJetty` to the integration test command.
 - When waiting for the server to start, use `TaskOutput` with `block=false` to poll the background task output for the message "Frontend compiled successfully" rather than using arbitrary sleep commands.
-- When stopping a server that was started as a background task in the current session, use the `TaskStop` tool with the task ID instead of killing the process directly.
+- To stop a running Jetty server, run `mvn jetty:stop -pl vaadin-{component}-flow-parent/vaadin-{component}-flow-integration-tests`. Do not use `TaskStop` on the background `jetty:run` task — that terminates the Maven wrapper but leaves the forked Jetty JVM running and holding port 8080.
 
 ### Code Quality
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <jetty.version>12.1.2</jetty.version>
         <jetty.http.port>8080</jetty.http.port>
         <jetty.stop.port>9999</jetty.stop.port>
+        <jetty.scan>0</jetty.scan>
         <karaf-maven-plugin.version>4.4.10</karaf-maven-plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
         <maven.failsafe.plugin.version>3.5.5</maven.failsafe.plugin.version>
@@ -366,6 +367,7 @@
                         <stopPort>${jetty.stop.port}</stopPort>
                         <stopWait>5</stopWait>
                         <stopKey>foo</stopKey>
+                        <scan>${jetty.scan}</scan>
                         <systemProperties>
                             <force>true</force>
                             <project.basedir>${project.basedir}</project.basedir>

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -132,6 +132,7 @@ function runJetty(module, modeKey) {
     'jetty:run',
     '-Dvaadin.pnpm.enable',
     '-Dvaadin.frontend.hotdeploy=true',
+    '-Djetty.scan=5',
     '-am',
     '-B',
     '-q',

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -177,9 +177,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
@@ -173,9 +173,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -182,9 +182,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
@@ -125,9 +125,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -156,9 +156,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
@@ -148,9 +148,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -152,9 +152,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -170,9 +170,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
@@ -147,9 +147,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -186,9 +186,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -166,9 +166,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -192,9 +192,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -178,9 +178,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -167,9 +167,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -203,9 +203,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -161,9 +161,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
@@ -168,9 +168,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -165,9 +165,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -162,9 +162,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -153,9 +153,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -181,9 +181,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -171,9 +171,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -177,9 +177,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -248,9 +248,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -170,9 +170,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -156,9 +156,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -167,9 +167,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -164,9 +164,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -153,9 +153,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -157,9 +157,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
@@ -138,9 +138,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
@@ -175,9 +175,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -155,9 +155,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -163,9 +163,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -175,9 +175,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -174,9 +174,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -164,9 +164,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -163,9 +163,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -168,9 +168,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -141,9 +141,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -185,9 +185,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -179,9 +179,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -147,9 +147,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
@@ -147,9 +147,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -170,9 +170,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -234,9 +234,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -163,9 +163,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -166,9 +166,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -155,9 +155,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -162,9 +162,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -169,9 +169,6 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <configuration>
-                            <scan>5</scan>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Removes the default scan interval of 5 seconds and adds a configurable `jetty.scan` property instead. By default the scan interval is zero, which means Jetty will not redeploy automatically on class path changes.

This helps with:
- Letting Claude run the server in the background, while also allowing to run `mvn verify` without the class path changes resulting from that in redeployments that could then interfere with tests
- Running the server manually and then starting tests from IntelliJ. IntelliJ also syncs the whole class path, which also often leads to tests failures.

Redeploy is still easy to do when working on IT pages:
- With a scan interval of zero, Jetty switches to a manual redeploy mode. For that, just focus the Terminal window and press <kbd>Enter</kbd>.
- Alternatively, add `-Djetty.scan=5` when starting Jetty
- The `run.js` script automatically adds `-Djetty.scan=5`

Additionally, this improves instructions for Claude to use the `jetty:stop` goal for shutting down the Jetty server.