### PR TITLE
chore: hide individual ChartAITools and GridAITools tool getters

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -40,6 +40,9 @@ import tools.jackson.databind.JsonNode;
  * dashboard). Callers provide a {@link Callbacks} implementation for state
  * retrieval and mutation.
  * </p>
+ * <p>
+ * Intended only for internal use and can be removed in the future.
+ * </p>
  *
  * @author Vaadin Ltd
  */
@@ -233,7 +236,7 @@ public final class ChartAITools {
                 updateChartDataSource(callbacks), getPlotOptionsSchema());
     }
 
-    public static LLMProvider.ToolSpec getChartState(Callbacks callbacks) {
+    static LLMProvider.ToolSpec getChartState(Callbacks callbacks) {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {
@@ -279,8 +282,7 @@ public final class ChartAITools {
         };
     }
 
-    public static LLMProvider.ToolSpec updateChartConfiguration(
-            Callbacks callbacks) {
+    static LLMProvider.ToolSpec updateChartConfiguration(Callbacks callbacks) {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {
@@ -543,8 +545,7 @@ public final class ChartAITools {
         };
     }
 
-    public static LLMProvider.ToolSpec updateChartDataSource(
-            Callbacks callbacks) {
+    static LLMProvider.ToolSpec updateChartDataSource(Callbacks callbacks) {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {
@@ -698,7 +699,7 @@ public final class ChartAITools {
      * Tool that returns the JSON schema for a specific chart type's plot
      * options. Stateless — no callbacks needed.
      */
-    public static LLMProvider.ToolSpec getPlotOptionsSchema() {
+    static LLMProvider.ToolSpec getPlotOptionsSchema() {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -35,6 +35,9 @@ import tools.jackson.databind.JsonNode;
  * dashboard). Callers provide a {@link Callbacks} implementation for state
  * retrieval and mutation, keeping this class decoupled from {@code Grid}.
  * </p>
+ * <p>
+ * Intended only for internal use and can be removed in the future.
+ * </p>
  *
  * @author Vaadin Ltd
  */
@@ -121,7 +124,7 @@ public final class GridAITools {
      *            the callbacks for grid state access, not {@code null}
      * @return the tool definition, never {@code null}
      */
-    public static LLMProvider.ToolSpec getGridState(Callbacks callbacks) {
+    static LLMProvider.ToolSpec getGridState(Callbacks callbacks) {
         Objects.requireNonNull(callbacks, "callbacks must not be null");
         return new LLMProvider.ToolSpec() {
             @Override
@@ -174,7 +177,7 @@ public final class GridAITools {
      *            the callbacks for grid mutation, not {@code null}
      * @return the tool definition, never {@code null}
      */
-    public static LLMProvider.ToolSpec updateGridData(Callbacks callbacks) {
+    static LLMProvider.ToolSpec updateGridData(Callbacks callbacks) {
         Objects.requireNonNull(callbacks, "callbacks must not be null");
         return new LLMProvider.ToolSpec() {
             @Override


### PR DESCRIPTION
## Summary
- Marked `ChartAITools` and `GridAITools` as intended for internal use only in their class javadoc.
- Reduced visibility of the individual tool getters (`getChartState`, `updateChartConfiguration`, `updateChartDataSource`, `getPlotOptionsSchema`, `getGridState`, `updateGridData`) from `public` to package-private. `createAll(...)` and the `Callbacks` interfaces remain the public entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)