### PR TITLE
chore: replace blur() helper with Keys.TAB/ENTER in tests

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -437,15 +437,6 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     }
 
     /**
-     * Calls the {@code blur()} function on the current active element of the
-     * page, if any.
-     */
-    public void blur() {
-        executeScript(
-                "!!document.activeElement ? document.activeElement.blur() : 0");
-    }
-
-    /**
      * Gets a property value from a web element using JavaScript.
      */
     public String getProperty(WebElement element, String propertyName) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridPageSizePageIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridPageSizePageIT.java
@@ -48,7 +48,6 @@ public class GridPageSizePageIT extends AbstractComponentIT {
         WebElement button = findElement(By.id("size-submit"));
 
         input.sendKeys("80");
-        blur();
         button.click();
 
         assertPageSize(grid, 80);
@@ -56,7 +55,6 @@ public class GridPageSizePageIT extends AbstractComponentIT {
 
         input.clear();
         input.sendKeys("10");
-        blur();
         button.click();
 
         assertPageSize(grid, 10);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewBasicFeaturesIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewBasicFeaturesIT.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -41,8 +42,7 @@ public class GridViewBasicFeaturesIT extends AbstractComponentIT {
 
         TestBenchElement filteringField = grid
                 .findElement(By.tagName("vaadin-text-field"));
-        filteringField.sendKeys("sek");
-        blur();
+        filteringField.sendKeys("sek", Keys.ENTER);
 
         Assert.assertTrue(
                 "The first company name should contain the applied filter string",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
@@ -55,8 +56,7 @@ public class TreeGridPageSizeIT extends AbstractTreeGridIT {
         WebElement input = findElement(By.id("size-input"));
         WebElement button = findElement(By.id("size-submit"));
 
-        input.sendKeys("80");
-        blur();
+        input.sendKeys("80", Keys.ENTER);
         button.click();
 
         // assert here only minimum required fetches
@@ -74,8 +74,7 @@ public class TreeGridPageSizeIT extends AbstractTreeGridIT {
         clearLog();
 
         input.clear();
-        input.sendKeys("10");
-        blur();
+        input.sendKeys("10", Keys.ENTER);
         button.click();
 
         // assert here only minimum required fetches

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -152,7 +152,6 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
 
         WebElement input = field.$("input").first();
         input.sendKeys("300");
-        blur();
 
         field.clickClearButton();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.textfield.BigDecimalField;
@@ -151,7 +152,7 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
         field = $(BigDecimalFieldElement.class).id("clear-big-decimal-field");
 
         WebElement input = field.$("input").first();
-        input.sendKeys("300");
+        input.sendKeys("300", Keys.TAB);
 
         field.clickClearButton();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldPageIT.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.textfield.EmailField;
@@ -100,8 +101,7 @@ public class EmailFieldPageIT extends AbstractComponentIT {
                 .id("clear-email-field");
 
         WebElement input = field.$("input").first();
-        input.sendKeys("foo");
-        blur();
+        input.sendKeys("foo", Keys.ENTER);
 
         field.clickClearButton();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldPageIT.java
@@ -108,8 +108,7 @@ public class IntegerFieldPageIT extends AbstractComponentIT {
         field = $(IntegerFieldElement.class).id("clear-integer-field");
 
         WebElement input = field.$("input").first();
-        input.sendKeys("300");
-        blur();
+        input.sendKeys("300", Keys.ENTER);
 
         field.clickClearButton();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldPageIT.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.textfield.NumberField;
@@ -107,8 +108,7 @@ public class NumberFieldPageIT extends AbstractComponentIT {
                 .id("clear-number-field");
 
         WebElement input = field.$("input").first();
-        input.sendKeys("300");
-        blur();
+        input.sendKeys("300", Keys.ENTER);
 
         field.clickClearButton();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldPageIT.java
@@ -78,8 +78,7 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
 
         executeScript("arguments[0].removeAttribute(\"disabled\");",
                 passwordField);
-        passwordField.sendKeys("abc");
-        blur();
+        passwordField.sendKeys("abc", Keys.ENTER);
 
         message = findElement(By.id("disabled-password-field-message"));
         Assert.assertEquals("", message.getText());
@@ -106,25 +105,21 @@ public class PasswordFieldPageIT extends AbstractComponentIT {
         WebElement passwordField = findElement(
                 By.id("password-field-with-value-change-listener"));
 
-        updateValues(passwordFieldValueDiv, passwordField, true);
+        passwordField.sendKeys("a", Keys.TAB);
+        waitUntilTextsEqual("Password field value changed from '' to 'a'",
+                passwordFieldValueDiv);
+
+        passwordField.sendKeys(Keys.BACK_SPACE, Keys.TAB);
+        waitUntilTextsEqual("Password field value changed from 'a' to ''",
+                passwordFieldValueDiv);
 
         $(RadioButtonGroupElement.class).first().selectByText(EAGER.toString());
-        updateValues(passwordFieldValueDiv, passwordField, false);
-    }
 
-    private void updateValues(WebElement passwordFieldValueDiv,
-            WebElement passwordField, boolean toggleBlur) {
         passwordField.sendKeys("a");
-        if (toggleBlur) {
-            blur();
-        }
         waitUntilTextsEqual("Password field value changed from '' to 'a'",
                 passwordFieldValueDiv);
 
         passwordField.sendKeys(Keys.BACK_SPACE);
-        if (toggleBlur) {
-            blur();
-        }
         waitUntilTextsEqual("Password field value changed from 'a' to ''",
                 passwordFieldValueDiv);
     }

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -49,8 +49,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
         TextAreaElement field = $(TextAreaElement.class).id("clear-text-area");
 
         TestBenchElement input = field.$("textarea").first();
-        input.sendKeys("foo");
-        blur();
+        input.sendKeys("foo", Keys.ENTER);
 
         field.clickClearButton();
 
@@ -79,8 +78,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
         Assert.assertEquals("", message.getText());
 
         executeScript("arguments[0].removeAttribute(\"disabled\");", textArea);
-        textArea.sendKeys("abc");
-        blur();
+        textArea.sendKeys("abc", Keys.ENTER);
 
         message = findElement(By.id("disabled-text-area-message"));
         Assert.assertEquals("", message.getText());
@@ -88,30 +86,27 @@ public class TextAreaPageIT extends AbstractComponentIT {
 
     @Test
     public void valueChangeListenerReportsCorrectValues() {
-        WebElement textFieldValueDiv = findElement(By.id("text-area-value"));
+        WebElement textAreaValueDiv = findElement(By.id("text-area-value"));
         WebElement textArea = findElement(
                 By.id("text-area-with-value-change-listener"));
 
-        updateValues(textFieldValueDiv, textArea, true);
-        $(RadioButtonGroupElement.class).first().selectByText(EAGER.toString());
-        updateValues(textFieldValueDiv, textArea, false);
-    }
-
-    private void updateValues(WebElement textFieldValueDiv, WebElement textArea,
-            boolean toggleBlur) {
-        textArea.sendKeys("a");
-        if (toggleBlur) {
-            blur();
-        }
+        textArea.sendKeys("a", Keys.TAB);
         waitUntilTextsEqual("Text area value changed from '' to 'a'",
-                textFieldValueDiv);
+                textAreaValueDiv);
+
+        textArea.sendKeys(Keys.BACK_SPACE, Keys.TAB);
+        waitUntilTextsEqual("Text area value changed from 'a' to ''",
+                textAreaValueDiv);
+
+        $(RadioButtonGroupElement.class).first().selectByText(EAGER.toString());
+
+        textArea.sendKeys("a");
+        waitUntilTextsEqual("Text area value changed from '' to 'a'",
+                textAreaValueDiv);
 
         textArea.sendKeys(Keys.BACK_SPACE);
-        if (toggleBlur) {
-            blur();
-        }
         waitUntilTextsEqual("Text area value changed from 'a' to ''",
-                textFieldValueDiv);
+                textAreaValueDiv);
     }
 
     private void waitUntilTextsEqual(String expected, WebElement valueDiv) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -49,7 +49,7 @@ public class TextAreaPageIT extends AbstractComponentIT {
         TextAreaElement field = $(TextAreaElement.class).id("clear-text-area");
 
         TestBenchElement input = field.$("textarea").first();
-        input.sendKeys("foo", Keys.ENTER);
+        input.sendKeys("foo", Keys.TAB);
 
         field.clickClearButton();
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
@@ -201,8 +201,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
     public void assertValueWithoutListener() {
         TextFieldElement field = $(TextFieldElement.class).id("value-change");
         WebElement input = field.$("input").first();
-        input.sendKeys("foo");
-        blur();
+        input.sendKeys("foo", Keys.ENTER);
         WebElement button = findElement(By.id("get-value"));
         new Actions(getDriver())
                 .moveToElement(button, button.getSize().getWidth() / 2,
@@ -218,8 +217,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
         TextFieldElement field = $(TextFieldElement.class)
                 .id("clear-text-field");
         WebElement input = field.$("input").first();
-        input.sendKeys("foo");
-        blur();
+        input.sendKeys("foo", Keys.ENTER);
 
         field.clickClearButton();
 
@@ -234,8 +232,7 @@ public class TextFieldPageIT extends AbstractComponentIT {
         Assert.assertEquals("", message.getText());
 
         executeScript("arguments[0].removeAttribute(\"disabled\");", textField);
-        textField.sendKeys("abc");
-        blur();
+        textField.sendKeys("abc", Keys.ENTER);
 
         message = findElement(By.id("disabled-text-field-message"));
         Assert.assertEquals("", message.getText());
@@ -246,9 +243,24 @@ public class TextFieldPageIT extends AbstractComponentIT {
         WebElement textFieldValueDiv = findElement(By.id("text-field-value"));
         WebElement textField = findElement(
                 By.id("text-field-with-value-change-listener"));
-        updateValues(textFieldValueDiv, textField, true);
+
+        textField.sendKeys("a", Keys.TAB);
+        waitUntilTextsEqual("Text field value changed from '' to 'a'",
+                textFieldValueDiv);
+
+        textField.sendKeys(Keys.BACK_SPACE, Keys.TAB);
+        waitUntilTextsEqual("Text field value changed from 'a' to ''",
+                textFieldValueDiv);
+
         $(RadioButtonGroupElement.class).first().selectByText(EAGER.toString());
-        updateValues(textFieldValueDiv, textField, false);
+
+        textField.sendKeys("a");
+        waitUntilTextsEqual("Text field value changed from '' to 'a'",
+                textFieldValueDiv);
+
+        textField.sendKeys(Keys.BACK_SPACE);
+        waitUntilTextsEqual("Text field value changed from 'a' to ''",
+                textFieldValueDiv);
     }
 
     @Test
@@ -299,23 +311,6 @@ public class TextFieldPageIT extends AbstractComponentIT {
 
         $(TestBenchElement.class).id("clear-helper-component-button").click();
         Assert.assertNull(textFieldElement.getHelperComponent());
-    }
-
-    private void updateValues(WebElement textFieldValueDiv,
-            WebElement textField, boolean toggleBlur) {
-        textField.sendKeys("a");
-        if (toggleBlur) {
-            blur();
-        }
-        waitUntilTextsEqual("Text field value changed from '' to 'a'",
-                textFieldValueDiv);
-
-        textField.sendKeys(Keys.BACK_SPACE);
-        if (toggleBlur) {
-            blur();
-        }
-        waitUntilTextsEqual("Text field value changed from 'a' to ''",
-                textFieldValueDiv);
     }
 
     private void waitUntilTextsEqual(String expected, WebElement valueDiv) {

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/ValueChangeModeIT.java
@@ -127,7 +127,7 @@ public class ValueChangeModeIT extends AbstractComponentIT {
         field.sendKeys("1");
         assertMessageNotUpdated(
                 "By default the value change events should not be sent on every key stroke (ValueChangeMode should be ON_CHANGE)");
-        blur();
+        field.sendKeys(Keys.TAB);
         waitUntilMessageUpdated();
 
         clickButton(componentName + "-on-blur");
@@ -140,7 +140,7 @@ public class ValueChangeModeIT extends AbstractComponentIT {
         assertMessageNotUpdated(
                 "The value change events should not be sent with enter key when using ValueChangeMode.ON_BLUR");
 
-        blur();
+        field.sendKeys(Keys.TAB);
         waitUntilMessageUpdated();
 
         clickButton(componentName + "-eager");
@@ -148,14 +148,14 @@ public class ValueChangeModeIT extends AbstractComponentIT {
 
         waitUntilMessageUpdated();
 
-        blur();
+        field.sendKeys(Keys.TAB);
         assertMessageNotUpdated(
                 "The value change event should not be sent again on blur, because it was already sent eagerly when typing");
 
         WebElement changeTimeoutField = findElement(
                 By.id(componentName + "-set-change-timeout"));
         changeTimeoutField.sendKeys("1000");
-        blur();
+        field.sendKeys(Keys.TAB);
 
         testValueChangeTimeout(field, componentName);
     }


### PR DESCRIPTION
The `blur()` helper in `AbstractComponentIT` ran `document.activeElement.blur()` through JavaScript to commit pending value changes in field tests. Triggering blur out-of-band from the typed input is fragile and hides what the test does.

Replace it with `Keys.TAB` or `Keys.ENTER` sent through `sendKeys`. The focus change now happens in the same input stream as the value. As a side benefit, the helper can be dropped from `AbstractComponentIT`, keeping the shared base class smaller.
