### PR TITLE
fix: Make SpreadsheetOverlay native popover

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
@@ -18,7 +18,7 @@ import com.vaadin.client.ui.VOverlay;
  * A VOverlay Implementation that attaches the overlay to the container added by
  * vaadin-spreadsheet webcomponent
  */
-@SuppressWarnings({ "deprecation", "java:S1699"} )
+@SuppressWarnings({ "deprecation", "java:S1699" })
 public class SpreadsheetOverlay extends VOverlay {
 
     private static final String POPOVER_ATTRIBUTE = "popover";

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
@@ -21,14 +21,17 @@ import com.vaadin.client.ui.VOverlay;
 @SuppressWarnings("deprecation")
 public class SpreadsheetOverlay extends VOverlay {
 
+    private static final String POPOVER_ATTRIBUTE = "popover";
+
     /**
      * A VContextMenu Implementation that attaches the overlay to the container
      * added by vaadin-spreadsheet webcomponent
      */
     public static class SpreadsheetContextMenu extends VContextMenu {
+
         public SpreadsheetContextMenu() {
             DOM.setElementProperty(getElement(), "id", "PID_VAADIN_CM");
-            getElement().setAttribute("popover", "manual");
+            setPopover(getElement());
         }
 
         @Override
@@ -51,17 +54,23 @@ public class SpreadsheetOverlay extends VOverlay {
 
     public SpreadsheetOverlay() {
         super();
-        getElement().setAttribute("popover", "manual");
+        setPopover(getElement());
     }
 
     public SpreadsheetOverlay(boolean autoHide, boolean modal) {
         super(autoHide, modal);
-        getElement().setAttribute("popover", "manual");
+        setPopover(getElement());
     }
 
     public SpreadsheetOverlay(boolean autoHide) {
         super(autoHide);
-        getElement().setAttribute("popover", "manual");
+        setPopover(getElement());
+    }
+
+    private static void setPopover(Element el) {
+        if (el != null) {
+            el.setAttribute(POPOVER_ATTRIBUTE, "manual");
+        }
     }
 
     @Override

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
@@ -28,11 +28,24 @@ public class SpreadsheetOverlay extends VOverlay {
     public static class SpreadsheetContextMenu extends VContextMenu {
         public SpreadsheetContextMenu() {
             DOM.setElementProperty(getElement(), "id", "PID_VAADIN_CM");
+            getElement().setAttribute("popover", "manual");
         }
 
         @Override
         public Element getOverlayContainer() {
             return getOverlayContainerElement();
+        }
+
+        @Override
+        public void show() {
+            super.show();
+            showPopover(getElement());
+        }
+
+        @Override
+        public void showAt(int x, int y) {
+            super.showAt(x, y);
+            showPopover(getElement());
         }
     }
 
@@ -68,7 +81,7 @@ public class SpreadsheetOverlay extends VOverlay {
     }
 
     // @formatter:off
-    private native void showPopover(Element el) 
+    private static native void showPopover(Element el) 
     /*-{
         var fn = el && el.showPopover;
         if (typeof fn === "function") {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
@@ -38,14 +38,23 @@ public class SpreadsheetOverlay extends VOverlay {
 
     public SpreadsheetOverlay() {
         super();
+        getElement().setAttribute("popover", "manual");
     }
 
     public SpreadsheetOverlay(boolean autoHide, boolean modal) {
         super(autoHide, modal);
+        getElement().setAttribute("popover", "manual");
     }
 
     public SpreadsheetOverlay(boolean autoHide) {
         super(autoHide);
+        getElement().setAttribute("popover", "manual");
+    }
+
+    @Override
+    public void show() {
+        super.show();
+        showPopover(getElement());
     }
 
     @Override
@@ -57,4 +66,14 @@ public class SpreadsheetOverlay extends VOverlay {
         Element overlays = DOM.getElementById("spreadsheet-overlays");
         return overlays == null ? RootPanel.getBodyElement() : overlays;
     }
+
+    // @formatter:off
+    private native void showPopover(Element el) 
+    /*-{
+        var fn = el && el.showPopover;
+        if (typeof fn === "function") {
+            fn.call(el);
+        }
+    }-*/;
+    // @formatter:on
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetOverlay.java
@@ -18,7 +18,7 @@ import com.vaadin.client.ui.VOverlay;
  * A VOverlay Implementation that attaches the overlay to the container added by
  * vaadin-spreadsheet webcomponent
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({ "deprecation", "java:S1699"} )
 public class SpreadsheetOverlay extends VOverlay {
 
     private static final String POPOVER_ATTRIBUTE = "popover";

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetDialogPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetDialogPage.java
@@ -1,0 +1,114 @@
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import java.util.GregorianCalendar;
+
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.DataFormat;
+import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFRichTextString;
+
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet.SpreadsheetTheme;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetFilterTable;
+import com.vaadin.flow.component.spreadsheet.framework.Action;
+import com.vaadin.flow.component.spreadsheet.framework.Action.Handler;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@Route("spreadsheet-dialog")
+@PageTitle("Demo")
+public class SpreadsheetDialogPage extends VerticalLayout {
+
+    public SpreadsheetDialogPage() {
+        Spreadsheet spreadsheet = new Spreadsheet();
+        spreadsheet.setTheme(SpreadsheetTheme.LUMO);
+        spreadsheet.setHeight("400px");
+        spreadsheet.createFreezePane(2, 1);
+        spreadsheet.setSheetName(0, "First");
+
+        Drawing<?> drawing = spreadsheet.getActiveSheet()
+                .createDrawingPatriarch();
+        CreationHelper factory = spreadsheet.getActiveSheet().getWorkbook()
+                .getCreationHelper();
+
+        ClientAnchor anchor = factory.createClientAnchor();
+        Comment comment = drawing.createCellComment(anchor);
+        comment.setString(new XSSFRichTextString("First cell comment"));
+
+        spreadsheet.createCell(0, 0, "cell").setCellComment(comment);
+
+        // Define a cell style for dates
+        CellStyle dateStyle = spreadsheet.getWorkbook().createCellStyle();
+        DataFormat format = spreadsheet.getWorkbook().createDataFormat();
+        dateStyle.setDataFormat(format.getFormat("yyyy-mm-dd"));
+
+        // Add some data rows
+        spreadsheet.createCell(1, 0, "Nicolaus");
+        spreadsheet.createCell(1, 1, "Copernicus");
+        spreadsheet.createCell(1, 2,
+                new GregorianCalendar(1999, 2, 19).getTime());
+
+        // Style the date cell
+        spreadsheet.getCell(1, 2).setCellStyle(dateStyle);
+
+        spreadsheet.createNewSheet("Second", 10, 10);
+
+        int maxColumns = 5;
+        int maxRows = 5;
+
+        for (int column = 1; column < maxColumns + 1; column++) {
+            spreadsheet.createCell(1, column, "Column " + column);
+        }
+
+        for (int row = 2; row < maxRows + 2; row++) {
+            for (int col = 1; col < maxColumns + 1; col++) {
+                spreadsheet.createCell(row, col, row + col);
+            }
+        }
+        CellRangeAddress range = new CellRangeAddress(1, maxRows, 1,
+                maxColumns);
+        SpreadsheetFilterTable table = new SpreadsheetFilterTable(spreadsheet,
+                range);
+        spreadsheet.registerTable(table);
+        spreadsheet.refreshAllCellValues();
+
+        spreadsheet.setSelectionRange(2, 7, 2 + 5, 7 + 3);
+
+        var action0 = new Action("Test", VaadinIcon.ABACUS.create());
+        var action1 = new Action("Other", VaadinIcon.CARET_DOWN.create());
+        spreadsheet.getContextMenuManager().addActionHandler(new Handler() {
+
+            @Override
+            public Action[] getActions(Object target, Object sender) {
+                Action[] actions = new Action[2];
+                actions[0] = action0;
+                actions[1] = action1;
+                return actions;
+            }
+
+            @Override
+            public void handleAction(Action action, Object sender,
+                    Object target) {
+                if (action == action0) {
+                    System.out.println("Test!");
+                } else if (action == action1) {
+                    System.out.println("Other!");
+                }
+            }
+
+        });
+
+        Dialog dialog = new Dialog();
+        dialog.add(spreadsheet);
+        dialog.setSizeFull();
+        dialog.open();
+    }
+
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetDialogPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetDialogPage.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
 package com.vaadin.flow.component.spreadsheet.tests;
 
 import java.util.GregorianCalendar;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet-styles.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet-styles.js
@@ -1520,6 +1520,7 @@ export const spreadsheetOverlayStyles = css`
     white-space: pre-wrap;
   }
   #spreadsheet-overlays .v-contextmenu {
+    border: unset;
     padding: 4px 4px;
     border-radius: 4px;
     background-color: white;
@@ -1574,6 +1575,7 @@ export const spreadsheetOverlayStyles = css`
   }
 
   #spreadsheet-overlays .v-spreadsheet-comment-overlay {
+    border: unset;
     padding: 4px 4px;
     border-radius: 4px;
     background-color: white;
@@ -1630,6 +1632,7 @@ export const spreadsheetOverlayStyles = css`
     margin-bottom: 7px;
   }
   #spreadsheet-overlays .v-spreadsheet-popupbutton-overlay {
+    border: unset;
     padding: 4px 4px;
     border-radius: 4px;
     background-color: var(--lumo-base-color, #fff);


### PR DESCRIPTION
Fixes #9240 

Note1: Spreadsheet tabs initial alignment is wrong if the first tab is not the selected one when Spreadsheet is placed on Dialog. This is not regression from this PR, but a different bug that needs to be addressed separately.

Note2: When Spreadsheet is in Dialog, inserting comment does not work. This is not regression from this PR, as inserting comment after this PR still works, when Spreadsheet is not in Dialog. This is different bug that needs to be address separately.

- Actually these bugs happen also with Vaadin 24.10, so they are not regressions from Dialog's native popover refactor. 