### PR TITLE
feat: add shareDriver, isReuseDriver hook, SPA navigation and headed mode to AbstractComponentIT

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -492,7 +492,7 @@ jobs:
             -Dcom.vaadin.testbench.Parameters.testsInParallel=2 \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
-            -Dtest.reuseDriver=true \
+            -Dtest.shareDriver=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -488,8 +488,8 @@ jobs:
             jetty:start-war failsafe:integration-test jetty:stop failsafe:verify \
             -Dvaadin.productionMode \
             -DskipFrontend \
-            -Dfailsafe.forkCount=$FORK_COUNT \
-            -Dcom.vaadin.testbench.Parameters.testsInParallel=2 \
+            -Dfailsafe.forkCount=1 \
+            -Dcom.vaadin.testbench.Parameters.testsInParallel=1 \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
             -Dtest.shareDriver=true \

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -488,11 +488,11 @@ jobs:
             jetty:start-war failsafe:integration-test jetty:stop failsafe:verify \
             -Dvaadin.productionMode \
             -DskipFrontend \
-            -Dfailsafe.forkCount=1 \
-            -Dcom.vaadin.testbench.Parameters.testsInParallel=1 \
+            -Dfailsafe.forkCount=$FORK_COUNT \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
-            -Dtest.reuseDriver=true \
+            -Dtest.shareDriver=true \
+            -Dtest.useSpa=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -388,7 +388,7 @@ jobs:
         env:
           SHARDS: ${{ github.event.inputs.shards || '0' }}
           TARGET_PER_SHARD: 35
