### PR TITLE
ci: fail on cache miss instead of rebuilding

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -178,6 +178,10 @@ jobs:
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
 
+      - name: Merge ITs
+        if: matrix.type == 'war'
+        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
+
       - name: Compute WAR cache key
         if: matrix.type == 'war'
         id: war-key
@@ -221,10 +225,6 @@ jobs:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
           fail-on-cache-miss: true
-
-      - name: Merge ITs
-        if: matrix.type == 'war' && steps.war-cache.outputs.cache-hit != 'true'
-        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
 
       - name: Run unit tests
         if: matrix.type == 'unit'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -178,10 +178,6 @@ jobs:
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
 
-      - name: Merge ITs
-        if: matrix.type == 'war'
-        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
-
       - name: Compute WAR cache key
         if: matrix.type == 'war'
         id: war-key
@@ -225,6 +221,10 @@ jobs:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
           fail-on-cache-miss: true
+
+      - name: Merge ITs
+        if: matrix.type == 'war' && steps.war-cache.outputs.cache-hit != 'true'
+        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
 
       - name: Run unit tests
         if: matrix.type == 'unit'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -224,15 +224,7 @@ jobs:
         with:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install artifacts (cache miss)
-        if: steps.build-cache.outputs.cache-hit != 'true' && steps.war-cache.outputs.cache-hit != 'true'
-        run: |
-          mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
-            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
-            sleep 15
-            mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS
-          }
+          fail-on-cache-miss: true
 
       - name: Run unit tests
         if: matrix.type == 'unit'
@@ -360,6 +352,7 @@ jobs:
         with:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+          fail-on-cache-miss: true
 
       - name: Restore WAR cache
         uses: actions/cache@v5


### PR DESCRIPTION
Cache misses in `fast-tests` and `integration-tests` jobs indicate something went wrong upstream. Silently rebuilding artifacts wastes time and masks the real issue. A re-run of the full workflow is the correct recovery.

- Added `fail-on-cache-miss: true` to both build cache and WAR cache restores in `integration-tests`
- Added `fail-on-cache-miss: true` to the build cache restore in `fast-tests`
- Removed the "Install artifacts (cache miss)" fallback step from `fast-tests`