### PR TITLE
fix: propagate menu-bar item tooltip to connector items

### DIFF
--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -500,19 +500,11 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
     public void setTooltipText(MenuItem item, String tooltipText) {
         if (!getElement().getChildren().anyMatch(
                 child -> "tooltip".equals(child.getAttribute("slot")))) {
-            // No <vaadin-tooltip> yet added, add one
-            Element tooltipElement = new Element("vaadin-tooltip");
-
-            tooltipElement.addAttachListener(e -> {
-                // Assigns a generator that reads the tooltip property of the
-                // item component
-                tooltipElement.executeJs(
-                        "this.generator = ({item}) => { return (item && item.component) ? item.component.tooltip : ''; }");
-            });
-            SlotUtils.addToSlot(this, "tooltip", tooltipElement);
+            SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
         }
 
         item.getElement().setProperty("tooltip", tooltipText);
+        updateButtons();
     }
 
     /**

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -72,6 +72,10 @@ function initLazy(menubar, appId) {
         // Propagate disabled state from items to parent buttons
         item.disabled = item.component.disabled;
 
+        // Propagate tooltip text so the menu-bar's tooltip controller
+        // recognizes the item as having a tooltip and shows it.
+        item.tooltip = item.component.tooltip;
+
         // Saving item to component because `_item` can be reassigned to a new value
         // when the component goes to the overflow menu
         item.component._rootItem = item;


### PR DESCRIPTION
## Description

The new `MenuBarTooltipController` in `@vaadin/menu-bar` 25.2.0-alpha9 (introduced in [vaadin/web-components#11586](https://github.com/vaadin/web-components/pull/11586)) short-circuits in `setTarget` when the target's item has no `tooltip` property — it clears the target and closes the tooltip immediately. Flow's connector built items without a `tooltip` field (tooltip text was only stored on the wrapper component and read via a custom generator), so menu-bar tooltips never opened.

Fix: copy `tooltip` from the wrapper component onto each item in `menubarConnector.js` so the controller's gating check recognizes the item as having a tooltip. The existing custom generator continues to read the live value from `item.component.tooltip`, so updates via `setTooltipText` still display the latest text.

Verified `MenuBarTooltipIT` passes (3/3) against local `web-components` at `main`.

## Type of change

- Bugfix