### PR TITLE
feat: add collapseChips API to MultiSelectComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -549,6 +549,30 @@ public class MultiSelectComboBox<TItem>
     }
 
     /**
+     * Gets whether all selected item chips collapse into the overflow chip when
+     * they don't all fit.
+     *
+     * @since 25.2
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    public boolean isCollapseChips() {
+        return getElement().getProperty("collapseChips", false);
+    }
+
+    /**
+     * Enables or disables collapsing of all selected item chips into the
+     * overflow chip when they don't all fit. By default, as many chips as
+     * possible are shown and only the remaining ones are collapsed.
+     *
+     * @since 25.2
+     * @param collapseChips
+     *            {@code true} to collapse all chips into the overflow chip
+     */
+    public void setCollapseChips(boolean collapseChips) {
+        getElement().setProperty("collapseChips", collapseChips);
+    }
+
+    /**
      * Gets whether the filter is kept after selecting items. {@code false} by
      * default.
      *

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
@@ -328,6 +328,21 @@ class MultiSelectComboBoxTest extends ComboBoxBaseTest {
     }
 
     @Test
+    void setCollapseChips() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+
+        Assertions.assertFalse(comboBox.isCollapseChips());
+        Assertions.assertFalse(
+                comboBox.getElement().getProperty("collapseChips", false));
+
+        comboBox.setCollapseChips(true);
+
+        Assertions.assertTrue(comboBox.isCollapseChips());
+        Assertions.assertTrue(
+                comboBox.getElement().getProperty("collapseChips", true));
+    }
+
+    @Test
     void setKeepFilter() {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
 


### PR DESCRIPTION
The web component side added a [collapseChips](https://github.com/vaadin/web-components/pull/11585) boolean property to `vaadin-multi-select-combo-box`. When enabled, all selected-item chips collapse into the overflow chip whenever they don't all fit, instead of showing as many as possible.

Without this PR, Flow users have to reach for `getElement().setProperty("collapseChips", true)` to use the new behavior. The change adds a typed `isCollapseChips()` / `setCollapseChips(boolean)` pair on `MultiSelectComboBox`, mirroring the shape of the existing `selectedItemsOnTop` API.

Fixes #8533

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)