### PR TITLE
chore: pin actions/cache by SHA

### DIFF
--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Restore build cache
         id: build-cache
         if: steps.skip-ci.outputs.skip != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -332,6 +332,11 @@ jobs:
       checks: write
       actions: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 1
+
       - uses: actions/download-artifact@v6
         with:
           pattern: failsafe-reports-*

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -26,6 +26,7 @@ concurrency:
 
 env:
   FORK_COUNT: 4
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   setup:


### PR DESCRIPTION
## Summary

- Pin actions/cache to its commit SHA for consistency with dorny/test-reporter which is already pinned by SHA