### PR TITLE
fix: reset cell order according to order of columns in DOM

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
@@ -82,7 +82,7 @@ public class GridOrderColumnsIT extends AbstractComponentIT {
     private void assertColumnHeaders(String... headers) {
         for (int i = 0; i < headers.length; i++) {
             Assert.assertEquals("Unexpected header for column " + i, headers[i],
-                    grid.getHeaderCell(i).getText());
+                    grid.getHeaderCell(0, i).getText());
         }
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -100,7 +100,7 @@ class GridColumnOrderHelper<T> {
 
         // This will reset all column orders so that the visual column order
         // will also reflect that in the DOM.
-        grid.getElement().callJsFunction("resetColumnOrder");
+        grid.getElement().callJsFunction("_resetColumnOrder");
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -100,7 +100,7 @@ class GridColumnOrderHelper<T> {
 
         // This will reset all column orders so that the visual column order
         // will also reflect that in the DOM.
-        grid.getElement().executeJs("this._resetColumnOrder()");
+        grid.getElement().callJsFunction("resetColumnOrder");
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -100,8 +100,7 @@ class GridColumnOrderHelper<T> {
 
         // This will reset all column orders so that the visual column order
         // will also reflect that in the DOM.
-        grid.getElement()
-                .executeJs("this._updateOrders(this._columnTree, null)");
+        grid.getElement().executeJs("this._resetColumnOrder()");
     }
 
     /**


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/vaadin/web-components/pull/11522, this makes the Flow component use the newly introduced `_resetColumnOrder` method, and updates a test with a previously incorrect test setup to serve as a proper regression test.

Fixes https://github.com/vaadin/flow-components/issues/9119

## Type of change

- Bugfix
