### PR TITLE
docs: explain ol @NpmPackage on Map component

### DIFF
--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/Map.java
@@ -82,6 +82,9 @@ import tools.jackson.databind.node.ObjectNode;
  */
 @Tag("vaadin-map")
 @NpmPackage(value = "@vaadin/map", version = "25.2.0-alpha10")
+// ol is also a transitive dep of @vaadin/map, but mapConnector.js imports
+// from `ol/*` directly, which only resolves when ol is a top-level
+// node_modules entry. Keep version in sync with the one in @vaadin/map.
 @NpmPackage(value = "ol", version = "10.6.0")
 @NpmPackage(value = "proj4", version = "2.17.0")
 @JsModule("@vaadin/map/src/vaadin-map.js")


### PR DESCRIPTION
The `ol` `@NpmPackage` annotation on the `Map` component duplicates a dependency already declared by `@vaadin/map`. Without context, this looks redundant and an obvious candidate for cleanup — which has happened before (see #9254, reverted in #9256).

Add an inline comment documenting:
- mapConnector.js imports from `ol/*` directly, which only resolves when `ol` is a top-level `node_modules` entry, so the duplicate declaration is required.
- The version must be kept in sync with the one shipped by `@vaadin/map`.

Follow-up to #9256
