### PR TITLE
feat: expose minZoom and maxZoom on Map View

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ViewPage.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/main/java/com/vaadin/flow/component/map/ViewPage.java
@@ -37,6 +37,14 @@ public class ViewPage extends Div {
         });
         setRotation.setId("set-rotation-button");
 
-        add(map, setCenterButton, setZoom, setRotation);
+        NativeButton setMinZoom = new NativeButton("Set Min Zoom",
+                e -> map.getView().setMinZoom(3.0));
+        setMinZoom.setId("set-min-zoom-button");
+
+        NativeButton setMaxZoom = new NativeButton("Set Max Zoom",
+                e -> map.getView().setMaxZoom(10.0));
+        setMaxZoom.setId("set-max-zoom-button");
+
+        add(map, setCenterButton, setZoom, setRotation, setMinZoom, setMaxZoom);
     }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ViewIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ViewIT.java
@@ -51,4 +51,16 @@ public class ViewIT extends AbstractComponentIT {
 
         Assert.assertEquals(0.785398, view.getRotation(), 0.0001);
     }
+
+    @Test
+    public void zoomLimits_appliedToOpenLayersView() {
+        MapElement map = $(MapElement.class).first();
+        MapElement.ViewReference view = map.getMapReference().getView();
+
+        $("button").id("set-min-zoom-button").click();
+        $("button").id("set-max-zoom-button").click();
+
+        Assert.assertEquals(3, view.getMinZoom(), 0.0001);
+        Assert.assertEquals(10, view.getMaxZoom(), 0.0001);
+    }
 }

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ViewIT.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/src/test/java/com/vaadin/flow/components/map/ViewIT.java
@@ -53,7 +53,7 @@ public class ViewIT extends AbstractComponentIT {
     }
 
     @Test
-    public void zoomLimits_appliedToOpenLayersView() {
+    public void setZoomLimits() {
         MapElement map = $(MapElement.class).first();
         MapElement.ViewReference view = map.getMapReference().getView();
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/View.java
@@ -23,6 +23,8 @@ public class View extends AbstractConfigurationObject {
     private Coordinate center;
     private double rotation;
     private double zoom;
+    private double minZoom;
+    private double maxZoom;
     private Extent extent;
     private final String projection;
 
@@ -48,6 +50,8 @@ public class View extends AbstractConfigurationObject {
         this.center = new Coordinate(0, 0);
         this.rotation = 0;
         this.zoom = 0;
+        this.minZoom = 0;
+        this.maxZoom = 28;
         this.extent = new Extent(0, 0, 0, 0);
         this.projection = projection;
     }
@@ -125,12 +129,57 @@ public class View extends AbstractConfigurationObject {
      * currently restricted to {@code 28}. In practical terms, the level of
      * detail of the map data that a map service provides determines how useful
      * higher zoom levels are.
+     * <p>
+     * The allowed zoom range can be customized using
+     * {@link #setMinZoom(double)} and {@link #setMaxZoom(double)}.
      *
      * @param zoom
      *            new zoom level
      */
     public void setZoom(double zoom) {
         this.zoom = zoom;
+        markAsDirty();
+    }
+
+    /**
+     * Gets the minimum zoom level that the view allows. Defaults to {@code 0}.
+     *
+     * @return the minimum zoom level
+     */
+    public double getMinZoom() {
+        return minZoom;
+    }
+
+    /**
+     * Sets the minimum zoom level the user can zoom out to. Defaults to
+     * {@code 0}.
+     *
+     * @param minZoom
+     *            the new minimum zoom level
+     */
+    public void setMinZoom(double minZoom) {
+        this.minZoom = minZoom;
+        markAsDirty();
+    }
+
+    /**
+     * Gets the maximum zoom level that the view allows. Defaults to {@code 28}.
+     *
+     * @return the maximum zoom level
+     */
+    public double getMaxZoom() {
+        return maxZoom;
+    }
+
+    /**
+     * Sets the maximum zoom level the user can zoom in to. Defaults to
+     * {@code 28}.
+     *
+     * @param maxZoom
+     *            the new maximum zoom level
+     */
+    public void setMaxZoom(double maxZoom) {
+        this.maxZoom = maxZoom;
         markAsDirty();
     }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/resources/frontend/vaadin-map/synchronization/index.js
@@ -64,6 +64,8 @@ function synchronizeView(target, source, _context) {
 
   target.setCenter(source.center ? convertToCoordinateArray(source.center) : [0, 0]);
   target.setRotation(source.rotation || 0);
+  target.setMinZoom(source.minZoom);
+  target.setMaxZoom(source.maxZoom);
   target.setZoom(source.zoom || 0);
 
   return target;

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapSerializationTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/MapSerializationTest.java
@@ -74,6 +74,8 @@ class MapSerializationTest {
         // Configure view
         map.getView().setZoom(13);
         map.getView().setCenter(new Coordinate(42, 27));
+        map.getView().setMinZoom(3.0);
+        map.getView().setMaxZoom(10.0);
 
         // Configure custom source
         OSMSource.Options options = new OSMSource.Options();
@@ -97,6 +99,10 @@ class MapSerializationTest {
         ObjectNode centerNode = (ObjectNode) viewNode.get("center");
         Assertions.assertEquals(42, centerNode.get("x").asDouble(), 0.0001);
         Assertions.assertEquals(27, centerNode.get("y").asDouble(), 0.0001);
+        Assertions.assertEquals(3.0, viewNode.get("minZoom").asDouble(),
+                0.0001);
+        Assertions.assertEquals(10.0, viewNode.get("maxZoom").asDouble(),
+                0.0001);
 
         // Verify custom source
         ObjectNode sourceNode = findSyncedItem(syncedItems, source.getId());

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/ViewTest.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/test/java/com/vaadin/flow/component/map/ViewTest.java
@@ -36,4 +36,12 @@ class ViewTest {
 
         Assertions.assertEquals("EPSG:4326", view.getProjection());
     }
+
+    @Test
+    void zoomLimitDefaults() {
+        View view = new View();
+
+        Assertions.assertEquals(0, view.getMinZoom());
+        Assertions.assertEquals(28, view.getMaxZoom());
+    }
 }

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -319,6 +319,14 @@ public class MapElement extends TestBenchElement {
             executor.executeScript(path("setRotation(%s)", rotation));
         }
 
+        public float getMinZoom() {
+            return getFloat("getMinZoom()");
+        }
+
+        public float getMaxZoom() {
+            return getFloat("getMaxZoom()");
+        }
+
         public List<Double> calculateExtent() {
             return (List<Double>) get("calculateExtent()");
         }


### PR DESCRIPTION
Add View#setMinZoom and View#setMaxZoom that map to OpenLayers' View#setMinZoom and View#setMaxZoom so developers can constrain the viewport zoom range without writing custom client-side code.

Fixes #9207
