### PR TITLE
chore: upgrade xml2js to fix prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "APACHE",
       "devDependencies": {
         "replace-in-file": "6.1.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/ansi-regex": {
@@ -450,9 +450,9 @@
       "license": "ISC"
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "devDependencies": {
     "replace-in-file": "6.1.0",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.6.2"
   },
   "license": "APACHE"
 }


### PR DESCRIPTION
Upgrades xml2js from ^0.4.23 to ^0.6.2 to fix a prototype pollution vulnerability (moderate severity, dependabot alert #9).

Fixes https://github.com/vaadin/flow-components/security/dependabot/9