### PR TITLE
fix: surface controller render errors in chat

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -272,7 +272,11 @@ public class ChartAIController implements AIController {
         chart.setConfiguration(copyConfiguration(state.configuration()));
         ChartEntry entry = ChartEntry.getOrCreate(chart, CHART_ID);
         entry.setQueries(state.queries());
-        deferRender(entry, state.queries(), null, false);
+        try {
+            render(entry, state.queries(), null, false);
+        } catch (Exception e) {
+            LOGGER.error("Rendering failed during state restore", e);
+        }
     }
 
     /**
@@ -313,24 +317,24 @@ public class ChartAIController implements AIController {
         }
 
         String configJson = entry.getPendingConfigurationJson();
-        deferRender(entry, queries, configJson, true);
+        // Render synchronously so exceptions propagate to the orchestrator,
+        // which runs this on the UI thread under session lock. Attachment
+        // is not required: Configuration is server-side state and any JS
+        // calls are queued by Flow until the chart attaches.
+        render(entry, queries, configJson, true);
     }
 
-    private void deferRender(ChartEntry entry, List<String> queries,
+    private void render(ChartEntry entry, List<String> queries,
             String configJson, boolean fireListeners) {
-        chart.getElement().getNode().runWhenAttached(ui -> ui.access(() -> {
-            try {
-                ChartRenderer.renderChart(chart, databaseProvider,
-                        dataConverter, queries, configJson);
-                if (fireListeners) {
-                    fireStateChangeListeners();
-                }
-            } catch (Exception e) {
-                LOGGER.error("Rendering failed", e);
-            } finally {
-                entry.clearPendingState();
+        try {
+            ChartRenderer.renderChart(chart, databaseProvider, dataConverter,
+                    queries, configJson);
+            if (fireListeners) {
+                fireStateChangeListeners();
             }
-        }));
+        } finally {
+            entry.clearPendingState();
+        }
     }
 
     private void fireStateChangeListeners() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -214,7 +214,12 @@ public class GridAIController implements AIController {
         }
         var query = entry.getPendingQuery();
         LOGGER.info("onRequestCompleted: applying query: {}", query);
-        deferRender(entry, query, true);
+        // Render synchronously so exceptions propagate to the orchestrator,
+        // which runs this on the UI thread under session lock. Attachment
+        // is not required: grid state (columns, data provider) is
+        // server-side and syncs to the client on attach.
+        render(entry, query, true);
+        LOGGER.info("Grid updated successfully");
     }
 
     /**
@@ -247,7 +252,23 @@ public class GridAIController implements AIController {
             return;
         }
         var entry = GridEntry.getOrCreate(grid, GRID_ID);
-        deferRender(entry, state.query(), false);
+        try {
+            render(entry, state.query(), false);
+        } catch (Exception e) {
+            LOGGER.error("Error updating grid during state restore", e);
+        }
+    }
+
+    private void render(GridEntry entry, String query, boolean fireListeners) {
+        try {
+            GridRenderer.renderGrid(grid, databaseProvider, query);
+            entry.setCurrentQuery(query);
+            if (fireListeners) {
+                fireStateChangeListeners();
+            }
+        } finally {
+            entry.clearPendingState();
+        }
     }
 
     /**
@@ -269,24 +290,6 @@ public class GridAIController implements AIController {
         Objects.requireNonNull(listener, "Listener cannot be null");
         stateChangeListeners.add(listener);
         return () -> stateChangeListeners.remove(listener);
-    }
-
-    private void deferRender(GridEntry entry, String query,
-            boolean fireListeners) {
-        grid.getElement().getNode().runWhenAttached(ui -> ui.access(() -> {
-            try {
-                GridRenderer.renderGrid(grid, databaseProvider, query);
-                entry.setCurrentQuery(query);
-                if (fireListeners) {
-                    fireStateChangeListeners();
-                }
-                LOGGER.info("Grid updated successfully");
-            } catch (Exception e) {
-                LOGGER.error("Error updating grid", e);
-            } finally {
-                entry.clearPendingState();
-            }
-        }));
     }
 
     private void fireStateChangeListeners() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -57,7 +57,12 @@ public interface AIController {
      * can use this callback to perform deferred operations, such as rendering
      * UI updates or committing state changes.
      * </p>
-     *
+     * <p>
+     * The orchestrator invokes this method on the UI thread under the session
+     * lock, so implementations may update UI components directly. Any exception
+     * thrown is caught by the orchestrator and reported to the user as a
+     * generic error message.
+     * </p>
      */
     void onRequestCompleted();
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -371,7 +371,7 @@ public class AIOrchestrator implements Serializable {
                 conversationHistory
                         .add(new ChatMessage(ChatMessage.Role.ASSISTANT,
                                 responseText, null, Instant.now()));
-                fireResponseCompleteListener(responseText);
+                fireResponseCompleteListener(responseText, ui);
             }
             LOGGER.debug("LLM streaming completed successfully");
         });
