### PR TITLE
ci: exclude integration-tests from build cache key

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
 
       - name: Setup JDK 21
         if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
@@ -223,7 +223,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
 
       - name: Install artifacts (cache miss)
         if: steps.build-cache.outputs.cache-hit != 'true' && steps.war-cache.outputs.cache-hit != 'true'
@@ -359,7 +359,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
 
       - name: Restore WAR cache
         uses: actions/cache@v5


### PR DESCRIPTION
The Package WAR job kept missing the build cache populated by the Build job, forcing a redundant `mvn install` run. Example: https://github.com/vaadin/flow-components/actions/runs/25744332069/job/75603575290?pr=9273

Root cause: the `Merge ITs` step (`node scripts/mergeITs.js`) runs before `Restore build cache` in Package WAR and writes files into `integration-tests/` (pom.xml, `src/main/java/**`, `src/main/resources/**`). Those paths match the `hashFiles` globs used in the cache key, so the hash diverges from the Build job, which never runs `mergeITs`. Result: cache miss every time.

Exclude `integration-tests/**` from the `hashFiles` input on all three jobs (Build, Package WAR, ITs) so the key matches the Build job's hashing surface.

🤖 Generated with Claude Code