### PR TITLE
chore: reuse Chrome driver per class with parallel test execution

### DIFF
--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -482,7 +482,7 @@ jobs:
             -Dvaadin.productionMode \
             -DskipFrontend \
             -Dfailsafe.forkCount=$FORK_COUNT \
-            -Dcom.vaadin.testbench.Parameters.testsInParallel=1 \
+            -Dcom.vaadin.testbench.Parameters.testsInParallel=2 \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
             -Dtest.reuseDriver=true \

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -189,7 +189,7 @@ jobs:
           }
 
       - name: Run unit tests
-        run: mvn test -Drelease -T $FORK_COUNT $MAVEN_ARGS
+        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 $MAVEN_ARGS
 
       - name: Publish unit test results
         if: always()

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -485,6 +485,7 @@ jobs:
             -Dcom.vaadin.testbench.Parameters.testsInParallel=1 \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
+            -Dtest.reuseDriver=true \
             -Dit.test="$SHARD_TESTS" \
             $MAVEN_ARGS
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractChartIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/AbstractChartIT.java
@@ -8,6 +8,8 @@
  */
 package com.vaadin.flow.component.charts.tests;
 
+import org.junit.Before;
+
 import com.vaadin.flow.component.charts.testbench.ChartElement;
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
@@ -15,9 +17,8 @@ import com.vaadin.tests.AbstractComponentIT;
 
 public abstract class AbstractChartIT extends AbstractComponentIT {
 
-    @Override
-    public void setup() throws Exception {
-        super.setup();
+    @Before
+    public void setup() {
         open();
     }
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -15,33 +15,361 @@
  */
 package com.vaadin.tests;
 
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public abstract class AbstractComponentIT
-        extends com.vaadin.flow.testutil.AbstractComponentIT {
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.flow.testutil.net.PortProber;
+import com.vaadin.testbench.ScreenshotOnFailureRule;
+import com.vaadin.testbench.TestBench;
+import com.vaadin.testbench.TestBenchTestCase;
 
-    protected int getDeploymentPort() {
-        return 8080;
+/**
+ * Base class for Flow component integration tests.
+ * <p>
+ * Extends {@link TestBenchTestCase} directly and manages a local headless
+ * Chrome driver that is reused across all test methods in the same test class.
+ * <p>
+ * This test setup does not support running tests in parallel. The only way to
+ * parallelize tests is forking separate JVMs that run one suite at a time, for
+ * example using {@code failsafe.forkCount}.
+ * <p>
+ * Test classes must be annotated with {@link TestPath} to specify the URL path
+ * of the test view.
+ */
+public abstract class AbstractComponentIT extends TestBenchTestCase {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(AbstractComponentIT.class);
+
+    private static WebDriver sharedDriver;
+
+    @Rule
+    public ScreenshotOnFailureRule screenshotOnFailure = new ScreenshotOnFailureRule(
+            this, false);
+
+    @BeforeClass
+    public static void createDriver() {
+        sharedDriver = createChromeDriver();
+        sharedDriver.manage().window().setSize(new Dimension(1024, 800));
+        sharedDriver.manage().timeouts()
+                .pageLoadTimeout(Duration.ofSeconds(10));
     }
 
-    @Override
-    protected void updateHeadlessChromeOptions(ChromeOptions chromeOptions) {
+    @Before
+    public void resetDriver() throws Exception {
+        setDriver(sharedDriver);
+        getDriver().manage().deleteAllCookies();
+        getDriver().navigate().to("about:blank");
+    }
+
+    @AfterClass
+    public static void quitDriver() {
+        tryQuitDriver(sharedDriver);
+        sharedDriver = null;
+    }
+
+    // ----- Test path and URL resolution -----
+
+    protected String getTestPath() {
+        TestPath annotation = getClass().getAnnotation(TestPath.class);
+        if (annotation == null) {
+            throw new IllegalStateException(
+                    "The test class should be annotated with @TestPath");
+        }
+        String path = annotation.value();
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        return path;
+    }
+
+    protected String getRootURL() {
+        return "http://localhost:8080";
+    }
+
+    protected String getTestURL(String... parameters) {
+        return getTestURL(getRootURL(), getTestPath(), parameters);
+    }
+
+    public static String getTestURL(String rootUrl, String testPath,
+            String... parameters) {
+        while (rootUrl.endsWith("/")) {
+            rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
+        }
+        rootUrl = rootUrl + testPath;
+
+        if (parameters != null && parameters.length != 0) {
+            if (!rootUrl.contains("?")) {
+                rootUrl += "?";
+            } else {
+                rootUrl += "&";
+            }
+            rootUrl += Arrays.stream(parameters)
+                    .collect(Collectors.joining("&"));
+        }
+
+        return rootUrl;
+    }
+
+    protected void open() {
+        open((String[]) null);
+    }
+
+    protected void open(String... parameters) {
+        String url = getTestURL(parameters);
+        TimeoutException lastTimeout = null;
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            try {
+                getDriver().get(url);
+                waitForDevServer();
+                return;
+            } catch (TimeoutException e) {
+                lastTimeout = e;
+                logger.warn(
+                        "Page load timed out for {} (attempt {}/3), retrying",
+                        url, attempt);
+            }
+        }
+        throw lastTimeout;
+    }
+
+    // ----- Driver management -----
+
+    private static void tryQuitDriver(WebDriver driver) {
+        try {
+            driver.quit();
+        } catch (Exception e) {
+            // Ignore - driver may already be dead
+        }
+    }
+
+    private static boolean isJavaInDebugMode() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments()
+                .toString().contains("jdwp");
+    }
+
+    private static WebDriver createChromeDriver() {
+        for (int i = 0; i < 3; i++) {
+            try {
+                return tryCreateChromeDriver();
+            } catch (Exception e) {
+                logger.warn("Unable to create chromedriver on attempt " + i, e);
+            }
+        }
+        throw new RuntimeException(
+                "Gave up trying to create a chromedriver instance");
+    }
+
+    private static WebDriver tryCreateChromeDriver() {
+        ChromeOptions options = new ChromeOptions();
+        if (!isJavaInDebugMode()) {
+            options.addArguments("--headless=new", "--disable-gpu",
+                    "--disable-backgrounding-occluded-windows");
+        }
+
         String extraArgs = System.getenv("TESTBENCH_CHROME_EXTRA_ARGS");
         if (extraArgs != null && !extraArgs.isBlank()) {
-            chromeOptions.addArguments(extraArgs.split("\\s+"));
+            options.addArguments(extraArgs.split("\\s+"));
         }
 
         String chromeBinary = System.getenv("TESTBENCH_CHROME_BINARY");
         if (chromeBinary != null && !chromeBinary.isBlank()) {
-            chromeOptions.setBinary(chromeBinary);
+            options.setBinary(chromeBinary);
+        }
+
+        int port = PortProber.findFreePort();
+        ChromeDriverService service = new ChromeDriverService.Builder()
+                .usingPort(port).withSilent(true).build();
+        ChromeDriver chromeDriver = new ChromeDriver(service, options);
+        return TestBench.createDriver(chromeDriver);
+    }
+
+    // ----- Test helper methods -----
+
+    /**
+     * Waits up to 10s for the given condition to become false.
+     */
+    protected <T> void waitUntilNot(ExpectedCondition<T> condition) {
+        waitUntilNot(condition, 10);
+    }
+
+    /**
+     * Waits the given number of seconds for the given condition to become
+     * false.
+     */
+    protected <T> void waitUntilNot(ExpectedCondition<T> condition,
+            long timeoutInSeconds) {
+        waitUntil(ExpectedConditions.not(condition), timeoutInSeconds);
+    }
+
+    /**
+     * Returns true if an element can be found from the driver with given
+     * selector.
+     */
+    public boolean isElementPresent(By by) {
+        try {
+            WebElement element = getDriver().findElement(by);
+            return element != null;
+        } catch (Exception e) {
+            return false;
         }
     }
 
-    @Override
-    public void setup() throws Exception {
-        super.setup();
-
-        // Set a default window size
-        testBench().resizeViewPortTo(1024, 800);
+    /**
+     * Clicks on the element, using JS. This method is more convenient than
+     * Selenium {@code findElement(By.id(urlId)).click()}, because Selenium
+     * method changes scroll position, which is not always needed.
+     */
+    protected void clickElementWithJs(String elementId) {
+        executeScript(String.format("document.getElementById('%s').click();",
+                elementId));
     }
+
+    /**
+     * Clicks on the element, using JS.
+     */
+    protected void clickElementWithJs(WebElement element) {
+        executeScript("arguments[0].click();", element);
+    }
+
+    protected void waitForElementPresent(final By by) {
+        waitUntil(ExpectedConditions.presenceOfElementLocated(by));
+    }
+
+    protected void waitForElementNotPresent(final By by) {
+        waitUntil(input -> input.findElements(by).isEmpty());
+    }
+
+    protected void waitForElementVisible(final By by) {
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(by));
+    }
+
+    /**
+     * Scrolls the page to the element given using javascript.
+     */
+    protected void scrollToElement(WebElement element) {
+        Objects.requireNonNull(element,
+                "The element to scroll to should not be null");
+        getCommandExecutor().executeScript("arguments[0].scrollIntoView(true);",
+                element);
+    }
+
+    /**
+     * Scrolls the page to the element specified and clicks it.
+     */
+    protected void scrollIntoViewAndClick(WebElement element) {
+        scrollToElement(element);
+        element.click();
+    }
+
+    /**
+     * Gets the log entries from the browser that have the given logging level
+     * or higher.
+     */
+    protected List<LogEntry> getLogEntries(Level level) {
+        getCommandExecutor().waitForVaadin();
+
+        return getDriver().manage().logs().get(LogType.BROWSER).getAll()
+                .stream()
+                .filter(logEntry -> logEntry.getLevel().intValue() >= level
+                        .intValue())
+                .filter(logEntry -> !logEntry.getMessage()
+                        .contains("favicon.ico"))
+                .collect(Collectors.toList());
+    }
+
+    private static final String WEB_SOCKET_CONNECTION_ERROR_PREFIX = "WebSocket connection to ";
+
+    /**
+     * Checks browser's log entries, throws an error for any client-side error
+     * and logs any client-side warnings.
+     */
+    protected void checkLogsForErrors(
+            Predicate<String> acceptableMessagePredicate) {
+        getLogEntries(Level.WARNING).forEach(logEntry -> {
+            if (logEntry.getMessage().contains(
+                    "Lit is in dev mode. Not recommended for production")) {
+                return;
+            }
+            if ((Objects.equals(logEntry.getLevel(), Level.SEVERE)
+                    || logEntry.getMessage().contains(" 404 "))
+                    && !logEntry.getMessage()
+                            .contains(WEB_SOCKET_CONNECTION_ERROR_PREFIX)
+                    && !acceptableMessagePredicate
+                            .test(logEntry.getMessage())) {
+                throw new AssertionError(String
+                        .format("Error message in browser log: %s", logEntry));
+            } else {
+                LoggerFactory.getLogger(AbstractComponentIT.class.getName())
+                        .warn("This message in browser log console may be a potential error: '{}'",
+                                logEntry);
+            }
+        });
+    }
+
+    /**
+     * Checks browser's log entries, throws an error for any client-side error
+     * and logs any client-side warnings.
+     */
+    protected void checkLogsForErrors() {
+        checkLogsForErrors(msg -> false);
+    }
+
+    /**
+     * If dev server start in progress wait until it's started. Otherwise return
+     * immediately.
+     */
+    protected void waitForDevServer() {
+        Object result;
+        do {
+            getCommandExecutor().waitForVaadin();
+            result = getCommandExecutor().executeScript(
+                    "return window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.devServerIsNotLoaded;");
+        } while (Boolean.TRUE.equals(result));
+    }
+
+    /**
+     * Calls the {@code blur()} function on the current active element of the
+     * page, if any.
+     */
+    public void blur() {
+        executeScript(
+                "!!document.activeElement ? document.activeElement.blur() : 0");
+    }
+
+    /**
+     * Gets a property value from a web element using JavaScript.
+     */
+    public String getProperty(WebElement element, String propertyName) {
+        Object result = executeScript(
+                "return arguments[0]." + propertyName + ";", element);
+        return result == null ? null : String.valueOf(result);
+    }
+
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -67,6 +68,9 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     private static final Logger logger = LoggerFactory
             .getLogger(AbstractComponentIT.class);
 
+    private static final boolean REUSE_DRIVER =
+            Boolean.getBoolean("test.reuseDriver");
+
     private static WebDriver sharedDriver;
 
     @Rule
@@ -75,6 +79,9 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     @BeforeClass
     public static void createDriver() {
+        if (!REUSE_DRIVER) {
+            return;
+        }
         sharedDriver = createChromeDriver();
         sharedDriver.manage().window().setSize(new Dimension(1024, 800));
         sharedDriver.manage().timeouts()
@@ -83,13 +90,30 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     @Before
     public void resetDriver() throws Exception {
+        if (!REUSE_DRIVER) {
+            sharedDriver = createChromeDriver();
+            sharedDriver.manage().window().setSize(new Dimension(1024, 800));
+            sharedDriver.manage().timeouts()
+                    .pageLoadTimeout(Duration.ofSeconds(10));
+        }
         setDriver(sharedDriver);
         getDriver().manage().deleteAllCookies();
         getDriver().navigate().to("about:blank");
     }
 
+    @After
+    public void quitDriverPerMethod() {
+        if (!REUSE_DRIVER) {
+            tryQuitDriver(sharedDriver);
+            sharedDriver = null;
+        }
+    }
+
     @AfterClass
     public static void quitDriver() {
+        if (!REUSE_DRIVER) {
+            return;
+        }
         tryQuitDriver(sharedDriver);
         sharedDriver = null;
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -71,7 +71,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     private static final boolean REUSE_DRIVER =
             Boolean.getBoolean("test.reuseDriver");
 
-    private static WebDriver sharedDriver;
+    private static final ThreadLocal<WebDriver> sharedDriver = new ThreadLocal<>();
 
     @Rule
     public ScreenshotOnFailureRule screenshotOnFailure = new ScreenshotOnFailureRule(
@@ -82,21 +82,21 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         if (!REUSE_DRIVER) {
             return;
         }
-        sharedDriver = createChromeDriver();
-        sharedDriver.manage().window().setSize(new Dimension(1024, 800));
-        sharedDriver.manage().timeouts()
-                .pageLoadTimeout(Duration.ofSeconds(10));
+        WebDriver driver = createChromeDriver();
+        driver.manage().window().setSize(new Dimension(1024, 800));
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
+        sharedDriver.set(driver);
     }
 
     @Before
     public void resetDriver() throws Exception {
         if (!REUSE_DRIVER) {
-            sharedDriver = createChromeDriver();
-            sharedDriver.manage().window().setSize(new Dimension(1024, 800));
-            sharedDriver.manage().timeouts()
-                    .pageLoadTimeout(Duration.ofSeconds(10));
+            WebDriver driver = createChromeDriver();
+            driver.manage().window().setSize(new Dimension(1024, 800));
+            driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
+            sharedDriver.set(driver);
         }
-        setDriver(sharedDriver);
+        setDriver(sharedDriver.get());
         getDriver().manage().deleteAllCookies();
         getDriver().navigate().to("about:blank");
     }
@@ -104,8 +104,8 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     @After
     public void quitDriverPerMethod() {
         if (!REUSE_DRIVER) {
-            tryQuitDriver(sharedDriver);
-            sharedDriver = null;
+            tryQuitDriver(sharedDriver.get());
+            sharedDriver.remove();
         }
     }
 
@@ -114,8 +114,8 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         if (!REUSE_DRIVER) {
             return;
         }
-        tryQuitDriver(sharedDriver);
-        sharedDriver = null;
+        tryQuitDriver(sharedDriver.get());
+        sharedDriver.remove();
     }
 
     // ----- Test path and URL resolution -----

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -68,8 +68,8 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     private static final Logger logger = LoggerFactory
             .getLogger(AbstractComponentIT.class);
 
-    private static final boolean REUSE_DRIVER =
-            Boolean.getBoolean("test.reuseDriver");
+    private static final boolean REUSE_DRIVER = Boolean
+            .getBoolean("test.reuseDriver");
 
     private static final ThreadLocal<WebDriver> sharedDriver = new ThreadLocal<>();
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -16,6 +16,8 @@
 package com.vaadin.tests;
 
 import java.lang.management.ManagementFactory;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -39,6 +41,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
@@ -53,8 +56,11 @@ import com.vaadin.testbench.TestBenchTestCase;
 /**
  * Base class for Flow component integration tests.
  * <p>
- * Extends {@link TestBenchTestCase} directly and manages a local headless
- * Chrome driver that is reused across all test methods in the same test class.
+ * Extends {@link TestBenchTestCase} directly and manages a headless Chrome
+ * driver that is reused across all test methods in the same test class. By
+ * default the driver is started locally; setting {@code -Dtest.use.hub=true}
+ * routes driver creation to a Selenium Grid endpoint configured via
+ * {@code -Dtest.hub.url} (default {@code http://localhost:4444/wd/hub}).
  * <p>
  * This test setup does not support running tests in parallel. The only way to
  * parallelize tests is forking separate JVMs that run one suite at a time, for
@@ -71,6 +77,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     private static final boolean REUSE_DRIVER = Boolean
             .getBoolean("test.reuseDriver");
 
+    private static final boolean USE_HUB = Boolean.getBoolean("test.use.hub");
+
+    private static final String HUB_URL = System.getProperty("test.hub.url",
+            "http://localhost:4444/wd/hub");
+
     private static final ThreadLocal<WebDriver> sharedDriver = new ThreadLocal<>();
 
     @Rule
@@ -82,7 +93,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         if (!REUSE_DRIVER) {
             return;
         }
-        WebDriver driver = createChromeDriver();
+        WebDriver driver = createWebDriver();
         driver.manage().window().setSize(new Dimension(1024, 800));
         driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
         sharedDriver.set(driver);
@@ -91,7 +102,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     @Before
     public void resetDriver() throws Exception {
         if (!REUSE_DRIVER) {
-            WebDriver driver = createChromeDriver();
+            WebDriver driver = createWebDriver();
             driver.manage().window().setSize(new Dimension(1024, 800));
             driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
             sharedDriver.set(driver);
@@ -198,19 +209,20 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
                 .toString().contains("jdwp");
     }
 
-    private static WebDriver createChromeDriver() {
+    private static WebDriver createWebDriver() {
         for (int i = 0; i < 3; i++) {
             try {
-                return tryCreateChromeDriver();
+                return USE_HUB ? tryCreateRemoteDriver()
+                        : tryCreateChromeDriver();
             } catch (Exception e) {
-                logger.warn("Unable to create chromedriver on attempt " + i, e);
+                logger.warn("Unable to create driver on attempt " + i, e);
             }
         }
         throw new RuntimeException(
-                "Gave up trying to create a chromedriver instance");
+                "Gave up trying to create a driver instance");
     }
 
-    private static WebDriver tryCreateChromeDriver() {
+    private static ChromeOptions buildChromeOptions() {
         ChromeOptions options = new ChromeOptions();
         if (!isJavaInDebugMode()) {
             options.addArguments("--headless=new", "--disable-gpu",
@@ -226,12 +238,24 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         if (chromeBinary != null && !chromeBinary.isBlank()) {
             options.setBinary(chromeBinary);
         }
+        return options;
+    }
 
+    private static WebDriver tryCreateChromeDriver() {
+        ChromeOptions options = buildChromeOptions();
         int port = PortProber.findFreePort();
         ChromeDriverService service = new ChromeDriverService.Builder()
                 .usingPort(port).withSilent(true).build();
         ChromeDriver chromeDriver = new ChromeDriver(service, options);
         return TestBench.createDriver(chromeDriver);
+    }
+
+    private static WebDriver tryCreateRemoteDriver()
+            throws MalformedURLException {
+        ChromeOptions options = buildChromeOptions();
+        RemoteWebDriver remoteDriver = new RemoteWebDriver(
+                URI.create(HUB_URL).toURL(), options);
+        return TestBench.createDriver(remoteDriver);
     }
 
     // ----- Test helper methods -----

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/LitRendererIT.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/test/java/com/vaadin/flow/data/renderer/tests/LitRendererIT.java
@@ -99,7 +99,9 @@ public class LitRendererIT extends AbstractComponentIT {
     @Test
     public void shouldNotIncludeEventInCallableArguments() {
         WebElement itemContent = findElement(By.id("content-0"));
-        drag(itemContent);
+        executeScript(
+                "arguments[0].dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true }))",
+                itemContent);
         Assert.assertEquals("event: dragged, item: 0, argument count: 0",
                 getFirstClientCallableLogMessage());
     }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -48,11 +48,6 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
         $(TimePickerElement.class).waitForFirst();
     }
 
-    @Override
-    protected int getDeploymentPort() {
-        return super.getDeploymentPort();
-    }
-
     @Test
     public void testAllAvailableLocalesWhenValueChangedFromDropDown_stepOneHourAndFormatHourMinute_pickerValuesMatchesBrowserFormatted() {
         // select locale based on locale string


### PR DESCRIPTION
The IT suite pays a significant startup cost for each test method: a new Chrome process is launched, the page is loaded, and the driver is quit after every single method. With hundreds of test classes and multiple methods each, this overhead accumulates across the shard wall-clock time.

This change introduces three improvements targeting that cost.

**Driver reuse per class:** A single Chrome driver is created once in `@BeforeClass` and quit in `@AfterClass`. Between methods, cookies are cleared and the browser navigates to `about:blank` so each test starts from a clean state. Reuse is controlled by `-Dtest.reuseDriver=true` (enabled in CI) so the original per-method behavior is preserved locally when the flag is off.

**Parallel test classes:** With a plain `static` field, two test classes running in the same JVM would share the same driver and corrupt each other. Storing the driver in a `ThreadLocal` gives each thread its own independent instance. This makes it safe to set `testsInParallel=2`, running 2 test classes concurrently per JVM fork. With `forkCount=4`, that yields 8 classes in parallel per shard.

**Parallel unit tests:** Unit tests run with `parallel=classes threadCount=2` within each Maven module, cutting the wall-clock time of the `unit-tests` job roughly in half with no risk since unit tests are stateless and use Mockito rather than shared external resources.