### PR TITLE
chore: invalidate WAR cache on component source change

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Compute WAR cache key
         id: war-key
         env:
-          KEY: ${{ runner.os }}-war-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', 'integration-tests/src/**') }}
+          KEY: ${{ runner.os }}-war-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', 'integration-tests/src/test/java/**') }}
         run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore WAR cache

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Compute WAR cache key
         id: war-key
         env:
-          KEY: ${{ runner.os }}-war-${{ hashFiles('integration-tests/pom.xml', 'integration-tests/src/**') }}
+          KEY: ${{ runner.os }}-war-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', 'integration-tests/src/**') }}
         run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore WAR cache


### PR DESCRIPTION
WAR cache key only hashed integration-tests sources. Component production sources (`vaadin-*/src/main/**`) were not part of the key, so rebasing onto main commits that touched component code did not invalidate the WAR cache. 

Build cache (jars in `~/.m2/repository/com/vaadin`) does hash component sources and rebuilds correctly on miss, but the WAR cache hit on the unchanged key restored a WAR packaged against the previous jars. ITs then ran against a stale WAR. Only workaround was deleting the cache manually.

The PR extends WAR key globs to match the build cache so both invalidate together