### PR TITLE
fix: detect silent abort after tool calls

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -201,36 +201,44 @@ public class SpringAILLMProvider implements LLMProvider {
 
     /**
      * Passes the stream through unchanged, raising an
-     * {@link IllegalStateException} on completion if no chunk carried a
-     * finish_reason.
+     * {@link IllegalStateException} on completion if the most recent chunk did
+     * not represent a terminal model state.
      * <p>
-     * A compliant OpenAI-style streaming response terminates with a chunk whose
-     * finish_reason is set; any termination reason that legitimately yields
-     * empty content (TOOL_CALLS, CONTENT_FILTER, STOP with no text, etc.) still
-     * provides one. A stream that completes without ever carrying a
-     * finish_reason therefore indicates abnormal termination, typically an
-     * error that was not surfaced by the transport.
+     * A streaming chunk is terminal when it carries a finish_reason and the
+     * response has no pending tool calls. The second condition uses
+     * {@link ChatResponse#hasToolCalls()} - the same method Spring AI's default
+     * {@code ToolExecutionEligibilityPredicate} consults to decide whether to
+     * dispatch tools and start a follow-up roundtrip. Pending tool calls mean
+     * such a follow-up is expected, and its chunks would be concatenated to
+     * this same Flux, so a chunk with tool calls is intermediate even when it
+     * carries a finish_reason. A stream that completes on a non-terminal chunk
+     * - whether because no chunk ever carried a finish_reason at all, or
+     * because the last one still had tool calls pending - indicates abnormal
+     * termination.
      */
     private static Flux<ChatResponse> failOnMissingFinishReason(
             Flux<ChatResponse> source) {
-        var finishReasonSeen = new AtomicBoolean(false);
-        return source.doOnNext(response -> {
-            if (!finishReasonSeen.get() && hasFinishReason(response)) {
-                finishReasonSeen.set(true);
-            }
-        }).concatWith(Flux.defer(() -> finishReasonSeen.get() ? Flux.empty()
-                : Flux.error(new IllegalStateException(
-                        "LLM stream ended without a finish reason, "
-                                + "indicating abnormal termination."))));
+        var lastChunkTerminal = new AtomicBoolean(false);
+        return source.doOnNext(
+                response -> lastChunkTerminal.set(isTerminalChunk(response)))
+                .concatWith(Flux.defer(() -> lastChunkTerminal.get()
+                        ? Flux.empty()
+                        : Flux.error(new IllegalStateException(
+                                "LLM stream ended without reaching a terminal "
+                                        + "state, indicating abnormal "
+                                        + "termination."))));
     }
 
-    private static boolean hasFinishReason(ChatResponse response) {
+    private static boolean isTerminalChunk(ChatResponse response) {
         var result = response.getResult();
         if (result == null) {
             return false;
         }
         var reason = result.getMetadata().getFinishReason();
-        return reason != null && !reason.isEmpty();
+        if (reason == null || reason.isEmpty()) {
+            return false;
+        }
+        return !response.hasToolCalls();
     }
 
     private static String getAssistantText(ChatResponse response) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -191,7 +191,7 @@ public class SpringAILLMProvider implements LLMProvider {
     private Flux<String> executeStreamingChat(LLMRequest request) {
         try {
             var chatResponses = getPromptSpec(request).stream().chatResponse();
-            return failOnMissingFinishReason(chatResponses)
+            return warnOnMissingFinishReason(chatResponses)
                     .map(SpringAILLMProvider::getAssistantText)
                     .filter(text -> !text.isEmpty());
         } catch (Exception e) {
@@ -200,9 +200,8 @@ public class SpringAILLMProvider implements LLMProvider {
     }
 
     /**
-     * Passes the stream through unchanged, raising an
-     * {@link IllegalStateException} on completion if no chunk in the stream
-     * ever represented a terminal model state.
+     * Passes the stream through unchanged, logging a warning on completion if
+     * no chunk in the stream ever represented a terminal model state.
      * <p>
      * A streaming chunk is terminal when it carries a {@code finish_reason} and
      * the response has no pending tool calls. Pending tool calls mean a
@@ -214,20 +213,27 @@ public class SpringAILLMProvider implements LLMProvider {
      * back. A stream that completes without ever seeing a terminal chunk -
      * whether because no chunk carried a {@code finish_reason} at all, or
      * because the only terminal-looking chunks still had tool calls pending -
-     * indicates abnormal termination.
+     * may indicate abnormal termination.
      */
-    private static Flux<ChatResponse> failOnMissingFinishReason(
+    private static Flux<ChatResponse> warnOnMissingFinishReason(
             Flux<ChatResponse> source) {
         var terminalSeen = new AtomicBoolean(false);
         return source.doOnNext(response -> {
             if (isTerminalChunk(response)) {
                 terminalSeen.set(true);
             }
-        }).concatWith(Flux.defer(() -> terminalSeen.get() ? Flux.empty()
-                : Flux.error(new IllegalStateException(
-                        "LLM stream ended without reaching a terminal "
-                                + "state, indicating abnormal "
-                                + "termination."))));
+        }).concatWith(Flux.defer(() -> {
+            if (!terminalSeen.get()) {
+                LOGGER.warn("LLM stream ended without observing a terminal "
+                        + "chunk (one carrying finish_reason and "
+                        + "no pending tool calls). This may "
+                        + "indicate a silent abnormal termination "
+                        + "such as an upstream error or transport "
+                        + "closure; if responses appear truncated "
+                        + "this warning is the signal.");
+            }
+            return Flux.empty();
+        }));
     }
 
     private static boolean isTerminalChunk(ChatResponse response) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -201,29 +201,33 @@ public class SpringAILLMProvider implements LLMProvider {
 
     /**
      * Passes the stream through unchanged, raising an
-     * {@link IllegalStateException} on completion if the most recent chunk did
-     * not represent a terminal model state.
+     * {@link IllegalStateException} on completion if no chunk in the stream
+     * ever represented a terminal model state.
      * <p>
      * A streaming chunk is terminal when it carries a {@code finish_reason} and
      * the response has no pending tool calls. Pending tool calls mean a
      * follow-up round-trip is expected, and its chunks would be concatenated to
      * this same Flux, so a chunk with tool calls is intermediate even when it
-     * carries a {@code finish_reason}. A stream that completes on a
-     * non-terminal chunk - whether because no chunk ever carried a
-     * {@code finish_reason} at all, or because the last one still had tool
-     * calls pending - indicates abnormal termination.
+     * carries a {@code finish_reason}. The check is sticky - once any terminal
+     * chunk is observed the gate stays open - so that trailing metadata-only
+     * chunks emitted by some providers after the terminal chunk cannot flip it
+     * back. A stream that completes without ever seeing a terminal chunk -
+     * whether because no chunk carried a {@code finish_reason} at all, or
+     * because the only terminal-looking chunks still had tool calls pending -
+     * indicates abnormal termination.
      */
     private static Flux<ChatResponse> failOnMissingFinishReason(
             Flux<ChatResponse> source) {
-        var isLastChunkTerminal = new AtomicBoolean(false);
-        return source.doOnNext(
-                response -> isLastChunkTerminal.set(isTerminalChunk(response)))
-                .concatWith(Flux.defer(() -> isLastChunkTerminal.get()
-                        ? Flux.empty()
-                        : Flux.error(new IllegalStateException(
-                                "LLM stream ended without reaching a terminal "
-                                        + "state, indicating abnormal "
-                                        + "termination."))));
+        var terminalSeen = new AtomicBoolean(false);
+        return source.doOnNext(response -> {
+            if (isTerminalChunk(response)) {
+                terminalSeen.set(true);
+            }
+        }).concatWith(Flux.defer(() -> terminalSeen.get() ? Flux.empty()
+                : Flux.error(new IllegalStateException(
+                        "LLM stream ended without reaching a terminal "
+                                + "state, indicating abnormal "
+                                + "termination."))));
     }
 
     private static boolean isTerminalChunk(ChatResponse response) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -204,24 +204,21 @@ public class SpringAILLMProvider implements LLMProvider {
      * {@link IllegalStateException} on completion if the most recent chunk did
      * not represent a terminal model state.
      * <p>
-     * A streaming chunk is terminal when it carries a finish_reason and the
-     * response has no pending tool calls. The second condition uses
-     * {@link ChatResponse#hasToolCalls()} - the same method Spring AI's default
-     * {@code ToolExecutionEligibilityPredicate} consults to decide whether to
-     * dispatch tools and start a follow-up roundtrip. Pending tool calls mean
-     * such a follow-up is expected, and its chunks would be concatenated to
+     * A streaming chunk is terminal when it carries a {@code finish_reason} and
+     * the response has no pending tool calls. Pending tool calls mean a
+     * follow-up round-trip is expected, and its chunks would be concatenated to
      * this same Flux, so a chunk with tool calls is intermediate even when it
-     * carries a finish_reason. A stream that completes on a non-terminal chunk
-     * - whether because no chunk ever carried a finish_reason at all, or
-     * because the last one still had tool calls pending - indicates abnormal
-     * termination.
+     * carries a {@code finish_reason}. A stream that completes on a
+     * non-terminal chunk - whether because no chunk ever carried a
+     * {@code finish_reason} at all, or because the last one still had tool
+     * calls pending - indicates abnormal termination.
      */
     private static Flux<ChatResponse> failOnMissingFinishReason(
             Flux<ChatResponse> source) {
-        var lastChunkTerminal = new AtomicBoolean(false);
+        var isLastChunkTerminal = new AtomicBoolean(false);
         return source.doOnNext(
-                response -> lastChunkTerminal.set(isTerminalChunk(response)))
-                .concatWith(Flux.defer(() -> lastChunkTerminal.get()
+                response -> isLastChunkTerminal.set(isTerminalChunk(response)))
+                .concatWith(Flux.defer(() -> isLastChunkTerminal.get()
                         ? Flux.empty()
                         : Flux.error(new IllegalStateException(
                                 "LLM stream ended without reaching a terminal "

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -859,6 +859,39 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_streamingEndsWithPendingToolCalls_throwsIllegalStateException() {
+        // Spring AI dispatches tools whenever the assistant message has
+        // pending tool calls (its ToolExecutionEligibilityPredicate). After
+        // dispatch a follow-up roundtrip is concatenated to this same Flux.
+        // If the follow-up silently aborts (server emits no chunks - e.g.
+        // context exceeded after tool result is added), the merged stream
+        // ends on a chunk whose tool calls are still pending. That is
+        // abnormal termination: the model never reached a terminal state.
+        var request = createSimpleRequest("invoke tool");
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.just(mockChatResponseWithPendingToolCall()));
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> provider.stream(request).collectList().block());
+    }
+
+    @Test
+    void stream_streamingMultiRoundtripCompletesSuccessfully_emitsTerminalText() {
+        // Counterpart: the merged Flux from a tool-using exchange contains
+        // chunks for each roundtrip. As long as the FINAL chunk has no
+        // pending tool calls (and a finish_reason set), the stream is
+        // healthy regardless of intermediate tool-call chunks.
+        var request = createSimpleRequest("invoke tool");
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.just(mockChatResponseWithPendingToolCall(),
+                        mockChatResponse("done", "STOP")));
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("done"), results);
+    }
+
+    @Test
     void stream_streamingWithFinishReasonOnlyOnLastChunk_completesNormally() {
         // Real OpenAI streams set finish_reason only on the terminal chunk.
         var request = createSimpleRequest("Hello");
@@ -993,6 +1026,21 @@ class SpringAILLMProviderTest {
                         .build();
         var generation = new Generation(assistantMessage, metadata);
         return new ChatResponse(List.of(generation));
+    }
+
+    private static ChatResponse mockChatResponseWithPendingToolCall() {
+        // Mirrors what a real backend emits at the end of a tool-using
+        // roundtrip: empty text, a tool call attached to the assistant
+        // message, and a finish_reason set (the exact value isn't
+        // inspected by the production code).
+        var toolCall = new AssistantMessage.ToolCall("call_1", "function",
+                "doSomething", "{}");
+        var assistantMessage = AssistantMessage.builder().content("")
+                .toolCalls(List.of(toolCall)).build();
+        var metadata = ChatGenerationMetadata.builder().finishReason("STOP")
+                .build();
+        return new ChatResponse(
+                List.of(new Generation(assistantMessage, metadata)));
     }
 
     private static LLMRequest createSimpleRequest(String message) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1018,9 +1018,8 @@ class SpringAILLMProviderTest {
 
     private static ChatResponse mockChatResponseWithPendingToolCall() {
         // Mirrors what a real backend emits at the end of a tool-using
-        // roundtrip: empty text, a tool call attached to the assistant
-        // message, and a finish_reason set (the exact value isn't
-        // inspected by the production code).
+        // round-trip: empty text, a tool call attached to the assistant
+        // message, and a finish_reason set.
         var toolCall = new AssistantMessage.ToolCall("call_1", "function",
                 "doSomething", "{}");
         var assistantMessage = AssistantMessage.builder().content("")

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -880,6 +880,22 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_streamingToolCallFollowedByNonTerminalChunks_throwsIllegalStateException() {
+        // Multi-roundtrip silent abort: a tool-call chunk is observed (which
+        // is intermediate, not terminal), then the follow-up round produces
+        // text but never reaches a real finish_reason - e.g. the provider
+        // truncates the stream after an upstream error. The sticky check
+        // must still fire because no terminal chunk was ever seen.
+        var request = createSimpleRequest("invoke tool");
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.just(mockChatResponseWithPendingToolCall(),
+                        mockChatResponse("partial", null)));
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> provider.stream(request).collectList().block());
+    }
+
+    @Test
     void stream_streamingWithFinishReasonOnlyOnLastChunk_completesNormally() {
         // Real OpenAI streams set finish_reason only on the terminal chunk.
         var request = createSimpleRequest("Hello");
@@ -920,6 +936,24 @@ class SpringAILLMProviderTest {
         var results = provider.stream(request).collectList().block();
 
         Assertions.assertEquals(List.of("ok"), results);
+    }
+
+    @Test
+    void stream_streamingTerminalChunkFollowedByMetadataOnlyChunk_completesNormally() {
+        // OpenAI's stream_options.include_usage=true appends a final
+        // empty-choices chunk carrying usage metadata after the terminal
+        // chunk. Once a real terminal chunk has been observed, a trailing
+        // metadata-only chunk must not flip the gate back and fail the
+        // response.
+        var request = createSimpleRequest("Hello");
+        var terminal = mockChatResponse("Hi", "STOP");
+        var trailingUsage = new ChatResponse(Collections.emptyList());
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.just(terminal, trailingUsage));
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("Hi"), results);
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -69,7 +69,7 @@ class SpringAILLMProviderTest {
     void setup() {
         mockChatModel = Mockito.mock(ChatModel.class);
         provider = new SpringAILLMProvider(mockChatModel);
-        logger.clear();
+        logger.clearAll();
     }
 
     @Test
@@ -810,27 +810,29 @@ class SpringAILLMProviderTest {
 
     @ParameterizedTest
     @NullAndEmptySource
-    void stream_streamingWithMissingFinishReason_throwsIllegalStateException(
-            String reason) {
+    void stream_streamingWithMissingFinishReason_logsWarning(String reason) {
         // OpenAI-compatible backends emit "" for an unset finish_reason;
-        // both "" and null must be treated as missing.
+        // both "" and null must be treated as missing and surfaced via
+        // the abnormal-termination warning.
         var request = createSimpleRequest("Hello");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.just(mockChatResponse("", reason)));
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> provider.stream(request).collectList().block());
+        provider.stream(request).collectList().block();
+
+        assertAbnormalTerminationWarningLogged();
     }
 
     @Test
-    void stream_streamingCompletesEmptyWithNoChunks_throwsIllegalStateException() {
-        // Zero-chunk stream: doOnNext never fires; the concatWith tail raises.
+    void stream_streamingCompletesEmptyWithNoChunks_logsWarning() {
+        // Zero-chunk stream: nothing ever flips the terminal gate.
         var request = createSimpleRequest("Hello");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.empty());
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> provider.stream(request).collectList().block());
+        provider.stream(request).collectList().block();
+
+        assertAbnormalTerminationWarningLogged();
     }
 
     @Test
@@ -859,13 +861,16 @@ class SpringAILLMProviderTest {
     }
 
     @Test
-    void stream_streamingEndsWithPendingToolCalls_throwsIllegalStateException() {
+    void stream_streamingEndsWithPendingToolCalls_logsWarning() {
+        // A tool-call chunk is intermediate, not terminal, so a stream
+        // that ends right after one has never seen a real terminal chunk.
         var request = createSimpleRequest("invoke tool");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.just(mockChatResponseWithPendingToolCall()));
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> provider.stream(request).collectList().block());
+        provider.stream(request).collectList().block();
+
+        assertAbnormalTerminationWarningLogged();
     }
 
     @Test
@@ -880,19 +885,21 @@ class SpringAILLMProviderTest {
     }
 
     @Test
-    void stream_streamingToolCallFollowedByNonTerminalChunks_throwsIllegalStateException() {
-        // Multi-roundtrip silent abort: a tool-call chunk is observed (which
-        // is intermediate, not terminal), then the follow-up round produces
-        // text but never reaches a real finish_reason - e.g. the provider
-        // truncates the stream after an upstream error. The sticky check
-        // must still fire because no terminal chunk was ever seen.
+    void stream_streamingToolCallFollowedByNonTerminalChunks_logsWarning() {
+        // Multi-roundtrip silent abort: a tool-call chunk is observed
+        // (which is intermediate, not terminal), then the follow-up round
+        // produces text but never reaches a real finish_reason - e.g. the
+        // provider truncates the stream after an upstream error. The
+        // sticky check must still surface this because no terminal chunk
+        // was ever seen.
         var request = createSimpleRequest("invoke tool");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.just(mockChatResponseWithPendingToolCall(),
                         mockChatResponse("partial", null)));
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> provider.stream(request).collectList().block());
+        provider.stream(request).collectList().block();
+
+        assertAbnormalTerminationWarningLogged();
     }
 
     @Test
@@ -911,7 +918,7 @@ class SpringAILLMProviderTest {
     }
 
     @Test
-    void stream_streamingWithNullGeneration_throwsIllegalStateException() {
+    void stream_streamingWithNullGeneration_logsWarning() {
         // ChatResponse(emptyList()) yields getResult() == null and no
         // finish_reason: indistinguishable from an abort.
         var request = createSimpleRequest("Hello");
@@ -919,8 +926,9 @@ class SpringAILLMProviderTest {
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.just(responseWithNoResult));
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> provider.stream(request).collectList().block());
+        provider.stream(request).collectList().block();
+
+        assertAbnormalTerminationWarningLogged();
     }
 
     @Test
@@ -943,8 +951,8 @@ class SpringAILLMProviderTest {
         // OpenAI's stream_options.include_usage=true appends a final
         // empty-choices chunk carrying usage metadata after the terminal
         // chunk. Once a real terminal chunk has been observed, a trailing
-        // metadata-only chunk must not flip the gate back and fail the
-        // response.
+        // metadata-only chunk must not flip the gate back and trigger the
+        // abnormal-termination warning.
         var request = createSimpleRequest("Hello");
         var terminal = mockChatResponse("Hi", "STOP");
         var trailingUsage = new ChatResponse(Collections.emptyList());
@@ -954,6 +962,7 @@ class SpringAILLMProviderTest {
         var results = provider.stream(request).collectList().block();
 
         Assertions.assertEquals(List.of("Hi"), results);
+        assertAbnormalTerminationWarningNotLogged();
     }
 
     @Test
@@ -1026,6 +1035,29 @@ class SpringAILLMProviderTest {
         var thrown = Assertions.assertThrows(RuntimeException.class,
                 () -> provider.stream(request).collectList().block());
         Assertions.assertEquals(originalError, thrown);
+    }
+
+    private void assertAbnormalTerminationWarningLogged() {
+        // The warning is emitted from a Reactor scheduler thread (Spring
+        // AI's chatResponse pipeline), so we have to query across all
+        // threads rather than just the current one.
+        var warning = logger.getAllLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("LLM stream ended without observing a "
+                                + "terminal chunk"))
+                .findFirst();
+        Assertions.assertTrue(warning.isPresent(),
+                "Expected abnormal-termination warning to be logged");
+    }
+
+    private void assertAbnormalTerminationWarningNotLogged() {
+        var warning = logger.getAllLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("LLM stream ended without observing a "
+                                + "terminal chunk"))
+                .findFirst();
+        Assertions.assertFalse(warning.isPresent(),
+                "Expected no abnormal-termination warning");
     }
 
     private void mockSimpleChat(String responseText) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -860,13 +860,6 @@ class SpringAILLMProviderTest {
 
     @Test
     void stream_streamingEndsWithPendingToolCalls_throwsIllegalStateException() {
-        // Spring AI dispatches tools whenever the assistant message has
-        // pending tool calls (its ToolExecutionEligibilityPredicate). After
-        // dispatch a follow-up roundtrip is concatenated to this same Flux.
-        // If the follow-up silently aborts (server emits no chunks - e.g.
-        // context exceeded after tool result is added), the merged stream
-        // ends on a chunk whose tool calls are still pending. That is
-        // abnormal termination: the model never reached a terminal state.
         var request = createSimpleRequest("invoke tool");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.just(mockChatResponseWithPendingToolCall()));
@@ -876,18 +869,13 @@ class SpringAILLMProviderTest {
     }
 
     @Test
-    void stream_streamingMultiRoundtripCompletesSuccessfully_emitsTerminalText() {
-        // Counterpart: the merged Flux from a tool-using exchange contains
-        // chunks for each roundtrip. As long as the FINAL chunk has no
-        // pending tool calls (and a finish_reason set), the stream is
-        // healthy regardless of intermediate tool-call chunks.
+    void stream_streamingMultiRoundTripCompletesSuccessfully_emitsTerminalText() {
         var request = createSimpleRequest("invoke tool");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.just(mockChatResponseWithPendingToolCall(),
                         mockChatResponse("done", "STOP")));
 
         var results = provider.stream(request).collectList().block();
-
         Assertions.assertEquals(List.of("done"), results);
     }
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/flow-components/pull/9195.

That previous fix catches a streaming response that ends without any `finish_reason`. But it misses a related case: a tool-using exchange where the first roundtrip succeeds (emitting tool calls and a `finish_reason`) but the follow-up roundtrip silently aborts. The check is sticky: once a real terminal chunk has been observed, trailing metadata-only chunks (e.g. OpenAI's streamUsage trailer with empty choices and usage stats) cannot flip the gate back.

This PR widens the check to track whether any chunk in the stream represented a terminal model state — a chunk that has a `finish_reason` and no pending tool calls. Pending tool calls mean Spring AI is going to make another roundtrip, so a chunk with them is intermediate even if it has a `finish_reason`.   

The signal is a logged warning rather than a thrown error. The heuristic cannot enumerate every provider quirk across vendors and configurations, so a false positive must not surface as a user-visible failure on a valid response. Developers retain observability via logs; if responses appear truncated, the warning is the signal.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.