### PR TITLE
test: configure hub-routed integration test driver for TeamCity

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -23,10 +23,8 @@ import java.net.SocketException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -151,48 +149,34 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     }
 
     protected String getRootURL() {
+        String host = "localhost";
         if (USE_HUB) {
-            return "http://" + getCurrentHostAddress() + ":8080";
+            host = findHostAddress();
         }
-
-        return "http://localhost:8080";
+        return "http://" + host + ":8080";
     }
 
-    private String getCurrentHostAddress() {
+    private String findHostAddress() {
         try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface
-                    .getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                NetworkInterface nwInterface = interfaces.nextElement();
-                if (!nwInterface.isUp() || nwInterface.isLoopback()
-                        || nwInterface.isVirtual()) {
-                    continue;
-                }
-                String address = getHostAddress(nwInterface);
-                if (address != null) {
-                    return address;
-                }
-            }
+            return NetworkInterface.networkInterfaces()
+                    .filter((networkInterface) -> {
+                        try {
+                            return networkInterface.isUp()
+                                    && !networkInterface.isLoopback()
+                                    && !networkInterface.isVirtual();
+                        } catch (SocketException e) {
+                            return false;
+                        }
+                    }).flatMap(NetworkInterface::inetAddresses)
+                    .filter(InetAddress::isSiteLocalAddress)
+                    .map(InetAddress::getHostAddress).findFirst()
+                    .orElseThrow(() -> {
+                        return new RuntimeException(
+                                "No compatible (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) ip address found.");
+                    });
         } catch (SocketException e) {
             throw new RuntimeException("Could not find the host name", e);
         }
-        throw new RuntimeException(
-                "No compatible (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) ip address found.");
-    }
-
-    private static String getHostAddress(
-            NetworkInterface nwInterface) {
-        Enumeration<InetAddress> addresses = nwInterface.getInetAddresses();
-        while (addresses.hasMoreElements()) {
-            InetAddress address = addresses.nextElement();
-            if (address.isLoopbackAddress()) {
-                continue;
-            }
-            if (address.isSiteLocalAddress()) {
-                return address.getHostAddress();
-            }
-        }
-        return null;
     }
 
     protected String getTestURL(String... parameters) {
@@ -259,8 +243,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     private static WebDriver createWebDriver() {
         for (int i = 0; i < 3; i++) {
             try {
-                return USE_HUB ? tryCreateRemoteDriver()
-                        : tryCreateChromeDriver();
+                if (USE_HUB) {
+                    return tryCreateRemoteDriver();
+                }
+
+                return tryCreateChromeDriver();
             } catch (Exception e) {
                 logger.warn("Unable to create driver on attempt " + i, e);
             }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -16,12 +16,17 @@
 package com.vaadin.tests;
 
 import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -146,7 +151,48 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     }
 
     protected String getRootURL() {
+        if (USE_HUB) {
+            return "http://" + getCurrentHostAddress() + ":8080";
+        }
+
         return "http://localhost:8080";
+    }
+
+    private String getCurrentHostAddress() {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface
+                    .getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface nwInterface = interfaces.nextElement();
+                if (!nwInterface.isUp() || nwInterface.isLoopback()
+                        || nwInterface.isVirtual()) {
+                    continue;
+                }
+                String address = getHostAddress(nwInterface);
+                if (address != null) {
+                    return address;
+                }
+            }
+        } catch (SocketException e) {
+            throw new RuntimeException("Could not find the host name", e);
+        }
+        throw new RuntimeException(
+                "No compatible (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) ip address found.");
+    }
+
+    private static String getHostAddress(
+            NetworkInterface nwInterface) {
+        Enumeration<InetAddress> addresses = nwInterface.getInetAddresses();
+        while (addresses.hasMoreElements()) {
+            InetAddress address = addresses.nextElement();
+            if (address.isLoopbackAddress()) {
+                continue;
+            }
+            if (address.isSiteLocalAddress()) {
+                return address.getHostAddress();
+            }
+        }
+        return null;
     }
 
     protected String getTestURL(String... parameters) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.flow.testutil.net.PortProber;
+import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.ScreenshotOnFailureRule;
 import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchTestCase;
@@ -80,7 +81,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     private static final boolean USE_HUB = Boolean.getBoolean("test.use.hub");
 
     private static final String HUB_URL = System.getProperty("test.hub.url",
-            "http://localhost:4444/wd/hub");
+            "http://" + Parameters.getHubHostname() + ":4444/wd/hub");
 
     private static final ThreadLocal<WebDriver> sharedDriver = new ThreadLocal<>();
 


### PR DESCRIPTION
TeamCity PR validation runs integration tests through a Selenium Grid hub. The remote browser opens the test page from its own machine, so `localhost` does not point to the Jetty server. The driver setup needs the agent's network address for the test page and the hub's hostname for the WebDriver URL.

#9217 rewrote driver bootstrap and replaced both with hard-coded `localhost`. As a result, TeamCity PR validation has been broken since that PR was merged. This PR restores the original behavior:

- Build the hub URL from `Parameters.getHubHostname()`.
- When `test.use.hub=true`, use the first site-local IPv4 address of an up, non-loopback, non-virtual network interface as the application host. This is the address the remote browser can reach.
- Keep the lookup short by using `NetworkInterface.networkInterfaces()` and `inetAddresses()` streams.

We are moving CI to GitHub Actions, but we want to keep TeamCity working until both pipelines produce the same results. Once TeamCity PR validation is removed, the whole hub path (`USE_HUB`, `HUB_URL`, `tryCreateRemoteDriver`, the site-local lookup) can go too. 

Follow-up to #9217
