### PR TITLE
feat: split build into parallel jobs with caching

### DIFF
--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -262,7 +262,7 @@ jobs:
           }
 
       - name: npm install
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Run WTR tests
         run: node scripts/wtr.js ${{ needs.build.outputs.components }}
@@ -301,7 +301,7 @@ jobs:
           node-version: '24'
 
       - name: npm install
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Merge ITs
         run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -110,10 +110,10 @@ jobs:
       - name: Install and unit tests
         if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
         run: |
-          mvn install -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
+          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
             echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
             sleep 15
-            mvn install -Drelease -T $FORK_COUNT $MAVEN_ARGS
+            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
           }
 
       - name: Detect modified components

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -37,6 +37,7 @@ jobs:
       matrix: ${{ steps.shards.outputs.matrix }}
       has-tests: ${{ steps.shards.outputs.has-tests }}
       skip: ${{ steps.skip-ci.outputs.skip }}
+      components: ${{ steps.components.outputs.elements }}
     steps:
       - name: Set Maven args
         run: |
@@ -107,7 +108,7 @@ jobs:
           key="${TB_LICENSE#*/}"
           echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
 
-      - name: Install and unit tests
+      - name: Install artifacts
         if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
         run: |
           mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
@@ -156,10 +157,6 @@ jobs:
       - name: Merge ITs
         if: steps.skip-ci.outputs.skip != 'true'
         run: node scripts/mergeITs.js ${{ steps.components.outputs.elements }}
-
-      - name: Run WTR tests
-        if: steps.skip-ci.outputs.skip != 'true'
-        run: node scripts/wtr.js ${{ steps.components.outputs.elements }}
 
       - name: Package integration-tests WAR
         if: steps.skip-ci.outputs.skip != 'true'
@@ -232,13 +229,109 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  unit-tests:
+    name: Unit Tests
+    needs: setup
+    if: needs.setup.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set Maven args
+        run: |
+          args="-ntp -B"
+          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
+          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+
+      - name: Install artifacts (cache miss)
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
+            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
+            sleep 15
+            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
+          }
+
+      - name: Run unit tests
+        run: mvn test -Drelease -T $FORK_COUNT $MAVEN_ARGS
+
       - name: Publish unit test results
-        if: always() && steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
+        if: always()
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
         with:
           name: Unit Tests
           path: '**/target/surefire-reports/TEST-*.xml'
           reporter: java-junit
+
+  wtr-tests:
+    name: WTR Tests
+    needs: setup
+    if: needs.setup.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set Maven args
+        run: |
+          args="-ntp -B"
+          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
+          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+
+      - name: Install artifacts (cache miss)
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
+            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
+            sleep 15
+            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
+          }
+
+      - name: npm install
+        run: npm install --ignore-scripts --silent --quiet --no-progress
+
+      - name: Run WTR tests
+        run: node scripts/wtr.js ${{ needs.setup.outputs.components }}
 
   it:
     name: IT shard ${{ matrix.shard }}
@@ -325,7 +418,7 @@ jobs:
 
   results:
     name: Collect Results
-    needs: [setup, it]
+    needs: [setup, unit-tests, wtr-tests, it]
     if: always() && needs.setup.outputs.skip != 'true' && needs.setup.outputs.has-tests == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -26,16 +26,13 @@ concurrency:
 
 env:
   FORK_COUNT: 4
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  setup:
-    name: Build & Package WAR
+  build:
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      matrix: ${{ steps.shards.outputs.matrix }}
-      has-tests: ${{ steps.shards.outputs.has-tests }}
       skip: ${{ steps.skip-ci.outputs.skip }}
       components: ${{ steps.components.outputs.elements }}
     steps:
@@ -66,8 +63,16 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup JDK 21
+      - name: Restore build cache
+        id: build-cache
         if: steps.skip-ci.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+
+      - name: Setup JDK 21
+        if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
@@ -75,13 +80,13 @@ jobs:
           cache: 'maven'
 
       - name: Setup Node
