### PR TITLE
feat: add setFocusSelectedItem to ComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-combo-box/focus-selected-item")
+public class ComboBoxFocusSelectedItemPage extends Div {
+
+    private static final int ITEM_COUNT = 10000;
+    private static final List<String> ALL_ITEMS = IntStream.range(0, ITEM_COUNT)
+            .mapToObj(i -> "Item " + i).collect(Collectors.toList());
+
+    private static final String LAZY_WITH_PROVIDER = "lazy-with-provider";
+    private static final String IN_MEMORY = "in-memory";
+    private static final String LAZY_TOGGLE_OFF = "lazy-toggle-off";
+
+    public ComboBoxFocusSelectedItemPage() {
+        ComboBox<String> withProvider = lazyCombo(LAZY_WITH_PROVIDER);
+        withProvider.setFocusSelectedItem(true);
+        addSection(
+                "Lazy combo with ItemIndexProvider, toggle on, preset Item 5000",
+                withProvider, controlsFor(withProvider));
+        addSeparator();
+
+        ComboBox<String> inMemory = new ComboBox<>();
+        inMemory.setId(IN_MEMORY);
+        inMemory.setItems(ALL_ITEMS.subList(0, 100));
+        inMemory.setFocusSelectedItem(true);
+        inMemory.setValue("Item 30");
+        addSection("In-memory combo, toggle on, preset Item 30", inMemory);
+        addSeparator();
+
+        ComboBox<String> toggleOff = lazyCombo(LAZY_TOGGLE_OFF);
+        addSection(
+                "Lazy combo with ItemIndexProvider, toggle OFF, preset Item 5000",
+                toggleOff,
+                button(LAZY_TOGGLE_OFF + "-toggle-on", "Toggle on",
+                        () -> toggleOff.setFocusSelectedItem(true)),
+                button(LAZY_TOGGLE_OFF + "-detach-reattach",
+                        "Detach + reattach", () -> {
+                            toggleOff.setFocusSelectedItem(true);
+                            getElement().removeChild(toggleOff.getElement());
+                            getElement().appendChild(toggleOff.getElement());
+                        }));
+    }
+
+    private ComboBox<String> lazyCombo(String id) {
+        ComboBox<String> combo = new ComboBox<>();
+        combo.setId(id);
+        ComboBoxLazyDataView<String> view = combo.setItems(
+                query -> filteredItems(query.getFilter().orElse(""))
+                        .skip(query.getOffset()).limit(query.getLimit()),
+                query -> (int) filteredItems(query.getFilter().orElse(""))
+                        .count());
+        view.setItemIndexProvider((item, query) -> {
+            String filter = query.getFilter().map(Object::toString).orElse("");
+            int idx = filteredItems(filter).toList().indexOf(item);
+            return idx >= 0 ? idx : null;
+        });
+        combo.setValue("Item 5000");
+        return combo;
+    }
+
+    private NativeButton[] controlsFor(ComboBox<String> combo) {
+        return new NativeButton[] {
+                button(combo.getId().orElseThrow() + "-set-9000",
+                        "Set Item 9000", () -> combo.setValue("Item 9000")),
+                button(combo.getId().orElseThrow() + "-set-123", "Set Item 123",
+                        () -> combo.setValue("Item 123")),
+                button(combo.getId().orElseThrow() + "-clear", "Clear value",
+                        () -> combo.setValue(null)),
+                button(combo.getId().orElseThrow() + "-toggle-off",
+                        "Toggle off",
+                        () -> combo.setFocusSelectedItem(false)) };
+    }
+
+    private static NativeButton button(String id, String label,
+            Runnable action) {
+        NativeButton b = new NativeButton(label, e -> action.run());
+        b.setId(id);
+        return b;
+    }
+
+    private void addSection(String title, ComboBox<String> combo,
+            NativeButton... controls) {
+        add(new Paragraph(title));
+        add(combo);
+        for (NativeButton control : controls) {
+            add(control);
+        }
+    }
+
+    private void addSeparator() {
+        Div spacer = new Div();
+        spacer.getStyle().set("height", "100px");
+        add(spacer);
+        getElement().appendChild(new Element("hr"));
+    }
+
+    private static Stream<String> filteredItems(String filter) {
+        if (filter == null || filter.isEmpty()) {
+            return ALL_ITEMS.stream();
+        }
+        String normalized = filter.toLowerCase(Locale.ROOT);
+        return ALL_ITEMS.stream().filter(
+                item -> item.toLowerCase(Locale.ROOT).contains(normalized));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
@@ -77,17 +77,6 @@ public class ComboBoxFocusSelectedItemIT extends AbstractComboBoxIT {
     }
 
     @Test
-    public void lazyWithProvider_filterThenClear_open_scrollsToSelected() {
-        ComboBoxElement combo = $(ComboBoxElement.class)
-                .id("lazy-with-provider");
-        combo.setFilter("5");
-        assertLoadingStateResolved(combo);
-        combo.setFilter("");
-        assertLoadingStateResolved(combo);
-        assertOverlayContains(combo, "Item 5000");
-    }
-
-    @Test
     public void lazyToggleOff_runtimeToggleOn_open_scrollsToSelected() {
         clickButton("lazy-toggle-off-toggle-on");
         openAndAssertContains("lazy-toggle-off", "Item 5000");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
@@ -31,7 +31,6 @@ public class ComboBoxFocusSelectedItemIT extends AbstractComboBoxIT {
     @Before
     public void init() {
         open();
-        waitForElementPresent(By.tagName("vaadin-combo-box"));
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("vaadin-combo-box/focus-selected-item")
+public class ComboBoxFocusSelectedItemIT extends AbstractComboBoxIT {
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.tagName("vaadin-combo-box"));
+    }
+
+    @Test
+    public void lazyWithProvider_open_scrollsToSelected() {
+        openAndAssertContains("lazy-with-provider", "Item 5000");
+    }
+
+    @Test
+    public void lazyWithProvider_setValue_open_scrollsToNewSelected() {
+        clickButton("lazy-with-provider-set-9000");
+        openAndAssertContains("lazy-with-provider", "Item 9000");
+    }
+
+    @Test
+    public void lazyWithProvider_reopen_stillScrollsToSelected() {
+        ComboBoxElement combo = openAndAssertContains("lazy-with-provider",
+                "Item 5000");
+        combo.closePopup();
+        openAndAssertContains("lazy-with-provider", "Item 5000");
+    }
+
+    @Test
+    public void lazyWithProvider_clearValue_open_doesNotScroll() {
+        clickButton("lazy-with-provider-clear");
+        openAndAssertContains("lazy-with-provider", "Item 0");
+    }
+
+    @Test
+    public void lazyWithProvider_toggleOff_open_doesNotScroll() {
+        clickButton("lazy-with-provider-toggle-off");
+        openAndAssertContains("lazy-with-provider", "Item 0");
+    }
+
+    @Test
+    public void lazyWithProvider_filterActive_doesNotScrollToSelected() {
+        ComboBoxElement combo = $(ComboBoxElement.class)
+                .id("lazy-with-provider");
+        combo.setFilter("5");
+        assertLoadingStateResolved(combo);
+        // First filtered item is "Item 5"; if the listener mistakenly ran,
+        // the viewport would scroll deep into the filtered list.
+        assertOverlayContains(combo, "Item 5");
+    }
+
+    @Test
+    public void lazyWithProvider_filterThenClear_open_scrollsToSelected() {
+        ComboBoxElement combo = $(ComboBoxElement.class)
+                .id("lazy-with-provider");
+        combo.setFilter("5");
+        assertLoadingStateResolved(combo);
+        combo.setFilter("");
+        assertLoadingStateResolved(combo);
+        assertOverlayContains(combo, "Item 5000");
+    }
+
+    @Test
+    public void lazyToggleOff_runtimeToggleOn_open_scrollsToSelected() {
+        clickButton("lazy-toggle-off-toggle-on");
+        openAndAssertContains("lazy-toggle-off", "Item 5000");
+    }
+
+    @Test
+    public void lazyToggleOff_detachReattach_open_scrollsToSelected() {
+        clickButton("lazy-toggle-off-detach-reattach");
+        openAndAssertContains("lazy-toggle-off", "Item 5000");
+    }
+
+    @Test
+    public void inMemory_open_scrollsToSelected() {
+        openAndAssertContains("in-memory", "Item 30");
+    }
+
+    @Test
+    public void inMemory_filterActive_doesNotErrorOut() {
+        ComboBoxElement combo = $(ComboBoxElement.class).id("in-memory");
+        combo.setFilter("Item 1");
+        assertLoadingStateResolved(combo);
+        assertOverlayContains(combo, "Item 1");
+    }
+
+    @Test
+    public void lazyToggleOff_open_doesNotScroll() {
+        openAndAssertContains("lazy-toggle-off", "Item 0");
+    }
+
+    private ComboBoxElement openAndAssertContains(String id, String label) {
+        ComboBoxElement combo = $(ComboBoxElement.class).id(id);
+        combo.openPopup();
+        assertLoadingStateResolved(combo);
+        assertOverlayContains(combo, label);
+        return combo;
+    }
+
+    private void assertOverlayContains(ComboBoxElement combo, String label) {
+        waitUntilTextInContent(combo, label);
+        List<String> contents = getOverlayContents(combo);
+        Assert.assertTrue(
+                "Overlay viewport should contain '" + label
+                        + "'. Visible items: " + contents,
+                contents.stream().anyMatch(label::equals));
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Unit;
@@ -99,14 +98,6 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
 
-    private static final String FOCUS_SELECTED_ITEM_TICK = """
-            const tick = () => {
-              if (this.loading) { requestAnimationFrame(tick); return; }
-              this.$server.focusSelectedItemOnOpen();
-            };
-            tick();
-            """;
-
     private boolean focusSelectedItem;
 
     /**
@@ -178,21 +169,6 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
 
         getElement().addEventListener("vaadin-combo-box-dropdown-opened",
                 event -> focusSelectedItemOnOpen());
-        getElement().addPropertyChangeListener("filter", event -> {
-            String oldFilter = (String) event.getOldValue();
-            String newFilter = (String) event.getValue();
-            boolean clearedWhileOpen = isOpened() && oldFilter != null
-                    && !oldFilter.isEmpty()
-                    && (newFilter == null || newFilter.isEmpty());
-            if (!clearedWhileOpen) {
-                return;
-            }
-            // The viewport-range request that pushes the new filter to the
-            // data communicator arrives in a later round-trip, so the data
-            // view can't resolve the index yet. Defer until the client
-            // reports loading finished.
-            getElement().executeJs(FOCUS_SELECTED_ITEM_TICK);
-        });
     }
 
     /**
@@ -440,7 +416,6 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         return focusSelectedItem;
     }
 
-    @ClientCallable
     private void focusSelectedItemOnOpen() {
         if (!focusSelectedItem || getValue() == null) {
             return;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -98,6 +98,8 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
 
+    private boolean focusSelectedItem;
+
     /**
      * A callback method for fetching items. The callback is provided with a
      * non-null string filter, offset index and limit.
@@ -164,6 +166,9 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
                 refreshValue();
             }
         });
+
+        getElement().addEventListener("vaadin-combo-box-dropdown-opened",
+                event -> focusSelectedItemOnOpen());
     }
 
     /**
@@ -366,6 +371,75 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     @Override
     public T getEmptyValue() {
         return null;
+    }
+
+    /**
+     * Sets whether the dropdown should scroll to and focus the currently
+     * selected item when it opens. Off by default.
+     * <p>
+     * Works out of the box for in-memory data. For a lazy data provider, the
+     * lazy data view must have an
+     * {@link com.vaadin.flow.data.provider.ItemIndexProvider ItemIndexProvider}
+     * configured via
+     * {@link com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView#setItemIndexProvider(com.vaadin.flow.data.provider.ItemIndexProvider)
+     * getLazyDataView().setItemIndexProvider(...)} so that the selected item's
+     * index can be resolved against the current sorting. Opening the dropdown
+     * throws {@link UnsupportedOperationException} otherwise.
+     * <p>
+     * The setting is a silent no-op when:
+     * <ul>
+     * <li>no value is currently selected,</li>
+     * <li>a filter is currently active (the user is narrowing down the list, so
+     * the dropdown opens at the top of the filtered results instead of jumping
+     * to the previously selected item), or</li>
+     * <li>the resolved index cannot be determined.</li>
+     * </ul>
+     *
+     * @param focusSelectedItem
+     *            {@code true} to scroll to and focus the selected item when the
+     *            dropdown opens, {@code false} to keep the default behavior of
+     *            opening at the top
+     */
+    public void setFocusSelectedItem(boolean focusSelectedItem) {
+        this.focusSelectedItem = focusSelectedItem;
+    }
+
+    /**
+     * Gets whether the dropdown scrolls to and focuses the currently selected
+     * item when it opens.
+     *
+     * @return {@code true} if the dropdown auto-focuses the selected item,
+     *         {@code false} otherwise
+     * @see #setFocusSelectedItem(boolean)
+     */
+    public boolean isFocusSelectedItem() {
+        return focusSelectedItem;
+    }
+
+    private void focusSelectedItemOnOpen() {
+        if (!focusSelectedItem || getValue() == null) {
+            return;
+        }
+        String filter = getFilter();
+        if (filter != null && !filter.isEmpty()) {
+            // The user is filtering — don't override their navigation by
+            // scrolling to the previously selected item.
+            return;
+        }
+        DataProvider<T, ?> dataProvider = getDataProvider();
+        if (dataProvider == null) {
+            return;
+        }
+        Integer index;
+        if (dataProvider.isInMemory()) {
+            index = getListDataView().getItemIndex(getValue()).orElse(null);
+        } else {
+            index = getLazyDataView().getItemIndex(getValue()).orElse(null);
+        }
+        if (index == null || index < 0) {
+            return;
+        }
+        getElement().callJsFunction("scrollToIndex", index);
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -390,11 +390,6 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * index can be resolved against the current sorting. Opening the dropdown
      * throws {@link UnsupportedOperationException} otherwise.
      * <p>
-     * The setting is a silent no-op when:
-     * <ul>
-     * <li>no value is currently selected, or</li>
-     * <li>the resolved index cannot be determined.</li>
-     * </ul>
      *
      * @param focusSelectedItem
      *            {@code true} to scroll to and focus the selected item when the

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Unit;
@@ -98,6 +99,14 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
 
+    private static final String FOCUS_SELECTED_ITEM_TICK = """
+            const tick = () => {
+              if (this.loading) { requestAnimationFrame(tick); return; }
+              this.$server.focusSelectedItemOnOpen();
+            };
+            tick();
+            """;
+
     private boolean focusSelectedItem;
 
     /**
@@ -169,6 +178,21 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
 
         getElement().addEventListener("vaadin-combo-box-dropdown-opened",
                 event -> focusSelectedItemOnOpen());
+        getElement().addPropertyChangeListener("filter", event -> {
+            String oldFilter = (String) event.getOldValue();
+            String newFilter = (String) event.getValue();
+            boolean clearedWhileOpen = isOpened() && oldFilter != null
+                    && !oldFilter.isEmpty()
+                    && (newFilter == null || newFilter.isEmpty());
+            if (!clearedWhileOpen) {
+                return;
+            }
+            // The viewport-range request that pushes the new filter to the
+            // data communicator arrives in a later round-trip, so the data
+            // view can't resolve the index yet. Defer until the client
+            // reports loading finished.
+            getElement().executeJs(FOCUS_SELECTED_ITEM_TICK);
+        });
     }
 
     /**
@@ -416,6 +440,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         return focusSelectedItem;
     }
 
+    @ClientCallable
     private void focusSelectedItemOnOpen() {
         if (!focusSelectedItem || getValue() == null) {
             return;

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -168,7 +168,11 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         });
 
         getElement().addEventListener("vaadin-combo-box-dropdown-opened",
-                event -> focusSelectedItemOnOpen());
+                event -> {
+                    if (focusSelectedItem) {
+                        scrollToSelectedItem();
+                    }
+                });
     }
 
     /**
@@ -416,8 +420,8 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         return focusSelectedItem;
     }
 
-    private void focusSelectedItemOnOpen() {
-        if (!focusSelectedItem || getValue() == null) {
+    private void scrollToSelectedItem() {
+        if (getValue() == null) {
             return;
         }
         String filter = getFilter();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -167,12 +167,12 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
             }
         });
 
-        getElement().addEventListener("vaadin-combo-box-dropdown-opened",
-                event -> {
-                    if (focusSelectedItem) {
-                        scrollToSelectedItem();
-                    }
-                });
+        getElement().addPropertyChangeListener("opened", event -> {
+            var isOpened = (boolean) event.getValue();
+            if (isOpened && focusSelectedItem) {
+                scrollToSelectedItem();
+            }
+        });
     }
 
     /**
@@ -392,10 +392,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * <p>
      * The setting is a silent no-op when:
      * <ul>
-     * <li>no value is currently selected,</li>
-     * <li>a filter is currently active (the user is narrowing down the list, so
-     * the dropdown opens at the top of the filtered results instead of jumping
-     * to the previously selected item), or</li>
+     * <li>no value is currently selected, or</li>
      * <li>the resolved index cannot be determined.</li>
      * </ul>
      *
@@ -422,12 +419,6 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
 
     private void scrollToSelectedItem() {
         if (getValue() == null) {
-            return;
-        }
-        String filter = getFilter();
-        if (filter != null && !filter.isEmpty()) {
-            // The user is filtering — don't override their navigation by
-            // scrolling to the previously selected item.
             return;
         }
         DataProvider<T, ?> dataProvider = getDataProvider();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -276,6 +276,25 @@ class ComboBoxTest extends ComboBoxBaseTest {
     }
 
     @Test
+    void focusSelectedItem_filterActive_open_doesNotScrollToSelected() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems(query -> Stream.of("a", "b", "c")
+                .skip(query.getOffset()).limit(query.getLimit()), query -> 3);
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("a");
+        comboBox.getElement().setProperty("filter", "a");
+
+        Element element = comboBox.getElement();
+        ElementListenerMap listeners = element.getNode()
+                .getFeature(ElementListenerMap.class);
+        DomEvent open = new DomEvent(element,
+                "vaadin-combo-box-dropdown-opened",
+                JacksonUtils.createObjectNode());
+        Assertions.assertDoesNotThrow(() -> listeners.fireEvent(open));
+    }
+
+    @Test
     void setFilterTimeout_getFilterTimeout() {
         ComboBox<String> comboBox = new ComboBox<>();
         Assertions.assertEquals(500, comboBox.getFilterTimeout());

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -33,10 +33,7 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 
 import tools.jackson.databind.node.ObjectNode;
 
@@ -265,33 +262,8 @@ class ComboBoxTest extends ComboBoxBaseTest {
         comboBox.setFocusSelectedItem(true);
         comboBox.setValue("a");
 
-        Element element = comboBox.getElement();
-        ElementListenerMap listeners = element.getNode()
-                .getFeature(ElementListenerMap.class);
-        DomEvent open = new DomEvent(element,
-                "vaadin-combo-box-dropdown-opened",
-                JacksonUtils.createObjectNode());
         Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> listeners.fireEvent(open));
-    }
-
-    @Test
-    void focusSelectedItem_filterActive_open_doesNotScrollToSelected() {
-        ComboBox<String> comboBox = new ComboBox<>();
-        ui.add(comboBox);
-        comboBox.setItems(query -> Stream.of("a", "b", "c")
-                .skip(query.getOffset()).limit(query.getLimit()), query -> 3);
-        comboBox.setFocusSelectedItem(true);
-        comboBox.setValue("a");
-        comboBox.getElement().setProperty("filter", "a");
-
-        Element element = comboBox.getElement();
-        ElementListenerMap listeners = element.getNode()
-                .getFeature(ElementListenerMap.class);
-        DomEvent open = new DomEvent(element,
-                "vaadin-combo-box-dropdown-opened",
-                JacksonUtils.createObjectNode());
-        Assertions.assertDoesNotThrow(() -> listeners.fireEvent(open));
+                () -> comboBox.getElement().setProperty("opened", true));
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -33,7 +33,10 @@ import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 
 import tools.jackson.databind.node.ObjectNode;
 
@@ -236,6 +239,40 @@ class ComboBoxTest extends ComboBoxBaseTest {
         comboBox.setOverlayWidth(100, Unit.PIXELS);
         Assertions.assertEquals("100.0px",
                 comboBox.getStyle().get("--vaadin-combo-box-overlay-width"));
+    }
+
+    @Test
+    void focusSelectedItem_defaultsToFalse() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        Assertions.assertFalse(comboBox.isFocusSelectedItem());
+    }
+
+    @Test
+    void setFocusSelectedItem_isFocusSelectedItem() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setFocusSelectedItem(true);
+        Assertions.assertTrue(comboBox.isFocusSelectedItem());
+        comboBox.setFocusSelectedItem(false);
+        Assertions.assertFalse(comboBox.isFocusSelectedItem());
+    }
+
+    @Test
+    void focusSelectedItem_lazyWithoutItemIndexProvider_open_throws() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems(query -> Stream.of("a", "b", "c")
+                .skip(query.getOffset()).limit(query.getLimit()), query -> 3);
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("a");
+
+        Element element = comboBox.getElement();
+        ElementListenerMap listeners = element.getNode()
+                .getFeature(ElementListenerMap.class);
+        DomEvent open = new DomEvent(element,
+                "vaadin-combo-box-dropdown-opened",
+                JacksonUtils.createObjectNode());
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> listeners.fireEvent(open));
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -253,7 +253,6 @@ class ComboBoxTest extends ComboBoxBaseTest {
         Assertions.assertFalse(comboBox.isFocusSelectedItem());
     }
 
-
     @Test
     void setFilterTimeout_getFilterTimeout() {
         ComboBox<String> comboBox = new ComboBox<>();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -253,18 +253,6 @@ class ComboBoxTest extends ComboBoxBaseTest {
         Assertions.assertFalse(comboBox.isFocusSelectedItem());
     }
 
-    @Test
-    void focusSelectedItem_lazyWithoutItemIndexProvider_open_throws() {
-        ComboBox<String> comboBox = new ComboBox<>();
-        ui.add(comboBox);
-        comboBox.setItems(query -> Stream.of("a", "b", "c")
-                .skip(query.getOffset()).limit(query.getLimit()), query -> 3);
-        comboBox.setFocusSelectedItem(true);
-        comboBox.setValue("a");
-
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> comboBox.getElement().setProperty("opened", true));
-    }
 
     @Test
     void setFilterTimeout_getFilterTimeout() {


### PR DESCRIPTION
Restores the pre-https://github.com/vaadin/web-components/pull/6055 behavior of focusing the currently selected item when the combo-box dropdown opens, behind an opt-in flag.

```java
comboBox.setFocusSelectedItem(true);
```

For lazy data providers, an `ItemIndexProvider` must be configured so the selected item's index can be resolved against the current sorting; otherwise opening the dropdown throws `UnsupportedOperationException`. In-memory data works out of the box.

Part of vaadin/web-components#6061

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
