### PR TITLE
fix: remove explicit ol @NpmPackage, let @vaadin/map own it

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -82,7 +82,6 @@ import tools.jackson.databind.node.ObjectNode;
  */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "25.2.0-alpha10")
-@NpmPackage(value = "ol", version = "10.6.0")
 @NpmPackage(value = "proj4", version = "2.17.0")
 @JsModule("@vaadin/map/src/vaadin-map.js")
 @JsModule("./vaadin-map/mapConnector.js")

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -82,7 +82,7 @@ import tools.jackson.databind.node.ObjectNode;
  */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "25.2.0-alpha10")
-@NpmPackage(value = "ol", version = "10.6.1")
+@NpmPackage(value = "ol", version = "10.6.0")
 @NpmPackage(value = "proj4", version = "2.17.0")
 @JsModule("@vaadin/map/src/vaadin-map.js")
 @JsModule("./vaadin-map/mapConnector.js")


### PR DESCRIPTION
Removing the explicit `ol` `@NpmPackage` declaration that conflicted with the version declared by `@vaadin/map` itself.

`@vaadin/map@25.2.0-alpha10` already declares `ol: "10.6.0"` as a direct dependency. Declaring `ol: "10.6.1"` here created a version conflict that was silently masked by pnpm `--shamefully-hoist=true`, but broke with the switch to `node-linker=hoisted` in vaadin/flow: Vite ended up bundling two separate OpenLayers instances, causing `synchronize()` to operate on a different `Map` object than the one exposed via `mapElement.configuration`.

Related to vaadin/flow#24307