### PR TITLE
refactor: drop @Synchronize on user-only GridPro properties

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -275,7 +275,6 @@ public class GridPro<E> extends Grid<E> {
          *
          * @return the editor type
          */
-        @Synchronize("editor-type-changed")
         protected String getEditorType() {
             return getElement().getProperty("editorType", "text");
         }
@@ -460,7 +459,6 @@ public class GridPro<E> extends Grid<E> {
      *
      * @return enterNextRow value
      */
-    @Synchronize("enter-next-row-changed")
     public boolean getEnterNextRow() {
         return getElement().getProperty("enterNextRow", false);
     }
@@ -486,7 +484,6 @@ public class GridPro<E> extends Grid<E> {
      *
      * @return singleCellEdit value
      */
-    @Synchronize("single-cell-edit-changed")
     public boolean getSingleCellEdit() {
         return getElement().getProperty("singleCellEdit", false);
     }


### PR DESCRIPTION
## Summary
- Remove `@Synchronize` from `getEnterNextRow()`, `getSingleCellEdit()`, and `EditColumn#getEditorType()` in `GridPro.java`.
- These three properties are only ever written from the server; the web component never reassigns them, so the `*-changed` listeners exist purely to receive notifications that never carry new information.
- The getters keep reading from Flow's element property cache, which already holds the last server-written value — existing round-trip unit tests continue to pass.

Unblocks a follow-up in `vaadin/web-components` to drop `notify: true` (and the `FIXME: needed by Flow counterpart` comments) on `enterNextRow`, `singleCellEdit`, and `editorType` once this ships in a platform release.

## Test plan
- [x] `mvn test -pl vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow` — 27/27 pass, including the existing `set → get` round-trips for `enterNextRow` and `singleCellEdit`.
- [x] `mvn spotless:apply` + `mvn checkstyle:check -pl vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow` — clean.
- [ ] CI integration tests for `vaadin-grid-pro-flow-integration-tests` (edit-mode keyboard navigation + editor rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)