### PR TITLE
ci: switch to sequential gate workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -134,79 +134,22 @@ jobs:
           fi
           echo "elements=$elements" >> "$GITHUB_OUTPUT"
 
-  unit-tests:
-    name: Unit tests
+  fast-tests:
+    name: ${{ matrix.name }}
     needs: build
     if: needs.build.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
-    steps:
-      - name: Set Maven args
-        run: |
-          args="-ntp -B"
-          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
-          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          fetch-depth: 1
-
-      - name: Setup JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Install TestBench license
-        if: env.TB_LICENSE != ''
-        env:
-          TB_LICENSE: ${{ secrets.TB_LICENSE }}
-        run: |
-          mkdir -p ~/.vaadin
-          user="${TB_LICENSE%%/*}"
-          key="${TB_LICENSE#*/}"
-          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
-
-      - name: Restore build cache
-        id: build-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install artifacts (cache miss)
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        run: |
-          mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
-            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
-            sleep 15
-            mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS
-          }
-
-      - name: Run unit tests
-        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 $MAVEN_ARGS
-
-      - name: Upload unit test reports
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: surefire-reports
-          path: '**/target/surefire-reports/TEST-*.xml'
-          retention-days: 1
-          if-no-files-found: ignore
-
-  wtr-tests:
-    name: WTR tests
-    needs: build
-    if: needs.build.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: Unit tests
+            type: unit
+          - name: WTR tests
+            type: wtr
     steps:
       - name: Set Maven args
         run: |
@@ -227,6 +170,7 @@ jobs:
           cache: 'maven'
 
       - name: Setup Node
+        if: matrix.type == 'wtr'
         uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -257,14 +201,29 @@ jobs:
             mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS
           }
 
+      - name: Run unit tests
+        if: matrix.type == 'unit'
+        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 $MAVEN_ARGS
+
+      - name: Upload unit test reports
+        if: always() && matrix.type == 'unit'
+        uses: actions/upload-artifact@v6
+        with:
+          name: surefire-reports
+          path: '**/target/surefire-reports/TEST-*.xml'
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: npm install
+        if: matrix.type == 'wtr'
         run: npm ci --ignore-scripts
 
       - name: Run WTR tests
+        if: matrix.type == 'wtr'
         run: node scripts/wtr.js ${{ needs.build.outputs.components }}
 
       - name: Upload WTR reports
-        if: always()
+        if: always() && matrix.type == 'wtr'
         uses: actions/upload-artifact@v6
         with:
           name: wtr-reports
@@ -413,7 +372,7 @@ jobs:
 
   its:
     name: ITs (${{ matrix.shard }})
-    needs: [unit-tests, wtr-tests, package-war]
+    needs: [fast-tests, package-war]
     if: needs.package-war.outputs.has-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -502,7 +461,7 @@ jobs:
 
   results:
     name: Collect tests
-    needs: [build, unit-tests, wtr-tests, package-war, its]
+    needs: [build, fast-tests, package-war, its]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -557,7 +516,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Unit test compilation error
-        if: steps.unit-check.outputs.count == '0' && needs.unit-tests.result == 'failure'
+        if: steps.unit-check.outputs.count == '0' && needs.fast-tests.result == 'failure'
         run: |
           echo ":x: Compilation failed. Check the **Unit tests** job for details." >> $GITHUB_STEP_SUMMARY
 
@@ -611,7 +570,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: WTR setup error
-        if: steps.wtr-check.outputs.count == '0' && needs.wtr-tests.result == 'failure'
+        if: steps.wtr-check.outputs.count == '0' && needs.fast-tests.result == 'failure'
         run: |
           echo ":x: WTR setup or compilation failed. Check the **WTR tests** job for details." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -142,6 +142,10 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      matrix:        ${{ steps.shards.outputs.matrix }}
+      has-tests:     ${{ steps.shards.outputs.has-tests }}
+      war-cache-key: ${{ steps.war-key.outputs.key }}
     strategy:
       fail-fast: true
       matrix:
@@ -150,6 +154,8 @@ jobs:
             type: unit
           - name: WTR tests
             type: wtr
+          - name: Package WAR
+            type: war
     steps:
       - name: Set Maven args
         run: |
@@ -162,21 +168,47 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           fetch-depth: 1
 
