### PR TITLE
fix: keep orchestrator usable after a sync failure

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -393,7 +393,7 @@ public class AIOrchestrator implements Serializable {
         }
         try {
             processUserInput(userMessage);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             // streamResponseToMessage's doFinally only fires after
             // subscription. If processUserInput throws before that (e.g. an
             // AttachmentSubmitListener failure), the flag would

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -391,7 +391,17 @@ public class AIOrchestrator implements Serializable {
                     "Ignoring prompt: another request is already in progress");
             return;
         }
-        processUserInput(userMessage);
+        try {
+            processUserInput(userMessage);
+        } catch (RuntimeException e) {
+            // streamResponseToMessage's doFinally only fires after
+            // subscription. If processUserInput throws before that (e.g. an
+            // AttachmentSubmitListener failure), the flag would
+            // stay stuck and the orchestrator would refuse every later
+            // prompt.
+            isProcessing.set(false);
+            throw e;
+        }
     }
 
     private void processUserInput(String userMessage) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -384,6 +384,41 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void prompt_attachmentSubmitListenerException_orchestratorRecoversForNextPrompt() {
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+        var attachment = new AIAttachment("file.txt", "text/plain",
+                "data".getBytes());
+        Mockito.when(mockFileReceiver.takeAttachments())
+                .thenReturn(List.of(attachment));
+
+        var attempts = new AtomicInteger();
+        AttachmentSubmitListener listener = event -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new RuntimeException("storage transiently unavailable");
+            }
+        };
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withFileReceiver(mockFileReceiver)
+                .withAttachmentSubmitListener(listener).build();
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("First"));
+
+        orchestrator.prompt("Second");
+
+        Mockito.verify(mockProvider, Mockito.times(1))
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
     void prompt_whileProcessing_isIgnored() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),


### PR DESCRIPTION
## Description

After a synchronous failure during prompt processing, the orchestrator can get permanently stuck, the subsequent prompts can be logged as "Ignoring prompt: another request is already in progress" and silently dropped. The `isProcessing` flag is only reset by `streamResponseToMessage`'s `doFinally`, which is registered on the Reactor subscription. If `processUserInput` throws before the subscription is wired (e.g. when an `AttachmentSubmitListener` throws) `doFinally` never fires and the flag stays stuck.

This PR wraps `processUserInput` in a `try/catch` that resets the flag and re-throws. The original exception still propagate to the caller, but the orchestrator stays usable so a retry once the dependency recovers actually reaches the provider.        

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.