### PR TITLE
feat!: add tooltip APIs to context-menu and menu-bar items

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.router.Route;
 public class ContextMenuTooltipPage extends Div {
 
     public ContextMenuTooltipPage() {
+        // Reset default delay values from 500 to 0
         TooltipConfiguration.setDefaultFocusDelay(0);
         TooltipConfiguration.setDefaultHoverDelay(0);
         TooltipConfiguration.setDefaultHideDelay(0);
@@ -34,23 +35,39 @@ public class ContextMenuTooltipPage extends Div {
         target.setId("target");
 
         var contextMenu = new ContextMenu(target);
-        var openItem = contextMenu.addItem("Open");
-        contextMenu.setTooltipText(openItem, "Open the selected file");
 
-        var deleteItem = contextMenu.addItem("Delete");
-        deleteItem.setEnabled(false);
-        contextMenu.setTooltipText(deleteItem, "Not available right now");
-        contextMenu.setTooltipPosition(deleteItem, TooltipPosition.START);
+        // Root items
+        var item0 = contextMenu.addItem("Item 0", "Item 0 / Tooltip");
 
-        var moreItem = contextMenu.addItem("More");
-        var subItem = moreItem.getSubMenu().addItem("Sub item");
-        contextMenu.setTooltipText(subItem, "Sub item tooltip");
+        var item1 = contextMenu.addItem("Item 1", "Item 1 / Tooltip");
+        item1.setEnabled(false);
 
-        var updateTooltipButton = new NativeButton("Update tooltip",
-                event -> contextMenu.setTooltipText(openItem,
-                        "Updated tooltip"));
-        updateTooltipButton.setId("update-tooltip-button");
+        var item2 = contextMenu.addItem("Item 2", "Item 2 / Tooltip");
+        item2.setTooltipPosition(TooltipPosition.TOP);
 
-        add(target, updateTooltipButton);
+        // Sub menu items
+        var item0_0 = item0.getSubMenu().addItem("Item 0-0",
+                "Item 0-0 / Tooltip");
+
+        var item0_1 = item0.getSubMenu().addItem("Item 0-1",
+                "Item 0-1 / Tooltip");
+        item0_1.setEnabled(false);
+
+        var item0_2 = item0.getSubMenu().addItem("Item 0-2",
+                "Item 0-2 / Tooltip");
+        item0_2.setTooltipPosition(TooltipPosition.TOP);
+
+        var attach = new NativeButton("Attach", event -> add(target));
+        attach.setId("attach");
+        var detach = new NativeButton("Detach", event -> remove(target));
+        detach.setId("detach");
+
+        var updateTooltips = new NativeButton("Update tooltips", event -> {
+            item0.setTooltipText("Item 0 / Updated Tooltip");
+            item0_0.setTooltipText("Item 0-0 / Updated Tooltip");
+        });
+        updateTooltips.setId("update-tooltips");
+
+        add(attach, detach, updateTooltips, target);
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu.it;
+
+import com.vaadin.flow.component.contextmenu.ContextMenu;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
+import com.vaadin.flow.component.shared.TooltipConfiguration;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-context-menu/tooltip")
+public class ContextMenuTooltipPage extends Div {
+
+    public ContextMenuTooltipPage() {
+        TooltipConfiguration.setDefaultFocusDelay(0);
+        TooltipConfiguration.setDefaultHoverDelay(0);
+        TooltipConfiguration.setDefaultHideDelay(0);
+
+        var target = new NativeButton("Target");
+        target.setId("target");
+
+        var contextMenu = new ContextMenu(target);
+        var openItem = contextMenu.addItem("Open");
+        contextMenu.setTooltipText(openItem, "Open the selected file");
+
+        var deleteItem = contextMenu.addItem("Delete");
+        deleteItem.setEnabled(false);
+        contextMenu.setTooltipText(deleteItem, "Not available right now");
+        contextMenu.setTooltipPosition(deleteItem, TooltipPosition.START);
+
+        var moreItem = contextMenu.addItem("More");
+        var subItem = moreItem.getSubMenu().addItem("Sub item");
+        contextMenu.setTooltipText(subItem, "Sub item tooltip");
+
+        var updateTooltipButton = new NativeButton("Update tooltip",
+                event -> contextMenu.setTooltipText(openItem,
+                        "Updated tooltip"));
+        updateTooltipButton.setId("update-tooltip-button");
+
+        add(target, updateTooltipButton);
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
@@ -68,6 +68,6 @@ public class ContextMenuTooltipPage extends Div {
         });
         updateTooltips.setId("update-tooltips");
 
-        add(attach, detach, updateTooltips, target);
+        add(attach, detach, updateTooltips, target, contextMenu);
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
@@ -1,0 +1,1 @@
+com.vaadin.experimental.accessibleDisabledMenuItems=true

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
@@ -35,12 +35,14 @@ public class ContextMenuTooltipIT extends AbstractComponentIT {
     public void init() {
         open();
         target = $(TestBenchElement.class).id("target");
-        contextMenu = ContextMenuElement.openByRightClick(target);
+        contextMenu = $(ContextMenuElement.class).single();
         contextMenuTooltip = contextMenu.$("vaadin-tooltip").single();
     }
 
     @Test
-    public void hoverOverRootItems_tooltipDisplayed() {
+    public void openMenu_hoverOverRootItems_tooltipDisplayed() {
+        ContextMenuElement.openByRightClick(target);
+
         var items = contextMenu.getMenuItems();
 
         items.get(0).hover();
@@ -56,7 +58,9 @@ public class ContextMenuTooltipIT extends AbstractComponentIT {
     }
 
     @Test
-    public void hoverOverSubMenuItems_tooltipDisplayed() {
+    public void openMenu_hoverOverSubMenuItems_tooltipDisplayed() {
+        ContextMenuElement.openByRightClick(target);
+
         var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
         var subMenuItems = subMenu.getMenuItems();
 
@@ -73,8 +77,10 @@ public class ContextMenuTooltipIT extends AbstractComponentIT {
     }
 
     @Test
-    public void updateTooltip_updatedTooltipDisplayed() {
+    public void updateTooltip_openMenu_hoverOverItems_updatedTooltipDisplayed() {
         clickElementWithJs("update-tooltips");
+
+        ContextMenuElement.openByRightClick(target);
 
         contextMenu.getMenuItems().get(0).hover();
         Assert.assertEquals("Item 0 / Updated Tooltip",
@@ -87,8 +93,10 @@ public class ContextMenuTooltipIT extends AbstractComponentIT {
     }
 
     @Test
-    public void detachAndAttach_hoverOverItems_tooltipDisplayed() {
+    public void detachAndAttach_openMenu_hoverOverItems_tooltipDisplayed() {
         detachAndAttach();
+
+        ContextMenuElement.openByRightClick(target);
 
         contextMenu.getMenuItems().get(0).hover();
         Assert.assertEquals("Item 0 / Tooltip", contextMenuTooltip.getText());
@@ -102,7 +110,5 @@ public class ContextMenuTooltipIT extends AbstractComponentIT {
         clickElementWithJs("detach");
         clickElementWithJs("attach");
         target = $(TestBenchElement.class).id("target");
-        contextMenu = ContextMenuElement.openByRightClick(target);
-        contextMenuTooltip = contextMenu.$("vaadin-tooltip").single();
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("vaadin-context-menu/tooltip")
+public class ContextMenuTooltipIT extends AbstractContextMenuIT {
+
+    @Before
+    public void init() {
+        open();
+        rightClickOn("target");
+        verifyOpened();
+    }
+
+    @Test
+    public void hoverOverItem_showItemTooltip() {
+        var items = getMenuItems();
+
+        showTooltip(items.get(0));
+        Assert.assertEquals("Open the selected file", getActiveTooltipText());
+    }
+
+    @Test
+    public void hoverOverDisabledItem_showItemTooltip() {
+        var items = getMenuItems();
+
+        showTooltip(items.get(1));
+        Assert.assertEquals("Not available right now", getActiveTooltipText());
+    }
+
+    @Test
+    public void updateTooltip_showUpdatedTooltip() {
+        // close menu so we can click the update button
+        clickBody();
+        verifyClosed();
+
+        clickElementWithJs("update-tooltip-button");
+
+        rightClickOn("target");
+        verifyOpened();
+
+        var items = getMenuItems();
+        showTooltip(items.get(0));
+        Assert.assertEquals("Updated tooltip", getActiveTooltipText());
+    }
+
+    private void showTooltip(TestBenchElement element) {
+        executeScript(
+                "arguments[0].dispatchEvent(new Event('mouseover', {bubbles:true}))",
+                element);
+    }
+
+    private String getActiveTooltipText() {
+        return findElement(By.tagName("vaadin-tooltip")).getText();
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
@@ -18,60 +18,91 @@ package com.vaadin.flow.component.contextmenu.it;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
+import com.vaadin.flow.component.contextmenu.testbench.ContextMenuElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-context-menu/tooltip")
-public class ContextMenuTooltipIT extends AbstractContextMenuIT {
+public class ContextMenuTooltipIT extends AbstractComponentIT {
+
+    private TestBenchElement target;
+    private ContextMenuElement contextMenu;
+    private TestBenchElement contextMenuTooltip;
 
     @Before
     public void init() {
         open();
-        rightClickOn("target");
-        verifyOpened();
+        target = $(TestBenchElement.class).id("target");
+        contextMenu = ContextMenuElement.openByRightClick(target);
+        contextMenuTooltip = contextMenu.$("vaadin-tooltip").single();
     }
 
     @Test
-    public void hoverOverItem_showItemTooltip() {
-        var items = getMenuItems();
+    public void hoverOverRootItems_tooltipDisplayed() {
+        var items = contextMenu.getMenuItems();
 
-        showTooltip(items.get(0));
-        Assert.assertEquals("Open the selected file", getActiveTooltipText());
+        items.get(0).hover();
+        Assert.assertEquals("Item 0 / Tooltip", contextMenuTooltip.getText());
+
+        items.get(1).hover();
+        Assert.assertEquals("Item 1 / Tooltip", contextMenuTooltip.getText());
+
+        items.get(2).hover();
+        Assert.assertEquals("Item 2 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("top",
+                contextMenuTooltip.getDomProperty("_position"));
     }
 
     @Test
-    public void hoverOverDisabledItem_showItemTooltip() {
-        var items = getMenuItems();
+    public void hoverOverSubMenuItems_tooltipDisplayed() {
+        var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
+        var subMenuItems = subMenu.getMenuItems();
 
-        showTooltip(items.get(1));
-        Assert.assertEquals("Not available right now", getActiveTooltipText());
+        subMenuItems.get(0).hover();
+        Assert.assertEquals("Item 0-0 / Tooltip", contextMenuTooltip.getText());
+
+        subMenuItems.get(1).hover();
+        Assert.assertEquals("Item 0-1 / Tooltip", contextMenuTooltip.getText());
+
+        subMenuItems.get(2).hover();
+        Assert.assertEquals("Item 0-2 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("top",
+                contextMenuTooltip.getDomProperty("_position"));
     }
 
     @Test
-    public void updateTooltip_showUpdatedTooltip() {
-        // close menu so we can click the update button
-        clickBody();
-        verifyClosed();
+    public void updateTooltip_updatedTooltipDisplayed() {
+        clickElementWithJs("update-tooltips");
 
-        clickElementWithJs("update-tooltip-button");
+        contextMenu.getMenuItems().get(0).hover();
+        Assert.assertEquals("Item 0 / Updated Tooltip",
+                contextMenuTooltip.getText());
 
-        rightClickOn("target");
-        verifyOpened();
-
-        var items = getMenuItems();
-        showTooltip(items.get(0));
-        Assert.assertEquals("Updated tooltip", getActiveTooltipText());
+        var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
+        subMenu.getMenuItems().get(0).hover();
+        Assert.assertEquals("Item 0-0 / Updated Tooltip",
+                contextMenuTooltip.getText());
     }
 
-    private void showTooltip(TestBenchElement element) {
-        executeScript(
-                "arguments[0].dispatchEvent(new Event('mouseover', {bubbles:true}))",
-                element);
+    @Test
+    public void detachAndAttach_hoverOverItems_tooltipDisplayed() {
+        detachAndAttach();
+
+        contextMenu.getMenuItems().get(0).hover();
+        Assert.assertEquals("Item 0 / Tooltip", contextMenuTooltip.getText());
+
+        var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
+        subMenu.getMenuItems().get(0).hover();
+        Assert.assertEquals("Item 0-0 / Tooltip", contextMenuTooltip.getText());
     }
 
-    private String getActiveTooltipText() {
-        return findElement(By.tagName("vaadin-tooltip")).getText();
+    private void detachAndAttach() {
+        clickElementWithJs("detach");
+        clickElementWithJs("attach");
+        target = $(TestBenchElement.class).id("target");
+        contextMenu = ContextMenuElement.openByRightClick(target);
+        contextMenuTooltip = contextMenu.$("vaadin-tooltip").single();
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -70,7 +70,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     private Component target;
     private MenuManager<C, I, S> menuManager;
-    MenuItemsArrayGenerator<I> menuItemsArrayGenerator;
+    private MenuItemsArrayGenerator<I> menuItemsArrayGenerator;
 
     private String openOnEventName = "vaadin-contextmenu";
     private Registration targetBeforeOpenRegistration;

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -30,8 +30,11 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
+import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.internal.OverlayAutoAddController;
 import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.shared.Registration;
 
@@ -55,7 +58,9 @@ import tools.jackson.databind.node.ObjectNode;
 @SuppressWarnings("serial")
 @Tag("vaadin-context-menu")
 @NpmPackage(value = "@vaadin/context-menu", version = "25.2.0-alpha10")
+@NpmPackage(value = "@vaadin/tooltip", version = "25.2.0-alpha10")
 @JsModule("@vaadin/context-menu/src/vaadin-context-menu.js")
+@JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 @JsModule("./flow-component-renderer.js")
 @JsModule("./contextMenuConnector.js")
 @JsModule("./contextMenuTargetConnector.js")
@@ -66,7 +71,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
 
     private Component target;
     private MenuManager<C, I, S> menuManager;
-    private MenuItemsArrayGenerator<I> menuItemsArrayGenerator;
+    MenuItemsArrayGenerator<I> menuItemsArrayGenerator;
 
     private String openOnEventName = "vaadin-contextmenu";
     private Registration targetBeforeOpenRegistration;
@@ -190,6 +195,61 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      */
     public boolean isOpenOnClick() {
         return "click".equals(openOnEventName);
+    }
+
+    /**
+     * Sets the tooltip text for the given menu item.
+     * <p>
+     * The first call to this method on a context menu attaches a slotted
+     * {@code <vaadin-tooltip>} element to the context menu host that is shared
+     * by all items, including items in sub-menus. Hover and hide delays as well
+     * as the position can be configured via the slotted element. Setting
+     * {@code null} or an empty text removes the tooltip from the item.
+     *
+     * @param item
+     *            the menu item to set the tooltip for, not {@code null}
+     * @param tooltipText
+     *            the tooltip text to set for the item, or {@code null} to clear
+     *            it
+     * @see #setTooltipPosition(MenuItemBase, TooltipPosition)
+     */
+    public void setTooltipText(I item, String tooltipText) {
+        ensureTooltipElement();
+        item.getElement().setProperty("tooltip", tooltipText);
+        scheduleTooltipUpdate();
+    }
+
+    /**
+     * Sets the tooltip position for the given menu item, overriding the
+     * default. Items with a sub-menu default to {@code start} so the tooltip
+     * doesn't overlap the opening sub-menu; all other items, including disabled
+     * ones, default to {@code end}. If the slotted {@code <vaadin-tooltip>}
+     * element has its own {@code position} property set, that value is used
+     * instead.
+     *
+     * @param item
+     *            the menu item to set the tooltip position for, not
+     *            {@code null}
+     * @param position
+     *            the tooltip position, or {@code null} to clear it and use the
+     *            default
+     * @see #setTooltipText(MenuItemBase, String)
+     */
+    public void setTooltipPosition(I item, TooltipPosition position) {
+        item.getElement().setProperty("tooltipPosition",
+                position != null ? position.getPosition() : null);
+        scheduleTooltipUpdate();
+    }
+
+    private void ensureTooltipElement() {
+        if (getElement().getChildren().noneMatch(
+                child -> "tooltip".equals(child.getAttribute("slot")))) {
+            SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
+        }
+    }
+
+    void scheduleTooltipUpdate() {
+        menuItemsArrayGenerator.generate();
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -197,8 +197,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
     }
 
     void ensureTooltipElement() {
-        if (getElement().getChildren().noneMatch(
-                child -> "tooltip".equals(child.getAttribute("slot")))) {
+        if (SlotUtils.getElementsInSlot(this, "tooltip").count() == 0) {
             SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
         }
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.component.shared.SlotUtils;
-import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.internal.OverlayAutoAddController;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
@@ -197,51 +196,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         return "click".equals(openOnEventName);
     }
 
-    /**
-     * Sets the tooltip text for the given menu item.
-     * <p>
-     * The first call to this method on a context menu attaches a slotted
-     * {@code <vaadin-tooltip>} element to the context menu host that is shared
-     * by all items, including items in sub-menus. Hover and hide delays as well
-     * as the position can be configured via the slotted element. Setting
-     * {@code null} or an empty text removes the tooltip from the item.
-     *
-     * @param item
-     *            the menu item to set the tooltip for, not {@code null}
-     * @param tooltipText
-     *            the tooltip text to set for the item, or {@code null} to clear
-     *            it
-     * @see #setTooltipPosition(MenuItemBase, TooltipPosition)
-     */
-    public void setTooltipText(I item, String tooltipText) {
-        ensureTooltipElement();
-        item.getElement().setProperty("tooltip", tooltipText);
-        scheduleTooltipUpdate();
-    }
-
-    /**
-     * Sets the tooltip position for the given menu item, overriding the
-     * default. Items with a sub-menu default to {@code start} so the tooltip
-     * doesn't overlap the opening sub-menu; all other items, including disabled
-     * ones, default to {@code end}. If the slotted {@code <vaadin-tooltip>}
-     * element has its own {@code position} property set, that value is used
-     * instead.
-     *
-     * @param item
-     *            the menu item to set the tooltip position for, not
-     *            {@code null}
-     * @param position
-     *            the tooltip position, or {@code null} to clear it and use the
-     *            default
-     * @see #setTooltipText(MenuItemBase, String)
-     */
-    public void setTooltipPosition(I item, TooltipPosition position) {
-        item.getElement().setProperty("tooltipPosition",
-                position != null ? position.getPosition() : null);
-        scheduleTooltipUpdate();
-    }
-
-    private void ensureTooltipElement() {
+    void ensureTooltipElement() {
         if (getElement().getChildren().noneMatch(
                 child -> "tooltip".equals(child.getAttribute("slot")))) {
             SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
@@ -283,6 +238,38 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      */
     public I addItem(Component component) {
         return getMenuManager().addItem(component);
+    }
+
+    /**
+     * Creates a new menu item with the given text content and tooltip text and
+     * adds it to the context menu.
+     *
+     * @param text
+     *            the text content for the created menu item
+     * @param tooltipText
+     *            the tooltip text for the created menu item
+     * @return the created menu item
+     */
+    public I addItem(String text, String tooltipText) {
+        var item = addItem(text);
+        item.setTooltipText(tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new menu item with the given component content and tooltip text
+     * and adds it to the context menu.
+     *
+     * @param component
+     *            the component to add to the created menu item
+     * @param tooltipText
+     *            the tooltip text for the created menu item
+     * @return the created menu item
+     */
+    public I addItem(Component component, String tooltipText) {
+        var item = addItem(component);
+        item.setTooltipText(tooltipText);
+        return item;
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -196,12 +196,6 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         return "click".equals(openOnEventName);
     }
 
-    void ensureTooltipElement() {
-        if (SlotUtils.getElementsInSlot(this, "tooltip").count() == 0) {
-            SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
-        }
-    }
-
     /**
      * Closes this context menu if it is currently open.
      */
@@ -516,5 +510,11 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         getElement().executeJs(
                 "window.Vaadin.Flow.contextMenuConnector.initLazy(this, $0)",
                 appId);
+    }
+
+    void ensureTooltipElement() {
+        if (SlotUtils.getElementsInSlot(this, "tooltip").count() == 0) {
+            SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
+        }
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -202,10 +202,6 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
         }
     }
 
-    void scheduleTooltipUpdate() {
-        menuItemsArrayGenerator.generate();
-    }
-
     /**
      * Closes this context menu if it is currently open.
      */
@@ -250,9 +246,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      * @return the created menu item
      */
     public I addItem(String text, String tooltipText) {
-        var item = addItem(text);
-        item.setTooltipText(tooltipText);
-        return item;
+        return getMenuManager().addItem(text, tooltipText);
     }
 
     /**
@@ -266,9 +260,7 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      * @return the created menu item
      */
     public I addItem(Component component, String tooltipText) {
-        var item = addItem(component);
-        item.setTooltipText(tooltipText);
-        return item;
+        return getMenuManager().addItem(component, tooltipText);
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
@@ -44,6 +44,11 @@ public class MenuItem extends MenuItemBase<ContextMenu, MenuItem, SubMenu>
         return new SubMenu(this, contentReset);
     }
 
+    @Override
+    protected void ensureTooltipElement() {
+        getContextMenu().ensureTooltipElement();
+    }
+
     /**
      * Sets the menu item explicitly disabled or enabled. When disabled, menu
      * items are rendered as "dimmed".

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
@@ -35,7 +35,7 @@ public class MenuItem extends MenuItemBase<ContextMenu, MenuItem, SubMenu>
 
     public MenuItem(ContextMenu contextMenu,
             SerializableRunnable contentReset) {
-        super(contextMenu);
+        super(contextMenu, contentReset);
         this.contentReset = contentReset;
     }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItem.java
@@ -44,11 +44,6 @@ public class MenuItem extends MenuItemBase<ContextMenu, MenuItem, SubMenu>
         return new SubMenu(this, contentReset);
     }
 
-    @Override
-    protected void ensureTooltipElement() {
-        getContextMenu().ensureTooltipElement();
-    }
-
     /**
      * Sets the menu item explicitly disabled or enabled. When disabled, menu
      * items are rendered as "dimmed".

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
 import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
@@ -337,6 +338,52 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         executeJsWhenAttached(
                 "window.Vaadin.Flow.contextMenuConnector.setTheme($0, $1)",
                 getElement(), themeName);
+    }
+
+    /**
+     * Sets the tooltip text for this menu item.
+     * <p>
+     * The first call to this method on an item attaches a slotted
+     * {@code <vaadin-tooltip>} element to the menu host that is shared by all
+     * items, including items in sub-menus. Hover and hide delays as well as the
+     * position can be configured via the slotted element. Setting {@code null}
+     * or an empty text removes the tooltip from the item.
+     *
+     * @param tooltipText
+     *            the tooltip text to set for the item, or {@code null} to clear
+     *            it
+     * @see #setTooltipPosition(TooltipPosition)
+     */
+    public void setTooltipText(String tooltipText) {
+        ensureTooltipElement();
+        getElement().setProperty("tooltip", tooltipText);
+        scheduleTooltipUpdate();
+    }
+
+    /**
+     * Sets the tooltip position for this menu item, overriding the default.
+     * Items with a sub-menu default to {@code start} so the tooltip doesn't
+     * overlap the opening sub-menu; all other items, including disabled ones,
+     * default to {@code end}. If the slotted {@code <vaadin-tooltip>} element
+     * has its own {@code position} property set, that value is used instead.
+     *
+     * @param position
+     *            the tooltip position, or {@code null} to clear it and use the
+     *            default
+     * @see #setTooltipText(String)
+     */
+    public void setTooltipPosition(TooltipPosition position) {
+        getElement().setProperty("tooltipPosition",
+                position != null ? position.getPosition() : null);
+        scheduleTooltipUpdate();
+    }
+
+    protected void ensureTooltipElement() {
+        contextMenu.ensureTooltipElement();
+    }
+
+    protected void scheduleTooltipUpdate() {
+        contextMenu.scheduleTooltipUpdate();
     }
 
     protected abstract S createSubMenu();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -389,7 +389,9 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         contentReset.run();
     }
 
-    protected abstract void ensureTooltipElement();
+    protected void ensureTooltipElement() {
+        contextMenu.ensureTooltipElement();
+    }
 
     protected abstract S createSubMenu();
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -389,9 +389,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         contentReset.run();
     }
 
-    protected void ensureTooltipElement() {
-        contextMenu.ensureTooltipElement();
-    }
+    protected abstract void ensureTooltipElement();
 
     protected abstract S createSubMenu();
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
 import com.vaadin.flow.dom.SignalBinding;
+import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.flow.signals.Signal;
 
@@ -63,6 +64,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     private final DisableOnClickController<MenuItemBase<C, I, S>> disableOnClickController = new DisableOnClickController<>(
             this);
 
+    private final SerializableRunnable contentReset;
+
     /**
      * Default constructor
      *
@@ -70,7 +73,21 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
      *            the context menu to which this item belongs to
      */
     public MenuItemBase(C contextMenu) {
+        this(contextMenu, () -> {
+        });
+    }
+
+    /**
+     * Creates a menu item belonging to the given menu.
+     *
+     * @param contextMenu
+     *            the context menu to which this item belongs to
+     * @param contentReset
+     *            callback to reset the menu content
+     */
+    public MenuItemBase(C contextMenu, SerializableRunnable contentReset) {
         this.contextMenu = contextMenu;
+        this.contentReset = contentReset;
         getElement().addEventListener("click", e -> {
             if (checkable) {
                 setChecked(!isChecked());
@@ -352,7 +369,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     public void setTooltipText(String tooltipText) {
         ensureTooltipElement();
         getElement().setProperty("tooltip", tooltipText);
-        scheduleTooltipUpdate();
+        contentReset.run();
     }
 
     /**
@@ -369,15 +386,11 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     public void setTooltipPosition(TooltipPosition position) {
         getElement().setProperty("tooltipPosition",
                 position != null ? position.getPosition() : null);
-        scheduleTooltipUpdate();
+        contentReset.run();
     }
 
     protected void ensureTooltipElement() {
         contextMenu.ensureTooltipElement();
-    }
-
-    protected void scheduleTooltipUpdate() {
-        contextMenu.scheduleTooltipUpdate();
     }
 
     protected abstract S createSubMenu();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -341,13 +341,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     }
 
     /**
-     * Sets the tooltip text for this menu item.
-     * <p>
-     * The first call to this method on an item attaches a slotted
-     * {@code <vaadin-tooltip>} element to the menu host that is shared by all
-     * items, including items in sub-menus. Hover and hide delays as well as the
-     * position can be configured via the slotted element. Setting {@code null}
-     * or an empty text removes the tooltip from the item.
+     * Sets the tooltip text for this menu item. Setting {@code null} or an
+     * empty text removes the tooltip from the item.
      *
      * @param tooltipText
      *            the tooltip text to set for the item, or {@code null} to clear
@@ -364,8 +359,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
      * Sets the tooltip position for this menu item, overriding the default.
      * Items with a sub-menu default to {@code start} so the tooltip doesn't
      * overlap the opening sub-menu; all other items, including disabled ones,
-     * default to {@code end}. If the slotted {@code <vaadin-tooltip>} element
-     * has its own {@code position} property set, that value is used instead.
+     * default to {@code end}.
      *
      * @param position
      *            the tooltip position, or {@code null} to clear it and use the

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -147,6 +147,72 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
     }
 
     /**
+     * Adds a text as a menu item with a tooltip text.
+     *
+     * @param text
+     *            the text for the menu item
+     * @param tooltipText
+     *            the tooltip text for the menu item
+     * @return a new menu item
+     */
+    public I addItem(String text, String tooltipText) {
+        I menuItem = addItem(text);
+        menuItem.setTooltipText(tooltipText);
+        return menuItem;
+    }
+
+    /**
+     * Adds a component as a menu item with a tooltip text.
+     *
+     * @param component
+     *            the component for the menu item
+     * @param tooltipText
+     *            the tooltip text for the menu item
+     * @return a new menu item
+     */
+    public I addItem(Component component, String tooltipText) {
+        I menuItem = addItem(component);
+        menuItem.setTooltipText(tooltipText);
+        return menuItem;
+    }
+
+    /**
+     * Adds a text as a menu item with a tooltip text and a click listener.
+     *
+     * @param text
+     *            the text for the menu item
+     * @param tooltipText
+     *            the tooltip text for the menu item
+     * @param clickListener
+     *            a click listener
+     * @return a new menu item
+     */
+    public I addItem(String text, String tooltipText,
+            ComponentEventListener<ClickEvent<I>> clickListener) {
+        I menuItem = addItem(text, clickListener);
+        menuItem.setTooltipText(tooltipText);
+        return menuItem;
+    }
+
+    /**
+     * Adds a component as a menu item with a tooltip text and a click listener.
+     *
+     * @param component
+     *            the component for the menu item
+     * @param tooltipText
+     *            the tooltip text for the menu item
+     * @param clickListener
+     *            a click listener
+     * @return a new menu item
+     */
+    public I addItem(Component component, String tooltipText,
+            ComponentEventListener<ClickEvent<I>> clickListener) {
+        I menuItem = addItem(component, clickListener);
+        menuItem.setTooltipText(tooltipText);
+        return menuItem;
+    }
+
+    /**
      * Adds components to the (sub)menu.
      * <p>
      * The components are added into the content as is, they are not wrapped as

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
@@ -61,9 +61,7 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
      * @return the added {@link MenuItem} component
      */
     public MenuItem addItem(String text, String tooltipText) {
-        var item = addItem(text);
-        item.setTooltipText(tooltipText);
-        return item;
+        return getMenuManager().addItem(text, tooltipText);
     }
 
     /**
@@ -78,9 +76,7 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
      * @return the added {@link MenuItem} component
      */
     public MenuItem addItem(Component component, String tooltipText) {
-        var item = addItem(component);
-        item.setTooltipText(tooltipText);
-        return item;
+        return getMenuManager().addItem(component, tooltipText);
     }
 
     /**
@@ -98,9 +94,7 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
      */
     public MenuItem addItem(String text, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
-        var item = addItem(text, clickListener);
-        item.setTooltipText(tooltipText);
-        return item;
+        return getMenuManager().addItem(text, tooltipText, clickListener);
     }
 
     /**
@@ -119,9 +113,7 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
      */
     public MenuItem addItem(Component component, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
-        var item = addItem(component, clickListener);
-        item.setTooltipText(tooltipText);
-        return item;
+        return getMenuManager().addItem(component, tooltipText, clickListener);
     }
 
     @Override

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenu.java
@@ -50,6 +50,80 @@ public class SubMenu extends SubMenuBase<ContextMenu, MenuItem, SubMenu>
         return getMenuManager().addItem(component, clickListener);
     }
 
+    /**
+     * Creates a new {@link MenuItem} component with the given text content and
+     * tooltip text and adds it to this sub menu.
+     *
+     * @param text
+     *            the text content for the new item
+     * @param tooltipText
+     *            the tooltip text for the new item
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(String text, String tooltipText) {
+        var item = addItem(text);
+        item.setTooltipText(tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the given tooltip text and
+     * adds it to this sub menu. The provided component is added into the
+     * created {@link MenuItem}.
+     *
+     * @param component
+     *            the component to add inside the new item
+     * @param tooltipText
+     *            the tooltip text for the new item
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(Component component, String tooltipText) {
+        var item = addItem(component);
+        item.setTooltipText(tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the given text content,
+     * tooltip text and click listener and adds it to this sub menu.
+     *
+     * @param text
+     *            the text content for the new item
+     * @param tooltipText
+     *            the tooltip text for the new item
+     * @param clickListener
+     *            the handler for clicking the new item, can be {@code null} to
+     *            not add listener
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(String text, String tooltipText,
+            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+        var item = addItem(text, clickListener);
+        item.setTooltipText(tooltipText);
+        return item;
+    }
+
+    /**
+     * Creates a new {@link MenuItem} component with the given tooltip text and
+     * click listener and adds it to this sub menu. The provided component is
+     * added into the created {@link MenuItem}.
+     *
+     * @param component
+     *            the component to add inside the new item
+     * @param tooltipText
+     *            the tooltip text for the new item
+     * @param clickListener
+     *            the handler for clicking the new item, can be {@code null} to
+     *            not add listener
+     * @return the added {@link MenuItem} component
+     */
+    public MenuItem addItem(Component component, String tooltipText,
+            ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
+        var item = addItem(component, clickListener);
+        item.setTooltipText(tooltipText);
+        return item;
+    }
+
     @Override
     protected MenuManager<ContextMenu, MenuItem, SubMenu> createMenuManager() {
         return new MenuManager<>(getParentMenuItem().getContextMenu(),

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/resources/frontend/contextMenuConnector.js
@@ -54,7 +54,9 @@ function generateItemsTree(appId, nodeId) {
       checked: child._checked,
       keepOpen: child._keepOpen,
       className: child.className,
-      theme: child.__theme
+      theme: child.__theme,
+      tooltip: child.tooltip,
+      tooltipPosition: child.tooltipPosition
     };
     // Do not hardcode tag name to allow `vaadin-menu-bar-item`
     if (child._hasVaadinItemMixin && child._containerNodeId) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
@@ -25,7 +25,9 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
@@ -96,7 +98,8 @@ class ContextMenuTest {
     @Test
     void addItem_getChildren_returnsMenuItem() {
         ContextMenu contextMenu = new ContextMenu();
-        contextMenu.addItem("foo", null);
+        contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
         List<Component> children = contextMenu.getChildren()
                 .collect(Collectors.toList());
         Assertions.assertEquals(1, children.size());
@@ -106,7 +109,8 @@ class ContextMenuTest {
     @Test
     void addItem_getItems_returnsMenuItem() {
         ContextMenu contextMenu = new ContextMenu();
-        contextMenu.addItem("foo", null);
+        contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
         List<MenuItem> children = contextMenu.getItems();
         Assertions.assertEquals(1, children.size());
         assertComponentIsMenuItem(children.get(0), "foo");
@@ -115,7 +119,8 @@ class ContextMenuTest {
     @Test
     void addItem_remove_noChildrenNorItems() {
         ContextMenu contextMenu = new ContextMenu();
-        MenuItem item = contextMenu.addItem("foo", null);
+        MenuItem item = contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
         contextMenu.remove(item);
         Assertions.assertEquals(0, contextMenu.getChildren().count());
         Assertions.assertEquals(0, contextMenu.getItems().size());
@@ -125,12 +130,14 @@ class ContextMenuTest {
     void addItemsAndComponents_getChildrenReturnsAllInOrder() {
         ContextMenu contextMenu = new ContextMenu();
 
-        MenuItem item1 = contextMenu.addItem("foo", null);
+        MenuItem item1 = contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Span span1 = new Span("foo");
         contextMenu.addComponent(span1);
 
-        MenuItem item2 = contextMenu.addItem("bar", null);
+        MenuItem item2 = contextMenu.addItem("bar",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Span span2 = new Span("bar");
         contextMenu.addComponent(span2);
@@ -148,9 +155,11 @@ class ContextMenuTest {
     @Test
     void addItemsAndSeparator_separatorOnlyIncludedInChildren() {
         var contextMenu = new ContextMenu();
-        var item1 = contextMenu.addItem("foo", null);
+        var item1 = contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
         contextMenu.addSeparator();
-        var item2 = contextMenu.addItem("bar", null);
+        var item2 = contextMenu.addItem("bar",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         var children = contextMenu.getChildren().toList();
         var items = contextMenu.getItems();
@@ -166,12 +175,14 @@ class ContextMenuTest {
     void addItemsAndComponents_getItemsReturnsItemsOnly() {
         ContextMenu contextMenu = new ContextMenu();
 
-        MenuItem item1 = contextMenu.addItem("foo", null);
+        MenuItem item1 = contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Span span1 = new Span("foo");
         contextMenu.addComponent(span1);
 
-        MenuItem item2 = contextMenu.addItem("bar", null);
+        MenuItem item2 = contextMenu.addItem("bar",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Span span2 = new Span("bar");
         contextMenu.addComponent(span2);
@@ -198,11 +209,15 @@ class ContextMenuTest {
     void addItemsWithNullClickListeners_doesNotThrow() {
         ContextMenu contextMenu = new ContextMenu();
 
-        MenuItem foo = contextMenu.addItem("foo", null);
-        contextMenu.addItem(new Div(), null);
+        MenuItem foo = contextMenu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
+        contextMenu.addItem(new Div(),
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
-        foo.getSubMenu().addItem("bar", null);
-        foo.getSubMenu().addItem(new Div(), null);
+        foo.getSubMenu().addItem("bar",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
+        foo.getSubMenu().addItem(new Div(),
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
     }
 
     @Test

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTooltipTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTooltipTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
+import com.vaadin.flow.dom.Element;
+
+class ContextMenuTooltipTest {
+
+    private ContextMenu contextMenu;
+
+    @BeforeEach
+    void setup() {
+        contextMenu = new ContextMenu();
+    }
+
+    @Test
+    void default_doesNotHaveTooltipElement() {
+        Assertions.assertFalse(getTooltipElement().isPresent());
+    }
+
+    @Test
+    void setTooltipText_addsSlottedTooltipElement() {
+        var item = contextMenu.addItem("Item");
+        contextMenu.setTooltipText(item, "Item tooltip");
+
+        var tooltip = getTooltipElement();
+        Assertions.assertTrue(tooltip.isPresent());
+        Assertions.assertEquals("tooltip", tooltip.get().getAttribute("slot"));
+    }
+
+    @Test
+    void setTooltipText_setsTooltipPropertyOnItem() {
+        var item = contextMenu.addItem("Item");
+        contextMenu.setTooltipText(item, "Item tooltip");
+
+        Assertions.assertEquals("Item tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void setTooltipText_multipleItems_singleTooltipElement() {
+        var item1 = contextMenu.addItem("Item 1");
+        var item2 = contextMenu.addItem("Item 2");
+        contextMenu.setTooltipText(item1, "Tooltip 1");
+        contextMenu.setTooltipText(item2, "Tooltip 2");
+
+        Assertions.assertEquals(1, getTooltipElements().count());
+    }
+
+    @Test
+    void setTooltipText_subMenuItem_setsTooltipProperty() {
+        var item = contextMenu.addItem("Item");
+        var subItem = item.getSubMenu().addItem("Sub item");
+
+        contextMenu.setTooltipText(subItem, "Sub tooltip");
+
+        Assertions.assertEquals("Sub tooltip",
+                subItem.getElement().getProperty("tooltip"));
+        Assertions.assertTrue(getTooltipElement().isPresent());
+    }
+
+    @Test
+    void setTooltipPosition_setsTooltipPositionPropertyOnItem() {
+        var item = contextMenu.addItem("Item");
+        contextMenu.setTooltipPosition(item, TooltipPosition.END);
+
+        Assertions.assertEquals("end",
+                item.getElement().getProperty("tooltipPosition"));
+    }
+
+    @Test
+    void setTooltipPositionNull_clearsTooltipPositionProperty() {
+        var item = contextMenu.addItem("Item");
+        contextMenu.setTooltipPosition(item, TooltipPosition.END);
+        contextMenu.setTooltipPosition(item, null);
+
+        Assertions.assertNull(item.getElement().getProperty("tooltipPosition"));
+    }
+
+    private Optional<Element> getTooltipElement() {
+        return getTooltipElements().findFirst();
+    }
+
+    private Stream<Element> getTooltipElements() {
+        return contextMenu.getElement().getChildren()
+                .filter(child -> "vaadin-tooltip".equals(child.getTag()));
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTooltipTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTooltipTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.dom.Element;
 
@@ -41,8 +42,8 @@ class ContextMenuTooltipTest {
 
     @Test
     void setTooltipText_addsSlottedTooltipElement() {
-        var item = contextMenu.addItem("Item");
-        contextMenu.setTooltipText(item, "Item tooltip");
+        var item = contextMenu.addItem("Item 0");
+        item.setTooltipText("Item 0 / Tooltip");
 
         var tooltip = getTooltipElement();
         Assertions.assertTrue(tooltip.isPresent());
@@ -51,39 +52,97 @@ class ContextMenuTooltipTest {
 
     @Test
     void setTooltipText_setsTooltipPropertyOnItem() {
-        var item = contextMenu.addItem("Item");
-        contextMenu.setTooltipText(item, "Item tooltip");
+        var item = contextMenu.addItem("Item 0");
+        item.setTooltipText("Item 0 / Tooltip");
 
-        Assertions.assertEquals("Item tooltip",
+        Assertions.assertEquals("Item 0 / Tooltip",
                 item.getElement().getProperty("tooltip"));
     }
 
     @Test
     void setTooltipText_multipleItems_singleTooltipElement() {
+        var item0 = contextMenu.addItem("Item 0");
         var item1 = contextMenu.addItem("Item 1");
-        var item2 = contextMenu.addItem("Item 2");
-        contextMenu.setTooltipText(item1, "Tooltip 1");
-        contextMenu.setTooltipText(item2, "Tooltip 2");
+        item0.setTooltipText("Item 0 / Tooltip");
+        item1.setTooltipText("Item 1 / Tooltip");
 
         Assertions.assertEquals(1, getTooltipElements().count());
     }
 
     @Test
     void setTooltipText_subMenuItem_setsTooltipProperty() {
-        var item = contextMenu.addItem("Item");
-        var subItem = item.getSubMenu().addItem("Sub item");
+        var item = contextMenu.addItem("Item 0");
+        var subItem = item.getSubMenu().addItem("Item 0-0");
 
-        contextMenu.setTooltipText(subItem, "Sub tooltip");
+        subItem.setTooltipText("Item 0-0 / Tooltip");
 
-        Assertions.assertEquals("Sub tooltip",
+        Assertions.assertEquals("Item 0-0 / Tooltip",
                 subItem.getElement().getProperty("tooltip"));
         Assertions.assertTrue(getTooltipElement().isPresent());
     }
 
     @Test
+    void addItemWithTextAndTooltip_setsTooltipProperty() {
+        var item = contextMenu.addItem("Item 0", "Item 0 / Tooltip");
+
+        Assertions.assertEquals("Item 0 / Tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void addItemWithComponentAndTooltip_setsTooltipProperty() {
+        var item = contextMenu.addItem(new Span("Item 0"), "Item 0 / Tooltip");
+
+        Assertions.assertEquals("Item 0 / Tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void subMenu_addItemWithTextAndTooltip_setsTooltipProperty() {
+        var item = contextMenu.addItem("Item 0");
+        var subItem = item.getSubMenu().addItem("Item 0-0",
+                "Item 0-0 / Tooltip");
+
+        Assertions.assertEquals("Item 0-0 / Tooltip",
+                subItem.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void subMenu_addItemWithComponentAndTooltip_setsTooltipProperty() {
+        var item = contextMenu.addItem("Item 0");
+        var subItem = item.getSubMenu().addItem(new Span("Item 0-0"),
+                "Item 0-0 / Tooltip");
+
+        Assertions.assertEquals("Item 0-0 / Tooltip",
+                subItem.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void subMenu_addItemWithTextTooltipAndListener_setsTooltipProperty() {
+        var item = contextMenu.addItem("Item 0");
+        var subItem = item.getSubMenu().addItem("Item 0-0",
+                "Item 0-0 / Tooltip", e -> {
+                });
+
+        Assertions.assertEquals("Item 0-0 / Tooltip",
+                subItem.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void subMenu_addItemWithComponentTooltipAndListener_setsTooltipProperty() {
+        var item = contextMenu.addItem("Item 0");
+        var subItem = item.getSubMenu().addItem(new Span("Item 0-0"),
+                "Item 0-0 / Tooltip", e -> {
+                });
+
+        Assertions.assertEquals("Item 0-0 / Tooltip",
+                subItem.getElement().getProperty("tooltip"));
+    }
+
+    @Test
     void setTooltipPosition_setsTooltipPositionPropertyOnItem() {
-        var item = contextMenu.addItem("Item");
-        contextMenu.setTooltipPosition(item, TooltipPosition.END);
+        var item = contextMenu.addItem("Item 0");
+        item.setTooltipPosition(TooltipPosition.END);
 
         Assertions.assertEquals("end",
                 item.getElement().getProperty("tooltipPosition"));
@@ -91,9 +150,9 @@ class ContextMenuTooltipTest {
 
     @Test
     void setTooltipPositionNull_clearsTooltipPositionProperty() {
-        var item = contextMenu.addItem("Item");
-        contextMenu.setTooltipPosition(item, TooltipPosition.END);
-        contextMenu.setTooltipPosition(item, null);
+        var item = contextMenu.addItem("Item 0");
+        item.setTooltipPosition(TooltipPosition.END);
+        item.setTooltipPosition(null);
 
         Assertions.assertNull(item.getElement().getProperty("tooltipPosition"));
     }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
@@ -117,7 +117,8 @@ class MenuManagerTest {
     void addItem_textNullListener_createItemUsingFactory_setText_addToItemAndNoListenerAdded() {
         TestMenuItem item = Mockito.mock(TestMenuItem.class);
         Mockito.when(factory.apply(menu, reset)).thenReturn(item);
-        manager.addItem("foo", null);
+        manager.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Mockito.verify(item).setText("foo");
         Mockito.verifyNoMoreInteractions(item);
@@ -147,7 +148,8 @@ class MenuManagerTest {
         TestMenuItem item = Mockito.mock(TestMenuItem.class);
         Mockito.when(factory.apply(menu, reset)).thenReturn(item);
         Component component = Mockito.mock(Component.class);
-        manager.addItem(component, null);
+        manager.addItem(component,
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Mockito.verify(item).add(component);
         Mockito.verifyNoMoreInteractions(item);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
@@ -69,7 +69,8 @@ class GridContextMenuTest {
     @Test
     void addTextItem_delegateToMenuManager() {
         TestContextMenu menu = new TestContextMenu();
-        menu.addItem("foo", (ComponentEventListener<ClickEvent<MenuItem>>) null);
+        menu.addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Mockito.verify(menuManager).addItem("foo", null);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
@@ -72,7 +72,8 @@ class GridContextMenuTest {
         menu.addItem("foo",
                 (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
-        Mockito.verify(menuManager).addItem("foo", null);
+        Mockito.verify(menuManager).addItem("foo",
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
     }
 
     @Test
@@ -82,7 +83,8 @@ class GridContextMenuTest {
         menu.addItem(component,
                 (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
-        Mockito.verify(menuManager).addItem(component, null);
+        Mockito.verify(menuManager).addItem(component,
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
@@ -19,12 +19,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.contextmenu.ContextMenu;
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.contextmenu.MenuManager;
 import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.contextmenu.GridContextMenu.GridContextMenuItemClickEvent;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.function.SerializableRunnable;
 
@@ -52,17 +55,21 @@ class GridContextMenuTest {
     void addItemsWithNullClickListener_doesNotThrow() {
         GridContextMenu<Object> gridContextMenu = new GridContextMenu<>();
 
-        GridMenuItem<Object> foo = gridContextMenu.addItem("foo", null);
-        gridContextMenu.addItem(new NativeButton(), null);
+        GridMenuItem<Object> foo = gridContextMenu.addItem("foo",
+                (ComponentEventListener<GridContextMenuItemClickEvent<Object>>) null);
+        gridContextMenu.addItem(new NativeButton(),
+                (ComponentEventListener<GridContextMenuItemClickEvent<Object>>) null);
 
-        foo.getSubMenu().addItem("bar", null);
-        foo.getSubMenu().addItem(new NativeButton(), null);
+        foo.getSubMenu().addItem("bar",
+                (ComponentEventListener<GridContextMenuItemClickEvent<Object>>) null);
+        foo.getSubMenu().addItem(new NativeButton(),
+                (ComponentEventListener<GridContextMenuItemClickEvent<Object>>) null);
     }
 
     @Test
     void addTextItem_delegateToMenuManager() {
         TestContextMenu menu = new TestContextMenu();
-        menu.addItem("foo", null);
+        menu.addItem("foo", (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Mockito.verify(menuManager).addItem("foo", null);
     }
@@ -71,7 +78,8 @@ class GridContextMenuTest {
     void addComponentItem_delegateToMenuManager() {
         TestContextMenu menu = new TestContextMenu();
         Component component = Mockito.mock(Component.class);
-        menu.addItem(component, null);
+        menu.addItem(component,
+                (ComponentEventListener<ClickEvent<MenuItem>>) null);
 
         Mockito.verify(menuManager).addItem(component, null);
     }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.menubar.tests;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.TooltipConfiguration;
@@ -33,41 +32,40 @@ public class MenuBarTooltipPage extends Div {
         TooltipConfiguration.setDefaultHideDelay(0);
 
         MenuBar menuBar = new MenuBar();
-        // Use each add API with tooltip parameter to add menu items
-        var editMenuItem = menuBar.addItem("Edit", "Edit tooltip");
-        menuBar.addItem(new Span("Share"), "Share tooltip");
-        menuBar.addItem("Move", "Move tooltip", (e) -> {
-        });
-        menuBar.addItem(new Span("Duplicate"), "Duplicate tooltip");
 
-        // Item with sub-menu containing items with tooltips
-        var viewMenuItem = menuBar.addItem("View");
-        var rulerSubItem = viewMenuItem.getSubMenu().addItem("Ruler");
-        menuBar.setTooltipText(rulerSubItem, "Show or hide the ruler");
-        menuBar.setTooltipPosition(rulerSubItem, TooltipPosition.END);
+        // Root items (buttons)
+        var item0 = menuBar.addItem("Item 0", "Item 0 / Tooltip");
 
-        // Tooltip position override on root item
-        menuBar.setTooltipPosition(editMenuItem, TooltipPosition.TOP);
+        var item1 = menuBar.addItem("Item 1", "Item 1 / Tooltip");
+        item1.setEnabled(false);
 
-        // Add a button for toggling the menu-bar attached state.
-        var toggleAttachedButton = new NativeButton("Toggle attached",
+        var item2 = menuBar.addItem("Item 2", "Item 2 / Tooltip");
+        item2.setTooltipPosition(TooltipPosition.TOP);
+
+        // Sub menu items
+        var item0_0 = item0.getSubMenu().addItem("Item 0-0",
+                "Item 0-0 / Tooltip");
+
+        var item0_1 = item0.getSubMenu().addItem("Item 0-1",
+                "Item 0-1 / Tooltip");
+        item0_1.setEnabled(false);
+
+        var item0_2 = item0.getSubMenu().addItem("Item 0-2",
+                "Item 0-2 / Tooltip");
+        item0_2.setTooltipPosition(TooltipPosition.TOP);
+
+        var attach = new NativeButton("Attach", event -> add(menuBar));
+        attach.setId("attach");
+        var detach = new NativeButton("Detach", event -> remove(menuBar));
+        detach.setId("detach");
+
+        var updateTooltips = new NativeButton("Update tooltips",
                 event -> {
-                    if (menuBar.getParent().isPresent()) {
-                        remove(menuBar);
-                    } else {
-                        add(menuBar);
-                    }
+                    item0.setTooltipText("Item 0 / Updated Tooltip");
+                    item0_0.setTooltipText("Item 0-0 / Updated Tooltip");
                 });
-        toggleAttachedButton.setId("toggle-attached-button");
+        updateTooltips.setId("update-tooltips");
 
-        // Add a button for updating an item's tooltip
-        var updateItemTooltipButton = new NativeButton("Update item tooltip",
-                event -> {
-                    menuBar.setTooltipText(editMenuItem,
-                            "Updated Edit tooltip");
-                });
-        updateItemTooltipButton.setId("update-item-tooltip-button");
-
-        add(toggleAttachedButton, updateItemTooltipButton, menuBar);
+        add(attach, detach, updateTooltips, menuBar);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.TooltipConfiguration;
 import com.vaadin.flow.router.Route;
 
@@ -38,6 +39,15 @@ public class MenuBarTooltipPage extends Div {
         menuBar.addItem("Move", "Move tooltip", (e) -> {
         });
         menuBar.addItem(new Span("Duplicate"), "Duplicate tooltip");
+
+        // Item with sub-menu containing items with tooltips
+        var viewMenuItem = menuBar.addItem("View");
+        var rulerSubItem = viewMenuItem.getSubMenu().addItem("Ruler");
+        menuBar.setTooltipText(rulerSubItem, "Show or hide the ruler");
+        menuBar.setTooltipPosition(rulerSubItem, TooltipPosition.END);
+
+        // Tooltip position override on root item
+        menuBar.setTooltipPosition(editMenuItem, TooltipPosition.TOP);
 
         // Add a button for toggling the menu-bar attached state.
         var toggleAttachedButton = new NativeButton("Toggle attached",

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -59,11 +59,10 @@ public class MenuBarTooltipPage extends Div {
         var detach = new NativeButton("Detach", event -> remove(menuBar));
         detach.setId("detach");
 
-        var updateTooltips = new NativeButton("Update tooltips",
-                event -> {
-                    item0.setTooltipText("Item 0 / Updated Tooltip");
-                    item0_0.setTooltipText("Item 0-0 / Updated Tooltip");
-                });
+        var updateTooltips = new NativeButton("Update tooltips", event -> {
+            item0.setTooltipText("Item 0 / Updated Tooltip");
+            item0_0.setTooltipText("Item 0-0 / Updated Tooltip");
+        });
         updateTooltips.setId("update-tooltips");
 
         add(attach, detach, updateTooltips, menuBar);

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
@@ -1,0 +1,2 @@
+com.vaadin.experimental.accessibleDisabledButtons=true
+com.vaadin.experimental.accessibleDisabledMenuItems=true

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -73,6 +73,27 @@ public class MenuBarTooltipIT extends AbstractComponentIT {
         Assert.assertEquals("Updated Edit tooltip", getActiveTooltipText());
     }
 
+    @Test
+    public void setTooltipPosition_tooltipUsesPosition() {
+        var menuBar = $(MenuBarElement.class).first();
+
+        showTooltip(menuBar.getButtons().get(0));
+        var tooltip = findElement(By.tagName("vaadin-tooltip"));
+        Assert.assertEquals("top", tooltip.getDomProperty("_position"));
+    }
+
+    @Test
+    public void hoverOverSubMenuItem_showTooltip() {
+        var menuBar = $(MenuBarElement.class).first();
+
+        // Open the View sub-menu and hover the Ruler item
+        var subMenu = menuBar.getButtons().get(4).openSubMenu();
+        var rulerItem = subMenu.getMenuItem("Ruler").orElseThrow();
+
+        showTooltip(rulerItem);
+        Assert.assertEquals("Show or hide the ruler", getActiveTooltipText());
+    }
+
     private void showTooltip(TestBenchElement button) {
         executeScript(
                 "arguments[0].dispatchEvent(new Event('mouseover', {bubbles:true}))",

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.menubar.tests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -28,79 +27,75 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-menu-bar/tooltip")
 public class MenuBarTooltipIT extends AbstractComponentIT {
 
+    private MenuBarElement menuBar;
+    private TestBenchElement menuBarTooltip;
+
     @Before
     public void init() {
         open();
+        menuBar = $(MenuBarElement.class).single();
+        menuBarTooltip = menuBar.$("vaadin-tooltip").single();
     }
 
     @Test
-    public void hoverOverMenuBarButton_showTooltip() {
-        var menuBar = $(MenuBarElement.class).first();
+    public void hoverOverRootItems_tooltipDisplayed() {
+        var buttons = menuBar.getButtons();
 
-        showTooltip(menuBar.getButtons().get(0));
-        Assert.assertEquals("Edit tooltip", getActiveTooltipText());
+        buttons.get(0).hover();
+        Assert.assertEquals("Item 0 / Tooltip", menuBarTooltip.getText());
 
-        showTooltip(menuBar.getButtons().get(1));
-        Assert.assertEquals("Share tooltip", getActiveTooltipText());
+        buttons.get(1).hover();
+        Assert.assertEquals("Item 1 / Tooltip", menuBarTooltip.getText());
 
-        showTooltip(menuBar.getButtons().get(2));
-        Assert.assertEquals("Move tooltip", getActiveTooltipText());
-
-        showTooltip(menuBar.getButtons().get(3));
-        Assert.assertEquals("Duplicate tooltip", getActiveTooltipText());
+        buttons.get(2).hover();
+        Assert.assertEquals("Item 2 / Tooltip", menuBarTooltip.getText());
+        Assert.assertEquals("top", menuBarTooltip.getDomProperty("_position"));
     }
 
     @Test
-    public void toggleAttached_hoverOverTooltipColumnCell_showTooltip() {
-        // Remove the menubar
-        clickElementWithJs("toggle-attached-button");
-        // Add the menubar
-        clickElementWithJs("toggle-attached-button");
+    public void hoverOverSubMenuItems_tooltipDisplayed() {
+        var subMenu = menuBar.getButtons().get(0).openSubMenu();
+        var subMenuItems = subMenu.getMenuItems();
 
-        var menuBar = $(MenuBarElement.class).first();
-        showTooltip(menuBar.getButtons().get(0));
-        Assert.assertEquals("Edit tooltip", getActiveTooltipText());
+        subMenuItems.get(0).hover();
+        Assert.assertEquals("Item 0-0 / Tooltip", menuBarTooltip.getText());
+
+        subMenuItems.get(1).hover();
+        Assert.assertEquals("Item 0-1 / Tooltip", menuBarTooltip.getText());
+
+        subMenuItems.get(2).hover();
+        Assert.assertEquals("Item 0-2 / Tooltip", menuBarTooltip.getText());
+        Assert.assertEquals("top", menuBarTooltip.getDomProperty("_position"));
     }
 
     @Test
-    public void updateTooltipText_showUpdatedTooltip() {
-        var menuBar = $(MenuBarElement.class).first();
+    public void updateTooltip_updatedTooltipDisplayed() {
+        clickElementWithJs("update-tooltips");
 
-        // Udpate tooltip text
-        clickElementWithJs("update-item-tooltip-button");
+        menuBar.getButtons().get(0).hover();
+        Assert.assertEquals("Item 0 / Updated Tooltip", menuBarTooltip.getText());
 
-        showTooltip(menuBar.getButtons().get(0));
-        Assert.assertEquals("Updated Edit tooltip", getActiveTooltipText());
+        var subMenu = menuBar.getButtons().get(0).openSubMenu();
+        subMenu.getMenuItems().get(0).hover();
+        Assert.assertEquals("Item 0-0 / Updated Tooltip", menuBarTooltip.getText());
     }
 
     @Test
-    public void setTooltipPosition_tooltipUsesPosition() {
-        var menuBar = $(MenuBarElement.class).first();
+    public void detachAndAttach_hoverOverItems_tooltipDisplayed() {
+        detachAndAttach();
 
-        showTooltip(menuBar.getButtons().get(0));
-        var tooltip = findElement(By.tagName("vaadin-tooltip"));
-        Assert.assertEquals("top", tooltip.getDomProperty("_position"));
+        menuBar.getButtons().get(0).hover();
+        Assert.assertEquals("Item 0 / Tooltip", menuBarTooltip.getText());
+
+        var subMenu = menuBar.getButtons().get(0).openSubMenu();
+        subMenu.getMenuItems().get(0).hover();
+        Assert.assertEquals("Item 0-0 / Tooltip", menuBarTooltip.getText());
     }
 
-    @Test
-    public void hoverOverSubMenuItem_showTooltip() {
-        var menuBar = $(MenuBarElement.class).first();
-
-        // Open the View sub-menu and hover the Ruler item
-        var subMenu = menuBar.getButtons().get(4).openSubMenu();
-        var rulerItem = subMenu.getMenuItem("Ruler").orElseThrow();
-
-        showTooltip(rulerItem);
-        Assert.assertEquals("Show or hide the ruler", getActiveTooltipText());
-    }
-
-    private void showTooltip(TestBenchElement button) {
-        executeScript(
-                "arguments[0].dispatchEvent(new Event('mouseover', {bubbles:true}))",
-                button);
-    }
-
-    private String getActiveTooltipText() {
-        return findElement(By.tagName("vaadin-tooltip")).getText();
+    private void detachAndAttach() {
+        clickElementWithJs("detach");
+        clickElementWithJs("attach");
+        menuBar = $(MenuBarElement.class).single();
+        menuBarTooltip = menuBar.$("vaadin-tooltip").single();
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -73,11 +73,13 @@ public class MenuBarTooltipIT extends AbstractComponentIT {
         clickElementWithJs("update-tooltips");
 
         menuBar.getButtons().get(0).hover();
-        Assert.assertEquals("Item 0 / Updated Tooltip", menuBarTooltip.getText());
+        Assert.assertEquals("Item 0 / Updated Tooltip",
+                menuBarTooltip.getText());
 
         var subMenu = menuBar.getButtons().get(0).openSubMenu();
         subMenu.getMenuItems().get(0).hover();
-        Assert.assertEquals("Item 0-0 / Updated Tooltip", menuBarTooltip.getText());
+        Assert.assertEquals("Item 0-0 / Updated Tooltip",
+                menuBarTooltip.getText());
     }
 
     @Test

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -289,6 +289,20 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
     }
 
     /**
+     * Sets the tooltip text for the given {@link MenuItem}.
+     *
+     * @param item
+     *            the menu item to set the tooltip for
+     * @param tooltipText
+     *            the tooltip text to set for the item
+     * @deprecated Use {@link MenuItem#setTooltipText(String)} instead.
+     */
+    @Deprecated
+    public void setTooltipText(MenuItem item, String tooltipText) {
+        item.setTooltipText(tooltipText);
+    }
+
+    /**
      * Gets the {@link MenuItem} components added to the root level of the menu
      * bar.
      * <p>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
@@ -490,21 +491,53 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
     }
 
     /**
-     * Sets the tooltip text for the given {@link MenuItem}.
+     * Sets the tooltip text for the given {@link MenuItem}. Works for both
+     * root-level items (rendered as buttons) and items inside sub-menus.
+     * <p>
+     * The first call to this method on a menu bar attaches a slotted
+     * {@code <vaadin-tooltip>} element to the menu-bar host that is shared by
+     * all items. Hover and hide delays as well as the position can be
+     * configured via the slotted element. Setting {@code null} or an empty text
+     * removes the tooltip from the item.
      *
      * @param item
      *            the menu item to set the tooltip for
      * @param tooltipText
      *            the tooltip text to set for the item
+     * @see #setTooltipPosition(MenuItem, TooltipPosition)
      */
     public void setTooltipText(MenuItem item, String tooltipText) {
-        if (!getElement().getChildren().anyMatch(
+        ensureTooltipElement();
+        item.getElement().setProperty("tooltip", tooltipText);
+        updateButtons();
+    }
+
+    /**
+     * Sets the tooltip position for the given {@link MenuItem}, overriding the
+     * default. Root-level items default to {@code bottom}; items with a
+     * sub-menu default to {@code start} so the tooltip doesn't overlap the
+     * opening sub-menu; all other items, including disabled ones, default to
+     * {@code end}. If the slotted {@code <vaadin-tooltip>} element has its own
+     * {@code position} property set, that value is used instead.
+     *
+     * @param item
+     *            the menu item to set the tooltip position for
+     * @param position
+     *            the tooltip position, or {@code null} to clear it and use the
+     *            default
+     * @see #setTooltipText(MenuItem, String)
+     */
+    public void setTooltipPosition(MenuItem item, TooltipPosition position) {
+        item.getElement().setProperty("tooltipPosition",
+                position != null ? position.getPosition() : null);
+        updateButtons();
+    }
+
+    private void ensureTooltipElement() {
+        if (getElement().getChildren().noneMatch(
                 child -> "tooltip".equals(child.getAttribute("slot")))) {
             SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
         }
-
-        item.getElement().setProperty("tooltip", tooltipText);
-        updateButtons();
     }
 
     /**

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -295,7 +295,8 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      *            the menu item to set the tooltip for
      * @param tooltipText
      *            the tooltip text to set for the item
-     * @deprecated Use {@link MenuItem#setTooltipText(String)} instead.
+     * @deprecated Use {@link MenuItem#setTooltipText(String)} instead. This
+     *             method is scheduled for removal in Vaadin 26.
      */
     @Deprecated
     public void setTooltipText(MenuItem item, String tooltipText) {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -38,7 +38,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.SlotUtils;
-import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
@@ -202,7 +201,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      */
     public MenuItem addItem(String text, String tooltipText) {
         var item = addItem(text);
-        setTooltipText(item, tooltipText);
+        item.setTooltipText(tooltipText);
         return item;
     }
 
@@ -227,7 +226,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      */
     public MenuItem addItem(Component component, String tooltipText) {
         var item = addItem(component);
-        setTooltipText(item, tooltipText);
+        item.setTooltipText(tooltipText);
         return item;
     }
 
@@ -256,7 +255,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
     public MenuItem addItem(String text, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         var item = addItem(text, clickListener);
-        setTooltipText(item, tooltipText);
+        item.setTooltipText(tooltipText);
         return item;
     }
 
@@ -285,7 +284,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
     public MenuItem addItem(Component component, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
         var item = addItem(component, clickListener);
-        setTooltipText(item, tooltipText);
+        item.setTooltipText(tooltipText);
         return item;
     }
 
@@ -490,50 +489,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
         }
     }
 
-    /**
-     * Sets the tooltip text for the given {@link MenuItem}. Works for both
-     * root-level items (rendered as buttons) and items inside sub-menus.
-     * <p>
-     * The first call to this method on a menu bar attaches a slotted
-     * {@code <vaadin-tooltip>} element to the menu-bar host that is shared by
-     * all items. Hover and hide delays as well as the position can be
-     * configured via the slotted element. Setting {@code null} or an empty text
-     * removes the tooltip from the item.
-     *
-     * @param item
-     *            the menu item to set the tooltip for
-     * @param tooltipText
-     *            the tooltip text to set for the item
-     * @see #setTooltipPosition(MenuItem, TooltipPosition)
-     */
-    public void setTooltipText(MenuItem item, String tooltipText) {
-        ensureTooltipElement();
-        item.getElement().setProperty("tooltip", tooltipText);
-        updateButtons();
-    }
-
-    /**
-     * Sets the tooltip position for the given {@link MenuItem}, overriding the
-     * default. Root-level items default to {@code bottom}; items with a
-     * sub-menu default to {@code start} so the tooltip doesn't overlap the
-     * opening sub-menu; all other items, including disabled ones, default to
-     * {@code end}. If the slotted {@code <vaadin-tooltip>} element has its own
-     * {@code position} property set, that value is used instead.
-     *
-     * @param item
-     *            the menu item to set the tooltip position for
-     * @param position
-     *            the tooltip position, or {@code null} to clear it and use the
-     *            default
-     * @see #setTooltipText(MenuItem, String)
-     */
-    public void setTooltipPosition(MenuItem item, TooltipPosition position) {
-        item.getElement().setProperty("tooltipPosition",
-                position != null ? position.getPosition() : null);
-        updateButtons();
-    }
-
-    private void ensureTooltipElement() {
+    void ensureTooltipElement() {
         if (getElement().getChildren().noneMatch(
                 child -> "tooltip".equals(child.getAttribute("slot")))) {
             SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -496,16 +496,16 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
         }
     }
 
-    void ensureTooltipElement() {
-        if (SlotUtils.getElementsInSlot(this, "tooltip").findAny().isEmpty()) {
-            SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
-        }
-    }
-
     /**
      * Closes the current submenu.
      */
     public void close() {
         getElement().callJsFunction("close");
+    }
+
+    void ensureTooltipElement() {
+        if (SlotUtils.getElementsInSlot(this, "tooltip").count() == 0) {
+            SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
+        }
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -505,8 +505,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
     }
 
     void ensureTooltipElement() {
-        if (getElement().getChildren().noneMatch(
-                child -> "tooltip".equals(child.getAttribute("slot")))) {
+        if (SlotUtils.getElementsInSlot(this, "tooltip").findAny().isEmpty()) {
             SlotUtils.addToSlot(this, "tooltip", new Element("vaadin-tooltip"));
         }
     }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBar.java
@@ -200,9 +200,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      * @return the added {@link MenuItem} component
      */
     public MenuItem addItem(String text, String tooltipText) {
-        var item = addItem(text);
-        item.setTooltipText(tooltipText);
-        return item;
+        return menuManager.addItem(text, tooltipText);
     }
 
     /**
@@ -225,9 +223,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      * @return the added {@link MenuItem} component
      */
     public MenuItem addItem(Component component, String tooltipText) {
-        var item = addItem(component);
-        item.setTooltipText(tooltipText);
-        return item;
+        return menuManager.addItem(component, tooltipText);
     }
 
     /**
@@ -254,9 +250,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      */
     public MenuItem addItem(String text, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
-        var item = addItem(text, clickListener);
-        item.setTooltipText(tooltipText);
-        return item;
+        return menuManager.addItem(text, tooltipText, clickListener);
     }
 
     /**
@@ -283,9 +277,7 @@ public class MenuBar extends Component implements HasEnabled, HasMenuItems,
      */
     public MenuItem addItem(Component component, String tooltipText,
             ComponentEventListener<ClickEvent<MenuItem>> clickListener) {
-        var item = addItem(component, clickListener);
-        item.setTooltipText(tooltipText);
-        return item;
+        return menuManager.addItem(component, tooltipText, clickListener);
     }
 
     /**

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
@@ -37,11 +37,6 @@ class MenuBarItem extends MenuItem {
     }
 
     @Override
-    protected void scheduleTooltipUpdate() {
-        menuBar.resetContent();
-    }
-
-    @Override
     protected MenuBarSubMenu createSubMenu() {
         return new MenuBarSubMenu(this, contentReset);
     }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
@@ -38,7 +38,7 @@ class MenuBarItem extends MenuItem {
 
     @Override
     protected void scheduleTooltipUpdate() {
-        menuBar.updateButtons();
+        menuBar.resetContent();
     }
 
     @Override

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarItem.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.menubar;
 
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.contextmenu.ContextMenu;
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.function.SerializableRunnable;
 
@@ -24,11 +23,22 @@ import com.vaadin.flow.function.SerializableRunnable;
 class MenuBarItem extends MenuItem {
 
     private final SerializableRunnable contentReset;
+    final MenuBar menuBar;
 
-    public MenuBarItem(ContextMenu contextMenu,
-            SerializableRunnable contentReset) {
-        super(contextMenu, contentReset);
+    public MenuBarItem(MenuBar menuBar, SerializableRunnable contentReset) {
+        super(null, contentReset);
+        this.menuBar = menuBar;
         this.contentReset = contentReset;
+    }
+
+    @Override
+    protected void ensureTooltipElement() {
+        menuBar.ensureTooltipElement();
+    }
+
+    @Override
+    protected void scheduleTooltipUpdate() {
+        menuBar.updateButtons();
     }
 
     @Override

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarRootItem.java
@@ -19,11 +19,8 @@ import com.vaadin.flow.function.SerializableRunnable;
 
 class MenuBarRootItem extends MenuBarItem {
 
-    private MenuBar menuBar;
-
     MenuBarRootItem(MenuBar menuBar, SerializableRunnable contentReset) {
-        super(null, contentReset);
-        this.menuBar = menuBar;
+        super(menuBar, contentReset);
     }
 
     @Override

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
@@ -35,7 +35,7 @@ class MenuBarSubMenu extends SubMenu {
     protected MenuManager<ContextMenu, MenuItem, SubMenu> createMenuManager() {
         var menuBar = ((MenuBarItem) getParentMenuItem()).menuBar;
         return new MenuManager<>(null, contentReset,
-                (menu, reset) -> new MenuBarItem(menuBar, reset), MenuItem.class,
-                getParentMenuItem());
+                (menu, reset) -> new MenuBarItem(menuBar, reset),
+                MenuItem.class, getParentMenuItem());
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
@@ -34,8 +34,8 @@ class MenuBarSubMenu extends SubMenu {
     @Override
     protected MenuManager<ContextMenu, MenuItem, SubMenu> createMenuManager() {
         var menuBar = ((MenuBarItem) getParentMenuItem()).menuBar;
-        return new MenuManager<ContextMenu, MenuItem, SubMenu>(null,
-                contentReset, (menu, reset) -> new MenuBarItem(menuBar, reset),
-                MenuItem.class, getParentMenuItem());
+        return new MenuManager<>(null, contentReset,
+                (menu, reset) -> new MenuBarItem(menuBar, reset), MenuItem.class,
+                getParentMenuItem());
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
@@ -33,9 +33,9 @@ class MenuBarSubMenu extends SubMenu {
 
     @Override
     protected MenuManager<ContextMenu, MenuItem, SubMenu> createMenuManager() {
-        var menuBar = ((MenuBarItem) getParentMenuItem()).menuBar;
+        var parentMenuItem = ((MenuBarItem) getParentMenuItem());
         return new MenuManager<>(null, contentReset,
-                (menu, reset) -> new MenuBarItem(menuBar, reset),
-                MenuItem.class, getParentMenuItem());
+                (menu, reset) -> new MenuBarItem(parentMenuItem.menuBar, reset),
+                MenuItem.class, parentMenuItem);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/java/com/vaadin/flow/component/menubar/MenuBarSubMenu.java
@@ -33,7 +33,9 @@ class MenuBarSubMenu extends SubMenu {
 
     @Override
     protected MenuManager<ContextMenu, MenuItem, SubMenu> createMenuManager() {
-        return new MenuManager<>(null, contentReset, MenuBarItem::new,
+        var menuBar = ((MenuBarItem) getParentMenuItem()).menuBar;
+        return new MenuManager<ContextMenu, MenuItem, SubMenu>(null,
+                contentReset, (menu, reset) -> new MenuBarItem(menuBar, reset),
                 MenuItem.class, getParentMenuItem());
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -68,13 +68,24 @@ function initLazy(menubar, appId) {
 
       let items = menubar.__generatedItems || [];
 
+      // Refresh tooltip text and position from the underlying components so
+      // the menu-bar's tooltip controller recognizes the item as having a
+      // tooltip. Walks sub-menu items recursively because tooltips work on
+      // any item, not just root buttons.
+      const refreshTooltips = (items) => {
+        items.forEach((item) => {
+          item.tooltip = item.component.tooltip;
+          item.tooltipPosition = item.component.tooltipPosition;
+          if (item.children) {
+            refreshTooltips(item.children);
+          }
+        });
+      };
+      refreshTooltips(items);
+
       items.forEach((item) => {
         // Propagate disabled state from items to parent buttons
         item.disabled = item.component.disabled;
-
-        // Propagate tooltip text so the menu-bar's tooltip controller
-        // recognizes the item as having a tooltip and shows it.
-        item.tooltip = item.component.tooltip;
 
         // Saving item to component because `_item` can be reassigned to a new value
         // when the component goes to the overflow menu

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/resources/frontend/menubarConnector.js
@@ -68,21 +68,6 @@ function initLazy(menubar, appId) {
 
       let items = menubar.__generatedItems || [];
 
-      // Refresh tooltip text and position from the underlying components so
-      // the menu-bar's tooltip controller recognizes the item as having a
-      // tooltip. Walks sub-menu items recursively because tooltips work on
-      // any item, not just root buttons.
-      const refreshTooltips = (items) => {
-        items.forEach((item) => {
-          item.tooltip = item.component.tooltip;
-          item.tooltipPosition = item.component.tooltipPosition;
-          if (item.children) {
-            refreshTooltips(item.children);
-          }
-        });
-      };
-      refreshTooltips(items);
-
       items.forEach((item) => {
         // Propagate disabled state from items to parent buttons
         item.disabled = item.component.disabled;

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.dom.Element;
 
 /**
@@ -62,6 +63,36 @@ class MenuBarTooltipTest {
         menuBar.addItem("Item 0", "Item 0 tooltip");
         menuBar.addItem("Item 1", "Item 1 tooltip");
         Assertions.assertEquals(1, getTooltipElements(menuBar).count());
+    }
+
+    @Test
+    void setTooltipText_subMenuItem_setsTooltipProperty() {
+        var rootItem = menuBar.addItem("Item");
+        var subItem = rootItem.getSubMenu().addItem("Sub item");
+
+        menuBar.setTooltipText(subItem, "Sub tooltip");
+
+        Assertions.assertEquals("Sub tooltip",
+                subItem.getElement().getProperty("tooltip"));
+        Assertions.assertTrue(getTooltipElement(menuBar).isPresent());
+    }
+
+    @Test
+    void setTooltipPosition_setsTooltipPositionPropertyOnItem() {
+        var item = menuBar.addItem("Item");
+        menuBar.setTooltipPosition(item, TooltipPosition.BOTTOM);
+
+        Assertions.assertEquals("bottom",
+                item.getElement().getProperty("tooltipPosition"));
+    }
+
+    @Test
+    void setTooltipPositionNull_clearsTooltipPositionProperty() {
+        var item = menuBar.addItem("Item");
+        menuBar.setTooltipPosition(item, TooltipPosition.BOTTOM);
+        menuBar.setTooltipPosition(item, null);
+
+        Assertions.assertNull(item.getElement().getProperty("tooltipPosition"));
     }
 
     private Optional<Element> getTooltipElement(MenuBar menuBar) {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.dom.Element;
@@ -47,40 +48,71 @@ class MenuBarTooltipTest {
 
     @Test
     void addItemWithTooltip_hasTooltipElement() {
-        menuBar.addItem("Item", "Item tooltip");
+        menuBar.addItem("Item 0", "Item 0 / Tooltip");
         Assertions.assertTrue(getTooltipElement(menuBar).isPresent());
     }
 
     @Test
     void addItemWithTooltip_tooltipHasSlot() {
-        menuBar.addItem("Item", "Item tooltip");
+        menuBar.addItem("Item 0", "Item 0 / Tooltip");
         Assertions.assertEquals("tooltip",
                 getTooltipElement(menuBar).get().getAttribute("slot"));
     }
 
     @Test
     void addAnotherItemWithTooltip_hasOneTooltipElement() {
-        menuBar.addItem("Item 0", "Item 0 tooltip");
-        menuBar.addItem("Item 1", "Item 1 tooltip");
+        menuBar.addItem("Item 0", "Item 0 / Tooltip");
+        menuBar.addItem("Item 1", "Item 1 / Tooltip");
         Assertions.assertEquals(1, getTooltipElements(menuBar).count());
     }
 
     @Test
+    void addItemWithTextAndTooltip_setsTooltipProperty() {
+        var item = menuBar.addItem("Item 0", "Item 0 / Tooltip");
+        Assertions.assertEquals("Item 0 / Tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void addItemWithComponentAndTooltip_setsTooltipProperty() {
+        var item = menuBar.addItem(new Span("Item 0"), "Item 0 / Tooltip");
+        Assertions.assertEquals("Item 0 / Tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void addItemWithTextTooltipAndListener_setsTooltipProperty() {
+        var item = menuBar.addItem("Item 0", "Item 0 / Tooltip", e -> {
+        });
+        Assertions.assertEquals("Item 0 / Tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
+    void setTooltipText_updatesTooltipProperty() {
+        var item = menuBar.addItem("Item 0", "Item 0 / Tooltip");
+        item.setTooltipText("Item 0 / Updated Tooltip");
+
+        Assertions.assertEquals("Item 0 / Updated Tooltip",
+                item.getElement().getProperty("tooltip"));
+    }
+
+    @Test
     void setTooltipText_subMenuItem_setsTooltipProperty() {
-        var rootItem = menuBar.addItem("Item");
-        var subItem = rootItem.getSubMenu().addItem("Sub item");
+        var rootItem = menuBar.addItem("Item 0");
+        var subItem = rootItem.getSubMenu().addItem("Item 0-0");
 
-        menuBar.setTooltipText(subItem, "Sub tooltip");
+        subItem.setTooltipText("Item 0-0 / Tooltip");
 
-        Assertions.assertEquals("Sub tooltip",
+        Assertions.assertEquals("Item 0-0 / Tooltip",
                 subItem.getElement().getProperty("tooltip"));
         Assertions.assertTrue(getTooltipElement(menuBar).isPresent());
     }
 
     @Test
     void setTooltipPosition_setsTooltipPositionPropertyOnItem() {
-        var item = menuBar.addItem("Item");
-        menuBar.setTooltipPosition(item, TooltipPosition.BOTTOM);
+        var item = menuBar.addItem("Item 0");
+        item.setTooltipPosition(TooltipPosition.BOTTOM);
 
         Assertions.assertEquals("bottom",
                 item.getElement().getProperty("tooltipPosition"));
@@ -88,9 +120,9 @@ class MenuBarTooltipTest {
 
     @Test
     void setTooltipPositionNull_clearsTooltipPositionProperty() {
-        var item = menuBar.addItem("Item");
-        menuBar.setTooltipPosition(item, TooltipPosition.BOTTOM);
-        menuBar.setTooltipPosition(item, null);
+        var item = menuBar.addItem("Item 0");
+        item.setTooltipPosition(TooltipPosition.BOTTOM);
+        item.setTooltipPosition(null);
 
         Assertions.assertNull(item.getElement().getProperty("tooltipPosition"));
     }


### PR DESCRIPTION
Adds Flow APIs for menu item tooltips, building on web-component support added in vaadin/web-components#11549.

A single `<vaadin-tooltip>` is slotted into the menu/context-menu and auto-attached on first use, shared across root and sub-menu items. The menu-bar connector recurses through the item tree so `tooltip` and `tooltipPosition` reach nested items, which the web component's tooltip controller picks up.

The previous `MenuBar#setTooltipText(MenuItem, String)` API is deprecated in favor of the new item-level methods and scheduled for removal in Vaadin 26.

## Examples

Set a tooltip on any menu item via `setTooltipText` / `setTooltipPosition`:

```java
MenuBar menuBar = new MenuBar();
MenuItem save = menuBar.addItem("Save");
save.setTooltipText("Save changes");
save.setTooltipPosition(TooltipPosition.BOTTOM);
```

Convenience `addItem` overloads accept the tooltip text directly:

```java
MenuBar menuBar = new MenuBar();
menuBar.addItem("Save", "Save changes", e -> save());
menuBar.addItem(new Icon(VaadinIcon.TRASH), "Delete selected", e -> delete());
```

Same APIs on `ContextMenu` (and `GridContextMenu`) items, including nested sub-menu items:

```java
ContextMenu contextMenu = new ContextMenu(target);
MenuItem edit = contextMenu.addItem("Edit", "Edit this row");

SubMenu more = contextMenu.addItem("More").getSubMenu();
more.addItem("Duplicate", "Create a copy");
more.addItem("Archive").setTooltipText("Move to archive");
```

> [!WARNING]
> New tooltip-aware `addItem` overloads may make existing call sites ambiguous when a `null` listener is passed with a cast, e.g.:
>
> ```java
> foo.getSubMenu().addItem("bar",
>         (ComponentEventListener<GridContextMenuItemClickEvent<Object>>) null);
> ```
>
> Such call sites need to be updated to disambiguate the overload.

Fixes vaadin/web-components#10415

---

🤖 Generated with Claude Code