-          MAX_SHARDS: 8
+          MAX_SHARDS: 10
         run: |
           mapfile -t its < <(find integration-tests/src/test/java -name '*IT.java' -printf '%P\n' | sed -e 's|/|.|g' -e 's|\.java$||' | sort)
           count=${#its[@]}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -492,7 +492,7 @@ jobs:
             -Dcom.vaadin.testbench.Parameters.testsInParallel=1 \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
-            -Dtest.shareDriver=true \
+            -Dtest.reuseDriver=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -492,6 +492,7 @@ jobs:
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
             -Dtest.reuseDriver=true \
+            -Dtest.useSpa=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -388,7 +388,7 @@ jobs:
         env:
           SHARDS: ${{ github.event.inputs.shards || '0' }}
           TARGET_PER_SHARD: 35
-          MAX_SHARDS: 10
+          MAX_SHARDS: 8
         run: |
           mapfile -t its < <(find integration-tests/src/test/java -name '*IT.java' -printf '%P\n' | sed -e 's|/|.|g' -e 's|\.java$||' | sort)
           count=${#its[@]}
@@ -492,7 +492,6 @@ jobs:
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
             -Dtest.shareDriver=true \
-            -Dtest.useSpa=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -492,7 +492,6 @@ jobs:
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
             -Dtest.reuseDriver=true \
-            -Dtest.useSpa=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -388,7 +388,7 @@ jobs:
         env:
           SHARDS: ${{ github.event.inputs.shards || '0' }}
           TARGET_PER_SHARD: 35
-          MAX_SHARDS: 10
+          MAX_SHARDS: 8
         run: |
           mapfile -t its < <(find integration-tests/src/test/java -name '*IT.java' -printf '%P\n' | sed -e 's|/|.|g' -e 's|\.java$||' | sort)
           count=${#its[@]}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -491,7 +491,7 @@ jobs:
             -Dfailsafe.forkCount=$FORK_COUNT \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dmaven.test.redirectTestOutputToFile=true \
-            -Dtest.shareDriver=true \
+            -Dtest.reuseDriver=true \
             -Dit.test="$SHARD_TESTS" \
             -B
 

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -16,35 +16,50 @@
 package com.vaadin.tests;
 
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.remote.codec.w3c.W3CHttpCommandCodec;
+import org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
@@ -60,52 +75,178 @@ import com.vaadin.testbench.TestBenchTestCase;
 /**
  * Base class for Flow component integration tests.
  * <p>
- * Extends {@link TestBenchTestCase} directly and manages a headless Chrome
- * driver that is reused across all test methods in the same test class. By
- * default the driver is started locally; setting {@code -Dtest.use.hub=true}
- * routes driver creation to a Selenium Grid endpoint configured via
- * {@code -Dtest.hub.url} (default {@code http://localhost:4444/wd/hub}).
- * <p>
- * This test setup does not support running tests in parallel. The only way to
- * parallelize tests is forking separate JVMs that run one suite at a time, for
- * example using {@code failsafe.forkCount}.
- * <p>
- * Test classes must be annotated with {@link TestPath} to specify the URL path
- * of the test view.
+ * Four independent opt-in features, each enabled by a system property:
+ * <ul>
+ * <li>{@code -Dtest.headed=true} — run Chrome in headed (visible) mode. Default
+ * is headless. Also implied when a JDWP debug agent is attached.</li>
+ * <li>{@code -Dtest.reuseDriver=true} — one Chrome window per test
+ * <em>class</em>. The driver is created in {@code @BeforeClass} and destroyed
+ * in {@code @AfterClass}; between methods cookies are cleared and the browser
+ * navigates to {@code about:blank}. Default: one window per test
+ * <em>method</em>.</li>
+ * <li>{@code -Dtest.shareDriver=true} — one Chrome window for the entire JVM
+ * fork (all test classes). Implies {@code test.reuseDriver}. A health-check
+ * guards against stale sessions. In debug (JDWP) mode the session is also
+ * persisted to a temp file so the same browser can be reconnected on subsequent
+ * runs.</li>
+ * <li>{@code -Dtest.useSpa=true} — when combined with {@code test.reuseDriver}
+ * or {@code test.shareDriver}, navigate between routes via the Vaadin
+ * {@code vaadin-navigate} client event instead of a full page load. Falls back
+ * to a full load automatically when the browser is not on a Vaadin page or when
+ * navigating to the same route (which would leak session state).</li>
+ * </ul>
+ * Subclasses can opt out of driver reuse on a per-class basis by overriding
+ * {@link #isReuseDriver()} to return {@code false} regardless of system
+ * properties.
  */
 public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     private static final Logger logger = LoggerFactory
             .getLogger(AbstractComponentIT.class);
 
+    // ----- Feature flags -----
+
+    /** One driver per class (reuse between methods). */
     private static final boolean REUSE_DRIVER = Boolean
             .getBoolean("test.reuseDriver");
+
+    /**
+     * One driver for the whole JVM fork (reuse between classes). Implies
+     * REUSE_DRIVER.
+     */
+    private static final boolean SHARE_DRIVER = Boolean
+            .getBoolean("test.shareDriver");
+
+    /** Use Vaadin SPA navigation instead of full page loads. */
+    private static final boolean USE_SPA = Boolean.getBoolean("test.useSpa");
+
+    /** Run Chrome in headed (visible) mode. Default is headless. */
+    private static final boolean HEADED = Boolean.getBoolean("test.headed");
 
     private static final boolean USE_HUB = Boolean.getBoolean("test.use.hub");
 
     private static final String HUB_URL = System.getProperty("test.hub.url",
             "http://" + Parameters.getHubHostname() + ":4444/wd/hub");
 
+    // ----- Driver state -----
+
+    /**
+     * Per-thread driver. Persists across classes when SHARE_DRIVER is true,
+     * across methods when REUSE_DRIVER is true, created fresh per method
+     * otherwise.
+     */
     private static final ThreadLocal<WebDriver> sharedDriver = new ThreadLocal<>();
+
+    /**
+     * Tracks all drivers created per thread so the JVM shutdown hook can quit
+     * them cleanly. Only used when SHARE_DRIVER is true.
+     */
+    private static final ConcurrentHashMap<Long, WebDriver> allDrivers = new ConcurrentHashMap<>();
+
+    private static volatile boolean shutdownHookRegistered = false;
+
+    /**
+     * File used to persist the ChromeDriver session across JVM restarts in
+     * local debug mode (JDWP present). One file per surefire fork.
+     */
+    private static final Path DRIVER_FILE = Path
+            .of(System.getProperty("java.io.tmpdir"), "vaadin-test-driver-"
+                    + System.getProperty("surefire.forkNumber", "0") + ".txt");
+
+    // ----- Consecutive-failure abort (only meaningful with driver sharing)
+    // -----
+
+    private static int consecutiveFailures = 0;
+    private static final int MAX_CONSECUTIVE_FAILURES = 5;
+
+    @Rule
+    public TestRule consecutiveFailureAbort = new TestRule() {
+        @Override
+        public Statement apply(Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    if (SHARE_DRIVER
+                            && consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                        throw new AssumptionViolatedException("Aborting: "
+                                + consecutiveFailures
+                                + " consecutive failures, driver may be unstable");
+                    }
+                    try {
+                        base.evaluate();
+                        consecutiveFailures = 0;
+                    } catch (AssumptionViolatedException e) {
+                        throw e;
+                    } catch (Throwable t) {
+                        consecutiveFailures++;
+                        throw t;
+                    }
+                }
+            };
+        }
+    };
 
     @Rule
     public ScreenshotOnFailureRule screenshotOnFailure = new ScreenshotOnFailureRule(
             this, false);
 
+    // ----- JUnit lifecycle -----
+
     @BeforeClass
     public static void createDriver() {
-        if (!REUSE_DRIVER) {
+        if (!REUSE_DRIVER && !SHARE_DRIVER) {
             return;
+        }
+        if (SHARE_DRIVER) {
+            ensureShutdownHook();
+            // Reuse the existing driver if it is still alive.
+            WebDriver existing = sharedDriver.get();
+            if (existing != null && isDriverAlive(existing)) {
+                return;
+            }
+            if (existing != null) {
+                tryQuitDriver(existing);
+                sharedDriver.remove();
+            }
+            // Try to reconnect to a persisted session in local debug mode.
+            if (isDebugMode() && Files.exists(DRIVER_FILE)) {
+                try {
+                    WebDriver reconnected = reconnectDriver();
+                    if (reconnected != null && isDriverAlive(reconnected)) {
+                        sharedDriver.set(reconnected);
+                        allDrivers.put(Thread.currentThread().getId(),
+                                reconnected);
+                        return;
+                    }
+                } catch (Exception e) {
+                    // Reconnect failed; fall through to create a fresh driver.
+                }
+            }
         }
         WebDriver driver = createWebDriver();
         driver.manage().window().setSize(new Dimension(1024, 800));
         driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
         sharedDriver.set(driver);
+        if (SHARE_DRIVER) {
+            allDrivers.put(Thread.currentThread().getId(), driver);
+            if (isDebugMode()) {
+                saveDriverInfo(driver);
+            }
+        }
+    }
+
+    /**
+     * Returns whether this test class participates in driver reuse. Override
+     * and return {@code false} in subclasses that require a fresh browser per
+     * method regardless of {@code test.reuseDriver} / {@code test.shareDriver}.
+     */
+    protected boolean isReuseDriver() {
+        return REUSE_DRIVER || SHARE_DRIVER;
     }
 
     @Before
     public void resetDriver() throws Exception {
-        if (!REUSE_DRIVER) {
+        if (!isReuseDriver()) {
             WebDriver driver = createWebDriver();
             driver.manage().window().setSize(new Dimension(1024, 800));
             driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
@@ -118,7 +259,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     @After
     public void quitDriverPerMethod() {
-        if (!REUSE_DRIVER) {
+        if (!isReuseDriver()) {
             tryQuitDriver(sharedDriver.get());
             sharedDriver.remove();
         }
@@ -126,6 +267,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     @AfterClass
     public static void quitDriver() {
+        if (SHARE_DRIVER) {
+            // Keep the driver alive for the next test class.
+            // The shutdown hook will quit it when the JVM exits.
+            return;
+        }
         if (!REUSE_DRIVER) {
             return;
         }
@@ -170,10 +316,8 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
                     }).flatMap(NetworkInterface::inetAddresses)
                     .filter(InetAddress::isSiteLocalAddress)
                     .map(InetAddress::getHostAddress).findFirst()
-                    .orElseThrow(() -> {
-                        return new RuntimeException(
-                                "No compatible (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) ip address found.");
-                    });
+                    .orElseThrow(() -> new RuntimeException(
+                            "No compatible (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) ip address found."));
         } catch (SocketException e) {
             throw new RuntimeException("Could not find the host name", e);
         }
@@ -209,6 +353,13 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     protected void open(String... parameters) {
         String url = getTestURL(parameters);
+
+        if (isReuseDriver() && USE_SPA) {
+            if (trySpaNavigation(getTestPath())) {
+                return;
+            }
+        }
+
         TimeoutException lastTimeout = null;
         for (int attempt = 1; attempt <= 3; attempt++) {
             try {
@@ -225,7 +376,49 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         throw lastTimeout;
     }
 
+    /**
+     * Attempts SPA navigation via the Vaadin client router.
+     *
+     * @return {@code true} if navigation succeeded, {@code false} if a full
+     *         page load is required
+     */
+    private boolean trySpaNavigation(String path) {
+        try {
+            Boolean hasVaadin = (Boolean) executeScript(
+                    "return !!(window.Vaadin && window.Vaadin.Flow)");
+            if (!Boolean.TRUE.equals(hasVaadin)) {
+                return false;
+            }
+            String currentPath = (String) executeScript(
+                    "return window.location.pathname");
+            String normalizedPath = path.startsWith("/") ? path : "/" + path;
+            if (normalizedPath.equals(currentPath)) {
+                // Same route: clear cookies so the server creates a fresh
+                // session, then fall through to a full page load.
+                getDriver().manage().deleteAllCookies();
+                return false;
+            }
+            executeScript(
+                    "window.dispatchEvent(new CustomEvent('vaadin-navigate',"
+                            + "{detail:{url:arguments[0],state:null,replace:false,callback:true}}))",
+                    path);
+            getCommandExecutor().waitForVaadin();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     // ----- Driver management -----
+
+    private static boolean isDriverAlive(WebDriver driver) {
+        try {
+            driver.getTitle();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
     private static void tryQuitDriver(WebDriver driver) {
         try {
@@ -235,9 +428,91 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         }
     }
 
-    private static boolean isJavaInDebugMode() {
+    private static boolean isDebugMode() {
         return ManagementFactory.getRuntimeMXBean().getInputArguments()
                 .toString().contains("jdwp");
+    }
+
+    private static void ensureShutdownHook() {
+        if (shutdownHookRegistered) {
+            return;
+        }
+        synchronized (AbstractComponentIT.class) {
+            if (shutdownHookRegistered) {
+                return;
+            }
+            shutdownHookRegistered = true;
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                allDrivers.values().forEach(AbstractComponentIT::tryQuitDriver);
+                allDrivers.clear();
+            }, "vaadin-test-driver-shutdown"));
+        }
+    }
+
+    private static WebDriver reconnectDriver() throws Exception {
+        String content = Files.readString(DRIVER_FILE);
+        String[] parts = content.strip().split("\n");
+        if (parts.length < 2) {
+            return null;
+        }
+        String driverUrl = parts[0];
+        String sessionId = parts[1];
+
+        HttpCommandExecutor executor = new HttpCommandExecutor(
+                new URL(driverUrl));
+        Field commandCodecField = HttpCommandExecutor.class
+                .getDeclaredField("commandCodec");
+        commandCodecField.setAccessible(true);
+        commandCodecField.set(executor, new W3CHttpCommandCodec());
+        Field responseCodecField = HttpCommandExecutor.class
+                .getDeclaredField("responseCodec");
+        responseCodecField.setAccessible(true);
+        responseCodecField.set(executor, new W3CHttpResponseCodec());
+
+        RemoteWebDriver driver = new RemoteWebDriver(executor,
+                (Capabilities) null) {
+            @Override
+            protected void startSession(Capabilities capabilities) {
+                // Do not start a new session; we are reconnecting.
+            }
+        };
+        Field sessionIdField = RemoteWebDriver.class
+                .getDeclaredField("sessionId");
+        sessionIdField.setAccessible(true);
+        sessionIdField.set(driver, new SessionId(sessionId));
+        Field capsField = RemoteWebDriver.class
+                .getDeclaredField("capabilities");
+        capsField.setAccessible(true);
+        capsField.set(driver, new ChromeOptions());
+
+        return TestBench.createDriver(driver);
+    }
+
+    private static void saveDriverInfo(WebDriver driver) {
+        try {
+            WebDriver actual = unwrap(driver);
+            if (actual instanceof RemoteWebDriver) {
+                RemoteWebDriver rwd = (RemoteWebDriver) actual;
+                SessionId sid = rwd.getSessionId();
+                if (sid != null) {
+                    HttpCommandExecutor exec = (HttpCommandExecutor) rwd
+                            .getCommandExecutor();
+                    String info = exec.getAddressOfRemoteServer().toString()
+                            + "\n" + sid.toString();
+                    Files.writeString(DRIVER_FILE, info);
+                }
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    private static WebDriver unwrap(WebDriver driver) {
+        WebDriver actual = driver;
+        while (actual instanceof WrapsDriver) {
+            actual = ((WrapsDriver) actual).getWrappedDriver();
+        }
+        return actual;
     }
 
     private static WebDriver createWebDriver() {
@@ -246,7 +521,6 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
                 if (USE_HUB) {
                     return tryCreateRemoteDriver();
                 }
-
                 return tryCreateChromeDriver();
             } catch (Exception e) {
                 logger.warn("Unable to create driver on attempt " + i, e);
@@ -258,7 +532,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     private static ChromeOptions buildChromeOptions() {
         ChromeOptions options = new ChromeOptions();
-        if (!isJavaInDebugMode()) {
+        if (!HEADED && !isDebugMode()) {
             options.addArguments("--headless=new", "--disable-gpu",
                     "--disable-backgrounding-occluded-windows");
         }
@@ -294,26 +568,15 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     // ----- Test helper methods -----
 
-    /**
-     * Waits up to 10s for the given condition to become false.
-     */
     protected <T> void waitUntilNot(ExpectedCondition<T> condition) {
         waitUntilNot(condition, 10);
     }
 
-    /**
-     * Waits the given number of seconds for the given condition to become
-     * false.
-     */
     protected <T> void waitUntilNot(ExpectedCondition<T> condition,
             long timeoutInSeconds) {
         waitUntil(ExpectedConditions.not(condition), timeoutInSeconds);
     }
 
-    /**
-     * Returns true if an element can be found from the driver with given
-     * selector.
-     */
     public boolean isElementPresent(By by) {
         try {
             WebElement element = getDriver().findElement(by);
@@ -323,19 +586,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         }
     }
 
-    /**
-     * Clicks on the element, using JS. This method is more convenient than
-     * Selenium {@code findElement(By.id(urlId)).click()}, because Selenium
-     * method changes scroll position, which is not always needed.
-     */
     protected void clickElementWithJs(String elementId) {
         executeScript(String.format("document.getElementById('%s').click();",
                 elementId));
     }
 
-    /**
-     * Clicks on the element, using JS.
-     */
     protected void clickElementWithJs(WebElement element) {
         executeScript("arguments[0].click();", element);
     }
@@ -352,9 +607,6 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         waitUntil(ExpectedConditions.visibilityOfElementLocated(by));
     }
 
-    /**
-     * Scrolls the page to the element given using javascript.
-     */
     protected void scrollToElement(WebElement element) {
         Objects.requireNonNull(element,
                 "The element to scroll to should not be null");
@@ -362,18 +614,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
                 element);
     }
 
-    /**
-     * Scrolls the page to the element specified and clicks it.
-     */
     protected void scrollIntoViewAndClick(WebElement element) {
         scrollToElement(element);
         element.click();
     }
 
-    /**
-     * Gets the log entries from the browser that have the given logging level
-     * or higher.
-     */
     protected List<LogEntry> getLogEntries(Level level) {
         getCommandExecutor().waitForVaadin();
 
@@ -388,10 +633,6 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     private static final String WEB_SOCKET_CONNECTION_ERROR_PREFIX = "WebSocket connection to ";
 
-    /**
-     * Checks browser's log entries, throws an error for any client-side error
-     * and logs any client-side warnings.
-     */
     protected void checkLogsForErrors(
             Predicate<String> acceptableMessagePredicate) {
         getLogEntries(Level.WARNING).forEach(logEntry -> {
@@ -415,18 +656,10 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         });
     }
 
-    /**
-     * Checks browser's log entries, throws an error for any client-side error
-     * and logs any client-side warnings.
-     */
     protected void checkLogsForErrors() {
         checkLogsForErrors(msg -> false);
     }
 
-    /**
-     * If dev server start in progress wait until it's started. Otherwise return
-     * immediately.
-     */
     protected void waitForDevServer() {
         Object result;
         do {
@@ -436,18 +669,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         } while (Boolean.TRUE.equals(result));
     }
 
-    /**
-     * Calls the {@code blur()} function on the current active element of the
-     * page, if any.
-     */
     public void blur() {
         executeScript(
                 "!!document.activeElement ? document.activeElement.blur() : 0");
     }
 
-    /**
-     * Gets a property value from a web element using JavaScript.
-     */
     public String getProperty(WebElement element, String propertyName) {
         Object result = executeScript(
                 "return arguments[0]." + propertyName + ";", element);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -327,7 +327,11 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     protected void open(String... parameters) {
         String url = getTestURL(parameters);
 
-        if (isReuseDriver() && USE_SPA && trySpaNavigation(getTestPath())) {
+        // Pass the relative URL (path + query string) so SPA navigation
+        // preserves query parameters used to configure the test view's
+        // initial state.
+        String relativeUrl = url.substring(getRootURL().length());
+        if (isReuseDriver() && USE_SPA && trySpaNavigation(relativeUrl)) {
             return;
         }
 
@@ -353,18 +357,21 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
      * @return {@code true} if navigation succeeded, {@code false} if a full
      *         page load is required
      */
-    private boolean trySpaNavigation(String path) {
+    private boolean trySpaNavigation(String relativeUrl) {
         try {
             Boolean hasVaadin = (Boolean) executeScript(
                     "return !!(window.Vaadin && window.Vaadin.Flow)");
             if (!Boolean.TRUE.equals(hasVaadin)) {
                 return false;
             }
-            String currentPath = (String) executeScript(
-                    "return window.location.pathname");
-            String normalizedPath = path.startsWith("/") ? path : "/" + path;
-            if (normalizedPath.equals(currentPath)) {
-                // Same route: clear cookies so the server creates a fresh
+            // Compare full path+query so tests with different query parameters
+            // get a fresh server-side view even when the path is the same.
+            String currentFullPath = (String) executeScript(
+                    "return window.location.pathname + window.location.search");
+            String normalizedUrl = relativeUrl.startsWith("/") ? relativeUrl
+                    : "/" + relativeUrl;
+            if (normalizedUrl.equals(currentFullPath)) {
+                // Same URL: clear cookies so the server creates a fresh
                 // session, then fall through to a full page load.
                 getDriver().manage().deleteAllCookies();
                 return false;
@@ -372,7 +379,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
             executeScript(
                     "window.dispatchEvent(new CustomEvent('vaadin-navigate',"
                             + "{detail:{url:arguments[0],state:null,replace:false,callback:true}}))",
-                    path);
+                    normalizedUrl);
             getCommandExecutor().waitForVaadin();
             return true;
         } catch (Exception e) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -16,20 +16,17 @@
 package com.vaadin.tests;
 
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.URI;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -41,10 +38,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
@@ -55,11 +49,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.LogType;
-import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.SessionId;
-import org.openqa.selenium.remote.codec.w3c.W3CHttpCommandCodec;
-import org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
@@ -86,9 +76,8 @@ import com.vaadin.testbench.TestBenchTestCase;
  * <em>method</em>.</li>
  * <li>{@code -Dtest.shareDriver=true} — one Chrome window for the entire JVM
  * fork (all test classes). Implies {@code test.reuseDriver}. A health-check
- * guards against stale sessions. In debug (JDWP) mode the session is also
- * persisted to a temp file so the same browser can be reconnected on subsequent
- * runs.</li>
+ * guards against stale sessions. A JVM shutdown hook ensures the browser is
+ * always quit cleanly.</li>
  * <li>{@code -Dtest.useSpa=true} — when combined with {@code test.reuseDriver}
  * or {@code test.shareDriver}, navigate between routes via the Vaadin
  * {@code vaadin-navigate} client event instead of a full page load. Falls back
@@ -145,46 +134,46 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
 
     private static volatile boolean shutdownHookRegistered = false;
 
-    /**
-     * File used to persist the ChromeDriver session across JVM restarts in
-     * local debug mode (JDWP present). One file per surefire fork.
-     */
-    private static final Path DRIVER_FILE = Path
-            .of(System.getProperty("java.io.tmpdir"), "vaadin-test-driver-"
-                    + System.getProperty("surefire.forkNumber", "0") + ".txt");
-
     // ----- Consecutive-failure abort (only meaningful with driver sharing)
     // -----
 
-    private static int consecutiveFailures = 0;
+    private static final AtomicInteger consecutiveFailures = new AtomicInteger(
+            0);
     private static final int MAX_CONSECUTIVE_FAILURES = 5;
 
+    /**
+     * JUnit rule that aborts the fork after too many consecutive failures when
+     * {@code test.shareDriver} is active, to avoid burning CI time on a dead
+     * driver.
+     */
     @Rule
-    public TestRule consecutiveFailureAbort = new TestRule() {
-        @Override
-        public Statement apply(Statement base, Description description) {
-            return new Statement() {
-                @Override
-                public void evaluate() throws Throwable {
-                    if (SHARE_DRIVER
-                            && consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-                        throw new AssumptionViolatedException("Aborting: "
-                                + consecutiveFailures
-                                + " consecutive failures, driver may be unstable");
-                    }
-                    try {
-                        base.evaluate();
-                        consecutiveFailures = 0;
-                    } catch (AssumptionViolatedException e) {
-                        throw e;
-                    } catch (Throwable t) {
-                        consecutiveFailures++;
-                        throw t;
-                    }
+    public TestRule consecutiveFailureAbort = (base,
+            description) -> base == null ? null
+                    : consecutiveFailureAbortStatement(base);
+
+    private static org.junit.runners.model.Statement consecutiveFailureAbortStatement(
+            org.junit.runners.model.Statement base) {
+        return new org.junit.runners.model.Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                if (SHARE_DRIVER && consecutiveFailures
+                        .get() >= MAX_CONSECUTIVE_FAILURES) {
+                    throw new AssumptionViolatedException("Aborting: "
+                            + consecutiveFailures.get()
+                            + " consecutive failures, driver may be unstable");
                 }
-            };
-        }
-    };
+                try {
+                    base.evaluate();
+                    consecutiveFailures.set(0);
+                } catch (AssumptionViolatedException e) {
+                    throw e;
+                } catch (Throwable t) {
+                    consecutiveFailures.incrementAndGet();
+                    throw t;
+                }
+            }
+        };
+    }
 
     @Rule
     public ScreenshotOnFailureRule screenshotOnFailure = new ScreenshotOnFailureRule(
@@ -197,42 +186,29 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         if (!REUSE_DRIVER && !SHARE_DRIVER) {
             return;
         }
-        if (SHARE_DRIVER) {
-            ensureShutdownHook();
-            // Reuse the existing driver if it is still alive.
-            WebDriver existing = sharedDriver.get();
-            if (existing != null && isDriverAlive(existing)) {
-                return;
-            }
-            if (existing != null) {
-                tryQuitDriver(existing);
-                sharedDriver.remove();
-            }
-            // Try to reconnect to a persisted session in local debug mode.
-            if (isDebugMode() && Files.exists(DRIVER_FILE)) {
-                try {
-                    WebDriver reconnected = reconnectDriver();
-                    if (reconnected != null && isDriverAlive(reconnected)) {
-                        sharedDriver.set(reconnected);
-                        allDrivers.put(Thread.currentThread().getId(),
-                                reconnected);
-                        return;
-                    }
-                } catch (Exception e) {
-                    // Reconnect failed; fall through to create a fresh driver.
-                }
-            }
+        if (SHARE_DRIVER && tryReuseExistingDriver()) {
+            return;
         }
         WebDriver driver = createWebDriver();
         driver.manage().window().setSize(new Dimension(1024, 800));
         driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
         sharedDriver.set(driver);
         if (SHARE_DRIVER) {
-            allDrivers.put(Thread.currentThread().getId(), driver);
-            if (isDebugMode()) {
-                saveDriverInfo(driver);
-            }
+            allDrivers.put(Thread.currentThread().threadId(), driver);
         }
+    }
+
+    private static boolean tryReuseExistingDriver() {
+        ensureShutdownHook();
+        WebDriver existing = sharedDriver.get();
+        if (existing != null && isDriverAlive(existing)) {
+            return true;
+        }
+        if (existing != null) {
+            tryQuitDriver(existing);
+            sharedDriver.remove();
+        }
+        return false;
     }
 
     /**
@@ -295,10 +271,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     }
 
     protected String getRootURL() {
-        String host = "localhost";
-        if (USE_HUB) {
-            host = findHostAddress();
-        }
+        String host = USE_HUB ? findHostAddress() : "localhost";
         return "http://" + host + ":8080";
     }
 
@@ -316,10 +289,10 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
                     }).flatMap(NetworkInterface::inetAddresses)
                     .filter(InetAddress::isSiteLocalAddress)
                     .map(InetAddress::getHostAddress).findFirst()
-                    .orElseThrow(() -> new RuntimeException(
+                    .orElseThrow(() -> new IllegalStateException(
                             "No compatible (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) ip address found."));
         } catch (SocketException e) {
-            throw new RuntimeException("Could not find the host name", e);
+            throw new IllegalStateException("Could not find the host name", e);
         }
     }
 
@@ -354,10 +327,8 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
     protected void open(String... parameters) {
         String url = getTestURL(parameters);
 
-        if (isReuseDriver() && USE_SPA) {
-            if (trySpaNavigation(getTestPath())) {
-                return;
-            }
+        if (isReuseDriver() && USE_SPA && trySpaNavigation(getTestPath())) {
+            return;
         }
 
         TimeoutException lastTimeout = null;
@@ -405,6 +376,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
             getCommandExecutor().waitForVaadin();
             return true;
         } catch (Exception e) {
+            logger.debug("SPA navigation failed, falling back to full load", e);
             return false;
         }
     }
@@ -416,6 +388,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
             driver.getTitle();
             return true;
         } catch (Exception e) {
+            logger.debug("Driver health check failed", e);
             return false;
         }
     }
@@ -424,7 +397,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         try {
             driver.quit();
         } catch (Exception e) {
-            // Ignore - driver may already be dead
+            logger.debug("Failed to quit driver", e);
         }
     }
 
@@ -449,84 +422,16 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         }
     }
 
-    private static WebDriver reconnectDriver() throws Exception {
-        String content = Files.readString(DRIVER_FILE);
-        String[] parts = content.strip().split("\n");
-        if (parts.length < 2) {
-            return null;
-        }
-        String driverUrl = parts[0];
-        String sessionId = parts[1];
-
-        HttpCommandExecutor executor = new HttpCommandExecutor(
-                new URL(driverUrl));
-        Field commandCodecField = HttpCommandExecutor.class
-                .getDeclaredField("commandCodec");
-        commandCodecField.setAccessible(true);
-        commandCodecField.set(executor, new W3CHttpCommandCodec());
-        Field responseCodecField = HttpCommandExecutor.class
-                .getDeclaredField("responseCodec");
-        responseCodecField.setAccessible(true);
-        responseCodecField.set(executor, new W3CHttpResponseCodec());
-
-        RemoteWebDriver driver = new RemoteWebDriver(executor,
-                (Capabilities) null) {
-            @Override
-            protected void startSession(Capabilities capabilities) {
-                // Do not start a new session; we are reconnecting.
-            }
-        };
-        Field sessionIdField = RemoteWebDriver.class
-                .getDeclaredField("sessionId");
-        sessionIdField.setAccessible(true);
-        sessionIdField.set(driver, new SessionId(sessionId));
-        Field capsField = RemoteWebDriver.class
-                .getDeclaredField("capabilities");
-        capsField.setAccessible(true);
-        capsField.set(driver, new ChromeOptions());
-
-        return TestBench.createDriver(driver);
-    }
-
-    private static void saveDriverInfo(WebDriver driver) {
-        try {
-            WebDriver actual = unwrap(driver);
-            if (actual instanceof RemoteWebDriver) {
-                RemoteWebDriver rwd = (RemoteWebDriver) actual;
-                SessionId sid = rwd.getSessionId();
-                if (sid != null) {
-                    HttpCommandExecutor exec = (HttpCommandExecutor) rwd
-                            .getCommandExecutor();
-                    String info = exec.getAddressOfRemoteServer().toString()
-                            + "\n" + sid.toString();
-                    Files.writeString(DRIVER_FILE, info);
-                }
-            }
-        } catch (Exception e) {
-            // Ignore
-        }
-    }
-
-    private static WebDriver unwrap(WebDriver driver) {
-        WebDriver actual = driver;
-        while (actual instanceof WrapsDriver) {
-            actual = ((WrapsDriver) actual).getWrappedDriver();
-        }
-        return actual;
-    }
-
     private static WebDriver createWebDriver() {
         for (int i = 0; i < 3; i++) {
             try {
-                if (USE_HUB) {
-                    return tryCreateRemoteDriver();
-                }
-                return tryCreateChromeDriver();
+                return USE_HUB ? tryCreateRemoteDriver()
+                        : tryCreateChromeDriver();
             } catch (Exception e) {
-                logger.warn("Unable to create driver on attempt " + i, e);
+                logger.warn("Unable to create driver on attempt {}", i, e);
             }
         }
-        throw new RuntimeException(
+        throw new IllegalStateException(
                 "Gave up trying to create a driver instance");
     }
 
@@ -564,6 +469,14 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
         RemoteWebDriver remoteDriver = new RemoteWebDriver(
                 URI.create(HUB_URL).toURL(), options);
         return TestBench.createDriver(remoteDriver);
+    }
+
+    private static WebDriver unwrap(WebDriver driver) {
+        WebDriver actual = driver;
+        while (actual instanceof WrapsDriver wrapsDriver) {
+            actual = wrapsDriver.getWrappedDriver();
+        }
+        return actual;
     }
 
     // ----- Test helper methods -----


### PR DESCRIPTION
Extends `AbstractComponentIT` with four independent opt-in features, each enabled by a system property:

**`-Dtest.reuseDriver=true`** (existing, unchanged behavior)
One Chrome window per test class. Reuses the driver between methods, creates a new one per class.

**`-Dtest.shareDriver=true`** (new)
One Chrome window for the entire JVM fork — reused across all test classes in the same process. Implies `test.reuseDriver`. Includes a health-check before each class, debug-mode session persistence to disk for reconnect across runs, a JVM shutdown hook for cleanup, and a consecutive-failure abort rule (stops the fork after 5 consecutive failures to avoid burning CI time on a dead driver).

**`-Dtest.useSpa=true`** (new)
When combined with `reuseDriver` or `shareDriver`, navigates between routes via the Vaadin `vaadin-navigate` client event instead of a full page load. Falls back to a full load automatically when the browser is not on a Vaadin page or when navigating to the same route (which would leak session state).

**`-Dtest.headed=true`** (new)
Runs Chrome in headed (visible) mode. Default is headless. Also implied when a JDWP debug agent is attached.

**`isReuseDriver()` hook** (new)
Allows subclasses to opt out of driver reuse on a per-class basis without changing the global system property. Returns `true` if either `test.reuseDriver` or `test.shareDriver` is active.

## Benchmark results (GHA, Ubuntu)

All runs use `forkCount=4` unless noted. "Longest shard" is the wall-clock time of the slowest IT shard job.

| Config | Shards | Driver | SPA | Longest shard |
|---|---|---|---|---|
| main baseline | 10 | reuseDriver | — | 369s |
| shareDriver | 10 | shareDriver | — | 358s |
| shareDriver + SPA | 10 | shareDriver | ✓ | 462s |
| reuseDriver + SPA | 10 | reuseDriver | ✓ | 468s |
| shareDriver | 8 | shareDriver | — | 525s |
| reuseDriver | 8 | reuseDriver | — | 441s |
| **reuseDriver + SPA** | **8** | **reuseDriver** | **✓** | **421s** |

Key findings:
- `shareDriver` vs `reuseDriver` with 10 shards: ~11s difference — within noise, not significant. With `forkCount=4` the Chrome startup cost is already amortized across 4 parallel forks.
- SPA navigation adds overhead with 10 shards (extra Vaadin client check per test) but helps with 8 shards where tests run more sequentially per fork.
- 8 shards is slower than 10 shards overall, but `reuseDriver + SPA` at 421s is the best 8-shard configuration.
- Local development benefit is significant: `headed + reuseDriver` reduces a 73s run to 16s for the same 29 tests.

The CI in this PR uses `8 shards + reuseDriver + useSpa` as a benchmark configuration.