-        if: steps.skip-ci.outputs.skip != 'true'
+        if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Show environment info
-        if: steps.skip-ci.outputs.skip != 'true'
+        if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
         run: |
           java -version
           mvn -version
@@ -89,24 +94,6 @@ jobs:
           npm --version
           google-chrome --version
           chromedriver --version
-
-      - name: Restore build cache
-        id: build-cache
-        if: steps.skip-ci.outputs.skip != 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install TestBench license
-        if: steps.skip-ci.outputs.skip != 'true' && env.TB_LICENSE != ''
-        env:
-          TB_LICENSE: ${{ secrets.TB_LICENSE }}
-        run: |
-          mkdir -p ~/.vaadin
-          user="${TB_LICENSE%%/*}"
-          key="${TB_LICENSE#*/}"
-          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
 
       - name: Install artifacts
         if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
@@ -150,198 +137,12 @@ jobs:
           fi
           echo "elements=$elements" >> "$GITHUB_OUTPUT"
 
-      - name: npm install
-        if: steps.skip-ci.outputs.skip != 'true'
-        run: npm install --ignore-scripts --silent --quiet --no-progress
-
-      - name: Merge ITs
-        if: steps.skip-ci.outputs.skip != 'true'
-        run: node scripts/mergeITs.js ${{ steps.components.outputs.elements }}
-
-      - name: Package integration-tests WAR
-        if: steps.skip-ci.outputs.skip != 'true'
-        run: |
-          mvn package -pl integration-tests \
-            -Dvaadin.pnpm.enable -Drun-it -Drelease \
-            -Dvaadin.productionMode -Dvaadin.force.production.build=true \
-            -DskipTests -DskipJetty $MAVEN_ARGS
-
-      - name: Compile IT test sources
-        if: steps.skip-ci.outputs.skip != 'true'
-        run: mvn test-compile -pl integration-tests -Drun-it -DskipFrontend -DskipJetty -DskipUnitTests $MAVEN_ARGS
-
-      - name: Compute IT shards
-        id: shards
-        if: steps.skip-ci.outputs.skip != 'true'
-        env:
-          SHARDS: ${{ github.event.inputs.shards || '5' }}
-        run: |
-          mapfile -t its < <(find integration-tests/src/test/java -name '*IT.java' -printf '%P\n' | sed -e 's|/|.|g' -e 's|\.java$||' | sort)
-          count=${#its[@]}
-          echo "Found $count IT classes"
-          if [ "$count" -eq 0 ]; then
-            echo "has-tests=false" >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          n=$SHARDS
-          if [ "$n" -gt "$count" ]; then n=$count; fi
-          declare -a buckets
-          for i in $(seq 1 $n); do buckets[$i]=""; done
-          i=1
-          for t in "${its[@]}"; do
-            if [ -n "${buckets[$i]}" ]; then buckets[$i]+=","; fi
-            buckets[$i]+="$t"
-            i=$((i+1))
-            [ $i -gt $n ] && i=1
-          done
-          json='{"include":['
-          for k in $(seq 1 $n); do
-            [ $k -gt 1 ] && json+=','
-            json+='{"shard":"'"$k"'","tests":"'"${buckets[$k]}"'"}'
-          done
-          json+=']}'
-          echo "$json"
-          echo "matrix=$json" >> "$GITHUB_OUTPUT"
-          echo "has-tests=true" >> "$GITHUB_OUTPUT"
-
-      - name: Package setup bundle
-        if: steps.skip-ci.outputs.skip != 'true' && steps.shards.outputs.has-tests == 'true'
-        run: |
-          tar --zstd -cf it-module.tzst \
-            integration-tests/pom.xml \
-            integration-tests/target/*.war \
-            integration-tests/target/classes \
-            integration-tests/target/test-classes
-          # Only this repo's freshly-installed SNAPSHOT artifacts; framework
-          # release deps come from the setup-java Maven cache in each shard.
-          ( cd "$HOME/.m2/repository" && find com/vaadin -maxdepth 3 -type d -name '*-SNAPSHOT' ) > m2-snapshots.lst
-          tar --zstd -cf m2-vaadin.tzst -C "$HOME/.m2/repository" --files-from=m2-snapshots.lst
-          ls -lh it-module.tzst m2-vaadin.tzst
-
-      - uses: actions/upload-artifact@v6
-        if: steps.skip-ci.outputs.skip != 'true' && steps.shards.outputs.has-tests == 'true'
-        with:
-          name: it-setup-bundle
-          path: |
-            it-module.tzst
-            m2-vaadin.tzst
-          retention-days: 1
-          compression-level: 0
-
   unit-tests:
     name: Unit Tests
-    needs: setup
-    if: needs.setup.outputs.skip != 'true'
+    needs: build
+    if: needs.build.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    steps:
-      - name: Set Maven args
-        run: |
-          args="-ntp -B"
-          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
-          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          fetch-depth: 1
-
-      - name: Setup JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Restore build cache
-        id: build-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install artifacts (cache miss)
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        run: |
-          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
-            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
-            sleep 15
-            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
-          }
-
-      - name: Run unit tests
-        run: mvn test -Drelease -T $FORK_COUNT $MAVEN_ARGS
-
-      - name: Publish unit test results
-        if: always()
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
-        with:
-          name: Unit Tests
-          path: '**/target/surefire-reports/TEST-*.xml'
-          reporter: java-junit
-
-  wtr-tests:
-    name: WTR Tests
-    needs: setup
-    if: needs.setup.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Set Maven args
-        run: |
-          args="-ntp -B"
-          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
-          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          fetch-depth: 1
-
-      - name: Setup JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Restore build cache
-        id: build-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install artifacts (cache miss)
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        run: |
-          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
-            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
-            sleep 15
-            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
-          }
-
-      - name: npm install
-        run: npm install --ignore-scripts --silent --quiet --no-progress
-
-      - name: Run WTR tests
-        run: node scripts/wtr.js ${{ needs.setup.outputs.components }}
-
-  it:
-    name: IT shard ${{ matrix.shard }}
-    needs: setup
-    if: needs.setup.outputs.skip != 'true' && needs.setup.outputs.has-tests == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Set Maven args
         run: |
