### PR TITLE
fix: fire response complete on empty responses

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -371,8 +371,8 @@ public class AIOrchestrator implements Serializable {
                 conversationHistory
                         .add(new ChatMessage(ChatMessage.Role.ASSISTANT,
                                 responseText, null, Instant.now()));
-                fireResponseCompleteListener(responseText, ui);
             }
+            fireResponseCompleteListener(responseText, ui);
             LOGGER.debug("LLM streaming completed successfully");
         });
     }
@@ -967,19 +967,25 @@ public class AIOrchestrator implements Serializable {
 
         /**
          * Sets a listener that is called after each successful exchange — when
-         * the assistant's response has been fully streamed and added to the
-         * conversation history. This is the recommended hook for persisting
-         * conversation state (via {@link AIOrchestrator#getHistory()}),
-         * triggering follow-up actions, or updating UI elements.
+         * the assistant's stream has completed without error. This is the
+         * recommended hook for persisting conversation state (via
+         * {@link AIOrchestrator#getHistory()}), triggering follow-up actions,
+         * or updating UI elements.
+         * <p>
+         * The response text passed to the listener may be empty if the model
+         * emitted only tool calls or otherwise stopped without producing
+         * visible content. Such turns are still successful exchanges; check
+         * {@code event.getResponse().isEmpty()} if your listener should only
+         * react to text-bearing responses. Empty responses are <i>not</i>
+         * appended to the conversation history.
          * <p>
          * The listener is called from a background thread (Reactor scheduler).
          * It is safe to perform blocking I/O (e.g. database writes) directly.
          * To update Vaadin UI components from this listener, use
          * {@code ui.access()}.
          * <p>
-         * The listener is not called when the LLM response fails, times out, or
-         * produces an empty response, nor when history is restored via
-         * {@link #withHistory(List, Map)}.
+         * The listener is not called when the LLM response fails or times out,
+         * nor when history is restored via {@link #withHistory(List, Map)}.
          *
          * @param listener
          *            the listener to call after each successful exchange

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseCompleteListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseCompleteListener.java
@@ -21,15 +21,19 @@ import java.io.Serializable;
  * Listener for LLM response completion events.
  * <p>
  * The listener is called after each successful exchange — when the assistant's
- * response has been fully streamed and added to the conversation history. This
- * is the recommended hook for persisting conversation state (via
- * {@link AIOrchestrator#getHistory()}), triggering follow-up actions, or
- * updating UI elements.
+ * stream has completed without error. This is the recommended hook for
+ * persisting conversation state (via {@link AIOrchestrator#getHistory()}),
+ * triggering follow-up actions, or updating UI elements.
+ * <p>
+ * The response text may be empty if the model emitted only tool calls or
+ * stopped without producing visible content. Such turns are still successful
+ * exchanges; check {@code event.getResponse().isEmpty()} if your listener
+ * should only react to text-bearing responses. Empty responses are <i>not</i>
+ * appended to {@link AIOrchestrator#getHistory()}.
  * <p>
  * The listener is <b>not</b> called when:
  * <ul>
  * <li>The LLM response fails with an error or times out</li>
- * <li>The assistant response is empty</li>
  * <li>History is restored via {@code Builder.withHistory()}</li>
  * </ul>
  * <p>
@@ -41,8 +45,7 @@ import java.io.Serializable;
 @FunctionalInterface
 public interface ResponseCompleteListener extends Serializable {
     /**
-     * Called when the assistant's response has been fully streamed and recorded
-     * in the conversation history.
+     * Called when the assistant's stream has completed without error.
      *
      * @param event
      *            the response complete event
@@ -50,8 +53,7 @@ public interface ResponseCompleteListener extends Serializable {
     void onResponseComplete(ResponseCompleteEvent event);
 
     /**
-     * Event fired after the assistant's response has been fully streamed and
-     * added to the conversation history.
+     * Event fired after the assistant's stream has completed without error.
      */
     class ResponseCompleteEvent implements Serializable {
         private final String response;
@@ -61,9 +63,11 @@ public interface ResponseCompleteListener extends Serializable {
         }
 
         /**
-         * Gets the full text of the assistant's response.
+         * Gets the full text of the assistant's response. May be empty when the
+         * model emitted only tool calls or otherwise produced no visible
+         * content.
          *
-         * @return the response text, never {@code null} or empty
+         * @return the response text, never {@code null}
          */
         public String getResponse() {
             return response;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1575,29 +1575,6 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void responseCompleteListener_afterEmptyResponse_firesWithEmptyText() {
-        var mockMessage = createMockMessage();
-        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyList()))
-                .thenReturn(mockMessage);
-        Mockito.when(
-                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
-                .thenReturn(Flux.empty());
-
-        var captured = new ArrayList<String>();
-        var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList)
-                .withFileReceiver(mockFileReceiver).withInput(mockInput)
-                .withResponseCompleteListener(
-                        event -> captured.add(event.getResponse()))
-                .build();
-        orchestrator.prompt("Hello");
-
-        Assertions.assertEquals(List.of(""), captured,
-                "Listener should fire once with empty response");
-    }
-
-    @Test
     void responseCompleteListener_receivesResponseText() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -419,6 +419,65 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void prompt_toolOnlyResponse_firesControllerOnResponseComplete() {
+        // Tool-only turns produce empty text, but the controller still
+        // needs the lifecycle hook to flush its pending state (e.g. a
+        // ChartAIController applies its pending query in onResponseComplete
+        // and would otherwise never render).
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        var controller = Mockito.mock(AIController.class);
+        var fakeTool = Mockito.mock(LLMProvider.ToolSpec.class);
+        Mockito.when(fakeTool.getName()).thenReturn("fake_tool");
+        Mockito.when(controller.getTools()).thenReturn(List.of(fakeTool));
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenAnswer(inv -> {
+                    var req = (LLMProvider.LLMRequest) inv.getArgument(0);
+                    req.explicitTools().get(0).execute(null);
+                    return Flux.empty();
+                });
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withController(controller)
+                .build();
+        orchestrator.prompt("do it");
+
+        Mockito.verify(fakeTool).execute(Mockito.any());
+        Mockito.verify(controller).onResponseComplete();
+    }
+
+    @Test
+    void prompt_emptyResponse_firesUserListenerWithEmptyText() {
+        // Empty-text turns are still successful exchanges (tool-only,
+        // content filter, deliberate silence). The listener fires with an
+        // empty response so apps can observe every completion. The history
+        // stays gated to avoid polluting it with empty assistant messages.
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        var listener = Mockito.mock(ResponseCompleteListener.class);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.empty());
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withResponseCompleteListener(listener).build();
+        orchestrator.prompt("hi");
+
+        var captor = ArgumentCaptor
+                .forClass(ResponseCompleteListener.ResponseCompleteEvent.class);
+        Mockito.verify(listener).onResponseComplete(captor.capture());
+        Assertions.assertEquals("", captor.getValue().getResponse());
+        Assertions.assertTrue(orchestrator.getHistory().stream()
+                .noneMatch(msg -> msg.role() == ChatMessage.Role.ASSISTANT));
+    }
+
+    @Test
     void prompt_whileProcessing_isIgnored() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
