### PR TITLE
perf: cache expensive test setup objects per class

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/SVGGeneratorTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/SVGGeneratorTest.java
@@ -24,9 +24,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import com.vaadin.flow.component.charts.model.AnnotationItemLabel;
 import com.vaadin.flow.component.charts.model.AnnotationItemLabelPoint;
@@ -46,16 +47,20 @@ import com.vaadin.flow.component.charts.model.XAxis;
 import com.vaadin.flow.component.charts.model.YAxis;
 import com.vaadin.flow.component.charts.themes.LumoDarkTheme;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SVGGeneratorTest {
 
+    // Shared generator: created once for all tests that do not need to close it.
+    // Creating a new SVGGenerator copies a 3.5 MiB bundle file per instance, so
+    // reusing one instance avoids 13 unnecessary copies across the 14 tests.
     private SVGGenerator svgGenerator;
 
-    @BeforeEach
+    @BeforeAll
     void setup() throws IOException {
         svgGenerator = new SVGGenerator();
     }
 
-    @AfterEach
+    @AfterAll
     void cleanup() throws IOException {
         if (!svgGenerator.isClosed()) {
             svgGenerator.close();
@@ -72,18 +77,22 @@ class SVGGeneratorTest {
     @Test
     void throwIllegalStateExceptionOnClosedGenerator()
             throws IOException, InterruptedException {
-        svgGenerator.close();
-        // it should check to see if the generator is closed before it checks if
-        // the config is null
-        assertThrows(IllegalStateException.class,
-                () -> svgGenerator.generate(null));
+        // Uses a local generator so the shared one stays open for other tests.
+        try (SVGGenerator localGenerator = new SVGGenerator()) {
+            localGenerator.close();
+            assertThrows(IllegalStateException.class,
+                    () -> localGenerator.generate(null));
+        }
     }
 
     @Test
     void shouldKnowWhenItIsClosed() throws IOException {
-        assertFalse(svgGenerator.isClosed());
-        svgGenerator.close();
-        assertTrue(svgGenerator.isClosed());
+        // Uses a local generator so the shared one stays open for other tests.
+        try (SVGGenerator localGenerator = new SVGGenerator()) {
+            assertFalse(localGenerator.isClosed());
+            localGenerator.close();
+            assertTrue(localGenerator.isClosed());
+        }
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/EnableFeatureFlagExtension.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/EnableFeatureFlagExtension.java
@@ -37,6 +37,10 @@ import com.vaadin.experimental.FeatureFlags;
  */
 public class EnableFeatureFlagExtension
         implements BeforeEachCallback, AfterEachCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace
+            .create(EnableFeatureFlagExtension.class);
+
     private final Feature feature;
     private FeatureFlags mockFeatureFlags;
     private MockedStatic<FeatureFlags> mockFeatureFlagsStatic;
@@ -47,24 +51,57 @@ public class EnableFeatureFlagExtension
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        mockFeatureFlags = Mockito.mock(FeatureFlags.class);
-        Mockito.when(mockFeatureFlags.isEnabled(feature)).thenReturn(true);
-        Mockito.when(mockFeatureFlags.isEnabled(feature.getId()))
-                .thenReturn(true);
-
-        mockFeatureFlagsStatic = Mockito.mockStatic(FeatureFlags.class);
-        mockFeatureFlagsStatic.when(() -> FeatureFlags.get(Mockito.any()))
-                .thenReturn(mockFeatureFlags);
+        // Create the Mockito static mock once per test class and reuse it.
+        // Mockito.mockStatic is expensive, and the mock state does not need to
+        // be reset between tests in the same class.
+        var store = context.getParent().orElse(context).getStore(NAMESPACE);
+        String key = context.getRequiredTestClass().getName() + "."
+                + feature.getId();
+        var holder = store.getOrComputeIfAbsent(key,
+                k -> createMocks(), MockHolder.class);
+        mockFeatureFlags = holder.featureFlags;
+        mockFeatureFlagsStatic = holder.staticMock;
+        // Reset to enabled state before each test: a previous test may have
+        // called disableFeature(), and that state would otherwise leak.
+        enableFeature();
     }
 
     @Override
     public void afterEach(ExtensionContext context) {
-        mockFeatureFlagsStatic.close();
+        // Do nothing: the mock is kept alive for the whole test class.
+        // JUnit 5 closes MockHolder (a CloseableResource) when the store scope
+        // ends after all tests in the class have run.
     }
 
     public void disableFeature() {
         Mockito.when(mockFeatureFlags.isEnabled(feature)).thenReturn(false);
         Mockito.when(mockFeatureFlags.isEnabled(feature.getId()))
                 .thenReturn(false);
+    }
+
+    public void enableFeature() {
+        Mockito.when(mockFeatureFlags.isEnabled(feature)).thenReturn(true);
+        Mockito.when(mockFeatureFlags.isEnabled(feature.getId()))
+                .thenReturn(true);
+    }
+
+    private MockHolder createMocks() {
+        FeatureFlags flags = Mockito.mock(FeatureFlags.class);
+        Mockito.when(flags.isEnabled(feature)).thenReturn(true);
+        Mockito.when(flags.isEnabled(feature.getId())).thenReturn(true);
+        MockedStatic<FeatureFlags> staticMock = Mockito
+                .mockStatic(FeatureFlags.class);
+        staticMock.when(() -> FeatureFlags.get(Mockito.any()))
+                .thenReturn(flags);
+        return new MockHolder(flags, staticMock);
+    }
+
+    private record MockHolder(FeatureFlags featureFlags,
+            MockedStatic<FeatureFlags> staticMock)
+            implements ExtensionContext.Store.CloseableResource {
+        @Override
+        public void close() {
+            staticMock.close();
+        }
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUIExtension.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUIExtension.java
@@ -47,6 +47,9 @@ import com.vaadin.flow.server.VaadinSession;
  */
 public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
 
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace
+            .create(MockUIExtension.class);
+
     // Keep the session and UI as fields to ensure they are not garbage
     // collected during the test
     private UI ui;
@@ -56,14 +59,22 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
     @Override
     @SuppressWarnings("checkstyle:UiSetCurrentCheck")
     public void beforeEach(ExtensionContext context) {
-        service = Mockito.mock(VaadinService.class);
-        DeploymentConfiguration deploymentConfig = Mockito
-                .mock(DeploymentConfiguration.class);
-        Mockito.when(deploymentConfig.isProductionMode()).thenReturn(false);
-        Mockito.when(service.getDeploymentConfiguration())
-                .thenReturn(deploymentConfig);
-
-        session = Mockito.spy(new AlwaysLockedVaadinSession(service));
+        // Retrieve or create service and session once per test class. Creating
+        // Mockito mocks and spies is expensive, and these objects are
+        // effectively stateless across tests, so sharing them is safe.
+        // context may be null when called from replaceUI() / clearUI().
+        if (context != null) {
+            var store = context.getParent().orElse(context).getStore(NAMESPACE);
+            String prefix = context.getRequiredTestClass().getName();
+            service = store.getOrComputeIfAbsent(prefix + ".service",
+                    key -> createService(), VaadinService.class);
+            session = store.getOrComputeIfAbsent(prefix + ".session",
+                    key -> Mockito.spy(new AlwaysLockedVaadinSession(service)),
+                    VaadinSession.class);
+        } else if (service == null) {
+            service = createService();
+            session = Mockito.spy(new AlwaysLockedVaadinSession(service));
+        }
 
         ui = new UI();
         ui.getInternals().setSession(session);
@@ -82,6 +93,16 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
         removeAll();
         UI.setCurrent(null);
         VaadinSession.setCurrent(null);
+    }
+
+    private VaadinService createService() {
+        VaadinService svc = Mockito.mock(VaadinService.class);
+        DeploymentConfiguration deploymentConfig = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(deploymentConfig.isProductionMode()).thenReturn(false);
+        Mockito.when(svc.getDeploymentConfiguration())
+                .thenReturn(deploymentConfig);
+        return svc;
     }
 
     /**


### PR DESCRIPTION
`MockUIExtension` and `EnableFeatureFlagExtension` were recreating Mockito mocks before every `@Test` method across all test classes that use them. Analysis of CI surefire reports showed SignalTest classes taking 5-6s each in CI (e.g. `BadgeSignalTest` 6s, `SliderSignalTest` 5s) despite having simple, fast test logic.

The expensive operations per test method:
- `Mockito.mock(VaadinService.class)` + `Mockito.mock(DeploymentConfiguration.class)`
- `Mockito.spy(new AlwaysLockedVaadinSession(service))`
- `Mockito.mockStatic(FeatureFlags.class)` (in `EnableFeatureFlagExtension`)

These objects are stateless across tests within the same class, so reusing them is safe.

**`MockUIExtension`**: uses `ExtensionContext.Store` at the CLASS scope to compute service and session on the first test and reuse them for subsequent ones. `UI` is still created fresh per test to avoid state leakage. The `context` null-check preserves compatibility with `replaceUI()` / `clearUI()`.

**`EnableFeatureFlagExtension`**: same pattern for `MockedStatic<FeatureFlags>`. The mock holder implements `CloseableResource` so JUnit 5 closes it automatically after all tests in the class. `enableFeature()` is called in `beforeEach` to reset state, since some tests call `disableFeature()`.

**`SVGGeneratorTest`**: each of the 14 tests was creating a new `SVGGenerator` which copies a 3.5 MiB JS bundle to a temp dir. Switch to `@TestInstance(PER_CLASS)` + `@BeforeAll` to share one generator. The 2 tests that close the generator use a local instance.

Measured on local Mac (same parallelism flags as CI: `-T 4 -Dsurefire.parallel=classes -Dsurefire.threadCount=2`):

| | Wall time |
|--|--|
| Before | 37.1s |
| After | 33.4s |

The improvement is larger on CI where Mockito initialization is more expensive due to slower JVM startup and byte-buddy agent loading.