@@ -458,7 +458,7 @@ public class AIOrchestrator implements Serializable {
         streamResponseToMessage(request, assistantMessage, ui);
     }
 
-    private void fireResponseCompleteListener(String responseText) {
+    private void fireResponseCompleteListener(String responseText, UI ui) {
         if (responseCompleteListener != null) {
             try {
                 responseCompleteListener.onResponseComplete(
@@ -469,11 +469,23 @@ public class AIOrchestrator implements Serializable {
             }
         }
         if (controller != null) {
-            try {
-                controller.onRequestCompleted();
-            } catch (Exception e) {
-                LOGGER.error("Error in controller onRequestCompleted", e);
-            }
+            ui.access(() -> {
+                try {
+                    controller.onRequestCompleted();
+                } catch (Exception e) {
+                    LOGGER.error("Error in controller onRequestCompleted", e);
+                    // Append a separate assistant message instead of
+                    // rewriting the LLM's response. By the time this
+                    // runs, the response is already in the provider's
+                    // chat memory and in our history; rewriting either
+                    // would misrepresent what the LLM actually said.
+                    if (messageList != null) {
+                        messageList.addMessage(
+                                "An error occurred. Please try again.",
+                                assistantName, Collections.emptyList());
+                    }
+                }
+            });
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -190,7 +190,7 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void onRequestCompleted_renderFails_doesNotThrow() {
+        void onRequestCompleted_renderFails_propagates() {
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
 
@@ -201,8 +201,9 @@ class ChartAIControllerTest {
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
 
-            Assertions
-                    .assertDoesNotThrow(() -> controller.onRequestCompleted());
+            var ex = Assertions.assertThrows(RuntimeException.class,
+                    () -> controller.onRequestCompleted());
+            Assertions.assertEquals("Render failure", ex.getMessage());
         }
 
         @Test
@@ -524,7 +525,8 @@ class ChartAIControllerTest {
 
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
-            controller.onRequestCompleted();
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> controller.onRequestCompleted());
 
             Assertions.assertNull(captured.get());
         }
@@ -617,26 +619,7 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void onRequestCompleted_pendingStateSurvivesUntilRender() {
-            databaseProvider.results = List
-                    .of(Map.of("category", "A", "value", 10));
-
-            var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(json(
-                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
-            findTool(tools, "update_chart_data_source")
-                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
-
-            // Render is deferred (chart detached), so pending state
-            // should not yet be cleared.
-            ChartEntry entry = ChartEntry.get(chart);
-            Assertions.assertTrue(entry.hasPendingState(),
-                    "Pending state should survive until render executes");
-        }
-
-        @Test
-        void onRequestCompleted_listenerFiresOnReattach() {
+        void onRequestCompleted_appliesStateAndFiresListenerImmediately() {
             AtomicReference<ChartState> captured = new AtomicReference<>();
             controller.addStateChangeListener(captured::set);
 
@@ -650,46 +633,30 @@ class ChartAIControllerTest {
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onRequestCompleted();
 
-            // Listener should not fire while chart is detached
-            Assertions.assertNull(captured.get(),
-                    "State change listener should not fire before "
-                            + "chart is attached and render completes");
-
-            // After re-attachment, deferred render should fire listener
-            ui.add(chart);
-            Assertions.assertNotNull(captured.get(),
-                    "State change listener should fire after "
-                            + "chart is re-attached");
+            // Attachment does not gate the controller: configuration
+            // lives on the server side and Flow queues any JS calls
+            // until attach, so a state change is a state change even
+            // when the chart is not currently visible.
+            ChartEntry entry = ChartEntry.get(chart);
+            Assertions.assertFalse(entry.hasPendingState());
+            Assertions.assertNotNull(captured.get());
         }
 
         @Test
-        void onRequestCompleted_rendersLatestStateOnAttach() {
-            var tools = controller.getTools();
-
-            // First request while detached
+        void onRequestCompleted_renderFails_propagates() {
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
-            findTool(tools, "update_chart_configuration").execute(json(
-                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
+
+            var tools = controller.getTools();
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
 
-            // Second request while still detached
-            databaseProvider.results = List
-                    .of(Map.of("category", "B", "value", 20));
-            findTool(tools, "update_chart_configuration").execute(json(
-                    "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
-            findTool(tools, "update_chart_data_source")
-                    .execute(json("{\"queries\": [\"SELECT 2\"]}"));
-            controller.onRequestCompleted();
+            databaseProvider.throwOnExecute = new RuntimeException("DB error");
 
-            ui.add(chart);
-
-            // After re-attachment, the chart should reflect the latest
-            // state from the second request.
-            Assertions.assertEquals(ChartType.PIE,
-                    chart.getConfiguration().getChart().getType());
+            // Errors propagate regardless of attach state so the
+            // orchestrator can still surface them in the chat UI.
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> controller.onRequestCompleted());
         }
 
         @Test
@@ -699,46 +666,11 @@ class ChartAIControllerTest {
             Configuration config = new Configuration();
             config.getChart().setType(ChartType.COLUMN);
 
-            controller
-                    .restoreState(new ChartState(List.of("SELECT 1"), config));
-
-            // Re-attach triggers the deferred render, which will fail.
-            // Should not propagate the exception.
-            Assertions.assertDoesNotThrow(() -> ui.add(chart));
-        }
-
-        @Test
-        void restoreState_pendingStateSurvivesUntilRender() {
-            databaseProvider.results = List
-                    .of(Map.of("category", "A", "value", 10));
-
-            // Create pending state via tools
-            var tools = controller.getTools();
-            findTool(tools, "update_chart_configuration").execute(json(
-                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
-            findTool(tools, "update_chart_data_source")
-                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-
-            Configuration config = new Configuration();
-            config.getChart().setType(ChartType.COLUMN);
-            controller
-                    .restoreState(new ChartState(List.of("SELECT 2"), config));
-
-            // Render is deferred (chart detached), so pending state
-            // from the tool calls should be cleared by restoreState,
-            // but the restoreState render itself hasn't executed yet.
-            ChartEntry entry = ChartEntry.get(chart);
-            Assertions.assertTrue(
-                    chart.getConfiguration().getSeries().isEmpty(),
-                    "Render should be deferred while chart is detached");
-
-            // After re-attachment, the chart should be rendered
-            ui.add(chart);
-            Assertions.assertFalse(
-                    chart.getConfiguration().getSeries().isEmpty(),
-                    "Chart should be rendered after re-attachment");
-            Assertions.assertFalse(entry.hasPendingState(),
-                    "Pending state should be cleared after render");
+            // restoreState catches render failures so a corrupted
+            // persisted state does not break the caller (typically
+            // view init code).
+            Assertions.assertDoesNotThrow(() -> controller
+                    .restoreState(new ChartState(List.of("SELECT 1"), config)));
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -211,12 +211,17 @@ class ChartRenderingTest {
             // Make DB throw for the render phase
             databaseProvider.throwOnExecute = new RuntimeException("DB error");
 
-            // Exception is caught internally; no exception should propagate
-            controller.onRequestCompleted();
+            // Exception propagates so the orchestrator can surface it to
+            // the user, but pending state must still be cleared.
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> controller.onRequestCompleted());
 
-            // Pending state should be cleared despite the error
+            // Pending state should be cleared despite the error: a
+            // subsequent call with no pending state is a no-op and
+            // must not re-trigger the DB (which would still throw).
             databaseProvider.throwOnExecute = null;
-            controller.onRequestCompleted(); // should be no-op
+            Assertions
+                    .assertDoesNotThrow(() -> controller.onRequestCompleted());
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -183,7 +183,8 @@ class GridAIControllerTest {
                 .execute(json("{\"query\": \"SELECT a FROM t\"}"));
 
         dbProvider.throwOnExecute = true;
-        controller.onRequestCompleted();
+        Assertions.assertThrows(RuntimeException.class,
+                () -> controller.onRequestCompleted());
 
         Assertions.assertNull(controller.getState());
     }
@@ -321,7 +322,8 @@ class GridAIControllerTest {
         findTool("update_grid_data")
                 .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
         dbProvider.throwOnExecute = true;
-        controller.onRequestCompleted();
+        Assertions.assertThrows(RuntimeException.class,
+                () -> controller.onRequestCompleted());
 
         // Previous successful query should be retained
         Assertions.assertEquals("SELECT a FROM good",
@@ -361,7 +363,8 @@ class GridAIControllerTest {
                 .execute(json("{\"query\": \"SELECT a FROM t\"}"));
 
         dbProvider.throwOnExecute = true;
-        controller.onRequestCompleted();
+        Assertions.assertThrows(RuntimeException.class,
+                () -> controller.onRequestCompleted());
 
         Assertions.assertNull(captured.get());
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1661,11 +1661,18 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withControllerOnRequestCompletedThrows_logsAndContinues() {
+    void builder_withControllerOnRequestCompletedThrows_showsErrorMessage()
+            throws InterruptedException {
         var mockMessage = createMockMessage();
+        var errorText = "An error occurred. Please try again.";
+        var latch = new CountDownLatch(1);
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyList()))
-                .thenReturn(mockMessage);
+                Mockito.anyString(), Mockito.anyList())).thenAnswer(inv -> {
+                    if (errorText.equals(inv.getArgument(0))) {
+                        latch.countDown();
+                    }
+                    return mockMessage;
+                });
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
                 .thenReturn(Flux.just("Response"));
@@ -1689,9 +1696,22 @@ class AIOrchestratorTest {
         // Should not throw
         orchestrator.prompt("Hello");
 
-        // History should still be recorded
+        Assertions.assertTrue(latch.await(2, TimeUnit.SECONDS),
+                "Error message should be appended within timeout");
+        Mockito.verify(mockMessageList).addMessage(Mockito.eq(errorText),
+                Mockito.anyString(), Mockito.anyList());
+
+        // History records what the LLM actually said. The render failure
+        // is surfaced as a separate UI message, not by rewriting the
+        // assistant entry: the LLM's response is already committed to
+        // the provider's chat memory, and overwriting only our local
+        // history would misrepresent what the LLM produced.
         var history = orchestrator.getHistory();
         Assertions.assertEquals(2, history.size());
+        var lastAssistant = history.get(history.size() - 1);
+        Assertions.assertEquals(ChatMessage.Role.ASSISTANT,
+                lastAssistant.role());
+        Assertions.assertEquals("Response", lastAssistant.content());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Chart and grid controllers render synchronously; failures now propagate to the orchestrator instead of being swallowed inside a deferred lambda.
- On controller failure, the orchestrator appends a new assistant message to the chat (e.g. "An error occurred. Please try again.").

Fixes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=178096320

🤖 Generated with [Claude Code](https://claude.com/claude-code)