+      - name: Setup Node
+        if: matrix.type != 'unit'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: npm install
+        if: matrix.type != 'unit'
+        run: npm ci --ignore-scripts
+
+      - name: Merge ITs
+        if: matrix.type == 'war'
+        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
+
+      - name: Compute WAR cache key
+        if: matrix.type == 'war'
+        id: war-key
+        env:
+          KEY: ${{ runner.os }}-war-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', 'integration-tests/src/test/java/**') }}
+        run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore WAR cache
+        if: matrix.type == 'war'
+        id: war-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            integration-tests/pom.xml
+            integration-tests/target
+          key: ${{ steps.war-key.outputs.key }}
+
       - name: Setup JDK 21
+        if: steps.war-cache.outputs.cache-hit != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Setup Node
-        if: matrix.type == 'wtr'
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
       - name: Install TestBench license
-        if: env.TB_LICENSE != ''
+        if: env.TB_LICENSE != '' && steps.war-cache.outputs.cache-hit != 'true'
         env:
           TB_LICENSE: ${{ secrets.TB_LICENSE }}
         run: |
@@ -186,6 +218,7 @@ jobs:
           echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
 
       - name: Restore build cache
+        if: steps.war-cache.outputs.cache-hit != 'true'
         id: build-cache
         uses: actions/cache@v5
         with:
@@ -193,7 +226,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
 
       - name: Install artifacts (cache miss)
-        if: steps.build-cache.outputs.cache-hit != 'true'
+        if: steps.build-cache.outputs.cache-hit != 'true' && steps.war-cache.outputs.cache-hit != 'true'
         run: |
           mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
             echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
@@ -214,10 +247,6 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      - name: npm install
-        if: matrix.type == 'wtr'
-        run: npm ci --ignore-scripts
-
       - name: Run WTR tests
         if: matrix.type == 'wtr'
         run: node scripts/wtr.js ${{ needs.build.outputs.components }}
@@ -231,93 +260,8 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-  package-war:
-    name: Package WAR
-    needs: build
-    if: needs.build.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    outputs:
-      matrix: ${{ steps.shards.outputs.matrix }}
-      has-tests: ${{ steps.shards.outputs.has-tests }}
-      war-cache-key: ${{ steps.war-key.outputs.key }}
-    steps:
-      - name: Set Maven args
-        run: |
-          args="-ntp -B"
-          [ "${{ runner.debug }}" != "1" ] && args="$args -q"
-          echo "MAVEN_ARGS=$args" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          fetch-depth: 1
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: npm install
-        run: npm ci --ignore-scripts
-
-      - name: Merge ITs
-        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
-
-      - name: Compute WAR cache key
-        id: war-key
-        env:
-          KEY: ${{ runner.os }}-war-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', 'integration-tests/src/test/java/**') }}
-        run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
-
-      - name: Restore WAR cache
-        id: war-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            integration-tests/pom.xml
-            integration-tests/target
-          key: ${{ steps.war-key.outputs.key }}
-
-      - name: Setup JDK 21
-        if: steps.war-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Install TestBench license
-        if: steps.war-cache.outputs.cache-hit != 'true' && env.TB_LICENSE != ''
-        env:
-          TB_LICENSE: ${{ secrets.TB_LICENSE }}
-        run: |
-          mkdir -p ~/.vaadin
-          user="${TB_LICENSE%%/*}"
-          key="${TB_LICENSE#*/}"
-          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
-
-      - name: Restore build cache
-        id: build-cache
-        if: steps.war-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install artifacts (cache miss)
-        if: steps.war-cache.outputs.cache-hit != 'true' && steps.build-cache.outputs.cache-hit != 'true'
-        run: |
-          mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
-            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
-            sleep 15
-            mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS
-          }
-
       - name: Package integration-tests WAR
-        if: steps.war-cache.outputs.cache-hit != 'true'
+        if: matrix.type == 'war' && steps.war-cache.outputs.cache-hit != 'true'
         run: |
           mvn package -pl integration-tests \
             -Dvaadin.pnpm.enable -Drun-it -Drelease \
@@ -325,10 +269,11 @@ jobs:
             -Dmaven.test.skip=true -DskipJetty $MAVEN_ARGS
 
       - name: Compile IT test sources
-        if: steps.war-cache.outputs.cache-hit != 'true'
+        if: matrix.type == 'war' && steps.war-cache.outputs.cache-hit != 'true'
         run: mvn test-compile -pl integration-tests -Drun-it -DskipFrontend -DskipJetty -DskipUnitTests $MAVEN_ARGS
 
       - name: Compute IT shards
+        if: matrix.type == 'war'
         id: shards
         env:
           SHARDS: ${{ github.event.inputs.shards || '0' }}
@@ -372,15 +317,15 @@ jobs:
 
   its:
     name: ITs (${{ matrix.shard }})