@@ -371,17 +172,296 @@ jobs:
           key="${TB_LICENSE#*/}"
           echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
 
-      - uses: actions/download-artifact@v6
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@v4
         with:
-          name: it-setup-bundle
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
 
-      - name: Restore setup bundle
+      - name: Install artifacts (cache miss)
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: |
-          tar --zstd -xf it-module.tzst
-          mkdir -p "$HOME/.m2/repository"
-          tar --zstd -xf m2-vaadin.tzst -C "$HOME/.m2/repository"
-          rm -f it-module.tzst m2-vaadin.tzst
-          ls integration-tests/target/*.war
+          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
+            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
+            sleep 15
+            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
+          }
+
+      - name: Run unit tests
+        run: mvn test -Drelease -T $FORK_COUNT $MAVEN_ARGS
+
+      - name: Publish unit test results
+        if: always()
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
+        with:
+          name: Unit Tests
+          path: '**/target/surefire-reports/TEST-*.xml'
+          reporter: java-junit
+
+      - name: Cancel workflow on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+
+  wtr-tests:
+    name: WTR Tests
+    needs: build
+    if: needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set Maven args
+        run: |
+          args="-ntp -B"
+          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
+          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install TestBench license
+        if: env.TB_LICENSE != ''
+        env:
+          TB_LICENSE: ${{ secrets.TB_LICENSE }}
+        run: |
+          mkdir -p ~/.vaadin
+          user="${TB_LICENSE%%/*}"
+          key="${TB_LICENSE#*/}"
+          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
+
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+
+      - name: Install artifacts (cache miss)
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
+            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
+            sleep 15
+            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
+          }
+
+      - name: npm install
+        run: npm install --ignore-scripts
+
+      - name: Run WTR tests
+        run: node scripts/wtr.js ${{ needs.build.outputs.components }}
+
+      - name: Cancel workflow on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+
+  package-war:
+    name: Package WAR
+    needs: build
+    if: needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      matrix: ${{ steps.shards.outputs.matrix }}
+      has-tests: ${{ steps.shards.outputs.has-tests }}
+      war-cache-key: ${{ steps.war-key.outputs.key }}
+    steps:
+      - name: Set Maven args
+        run: |
+          args="-ntp -B"
+          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
+          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: npm install
+        run: npm install --ignore-scripts
+
+      - name: Merge ITs
+        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
+
+      - name: Compute WAR cache key
+        id: war-key
+        env:
+          KEY: ${{ runner.os }}-war-${{ hashFiles('integration-tests/pom.xml', 'integration-tests/src/**') }}
+        run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore WAR cache
+        id: war-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            integration-tests/pom.xml
+            integration-tests/target
+          key: ${{ steps.war-key.outputs.key }}
+
+      - name: Setup JDK 21
+        if: steps.war-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Install TestBench license
+        if: steps.war-cache.outputs.cache-hit != 'true' && env.TB_LICENSE != ''
+        env:
+          TB_LICENSE: ${{ secrets.TB_LICENSE }}
+        run: |
+          mkdir -p ~/.vaadin
+          user="${TB_LICENSE%%/*}"
+          key="${TB_LICENSE#*/}"
+          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
+
+      - name: Restore build cache
+        id: build-cache
+        if: steps.war-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+
+      - name: Install artifacts (cache miss)
+        if: steps.war-cache.outputs.cache-hit != 'true' && steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
+            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
+            sleep 15
+            mvn install -DskipTests -Drelease -T $FORK_COUNT $MAVEN_ARGS
+          }
+
+      - name: Package integration-tests WAR
+        if: steps.war-cache.outputs.cache-hit != 'true'
+        run: |
+          mvn package -pl integration-tests \
+            -Dvaadin.pnpm.enable -Drun-it -Drelease \
+            -Dvaadin.productionMode -Dvaadin.force.production.build=true \
+            -DskipTests -DskipJetty $MAVEN_ARGS
+
+      - name: Compile IT test sources
+        if: steps.war-cache.outputs.cache-hit != 'true'
+        run: mvn test-compile -pl integration-tests -Drun-it -DskipFrontend -DskipJetty -DskipUnitTests $MAVEN_ARGS
+
+      - name: Compute IT shards
+        id: shards
+        env:
+          SHARDS: ${{ github.event.inputs.shards || '0' }}
+          TARGET_PER_SHARD: 35
+          MAX_SHARDS: 10
+        run: |
+          mapfile -t its < <(find integration-tests/src/test/java -name '*IT.java' -printf '%P\n' | sed -e 's|/|.|g' -e 's|\.java$||' | sort)
+          count=${#its[@]}
+          echo "Found $count IT classes"
+          if [ "$count" -eq 0 ]; then
+            echo "has-tests=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          n=$SHARDS
+          if [ "$n" -eq 0 ]; then
+            n=$(( (count + TARGET_PER_SHARD - 1) / TARGET_PER_SHARD ))
+            [ "$n" -lt 1 ] && n=1
+            [ "$n" -gt "$MAX_SHARDS" ] && n=$MAX_SHARDS
+          fi
+          if [ "$n" -gt "$count" ]; then n=$count; fi
+          echo "$n shards for $count classes (~$(( count / n )) per shard)"
+          declare -a buckets
+          for i in $(seq 1 $n); do buckets[$i]=""; done
+          i=1
+          for t in "${its[@]}"; do
+            if [ -n "${buckets[$i]}" ]; then buckets[$i]+=","; fi
+            buckets[$i]+="$t"
+            i=$((i+1))
+            [ $i -gt $n ] && i=1
+          done
+          json='{"include":['
+          for k in $(seq 1 $n); do
+            [ $k -gt 1 ] && json+=','
+            json+='{"shard":"'"$k"'","tests":"'"${buckets[$k]}"'"}'
+          done
+          json+=']}'
+          echo "$json"
+          echo "matrix=$json" >> "$GITHUB_OUTPUT"
+          echo "has-tests=true" >> "$GITHUB_OUTPUT"
+
+  it:
+    name: IT shard ${{ matrix.shard }}
+    needs: package-war
+    if: needs.package-war.outputs.has-tests == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.package-war.outputs.matrix) }}
+    steps:
+      - name: Set Maven args
+        run: |
+          args="-ntp -B"
+          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
+          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Install TestBench license
+        if: env.TB_LICENSE != ''
+        env:
+          TB_LICENSE: ${{ secrets.TB_LICENSE }}
+        run: |
+          mkdir -p ~/.vaadin
+          user="${TB_LICENSE%%/*}"
+          key="${TB_LICENSE#*/}"
+          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/com/vaadin
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+
+      - name: Restore WAR cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            integration-tests/pom.xml
+            integration-tests/target
+          key: ${{ needs.package-war.outputs.war-cache-key }}
+          fail-on-cache-miss: true
 
       - name: Run integration tests (shard ${{ matrix.shard }})
         env:
