### PR TITLE
refactor: rename AIController.onRequestCompleted to onResponseComplete

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerPage.java
@@ -41,7 +41,7 @@ import reactor.core.publisher.Flux;
 /**
  * Test page for ChartAIController with Dashboard. Uses an async LLM provider
  * that streams from a background thread (like a real LLM) and invokes chart
- * tools, so the orchestrator's onRequestCompleted() runs via ui.access() from
+ * tools, so the orchestrator's onResponseComplete() runs via ui.access() from
  * the background thread. This reproduces the real-world timing where the
  * dashboard widget addition and chart rendering happen across separate Push
  * updates, causing the connectedCallback/updateConfiguration microtask race.
@@ -74,7 +74,7 @@ public class DashboardChartControllerPage extends Div {
         var renderBarChart = new NativeButton("Render Bar Chart", e -> {
             // Add fresh chart widget to dashboard, then prompt the
             // async LLM which will call chart tools from a background
-            // thread and trigger onRequestCompleted via ui.access().
+            // thread and trigger onResponseComplete via ui.access().
             var widget = new DashboardWidget();
             widget.setTitle("Revenue");
             widget.setContent(chart);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/test/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerIT.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/test/java/com/vaadin/flow/component/ai/tests/DashboardChartControllerIT.java
@@ -41,7 +41,7 @@ public class DashboardChartControllerIT extends AbstractComponentIT {
      * Verifies that axis categories are applied when a new Chart widget is
      * added to a Dashboard and populated via an async LLM provider. This
      * reproduces the real AI dashboard flow where the orchestrator's
-     * onRequestCompleted() runs via ui.access() from a background thread,
+     * onResponseComplete() runs via ui.access() from a background thread,
      * causing the widget addition and chart rendering to span separate Push
      * updates.
      * <p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -57,7 +57,7 @@ import tools.jackson.databind.JsonNode;
  * </pre>
  * <p>
  * State changes requested by the LLM are deferred and applied in
- * {@link #onRequestCompleted()}, avoiding partial state and multiple redraws
+ * {@link #onResponseComplete()}, avoiding partial state and multiple redraws
  * during a multi-tool LLM turn. The chart state is stored directly on the
  * {@link Chart} component, so it survives serialization.
  * </p>
@@ -301,7 +301,7 @@ public class ChartAIController implements AIController {
     }
 
     @Override
-    public void onRequestCompleted() {
+    public void onResponseComplete() {
         ChartEntry entry = ChartEntry.get(chart);
         if (entry == null || !entry.hasPendingState()) {
             return;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -66,7 +66,7 @@ import tools.jackson.databind.JsonNode;
  * </ul>
  * <p>
  * State changes requested by the LLM are deferred and applied in
- * {@link #onRequestCompleted()}, avoiding partial state and multiple redraws
+ * {@link #onResponseComplete()}, avoiding partial state and multiple redraws
  * during a multi-tool LLM turn. The grid state is stored directly on the
  * {@link Grid} component, so it survives serialization.
  * </p>
@@ -206,14 +206,14 @@ public class GridAIController implements AIController {
     }
 
     @Override
-    public void onRequestCompleted() {
+    public void onResponseComplete() {
         var entry = GridEntry.get(grid);
         if (entry == null || !entry.hasPendingState()) {
-            LOGGER.debug("onRequestCompleted: no pending query");
+            LOGGER.debug("onResponseComplete: no pending query");
             return;
         }
         var query = entry.getPendingQuery();
-        LOGGER.info("onRequestCompleted: applying query: {}", query);
+        LOGGER.info("onResponseComplete: applying query: {}", query);
         // Render synchronously so exceptions propagate to the orchestrator,
         // which runs this on the UI thread under session lock. Attachment
         // is not required: grid state (columns, data provider) is

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -64,5 +64,5 @@ public interface AIController {
      * generic error message.
      * </p>
      */
