### PR TITLE
test: remove pointer-events check in ButtonIT

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -203,10 +203,6 @@ public class ButtonIT extends AbstractComponentIT {
         Assert.assertFalse("The button should contain the 'disabled' attribute",
                 button.isEnabled());
 
-        // valo theme adds the pointer-events: none CSS property, which makes
-        // the button unclickable by selenium.
-        Assert.assertEquals("none", button.getCssValue("pointer-events"));
-
         WebElement message = layout.findElement(By.id("buttonMessage"));
         Assert.assertEquals("", message.getText());
 


### PR DESCRIPTION
The `clickOnDisabledButton_nothingIsDisplayed` test asserts `pointer-events: none` on disabled buttons. With the `accessibleDisabledButtons` feature flag enabled, the value is `auto`, breaking the snapshot build:

```
org.junit.ComparisonFailure: expected:<[none]> but was:<[auto]>
  at com.vaadin.flow.component.button.tests.ButtonIT.clickOnDisabledButton_nothingIsDisplayed(ButtonIT.java:208)
```

Asserting CSS values is out of scope for this IT: the test only needs to verify that clicking a disabled button does not trigger its handler, which the empty message check already covers.

---

🤖 Generated with Claude Code