-    needs: [fast-tests, package-war]
-    if: needs.package-war.outputs.has-tests == 'true'
+    needs: [fast-tests]
+    if: needs.fast-tests.outputs.has-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.package-war.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.fast-tests.outputs.matrix) }}
     steps:
       - name: Set Maven args
         run: |
@@ -422,7 +367,7 @@ jobs:
           path: |
             integration-tests/pom.xml
             integration-tests/target
-          key: ${{ needs.package-war.outputs.war-cache-key }}
+          key: ${{ needs.fast-tests.outputs.war-cache-key }}
           fail-on-cache-miss: true
 
       - name: Run integration tests (shard ${{ matrix.shard }})
@@ -461,7 +406,7 @@ jobs:
 
   results:
     name: Collect tests
-    needs: [build, fast-tests, package-war, its]
+    needs: [build, fast-tests, its]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -543,7 +488,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: IT compilation error
-        if: steps.it-check.outputs.count == '0' && needs.package-war.result == 'failure'
+        if: steps.it-check.outputs.count == '0' && needs.fast-tests.result == 'failure'
         run: |
           echo ":x: Compilation failed. Check the **Package WAR** job for details." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -142,7 +142,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Set Maven args
         run: |
@@ -200,12 +199,6 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      - name: Cancel workflow on failure
-        if: failure()
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
-
   wtr-tests:
     name: WTR tests
     needs: build
@@ -214,7 +207,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Set Maven args
         run: |
@@ -279,12 +271,6 @@ jobs:
           path: '**/wtr-results.xml'
           retention-days: 1
           if-no-files-found: ignore
-
-      - name: Cancel workflow on failure
-        if: failure()
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
 
   package-war:
     name: Package WAR
@@ -427,7 +413,7 @@ jobs:
 
   its:
     name: ITs (${{ matrix.shard }})
-    needs: package-war
+    needs: [unit-tests, wtr-tests, package-war]
     if: needs.package-war.outputs.has-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
Replaces the current parallel-with-cancel strategy with a sequential gate: unit tests, WTR tests, and the WAR build must all pass before any IT shard starts.

NOTE: this is not the optimal solution for the fastest validation, but makes simplest to read the whole status of the build

## Replaced workflow (Strategy C — current `main`)

```
                 ┌─────────────┐
                 │    BUILD    │
                 └──────┬──────┘
                        │
          ┌─────────────┼──────────────────┐
          │             │                  │
          ▼             ▼                  ▼
  ┌──────────────┐ ┌──────────────┐ ┌───────────────────┐
  │  UNIT-TESTS  │ │  WTR-TESTS   │ │    PACKAGE-WAR    │
  │ (cancel on   │ │ (cancel on   │ └────────┬──────────┘
  │   failure)   │ │   failure)   │          │
  └──────┬───────┘ └──────┬───────┘          ▼
         │                │        ┌───────────────────┐
         │                │        │   ITs (shards)    │
         │                │        └────────┬──────────┘
         └────────────────┼─────────────────┘
                          │ (always, if build succeeded)
                          ▼
                ┌───────────────────┐
                │  "Collect tests"  │
                └───────────────────┘
```

**Pros:** ITs start at the earliest possible moment. Fastest green builds.
**Cons:** Build shows as `cancelled` (not `failed`) on any failure. IT runners may already be running when a unit/WTR failure arrives. Two independent cancellers can race.

## New workflow (Strategy B — sequential gate)

```
           ┌───────────┐
           │   BUILD   │
           └─────┬─────┘
                 │
                 ▼
┌────────────────────────────────────────────┐
│  ┌────────────┐ ┌───────────┐ ┌──────────┐ │
│  │ UNIT-TESTS │ │ WTR-TESTS │ │PACKAGE-  │ │
│  └────────────┘ └───────────┘ │WAR       │ │
│                               └──────────┘ │
└─────────────────────┬──────────────────────┘
                      │
                      ▼
           ┌──────────────────────┐
           │  INTEGRATION-TESTS   │
           │      (shards)        │
           └──────────┬───────────┘
                      │
                      ▼
           ┌─────────────────────┐
           │       RESULTS       │
           └─────────────────────┘
```

**Pros:** Build is always **red** (not cancelled) on any failure, which works cleanly with branch protection rules and merge queues. IT runners are never started if fast tests or WAR build fail, saving resources. Simple mental model.
**Cons:** ITs must wait for the slowest of unit/WTR/WAR (~2 min on a warm cache).

## Changes

- Remove `Cancel workflow on failure` steps from `unit-tests` and `wtr-tests`.
- Remove `actions: write` permission from `unit-tests` and `wtr-tests` (no longer needed).
- Add `unit-tests` and `wtr-tests` to the `needs` list of the `its` job, creating the sequential gate.