### PR TITLE
fix: Change client selectAll update to use LinkedHashSet (CP: 25.1) (#9169)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -224,7 +224,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
                 (Set<T>) getGrid().getDataCommunicator().getDataProvider()
                         .fetch(getGrid().getDataCommunicator().buildQuery(0,
                                 Integer.MAX_VALUE))
-                        .collect(Collectors.toSet()),
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Collections.emptySet());
         selectionColumn.setSelectAllCheckboxState(true);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);
@@ -415,7 +415,9 @@ public abstract class AbstractGridMultiSelectionModel<T>
             allItemsStream = dataProvider.fetch(getGrid().getDataCommunicator()
                     .buildQuery(0, Integer.MAX_VALUE));
         }
-        doUpdateSelection(allItemsStream.collect(Collectors.toSet()),
+        doUpdateSelection(
+                allItemsStream
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Collections.emptySet(), true);
         selectionColumn.setSelectAllCheckboxState(true);
         selectionColumn.setSelectAllCheckboxIndeterminateState(false);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridMultiSelectionModelTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -310,9 +309,29 @@ public class GridMultiSelectionModelTest {
     }
 
     @Test
-    @Ignore
-    // Ignored because selectAll is not implemented yet
-    // See https://github.com/vaadin/flow/issues/2546
+    public void clientSelectAll_preservesDataProviderOrder() {
+        var model = (AbstractGridMultiSelectionModel<Person>) selectionModel;
+        model.clientSelectAll();
+
+        var value = model.getSelectedItems().stream().toList();
+
+        assertEquals(PERSON_A, value.get(0));
+        assertEquals(PERSON_B, value.get(1));
+        assertEquals(PERSON_C, value.get(2));
+    }
+
+    @Test
+    public void selectAll_preservesDataProviderOrder() {
+        selectionModel.selectAll();
+
+        var value = selectionModel.getSelectedItems().stream().toList();
+
+        assertEquals(PERSON_A, value.get(0));
+        assertEquals(PERSON_B, value.get(1));
+        assertEquals(PERSON_C, value.get(2));
+    }
+
+    @Test
     public void selectAll() {
         selectionModel.selectAll();
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9169 to branch 25.1.

---

> Fixes https://github.com/vaadin/flow-components/issues/9170