### PR TITLE
ci: skip svg charts npm build when running unit tests

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -178,6 +178,10 @@ jobs:
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
 
+      - name: Merge ITs
+        if: matrix.type == 'war'
+        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
+
       - name: Compute WAR cache key
         if: matrix.type == 'war'
         id: war-key
@@ -221,10 +225,6 @@ jobs:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
           fail-on-cache-miss: true
-
-      - name: Merge ITs
-        if: matrix.type == 'war' && steps.war-cache.outputs.cache-hit != 'true'
-        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
 
       - name: Run unit tests
         if: matrix.type == 'unit'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -178,10 +178,6 @@ jobs:
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
 
-      - name: Merge ITs
-        if: matrix.type == 'war'
-        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
-
       - name: Compute WAR cache key
         if: matrix.type == 'war'
         id: war-key
@@ -225,6 +221,10 @@ jobs:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
           fail-on-cache-miss: true
+
+      - name: Merge ITs
+        if: matrix.type == 'war' && steps.war-cache.outputs.cache-hit != 'true'
+        run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
 
       - name: Run unit tests
         if: matrix.type == 'unit'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -224,15 +224,7 @@ jobs:
         with:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
-
-      - name: Install artifacts (cache miss)
-        if: steps.build-cache.outputs.cache-hit != 'true' && steps.war-cache.outputs.cache-hit != 'true'
-        run: |
-          mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS || {
-            echo "::warning::First attempt failed (Maven multi-thread race). Retrying..."
-            sleep 15
-            mvn install -Dmaven.test.skip=true -Drelease -T $FORK_COUNT $MAVEN_ARGS
-          }
+          fail-on-cache-miss: true
 
       - name: Run unit tests
         if: matrix.type == 'unit'
@@ -360,6 +352,7 @@ jobs:
         with:
           path: ~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**') }}
+          fail-on-cache-miss: true
 
       - name: Restore WAR cache
         uses: actions/cache@v5

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -228,7 +228,7 @@ jobs:
 
       - name: Run unit tests
         if: matrix.type == 'unit'
-        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 $MAVEN_ARGS
+        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 -DskipSvgChartsBuild $MAVEN_ARGS
 
       - name: Upload unit test reports
         if: always() && matrix.type == 'unit'

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -61,6 +61,7 @@
                             <arguments>
                                 <argument>install</argument>
                             </arguments>
+                            <skip>${skipSvgChartsBuild}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -75,6 +76,7 @@
                                 <argument>run</argument>
                                 <argument>build</argument>
                             </arguments>
+                            <skip>${skipSvgChartsBuild}</skip>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
The `vaadin-charts-flow-svg-generator` module runs `npm install` + webpack on every Maven build via the `validate` phase. This regenerates `jsdom-exporter-bundle.js` even though the bundle is already committed to git and the build cache guarantees nothing has changed.

Adding `skipSvgChartsBuild` to the `npm-install` and `generator-build` exec-maven-plugin executions allows skipping these steps. The unit test CI job passes `-DskipSvgChartsBuild` since the build cache is always present there (enforced by `fail-on-cache-miss: true`).

Reduces unit test job duration by ~5s locally, more in CI where `npm install` is slower.