### PR TITLE
feat: add response failed and request start hooks to ai controller

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -42,15 +42,19 @@ public interface AIController {
     List<LLMProvider.ToolSpec> getTools();
 
     /**
-     * Called synchronously on the UI thread at the start of every LLM turn,
-     * before the orchestrator opens the LLM stream. Implementations can prepare
-     * for the turn — locking UI surfaces, snapshotting state the tool
-     * definitions depend on, and so on.
+     * Called synchronously on the UI thread just before the LLM stream opens.
+     * By the time this method fires, the user message and an empty assistant
+     * placeholder are already in the message list and the user message is in
+     * the conversation history. Implementations can prepare for the turn —
+     * locking UI surfaces, snapshotting state the tool definitions depend on,
+     * and so on.
      * <p>
      * The default does nothing. Throwing from this method aborts the turn: the
-     * LLM stream is not opened, {@link #onResponseFailed(Throwable)} fires with
-     * the thrown exception so per-turn state captured before the throw can
-     * still be released, and the user sees a generic error message.
+     * LLM stream is not opened, the assistant placeholder is updated to a
+     * generic error message in the chat, {@link #onResponseFailed(Throwable)}
+     * fires with the thrown exception so per-turn state captured before the
+     * throw can still be released, and the exception propagates back to the
+     * caller of the prompt entry point.
      * </p>
      */
     default void onRequestStart() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -20,13 +20,9 @@ import java.util.List;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 
 /**
- * Interface for AI controllers that extend orchestrator capabilities by
- * providing tools that the LLM can use.
- * <p>
- * Controllers provide domain-specific tools and functionality to the AI
- * orchestrator. Tools are functions that the AI can call to perform actions
- * like querying databases, creating visualizations, filling forms, etc.
- * </p>
+ * Contributes tools and lifecycle hooks to an {@link AIOrchestrator} —
+ * domain-specific behaviour like populating a grid, building a chart, or
+ * filling a form from natural-language requests.
  * <p>
  * Controllers are <b>not serialized</b> with the orchestrator. After
  * deserialization, restore controllers via
@@ -39,30 +35,55 @@ import com.vaadin.flow.component.ai.provider.LLMProvider;
 public interface AIController {
 
     /**
-     * Returns the tools this controller provides to the LLM.
-     * <p>
-     * Tools are functions that the AI can call to perform actions. Each tool
-     * should have a clear name, description, and parameter schema.
-     * </p>
+     * Returns the tools this controller exposes to the LLM.
      *
      * @return list of tools, or empty list if controller provides no tools
      */
     List<LLMProvider.ToolSpec> getTools();
 
     /**
-     * Called by the orchestrator when an LLM request cycle has completed.
+     * Called synchronously on the UI thread at the start of every LLM turn,
+     * before the orchestrator opens the LLM stream. Implementations can prepare
+     * for the turn — locking UI surfaces, snapshotting state the tool
+     * definitions depend on, and so on.
      * <p>
-     * This method is invoked after all tool executions for a given user request
-     * have finished and the LLM has generated its final response. Controllers
-     * can use this callback to perform deferred operations, such as rendering
-     * UI updates or committing state changes.
+     * The default does nothing. Throwing from this method aborts the turn: the
+     * LLM stream is not opened, {@link #onResponseFailed(Throwable)} fires with
+     * the thrown exception so per-turn state captured before the throw can
+     * still be released, and the user sees a generic error message.
      * </p>
+     */
+    default void onRequestStart() {
+    }
+
+    /**
+     * Called on the UI thread under the session lock when the LLM stream
+     * completes successfully — after all tool calls for the turn have run and
+     * the LLM has produced its final response. Use it for deferred UI updates
+     * or to commit staged state.
      * <p>
-     * The orchestrator invokes this method on the UI thread under the session
-     * lock, so implementations may update UI components directly. Any exception
-     * thrown is caught by the orchestrator and reported to the user as a
-     * generic error message.
+     * Mutually exclusive with {@link #onResponseFailed(Throwable)}: every turn
+     * fires exactly one of the two. Exceptions thrown from the hook are caught
+     * and the user sees a generic error message; Errors propagate.
      * </p>
      */
     void onResponseComplete();
+
+    /**
+     * Called on the UI thread under the session lock when an LLM turn fails —
+     * stream error, timeout, or any throw between {@link #onRequestStart()} and
+     * the start of the stream. Implementations should release per-turn state
+     * captured in {@code onRequestStart} (locks, pending writes, snapshots).
+     * <p>
+     * Mutually exclusive with {@link #onResponseComplete()}: every turn fires
+     * exactly one of the two. The default does nothing. Exceptions thrown from
+     * the hook are caught and logged; Errors propagate.
+     * </p>
+     *
+     * @param error
+     *            the cause of the failure (Exception or Error), never
+     *            {@code null}
+     */
+    default void onResponseFailed(Throwable error) {
+    }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -44,17 +44,19 @@ public interface AIController {
     /**
      * Called synchronously on the UI thread just before the LLM stream opens.
      * By the time this method fires, the user message and an empty assistant
-     * placeholder are already in the message list and the user message is in
-     * the conversation history. Implementations can prepare for the turn —
+     * placeholder are already in the message list; the turn is committed to the
+     * conversation history and the attachment-submit listener only after this
+     * method returns successfully. Implementations can prepare for the turn —
      * locking UI surfaces, snapshotting state the tool definitions depend on,
      * and so on.
      * <p>
-     * The default does nothing. Throwing from this method aborts the turn: the
-     * LLM stream is not opened, the assistant placeholder is updated to a
-     * generic error message in the chat, {@link #onResponseFailed(Throwable)}
-     * fires with the thrown exception so per-turn state captured before the
-     * throw can still be released, and the exception propagates back to the
-     * caller of the prompt entry point.
+     * The default does nothing. Throwing from this method aborts the turn
+     * before the commit step: the conversation history is unchanged, the
+     * attachment-submit listener is not notified, the LLM stream is not opened,
+     * the assistant placeholder is updated to a generic error message,
+     * {@link #onResponseFailed(Throwable)} fires with the thrown exception so
+     * per-turn state captured before the throw can still be released, and the
+     * exception propagates back to the caller of the prompt entry point.
      * </p>
      */
     default void onRequestStart() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -365,6 +365,7 @@ public class AIOrchestrator implements Serializable {
             if (assistantMessage != null && messageList != null) {
                 ui.access(() -> assistantMessage.setText(userMessage));
             }
+            fireResponseFailed(error, ui);
         }, () -> {
             var responseText = responseBuilder.toString();
             if (!responseText.isEmpty()) {
@@ -393,20 +394,32 @@ public class AIOrchestrator implements Serializable {
         }
         try {
             processUserInput(userMessage);
-        } catch (Exception e) {
-            // streamResponseToMessage's doFinally only fires after
-            // subscription. If processUserInput throws before that (e.g. an
-            // AttachmentSubmitListener failure), the flag would
-            // stay stuck and the orchestrator would refuse every later
-            // prompt.
+        } catch (Throwable t) { // NOSONAR — Throwable for cleanup-then-rethrow
+            // Reset the flag before firing the hook so a controller can
+            // retry from onResponseFailed, matching the async paths where
+            // doFinally clears the flag before the hook runs. Catching
+            // Throwable rather than Exception covers Error subtypes (OOM,
+            // AssertionError) — otherwise the flag would stay stuck and
+            // every later prompt would be dropped. Firing the hook for
+            // any Throwable mirrors the async onError consumer.
             isProcessing.set(false);
-            throw e;
+            // null only if UI.getCurrentOrThrow inside processUserInput
+            // failed first — in which case nothing past it executed.
+            var currentUi = UI.getCurrent();
+            if (currentUi != null) {
+                fireResponseFailed(t, currentUi);
+            }
+            throw t;
         }
     }
 
     private void processUserInput(String userMessage) {
         var ui = UI.getCurrentOrThrow();
         checkFeatureFlag(ui);
+
+        if (controller != null) {
+            controller.onRequestStart();
+        }
 
         var attachments = fileReceiver != null ? fileReceiver.takeAttachments()
                 : List.<AIAttachment> of();
@@ -466,6 +479,19 @@ public class AIOrchestrator implements Serializable {
         LOGGER.debug("Processing prompt with {} attachments",
                 attachments.size());
         streamResponseToMessage(request, assistantMessage, ui);
+    }
+
+    private void fireResponseFailed(Throwable error, UI ui) {
+        if (controller == null) {
+            return;
+        }
+        ui.access(() -> {
+            try {
+                controller.onResponseFailed(error);
+            } catch (Exception e) {
+                LOGGER.error("Error in controller onResponseFailed", e);
+            }
+        });
     }
 
     private void fireResponseCompleteListener(String responseText, UI ui) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -421,65 +421,29 @@ public class AIOrchestrator implements Serializable {
                 : List.<AIAttachment> of();
         var userAIMessage = messageList == null ? null
                 : messageList.addMessage(userMessage, userName, attachments);
-
-        var messageId = UUID.randomUUID().toString();
-        conversationHistory.add(new ChatMessage(ChatMessage.Role.USER,
-                userMessage, messageId, Instant.now()));
-        if (userAIMessage != null) {
-            itemToMessageId.put(userAIMessage, messageId);
-        }
-
         var assistantMessage = createAssistantMessagePlaceholder();
 
         try {
-            if (!attachments.isEmpty() && attachmentSubmitListener != null) {
-                var attachmentsCopy = List.copyOf(attachments);
-                attachmentSubmitListener.onAttachmentSubmit(
-                        new AttachmentSubmitListener.AttachmentSubmitEvent(
-                                messageId, attachmentsCopy));
-            }
-
             if (controller != null) {
                 controller.onRequestStart();
             }
 
-            String effectiveSystemPrompt = null;
-            if (systemPrompt != null && !systemPrompt.isBlank()) {
-                effectiveSystemPrompt = systemPrompt.trim();
-            }
-            final var finalSystemPrompt = effectiveSystemPrompt;
-            var controllerTools = controller != null
-                    && controller.getTools() != null ? controller.getTools()
-                            : List.<LLMProvider.ToolSpec> of();
-            var request = new LLMProvider.LLMRequest() {
-
-                @Override
-                public String userMessage() {
-                    return userMessage;
-                }
-
-                @Override
-                public List<AIAttachment> attachments() {
-                    return attachments;
-                }
-
-                @Override
-                public String systemPrompt() {
-                    return finalSystemPrompt;
-                }
-
-                @Override
-                public Object[] tools() {
-                    return tools == null ? new Object[0] : tools;
-                }
-
-                @Override
-                public List<LLMProvider.ToolSpec> explicitTools() {
-                    return controllerTools;
-                }
-            };
+            var request = buildRequest(userMessage, attachments);
             LOGGER.debug("Processing prompt with {} attachments",
                     attachments.size());
+
+            var messageId = UUID.randomUUID().toString();
+            if (!attachments.isEmpty() && attachmentSubmitListener != null) {
+                attachmentSubmitListener.onAttachmentSubmit(
+                        new AttachmentSubmitListener.AttachmentSubmitEvent(
+                                messageId, List.copyOf(attachments)));
+            }
+            conversationHistory.add(new ChatMessage(ChatMessage.Role.USER,
+                    userMessage, messageId, Instant.now()));
+            if (userAIMessage != null) {
+                itemToMessageId.put(userAIMessage, messageId);
+            }
+
             streamResponseToMessage(request, assistantMessage, ui);
         } catch (Throwable t) { // NOSONAR — Throwable to surface UI on any
                                 // throw
@@ -493,6 +457,42 @@ public class AIOrchestrator implements Serializable {
             }
             throw t;
         }
+    }
+
+    private LLMProvider.LLMRequest buildRequest(String userMessage,
+            List<AIAttachment> attachments) {
+        final var effectiveSystemPrompt = systemPrompt != null
+                && !systemPrompt.isBlank() ? systemPrompt.trim() : null;
+        var controllerTools = controller != null
+                && controller.getTools() != null ? controller.getTools()
+                        : List.<LLMProvider.ToolSpec> of();
+        return new LLMProvider.LLMRequest() {
+
+            @Override
+            public String userMessage() {
+                return userMessage;
+            }
+
+            @Override
+            public List<AIAttachment> attachments() {
+                return attachments;
+            }
+
+            @Override
+            public String systemPrompt() {
+                return effectiveSystemPrompt;
+            }
+
+            @Override
+            public Object[] tools() {
+                return tools == null ? new Object[0] : tools;
+            }
+
+            @Override
+            public List<LLMProvider.ToolSpec> explicitTools() {
+                return controllerTools;
+            }
+        };
     }
 
     private void fireResponseFailed(Throwable error, UI ui) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -417,10 +417,6 @@ public class AIOrchestrator implements Serializable {
         var ui = UI.getCurrentOrThrow();
         checkFeatureFlag(ui);
 
-        if (controller != null) {
-            controller.onRequestStart();
-        }
-
         var attachments = fileReceiver != null ? fileReceiver.takeAttachments()
                 : List.<AIAttachment> of();
         var userAIMessage = messageList == null ? null
@@ -433,52 +429,70 @@ public class AIOrchestrator implements Serializable {
             itemToMessageId.put(userAIMessage, messageId);
         }
 
-        if (!attachments.isEmpty() && attachmentSubmitListener != null) {
-            var attachmentsCopy = List.copyOf(attachments);
-            attachmentSubmitListener.onAttachmentSubmit(
-                    new AttachmentSubmitListener.AttachmentSubmitEvent(
-                            messageId, attachmentsCopy));
-        }
-
         var assistantMessage = createAssistantMessagePlaceholder();
-        String effectiveSystemPrompt = null;
-        if (systemPrompt != null && !systemPrompt.isBlank()) {
-            effectiveSystemPrompt = systemPrompt.trim();
+
+        try {
+            if (!attachments.isEmpty() && attachmentSubmitListener != null) {
+                var attachmentsCopy = List.copyOf(attachments);
+                attachmentSubmitListener.onAttachmentSubmit(
+                        new AttachmentSubmitListener.AttachmentSubmitEvent(
+                                messageId, attachmentsCopy));
+            }
+
+            if (controller != null) {
+                controller.onRequestStart();
+            }
+
+            String effectiveSystemPrompt = null;
+            if (systemPrompt != null && !systemPrompt.isBlank()) {
+                effectiveSystemPrompt = systemPrompt.trim();
+            }
+            final var finalSystemPrompt = effectiveSystemPrompt;
+            var controllerTools = controller != null
+                    && controller.getTools() != null ? controller.getTools()
+                            : List.<LLMProvider.ToolSpec> of();
+            var request = new LLMProvider.LLMRequest() {
+
+                @Override
+                public String userMessage() {
+                    return userMessage;
+                }
+
+                @Override
+                public List<AIAttachment> attachments() {
+                    return attachments;
+                }
+
+                @Override
+                public String systemPrompt() {
+                    return finalSystemPrompt;
+                }
+
+                @Override
+                public Object[] tools() {
+                    return tools == null ? new Object[0] : tools;
+                }
+
+                @Override
+                public List<LLMProvider.ToolSpec> explicitTools() {
+                    return controllerTools;
+                }
+            };
+            LOGGER.debug("Processing prompt with {} attachments",
+                    attachments.size());
+            streamResponseToMessage(request, assistantMessage, ui);
+        } catch (Throwable t) { // NOSONAR — Throwable to surface UI on any
+                                // throw
+            // Single update — stream errors are async and never reach this
+            // catch; onResponseComplete throws are handled inside
+            // fireResponseCompleteListener (which appends rather than
+            // rewrites).
+            if (assistantMessage != null) {
+                assistantMessage
+                        .setText("An error occurred. Please try again.");
+            }
+            throw t;
         }
-        final var finalSystemPrompt = effectiveSystemPrompt;
-        var controllerTools = controller != null
-                && controller.getTools() != null ? controller.getTools()
-                        : List.<LLMProvider.ToolSpec> of();
-        var request = new LLMProvider.LLMRequest() {
-
-            @Override
-            public String userMessage() {
-                return userMessage;
-            }
-
-            @Override
-            public List<AIAttachment> attachments() {
-                return attachments;
-            }
-
-            @Override
-            public String systemPrompt() {
-                return finalSystemPrompt;
-            }
-
-            @Override
-            public Object[] tools() {
-                return tools == null ? new Object[0] : tools;
-            }
-
-            @Override
-            public List<LLMProvider.ToolSpec> explicitTools() {
-                return controllerTools;
-            }
-        };
-        LOGGER.debug("Processing prompt with {} attachments",
-                attachments.size());
-        streamResponseToMessage(request, assistantMessage, ui);
     }
 
     private void fireResponseFailed(Throwable error, UI ui) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1945,10 +1945,8 @@ class AIOrchestratorTest {
 
     @Test
     void streamError_setsErrorMessageOnAssistantPlaceholderExactlyOnce() {
-        // Pre-stream and async paths must not both set the placeholder
-        // text — the async onError consumer already handles this case,
-        // and our pre-stream catch is reached only when subscribe was
-        // never opened.
+        // Async errors and the pre-stream catch target the same text; the
+        // two paths must not stack.
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))
@@ -1964,12 +1962,76 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void attachmentListenerThrows_doesNotCommitToHistory() {
+        // Listener fires in the commit phase before history.add — a
+        // listener throw must not leave the user message in history.
+        stubAddMessage();
+        Mockito.when(mockFileReceiver.takeAttachments())
+                .thenReturn(List.of(createAttachment("a.txt")));
+
+        AttachmentSubmitListener listener = event -> {
+            throw new RuntimeException("listener failed");
+        };
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withFileReceiver(mockFileReceiver)
+                .withAttachmentSubmitListener(listener).build();
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("Hello"));
+
+        Assertions.assertTrue(orchestrator.getHistory().isEmpty(),
+                "Attachment listener throw must not commit user message to history");
+    }
+
+    @Test
+    void preStreamThrow_withoutMessageList_doesNotCrash() {
+        // No messageList means no assistant placeholder; the catch block
+        // must skip the setText update without an NPE.
+        var controller = mockController();
+        Mockito.doThrow(new RuntimeException("controller refused"))
+                .when(controller).onRequestStart();
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withController(controller).build();
+
+        var caught = Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("Hello"));
+        Assertions.assertEquals("controller refused", caught.getMessage());
+    }
+
+    @Test
+    void onRequestStartThrows_doesNotCommitToHistoryOrNotifyAttachmentListener() {
+        // No orphan state from a turn that never reached the LLM.
+        stubAddMessage();
+        Mockito.when(mockFileReceiver.takeAttachments())
+                .thenReturn(List.of(createAttachment("a.txt")));
+
+        var attachmentListener = Mockito.mock(AttachmentSubmitListener.class);
+        var controller = mockController();
+        Mockito.doThrow(new RuntimeException("controller refused"))
+                .when(controller).onRequestStart();
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withFileReceiver(mockFileReceiver).withController(controller)
+                .withAttachmentSubmitListener(attachmentListener).build();
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("Hello"));
+
+        Assertions.assertTrue(orchestrator.getHistory().isEmpty(),
+                "Pre-stream throw must not commit user message to history");
+        Mockito.verify(attachmentListener, Mockito.never())
+                .onAttachmentSubmit(Mockito.any());
+    }
+
+    @Test
     void preStreamThrow_setsErrorMessageOnAssistantPlaceholder() {
-        // Any synchronous pre-stream failure (onRequestStart here, but
-        // also the attachment listener or a synchronous provider throw)
-        // updates the assistant placeholder with a generic error message,
-        // matching the async stream-error path so every failure mode
-        // surfaces in chat.
+        // Synchronous pre-stream failures (onRequestStart, attachment
+        // listener, sync provider throw) update the placeholder, matching
+        // the async stream-error path.
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1944,6 +1944,50 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void streamError_setsErrorMessageOnAssistantPlaceholderExactlyOnce() {
+        // Pre-stream and async paths must not both set the placeholder
+        // text — the async onError consumer already handles this case,
+        // and our pre-stream catch is reached only when subscribe was
+        // never opened.
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.error(new RuntimeException("API died")));
+
+        orchestratorWith(mockController()).prompt("Hello");
+
+        Mockito.verify(mockMessage, Mockito.times(1))
+                .setText("An error occurred. Please try again.");
+    }
+
+    @Test
+    void preStreamThrow_setsErrorMessageOnAssistantPlaceholder() {
+        // Any synchronous pre-stream failure (onRequestStart here, but
+        // also the attachment listener or a synchronous provider throw)
+        // updates the assistant placeholder with a generic error message,
+        // matching the async stream-error path so every failure mode
+        // surfaces in chat.
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+
+        var thrown = new RuntimeException("simulated onRequestStart failure");
+        var controller = mockController();
+        Mockito.doThrow(thrown).when(controller).onRequestStart();
+
+        var orchestrator = orchestratorWith(controller);
+        Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("Hello"));
+
+        Mockito.verify(mockMessage)
+                .setText("An error occurred. Please try again.");
+    }
+
+    @Test
     void builder_withController_onResponseFailedThrows_isCaughtAndLogged() {
         // A misbehaving hook must not propagate; it gets logged so the
         // failure is operator-visible instead.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.Assertions;
@@ -1854,6 +1855,227 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void builder_withController_callsOnRequestStartBeforeStream() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var controller = mockController();
+        orchestratorWith(controller).prompt("Hello");
+
+        var inOrder = Mockito.inOrder(controller, mockProvider);
+        inOrder.verify(controller).onRequestStart();
+        inOrder.verify(mockProvider)
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void inputSubmit_callsOnRequestStartBeforeStream() {
+        // The input submit path must reach doPrompt the same way prompt(...)
+        // does — both go through processUserInput.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var controller = mockController();
+        AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withInput(mockInput)
+                .withController(controller).build();
+
+        var captor = ArgumentCaptor.forClass(SerializableConsumer.class);
+        Mockito.verify(mockInput).addSubmitListener(captor.capture());
+        captor.getValue().accept("Hi from input");
+
+        var inOrder = Mockito.inOrder(controller, mockProvider);
+        inOrder.verify(controller).onRequestStart();
+        inOrder.verify(mockProvider)
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void builder_withController_callsOnResponseFailedOnGenericStreamError() {
+        stubAddMessage();
+        var thrown = new RuntimeException("API died");
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.error(thrown));
+
+        var controller = mockController();
+        orchestratorWith(controller).prompt("Hello");
+
+        Mockito.verify(controller).onResponseFailed(thrown);
+        Mockito.verify(controller, Mockito.never()).onResponseComplete();
+    }
+
+    @Test
+    void builder_withController_callsOnResponseFailedOnTimeoutException() {
+        stubAddMessage();
+        var timeout = new TimeoutException("simulated");
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.error(timeout));
+
+        var controller = mockController();
+        orchestratorWith(controller).prompt("Hello");
+
+        Mockito.verify(controller).onResponseFailed(timeout);
+        Mockito.verify(controller, Mockito.never()).onResponseComplete();
+    }
+
+    @Test
+    void builder_withController_onRequestStartThrows_firesOnResponseFailedAndSkipsStream() {
+        stubAddMessage();
+        var thrown = new RuntimeException("controller refused");
+        var controller = mockController();
+        Mockito.doThrow(thrown).when(controller).onRequestStart();
+
+        var orchestrator = orchestratorWith(controller);
+        var caught = Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("Hello"));
+        Assertions.assertSame(thrown, caught);
+
+        Mockito.verify(mockProvider, Mockito.never())
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+        Mockito.verify(controller).onResponseFailed(thrown);
+        Mockito.verify(controller, Mockito.never()).onResponseComplete();
+    }
+
+    @Test
+    void builder_withController_onResponseFailedThrows_isCaughtAndLogged() {
+        // A misbehaving hook must not propagate; it gets logged so the
+        // failure is operator-visible instead.
+        stubAddMessage();
+        var streamError = new RuntimeException("API died");
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.error(streamError));
+
+        var controller = mockController();
+        Mockito.doThrow(new RuntimeException("controller blew up"))
+                .when(controller).onResponseFailed(Mockito.any());
+
+        orchestratorWith(controller).prompt("Hello");
+
+        Mockito.verify(controller).onResponseFailed(streamError);
+        var logged = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .equals("Error in controller onResponseFailed"))
+                .findFirst();
+        Assertions.assertTrue(logged.isPresent(),
+                "Expected an error log entry for the onResponseFailed throw");
+    }
+
+    @Test
+    void builder_withController_preStreamThrow_firesOnResponseFailed() {
+        stubAddMessage();
+        var thrown = new IllegalStateException(
+                "provider exploded before returning a stream");
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenThrow(thrown);
+
+        var controller = mockController();
+        var orchestrator = orchestratorWith(controller);
+        var caught = Assertions.assertThrows(IllegalStateException.class,
+                () -> orchestrator.prompt("Hello"));
+        Assertions.assertSame(thrown, caught);
+
+        Mockito.verify(controller).onResponseFailed(thrown);
+        Mockito.verify(controller, Mockito.never()).onResponseComplete();
+    }
+
+    @Test
+    void preStreamThrow_controllerCanRetryFromOnResponseFailed() {
+        // Order invariant: isProcessing must be released BEFORE
+        // onResponseFailed fires, otherwise a controller's recovery
+        // prompt is silently dropped at the CAS-false branch.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenThrow(new IllegalStateException("first turn dies"))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestratorRef = new AtomicReference<AIOrchestrator>();
+        var controller = mockController();
+        Mockito.doAnswer(invocation -> {
+            orchestratorRef.get().prompt("retry");
+            return null;
+        }).when(controller).onResponseFailed(Mockito.any());
+
+        var orchestrator = orchestratorWith(controller);
+        orchestratorRef.set(orchestrator);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> orchestrator.prompt("first"));
+
+        Mockito.verify(mockProvider, Mockito.times(2))
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+        Mockito.verify(controller).onResponseFailed(Mockito.any());
+        Mockito.verify(controller).onResponseComplete();
+    }
+
+    @Test
+    void preStreamThrow_firesOnResponseFailedForErrorSubtypes() {
+        // onResponseFailed must fire for any Throwable, not just
+        // Exception — controllers need to release per-turn state
+        // (snapshots, pending writes, locks) regardless of which
+        // failure mode killed the turn.
+        stubAddMessage();
+        var thrown = new AssertionError("simulated assertion in provider");
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenThrow(thrown);
+
+        var controller = mockController();
+        var orchestrator = orchestratorWith(controller);
+        var caught = Assertions.assertThrows(AssertionError.class,
+                () -> orchestrator.prompt("Hello"));
+        Assertions.assertSame(thrown, caught);
+
+        Mockito.verify(controller).onResponseFailed(thrown);
+        Mockito.verify(controller, Mockito.never()).onResponseComplete();
+    }
+
+    @Test
+    void doPrompt_hangSafety_releasesProcessingFlagOnNonExceptionThrowable() {
+        // Error subtypes (OOM, AssertionError) must still release
+        // isProcessing, otherwise every later prompt is silently
+        // dropped at the CAS-false branch.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenThrow(new AssertionError("simulated fatal"))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).build();
+        Assertions.assertThrows(AssertionError.class,
+                () -> orchestrator.prompt("first"));
+
+        orchestrator.prompt("second");
+        Mockito.verify(mockProvider, Mockito.times(2))
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void builder_withController_successfulTurnDoesNotFireOnResponseFailed() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var controller = mockController();
+        orchestratorWith(controller).prompt("Hello");
+
+        Mockito.verify(controller).onResponseComplete();
+        Mockito.verify(controller, Mockito.never())
+                .onResponseFailed(Mockito.any());
+    }
+
+    @Test
     void builder_withNoControllers_explicitToolsIsEmpty() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
@@ -2266,6 +2488,25 @@ class AIOrchestratorTest {
         return AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList)
                 .withFileReceiver(mockFileReceiver).withInput(mockInput)
+                .build();
+    }
+
+    private void stubAddMessage() {
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+    }
+
+    private AIController mockController() {
+        var controller = Mockito.mock(AIController.class);
+        Mockito.when(controller.getTools()).thenReturn(List.of());
+        return controller;
+    }
+
+    private AIOrchestrator orchestratorWith(AIController controller) {
+        return AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withController(controller)
                 .build();
     }
 


### PR DESCRIPTION
## Description

This PR:
- Adds the following to `AIController`:
  - `void onRequestStart()`: Fires synchronously on the UI thread before the LLM stream opens. Throwing aborts the turn and routes to `onResponseFailed`. Default does nothing.
  - `void onResponseFailed(Throwable)`: Fires on stream error, timeout, or any pre-stream throw. Mutually exclusive with `onResponseComplete`, every turn fires exactly one of the two. Default does nothing.
- Updates `AIOrchestrator` to uses the new API. Exceptions thrown from either hook are caught and logged; Errors propagate.

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=186537285

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.