-    void onRequestCompleted();
+    void onResponseComplete();
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -471,9 +471,9 @@ public class AIOrchestrator implements Serializable {
         if (controller != null) {
             ui.access(() -> {
                 try {
-                    controller.onRequestCompleted();
+                    controller.onResponseComplete();
                 } catch (Exception e) {
-                    LOGGER.error("Error in controller onRequestCompleted", e);
+                    LOGGER.error("Error in controller onResponseComplete", e);
                     // Append a separate assistant message instead of
                     // rewriting the LLM's response. By the time this
                     // runs, the response is already in the provider's

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -345,7 +345,7 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
             }
 
             @Override
-            public void onRequestCompleted() {
+            public void onResponseComplete() {
                 // Test controller doesn't need to handle request completion
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -134,7 +134,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"column\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String state = findTool(tools, "get_chart_state")
                     .execute(json("{}"));
@@ -155,7 +155,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             ChartEntry entry = ChartEntry.get(chart);
             Assertions.assertNotNull(entry);
@@ -189,7 +189,7 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void onRequestCompleted_renderFails_propagates() {
+        void onResponseComplete_renderFails_propagates() {
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
 
@@ -201,7 +201,7 @@ class ChartAIControllerTest {
                     "Render failure");
 
             var ex = Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onRequestCompleted());
+                    () -> controller.onResponseComplete());
             Assertions.assertEquals("Render failure", ex.getMessage());
         }
 
@@ -225,7 +225,7 @@ class ChartAIControllerTest {
                             + ChartSerialization.toJSON(configuration) + "}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Verify plot options were applied to the chart
             var applied = (PlotOptionsColumn) chart.getConfiguration()
@@ -285,7 +285,7 @@ class ChartAIControllerTest {
                     .findFirst().get()
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -315,7 +315,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"column\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             ChartState state = controller.getState();
             Assertions.assertNotNull(state);
@@ -338,7 +338,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"column\"}, \"title\": {\"text\": \"Original\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             ChartState savedState = controller.getState();
 
@@ -485,7 +485,7 @@ class ChartAIControllerTest {
     class StateChangeListeners {
 
         @Test
-        void firesAfterOnRequestCompleted() {
+        void firesAfterOnResponseComplete() {
             AtomicReference<ChartState> captured = new AtomicReference<>();
             controller.addStateChangeListener(captured::set);
 
@@ -497,7 +497,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNotNull(captured.get());
             Assertions.assertEquals(List.of("SELECT 1"),
@@ -525,7 +525,7 @@ class ChartAIControllerTest {
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onRequestCompleted());
+                    () -> controller.onResponseComplete());
 
             Assertions.assertNull(captured.get());
         }
@@ -544,7 +544,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNull(captured.get());
         }
@@ -559,15 +559,15 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             List<ChartState> states = new ArrayList<>();
             controller.addStateChangeListener(states::add);
 
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertTrue(states.isEmpty(),
-                    "Second onRequestCompleted should not fire listeners "
+                    "Second onResponseComplete should not fire listeners "
                             + "because pending state was already cleared");
         }
 
@@ -588,7 +588,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNotNull(secondListenerState.get(),
                     "Second listener should still fire even if the "
@@ -603,7 +603,7 @@ class ChartAIControllerTest {
             var tools = controller.getTools();
             findTool(tools, "update_chart_configuration").execute(json(
                     "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNull(captured.get());
         }
@@ -618,7 +618,7 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void onRequestCompleted_appliesStateAndFiresListenerImmediately() {
+        void onResponseComplete_appliesStateAndFiresListenerImmediately() {
             AtomicReference<ChartState> captured = new AtomicReference<>();
             controller.addStateChangeListener(captured::set);
 
@@ -630,7 +630,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Attachment does not gate the controller: configuration
             // lives on the server side and Flow queues any JS calls
@@ -642,7 +642,7 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void onRequestCompleted_renderFails_propagates() {
+        void onResponseComplete_renderFails_propagates() {
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
 
@@ -655,7 +655,7 @@ class ChartAIControllerTest {
             // Errors propagate regardless of attach state so the
             // orchestrator can still surface them in the chat UI.
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onRequestCompleted());
+                    () -> controller.onResponseComplete());
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -100,7 +100,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Sales\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Configuration config = chart.getConfiguration();
             Assertions.assertEquals(ChartType.COLUMN,
@@ -114,13 +114,13 @@ class ChartRenderingTest {
             // First request: config only
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Revenue\"}}");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Second request: data only
             databaseProvider.results = List
                     .of(row("category", "Q1", "value", 100));
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Configuration config = chart.getConfiguration();
             Assertions.assertEquals(ChartType.COLUMN,
@@ -137,13 +137,13 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Existing Title\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Second update: only data, no config change
             databaseProvider.results = List
                     .of(row("category", "B", "value", 20));
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals("Existing Title",
                     chart.getConfiguration().getTitle().getText());
@@ -160,7 +160,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"line\"},\"title\":{\"text\":\"Original\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals("Original",
                     chart.getConfiguration().getTitle().getText());
@@ -168,7 +168,7 @@ class ChartRenderingTest {
             // Second render: same type, only update title (merge path)
             updateConfiguration("{\"title\":{\"text\":\"Updated\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals("Updated",
                     chart.getConfiguration().getTitle().getText());
@@ -184,7 +184,7 @@ class ChartRenderingTest {
                     + "\"pane\":{\"startAngle\":-150,\"endAngle\":150},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Verify pane was set
             String json1 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -193,7 +193,7 @@ class ChartRenderingTest {
             // Second: config-only update to column (no data change)
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"title\":{\"text\":\"Revenue\"}}");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Pane should be cleared
             String json2 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -214,14 +214,14 @@ class ChartRenderingTest {
             // Exception propagates so the orchestrator can surface it to
             // the user, but pending state must still be cleared.
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onRequestCompleted());
+                    () -> controller.onResponseComplete());
 
             // Pending state should be cleared despite the error: a
             // subsequent call with no pending state is a no-op and
             // must not re-trigger the DB (which would still throw).
             databaseProvider.throwOnExecute = null;
             Assertions
-                    .assertDoesNotThrow(() -> controller.onRequestCompleted());
+                    .assertDoesNotThrow(() -> controller.onResponseComplete());
         }
     }
 
@@ -234,7 +234,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t1", "SELECT x, y FROM t2");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(2,
                     chart.getConfiguration().getSeries().size());
@@ -252,7 +252,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -270,7 +270,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -293,7 +293,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -321,7 +321,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT 1");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -335,7 +335,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"pie\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -350,7 +350,7 @@ class ChartRenderingTest {
                     row("category", "Feb", "value", 200));
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
             Assertions.assertNotNull(
                     chart.getConfiguration().getxAxis().getCategories());
 
@@ -361,7 +361,7 @@ class ChartRenderingTest {
                     row(ColumnNames.X, 2, ColumnNames.Y, 20));
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -379,7 +379,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"line\"},\"xAxis\":{\"type\":\"linear\"}}");
             updateData("SELECT 1");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(AxisType.LINEAR,
                     chart.getConfiguration().getxAxis().getType());
@@ -390,7 +390,7 @@ class ChartRenderingTest {
             // trigger auto-detection.
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT 1");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(AxisType.LINEAR,
                     chart.getConfiguration().getxAxis().getType());
@@ -406,7 +406,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"gantt\"}}");
             updateData("SELECT name, start, end");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -424,7 +424,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"}}");
             updateData("SELECT trade_date, open, high, low, close");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Should have datetime axis, not categories
             Assertions.assertEquals(AxisType.DATETIME,
@@ -454,7 +454,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"}}");
             updateData("SELECT 1");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Even though volumeSeries has X=0, the OHLC series with epoch
             // X values should still cause datetime detection
@@ -471,7 +471,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -485,7 +485,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNotEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -498,7 +498,7 @@ class ChartRenderingTest {
                     row("category", "Feb", "value", 200));
 
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -518,7 +518,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNotEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -537,7 +537,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Revenue\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -551,7 +551,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -569,7 +569,7 @@ class ChartRenderingTest {
                     + "\"type\":\"areaspline\","
                     + "\"plotOptions\":{\"fillColor\":\"green\"}}]}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -610,7 +610,7 @@ class ChartRenderingTest {
                                {"name":"Vol","type":"column","yAxis":1}]}
                     """);
             updateData("SELECT 1", "SELECT 2");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -637,7 +637,7 @@ class ChartRenderingTest {
                                {"name":"Costs","yAxis":1}]}
                     """);
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -665,7 +665,7 @@ class ChartRenderingTest {
                     + "\"series\":[" + "{\"name\":\"Revenue\",\"yAxis\":0},"
                     + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -705,7 +705,7 @@ class ChartRenderingTest {
                                {"name":"Count","type":"line","yAxis":1}]}
                     """);
             updateData("SELECT 1", "SELECT 2");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -744,7 +744,7 @@ class ChartRenderingTest {
                                {"name":"South","yAxis":1}]}
                     """);
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -776,7 +776,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Revenue\"}}");
             updateData("SELECT series_name, category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -800,7 +800,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"xAxis\":{\"categories\":[\"A\",\"B\"]}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Categories were set on X-axis
             Assertions.assertTrue(chart.getConfiguration().getxAxis()
@@ -813,7 +813,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"scatter\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Y-axis serialization must NOT contain "categories" — check
             // via JSON to distinguish null field from empty ArrayList
@@ -833,7 +833,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"heatmap\"},"
                     + "\"tooltip\":{\"pointFormat\":\"Day: {point.y}<br>Hour: {point.x}<br>Visitors: {point.value}\"}}");
             updateData("SELECT x, y, value");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNotNull(
                     chart.getConfiguration().getTooltip().getPointFormat());
@@ -846,7 +846,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"},"
                     + "\"title\":{\"text\":\"Stock Prices\"}}");
             updateData("SELECT trade_date, open");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Tooltip should be reset, not carry heatmap format
             Assertions.assertNull(
@@ -862,7 +862,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"}}");
             updateData("SELECT trade_date, open, high, low, close");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -875,7 +875,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"title\":{\"text\":\"Revenue\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Datetime axis type should be cleared, categories used instead
             Assertions.assertNotEquals(AxisType.DATETIME,
@@ -892,7 +892,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"gauge\"},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(0.0,
                     chart.getConfiguration().getyAxis().getMin().doubleValue());
@@ -905,7 +905,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Gauge min/max should be cleared
             Assertions.assertNull(chart.getConfiguration().getyAxis().getMin());
@@ -921,7 +921,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"plotOptions\":{\"column\":{\"stacking\":\"normal\"}}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertNotNull(
                     chart.getConfiguration().getPlotOptions(ChartType.COLUMN));
@@ -932,7 +932,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Stacked column plot options should be cleared
             Assertions.assertNull(
@@ -948,7 +948,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"heatmap\"},"
                     + "\"colorAxis\":{\"min\":0,\"max\":300}}");
             updateData("SELECT x, y, value");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(1,
                     chart.getConfiguration().getNumberOfColorAxes());
@@ -959,7 +959,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Color axis should be cleared
             Assertions.assertEquals(0,
@@ -976,7 +976,7 @@ class ChartRenderingTest {
                     + "\"center\":[\"50%\",\"50%\"],\"size\":\"80%\"},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Pane should be set
             String json1 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -989,7 +989,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Pane should be cleared
             String json2 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -1007,7 +1007,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"pie\"},"
                     + "\"legend\":{\"enabled\":false}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertFalse(
                     chart.getConfiguration().getLegend().getEnabled());
@@ -1018,7 +1018,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Legend should be reset to default (enabled=true or null)
             Boolean legendEnabled = chart.getConfiguration().getLegend()
@@ -1036,7 +1036,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"subtitle\":{\"text\":\"Q1 2024\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals("Q1 2024",
                     chart.getConfiguration().getSubTitle().getText());
@@ -1047,7 +1047,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Subtitle should be cleared
             Assertions.assertNull(
@@ -1063,7 +1063,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"line\",\"polar\":true}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions
                     .assertTrue(chart.getConfiguration().getChart().getPolar());
@@ -1074,7 +1074,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions
                     .assertNull(chart.getConfiguration().getChart().getPolar());
@@ -1089,7 +1089,7 @@ class ChartRenderingTest {
                     + "\"pane\":{\"startAngle\":-150,\"endAngle\":150},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Second gauge render (e.g. user changes the gauge value)
             databaseProvider.results = List.of(row(ColumnNames.Y, 85));
@@ -1097,7 +1097,7 @@ class ChartRenderingTest {
                     + "\"pane\":{\"startAngle\":-150,\"endAngle\":150},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             // Should have exactly 1 pane, not 2
             String json = ChartSerialization.toJSON(chart.getConfiguration());
@@ -1128,7 +1128,7 @@ class ChartRenderingTest {
                     + "{\"name\":\"North\",\"yAxis\":0},"
                     + "{\"name\":\"South\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(2,
                     chart.getConfiguration().getNumberOfyAxes(),
@@ -1142,7 +1142,7 @@ class ChartRenderingTest {
                     + "{\"name\":\"North\",\"yAxis\":0},"
                     + "{\"name\":\"South\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             Assertions.assertEquals(2,
                     chart.getConfiguration().getNumberOfyAxes(),
@@ -1165,7 +1165,7 @@ class ChartRenderingTest {
                     + "{\"name\":\"Revenue\",\"yAxis\":0},"
                     + "{\"name\":\"Volume\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -1201,7 +1201,7 @@ class ChartRenderingTest {
                             + "{\"name\":\"Revenue\",\"type\":\"column\"},"
                             + "{\"name\":\"Count\",\"type\":\"line\"}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             var countSeries = (com.vaadin.flow.component.charts.model.AbstractSeries) series
@@ -1241,7 +1241,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"waterfall\"},"
                     + "\"title\":{\"text\":\"Budget\"}}");
             updateData("SELECT name, y, type");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -1266,7 +1266,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT title AS _title, text AS _text FROM flags");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -1289,7 +1289,7 @@ class ChartRenderingTest {
                     + "\"type\":\"flags\","
                     + "\"plotOptions\":{\"onSeries\":\"price\"}}]}");
             updateData("SELECT title AS _title, text AS _text FROM flags");
-            controller.onRequestCompleted();
+            controller.onResponseComplete();
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -184,12 +184,12 @@ class GridAIControllerTest {
 
         dbProvider.throwOnExecute = true;
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onRequestCompleted());
+                () -> controller.onResponseComplete());
 
         Assertions.assertNull(controller.getState());
     }
 
-    // --- onRequestCompleted ---
+    // --- onResponseComplete ---
 
     @Test
     void currentStateTool_afterUpdate_returnsQuery() {
@@ -202,21 +202,21 @@ class GridAIControllerTest {
     }
 
     @Test
-    void onRequestCompleted_noPending_doesNotChangeGrid() {
+    void onResponseComplete_noPending_doesNotChangeGrid() {
         // No pending query — should be a no-op
         var columnsBefore = grid.getColumns().size();
-        controller.onRequestCompleted();
+        controller.onResponseComplete();
         Assertions.assertEquals(columnsBefore, grid.getColumns().size());
         Assertions.assertNull(controller.getState());
     }
 
     @Test
-    void onRequestCompleted_clearsPending_secondCallIsNoOp() {
+    void onResponseComplete_clearsPending_secondCallIsNoOp() {
         dbProvider.queryResults = List.of(row("a", 1));
         simulateUpdate("SELECT a FROM t");
 
         // Second call — no pending query
-        controller.onRequestCompleted();
+        controller.onResponseComplete();
 
         // State should still reflect the first update
         var stateTool = findTool("get_grid_state");
@@ -323,7 +323,7 @@ class GridAIControllerTest {
                 .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
         dbProvider.throwOnExecute = true;
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onRequestCompleted());
+                () -> controller.onResponseComplete());
 
         // Previous successful query should be retained
         Assertions.assertEquals("SELECT a FROM good",
@@ -342,7 +342,7 @@ class GridAIControllerTest {
     // --- State change listeners ---
 
     @Test
-    void stateChangeListener_firesAfterOnRequestCompleted() {
+    void stateChangeListener_firesAfterOnResponseComplete() {
         var captured = new AtomicReference<GridState>();
         controller.addStateChangeListener(captured::set);
 
@@ -364,7 +364,7 @@ class GridAIControllerTest {
 
         dbProvider.throwOnExecute = true;
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onRequestCompleted());
+                () -> controller.onResponseComplete());
 
         Assertions.assertNull(captured.get());
     }
@@ -400,10 +400,10 @@ class GridAIControllerTest {
         var states = new ArrayList<GridState>();
         controller.addStateChangeListener(states::add);
 
-        controller.onRequestCompleted();
+        controller.onResponseComplete();
 
         Assertions.assertTrue(states.isEmpty(),
-                "Second onRequestCompleted should not fire listeners");
+                "Second onResponseComplete should not fire listeners");
     }
 
     @Test
@@ -935,12 +935,12 @@ class GridAIControllerTest {
     }
 
     /**
-     * Simulates a full LLM update cycle: tool call + onRequestCompleted.
+     * Simulates a full LLM update cycle: tool call + onResponseComplete.
      */
     private void simulateUpdate(String query) {
         findTool("update_grid_data")
                 .execute(json("{\"query\": \"" + query + "\"}"));
-        controller.onRequestCompleted();
+        controller.onResponseComplete();
     }
 
     private static Map<String, Object> row(Object... keysAndValues) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1630,7 +1630,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withController_callsOnRequestCompleted() {
+    void builder_withController_callsOnResponseComplete() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))
@@ -1647,7 +1647,7 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onRequestCompleted() {
+            public void onResponseComplete() {
                 callCount.incrementAndGet();
             }
         };
@@ -1661,7 +1661,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withControllerOnRequestCompletedThrows_showsErrorMessage()
+    void builder_withControllerOnResponseCompleteThrows_showsErrorMessage()
             throws InterruptedException {
         var mockMessage = createMockMessage();
         var errorText = "An error occurred. Please try again.";
@@ -1684,7 +1684,7 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onRequestCompleted() {
+            public void onResponseComplete() {
                 throw new RuntimeException("Controller error");
             }
         };
@@ -1715,7 +1715,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withController_onRequestCompletedNotCalledOnError() {
+    void builder_withController_onResponseCompleteNotCalledOnError() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))
@@ -1732,7 +1732,7 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onRequestCompleted() {
+            public void onResponseComplete() {
                 callCount.incrementAndGet();
             }
         };
@@ -1743,7 +1743,7 @@ class AIOrchestratorTest {
         orchestrator.prompt("Hello");
 
         Assertions.assertEquals(0, callCount.get(),
-                "onRequestCompleted should not be called on error");
+                "onResponseComplete should not be called on error");
     }
 
     @Test
@@ -1765,7 +1765,7 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onRequestCompleted() {
+            public void onResponseComplete() {
                 controllerCallCount.incrementAndGet();
             }
         };
@@ -2160,7 +2160,7 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onRequestCompleted() {
+            public void onResponseComplete() {
                 // no-op
             }
         };


### PR DESCRIPTION
## Summary

- Renames `AIController.onRequestCompleted()` to `onResponseComplete()` to match the existing `ResponseCompleteListener.onResponseComplete()`.
- Both callbacks fire from the same site in `AIOrchestrator` (response fully streamed and added to history), so the names should align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)