### PR TITLE
feat: add row height API to Dashboard

### DIFF
--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/main/java/com/vaadin/flow/component/dashboard/Dashboard.java
@@ -349,6 +349,29 @@ public class Dashboard extends Component
     }
 
     /**
+     * Returns the fixed row height of the dashboard.
+     *
+     * @return the fixed row height of the dashboard
+     */
+    public String getRowHeight() {
+        return getStyle().get("--vaadin-dashboard-row-height");
+    }
+
+    /**
+     * Sets a fixed row height for the dashboard. When set, this value overrides
+     * the {@link #setMinimumRowHeight(String) minimum row height} and prevents
+     * rows from growing to fit their content, allowing widgets to use
+     * {@code 100%} height for their inner content.
+     *
+     * @param rowHeight
+     *            the new fixed row height. Pass in {@code null} to set the row
+     *            height back to the default value.
+     */
+    public void setRowHeight(String rowHeight) {
+        getStyle().set("--vaadin-dashboard-row-height", rowHeight);
+    }
+
+    /**
      * Returns the gap of the dashboard. This value adjusts the gap between
      * elements within the dashboard.
      *

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/src/test/java/com/vaadin/flow/component/dashboard/DashboardTest.java
@@ -907,6 +907,45 @@ class DashboardTest extends DashboardTestBase {
     }
 
     @Test
+    void setRowHeight_valueIsCorrectlySet() {
+        String propertyName = "--vaadin-dashboard-row-height";
+        String valueToSet = "200px";
+        Assertions.assertNull(dashboard.getStyle().get(propertyName));
+        dashboard.setRowHeight(valueToSet);
+        Assertions.assertEquals(valueToSet,
+                dashboard.getStyle().get(propertyName));
+        dashboard.setRowHeight(null);
+        Assertions.assertNull(dashboard.getStyle().get(propertyName));
+    }
+
+    @Test
+    void setRowHeightNull_propertyIsRemoved() {
+        dashboard.setRowHeight("200px");
+        dashboard.setRowHeight(null);
+        Assertions.assertNull(
+                dashboard.getStyle().get("--vaadin-dashboard-row-height"));
+    }
+
+    @Test
+    void defaultRowHeightValueIsCorrectlyRetrieved() {
+        Assertions.assertNull(dashboard.getRowHeight());
+    }
+
+    @Test
+    void setRowHeight_valueIsCorrectlyRetrieved() {
+        String valueToSet = "200px";
+        dashboard.setRowHeight(valueToSet);
+        Assertions.assertEquals(valueToSet, dashboard.getRowHeight());
+    }
+
+    @Test
+    void setRowHeightNull_valueIsCorrectlyRetrieved() {
+        dashboard.setRowHeight("200px");
+        dashboard.setRowHeight(null);
+        Assertions.assertNull(dashboard.getRowHeight());
+    }
+
+    @Test
     void setGap_valueIsCorrectlySet() {
         String propertyName = "--vaadin-dashboard-gap";
         String valueToSet = "10px";


### PR DESCRIPTION
## Summary
- Adds `setRowHeight(String)` / `getRowHeight()` to `Dashboard`, mapping to the `--vaadin-dashboard-row-height` CSS custom property introduced in the underlying web component.
- When set, the fixed row height overrides the minimum row height and prevents rows from growing to fit their content, allowing widgets to use `100%` height for their inner content.

Closes https://github.com/vaadin/web-components/issues/10943
Depends on https://github.com/vaadin/web-components/pull/11603

🤖 Generated with [Claude Code](https://claude.com/claude-code)