### PR TITLE
feat: add setTabFocusEnabled API to Popover

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -344,6 +344,42 @@ public class Popover extends Component implements HasAriaLabel, HasComponents,
     }
 
     /**
+     * Gets whether the popover's content can be reached via Tab navigation from
+     * the target or sibling elements.
+     * <p>
+     * By default, tab focus into the popover is enabled.
+     * <p>
+     * NOTE: this setting has no effect on modal popovers, which use their own
+     * focus trap.
+     *
+     * @return {@code true} if tab focus into the popover is enabled,
+     *         {@code false} otherwise
+     */
+    public boolean isTabFocusEnabled() {
+        return !getElement().getProperty("noTabFocus", false);
+    }
+
+    /**
+     * Sets whether the popover's content can be reached via Tab navigation from
+     * the target or sibling elements. When set to {@code false}, pressing Tab
+     * on the target skips past the popover, and Shift+Tab does not move focus
+     * into the popover's last focusable element. Focus still moves out of the
+     * popover on Tab / Shift+Tab if it was placed inside programmatically.
+     * <p>
+     * By default, tab focus into the popover is enabled.
+     * <p>
+     * NOTE: this setting has no effect on modal popovers, which use their own
+     * focus trap.
+     *
+     * @param tabFocusEnabled
+     *            {@code true} to allow tab focus into the popover,
+     *            {@code false} to skip the popover in tab order
+     */
+    public void setTabFocusEnabled(boolean tabFocusEnabled) {
+        getElement().setProperty("noTabFocus", !tabFocusEnabled);
+    }
+
+    /**
      * Sets the ARIA role for the popover element, used by screen readers.
      *
      * @param role

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -322,6 +322,23 @@ class PopoverTest {
     }
 
     @Test
+    void setTabFocusEnabled_isTabFocusEnabled() {
+        Assertions.assertTrue(popover.isTabFocusEnabled());
+        Assertions.assertFalse(
+                popover.getElement().getProperty("noTabFocus", false));
+
+        popover.setTabFocusEnabled(false);
+        Assertions.assertFalse(popover.isTabFocusEnabled());
+        Assertions.assertTrue(
+                popover.getElement().getProperty("noTabFocus", false));
+
+        popover.setTabFocusEnabled(true);
+        Assertions.assertTrue(popover.isTabFocusEnabled());
+        Assertions.assertFalse(
+                popover.getElement().getProperty("noTabFocus", false));
+    }
+
+    @Test
     void popoverWithContent() {
         Div content = new Div();
         Popover popoverWithContent = new Popover(content);


### PR DESCRIPTION
## Summary

Related to https://github.com/vaadin/web-components/issues/11423

- Adds `Popover#setTabFocusEnabled(boolean)` / `isTabFocusEnabled()` to the Flow wrapper, mapping to the web component's `noTabFocus` property in positive form (default `true`, matching the web component's default of `noTabFocus = false`).
- When set to `false`, pressing Tab on the target/sibling skips past the popover and Shift+Tab does not move focus into the popover's last focusable. Has no effect on modal popovers (which use their own focus trap), as documented in the Javadoc.
- Mirrors the existing inverted-boolean pattern used for `setCloseOnEsc` / `setCloseOnOutsideClick`.

## Test plan
- [x] Unit test `PopoverTest#setTabFocusEnabled_isTabFocusEnabled` covers the default state and toggling in both directions, asserting both the public getter and the underlying `noTabFocus` element property.
- [x] `mvn spotless:apply` clean.
- [x] `mvn test -pl vaadin-popover-flow-parent/vaadin-popover-flow -Dtest='PopoverTest'` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)