@@ -418,8 +498,8 @@ jobs:
 
   results:
     name: Collect Results
-    needs: [setup, unit-tests, wtr-tests, it]
-    if: always() && needs.setup.outputs.skip != 'true' && needs.setup.outputs.has-tests == 'true'
+    needs: [build, unit-tests, wtr-tests, package-war, it]
+    if: always() && needs.build.outputs.skip != 'true' && needs.package-war.outputs.has-tests == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -470,7 +550,6 @@ jobs:
         run: |
           gh api --paginate "repos/$GH_REPO/actions/runs/$RUN_ID/artifacts" \
             --jq '.artifacts[] | select(
-              .name == "it-setup-bundle" or
               (.name | startswith("error-screenshots-")) or
               (.name | startswith("failsafe-reports-"))
             ) | "\(.id) \(.name)"' \

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ vite.generated.ts
 /vite.config.ts
 node_modules
 .driver
-package*json
+**/package*json
+!/package.json
+!/package-lock.json
 pnpm*
 .npmrc
 .pnpmfile.cjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,521 @@
+{
+  "name": "vaadin-flow-components",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vaadin-flow-components",
+      "version": "1.0.0",
+      "license": "APACHE",
+      "devDependencies": {
+        "replace-in-file": "6.1.0",
+        "xml2js": "^0.4.23"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/replace-in-file": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.1.0.tgz",
+      "integrity": "sha512-URzjyF3nucvejuY13HFd7O+Q6tFJRLKGHLYVvSh+LiZj3gFXzSYGnIkQflnJJulCAI2/RTZaZkpOtdVdW0EhQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "glob": "^7.1.6",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "replace-in-file": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Restructure the sharded validation workflow from a single monolithic setup job into parallel specialized jobs with build caching.

- Split the setup job into 4 independent jobs: `build`, `unit-tests`, `wtr-tests`, `package-war`
- `build` only does `mvn install -DskipTests` and detects modified components
- `unit-tests`, `wtr-tests`, and `package-war` run in parallel after build
- IT shards start as soon as `package-war` finishes (don't wait for unit/wtr)
- If `unit-tests` or `wtr-tests` fail, the workflow is cancelled (`gh run cancel`)
- Cache `mvn install` output (`actions/cache` with source hash key) to skip rebuilds when source unchanged
- Cache WAR build output (keyed on merged IT content hash) to skip frontend compilation on repeated runs
- IT shards restore both caches instead of downloading a tar artifact
- Auto-compute shard count: `ceil(classes / 35)`, capped at 10 shards
- Add `package-lock.json` to repo and use `npm ci` to satisfy Sonar security rule (S8543)

## Context

The original setup job ran everything sequentially: install, unit tests, WTR tests, WAR packaging, and IT sharding. This meant ITs could not start until all preceding steps finished, and any re-run rebuilt everything from scratch.

With this change, the expensive `mvn install` (~15 min) and WAR build (~5 min) are cached across runs. When source hasn't changed, the build job completes in ~20s. Unit tests and WTR tests run in parallel, and if either fails the entire workflow is cancelled to save runner time.