@@ -1516,7 +1575,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void responseCompleteListener_afterEmptyResponse_doesNotFire() {
+    void responseCompleteListener_afterEmptyResponse_firesWithEmptyText() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))
@@ -1534,8 +1593,8 @@ class AIOrchestratorTest {
                 .build();
         orchestrator.prompt("Hello");
 
-        Assertions.assertTrue(captured.isEmpty(),
-                "Listener should not fire on empty response");
+        Assertions.assertEquals(List.of(""), captured,
+                "Listener should fire once with empty response");
     }
 
     @Test


### PR DESCRIPTION
## Description

A turn that produces no visible text — typically a tool-only turn where the model emits tool calls and stops without commentary — is still a successful exchange. But the response-complete lifecycle hooks were skipped: both the application-facing `ResponseCompleteListener.onResponseComplete` and the controller-facing `AIController.onResponseComplete` were gated behind a non-empty-text check. Controllers that flush their pending UI state in `onResponseComplete` (e.g. `ChartAIController` applying its pending query) never render on these turns; application listeners miss the completion entirely.

This PR moves both hook invocations out of the non-empty-text gate so every successful exchange fires them, with the firing cadence unchanged (still once per user prompt, not per tool call or round-trip). The `conversationHistory` add stays gated to avoid polluting history with empty assistant entries.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.