### PR TITLE
chore: remove invalid list-files from sharded workflow

### DIFF
--- a/.github/workflows/validation-sharded.yml
+++ b/.github/workflows/validation-sharded.yml
@@ -199,7 +199,6 @@ jobs:
           path: '**/target/surefire-reports/TEST-*.xml'
           reporter: java-junit
           collapsed: 'always'
-          list-files: 'failed'
           list-tests: 'failed'
           list-suites: 'failed'
 
@@ -534,7 +533,6 @@ jobs:
           path: failsafe-reports/TEST-*.xml
           reporter: java-junit
           collapsed: 'always'
-          list-files: 'failed'
           list-tests: 'failed'
           list-suites: 'failed'
 


### PR DESCRIPTION
`list-files` is not a valid input for `dorny/test-reporter`. Removing avoids spurious workflow warnings.

<img width="671" height="595" alt="image" src="https://github.com/user-attachments/assets/b9111bac-60c1-4274-baf0-ab94df45a44b" />


Follow-up to #9230

---

🤖 Generated with Claude Code