### PR TITLE
ci: show all passing tests when green, only failures when red

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -548,15 +548,6 @@ jobs:
           name: wtr-reports
           path: wtr-reports
 
-      - name: Remove passing test reports
-        run: |
-          for dir in surefire-reports failsafe-reports wtr-reports; do
-            [ -d "$dir" ] || continue
-            find "$dir" -name '*.xml' | while read -r f; do
-              grep -qE '<failure|<error' "$f" || rm -f "$f"
-            done
-          done
-
       - name: Check for unit test reports
         id: unit-check
         run: |
@@ -575,8 +566,8 @@ jobs:
           name: Unit Tests
           path: surefire-reports/**/TEST-*.xml
           reporter: java-junit
-          list-tests: 'failed'
-          list-suites: 'failed'
+          list-tests: ${{ (needs.unit-tests.result == 'failure' || needs.wtr-tests.result == 'failure' || needs.its.result == 'failure') && 'failed' || 'all' }}
+          list-suites: ${{ (needs.unit-tests.result == 'failure' || needs.wtr-tests.result == 'failure' || needs.its.result == 'failure') && 'failed' || 'all' }}
           fail-on-error: 'false'
 
       - name: Unit test compilation error
@@ -602,8 +593,8 @@ jobs:
           name: Integration Tests
           path: failsafe-reports/TEST-*.xml
           reporter: java-junit
-          list-tests: 'failed'
-          list-suites: 'failed'
+          list-tests: ${{ (needs.unit-tests.result == 'failure' || needs.wtr-tests.result == 'failure' || needs.its.result == 'failure') && 'failed' || 'all' }}
+          list-suites: ${{ (needs.unit-tests.result == 'failure' || needs.wtr-tests.result == 'failure' || needs.its.result == 'failure') && 'failed' || 'all' }}
           fail-on-error: 'false'
 
       - name: IT compilation error
@@ -629,8 +620,8 @@ jobs:
           name: WTR Tests
           path: wtr-reports/**/wtr-results.xml
           reporter: java-junit
-          list-tests: 'failed'
-          list-suites: 'failed'
+          list-tests: ${{ (needs.unit-tests.result == 'failure' || needs.wtr-tests.result == 'failure' || needs.its.result == 'failure') && 'failed' || 'all' }}
+          list-suites: ${{ (needs.unit-tests.result == 'failure' || needs.wtr-tests.result == 'failure' || needs.its.result == 'failure') && 'failed' || 'all' }}
           fail-on-error: 'false'
 
       - name: WTR setup error


### PR DESCRIPTION
When any test suite has failures, only the failing reports are shown so the summary stays focused on what broke. When everything passes, all reports are kept and all test suites are shown in full so the green build is visible.

**Detection:** uses testsuite attributes (`failures="[1-9]` / `errors="[1-9]"`) instead of element tags, so flaky tests retried by failsafe (`rerunFailingTestsCount`) do not trigger false positives — those leave `<flakyError>` elements but keep `failures="0" errors="0"` on the testsuite.

**dorny `list-tests`/`list-suites`:** set to `'failed'` when failures exist, `'all'` when everything is green.