### PR TITLE
ci: cache svg generator bundle, skip npm build in unit tests

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       skip: ${{ steps.skip-ci.outputs.skip }}
       components: ${{ steps.components.outputs.elements }}
+      build-cache-key: ${{ steps.build-key.outputs.key }}
     steps:
       - name: Set Maven args
         run: |
@@ -60,6 +61,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Compute build cache key
+        id: build-key
+        if: steps.skip-ci.outputs.skip != 'true'
+        env:
+          KEY: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/*.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json') }}
+        run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
       - name: Restore build cache
         id: build-cache
         if: steps.skip-ci.outputs.skip != 'true'
@@ -68,7 +76,7 @@ jobs:
           path: |
             ~/.m2/repository/com/vaadin
             vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/resources/META-INF/frontend/generated/
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/jsdom-exporter.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/customWidthsMap.js') }}
+          key: ${{ steps.build-key.outputs.key }}
 
       - name: Setup JDK 21
         if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
@@ -227,7 +235,7 @@ jobs:
           path: |
             ~/.m2/repository/com/vaadin
             vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/resources/META-INF/frontend/generated/
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/jsdom-exporter.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/customWidthsMap.js') }}
+          key: ${{ needs.build.outputs.build-cache-key }}
           fail-on-cache-miss: true
 
       - name: Run unit tests
@@ -357,7 +365,7 @@ jobs:
           path: |
             ~/.m2/repository/com/vaadin
             vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/resources/META-INF/frontend/generated/
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/jsdom-exporter.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/customWidthsMap.js') }}
+          key: ${{ needs.build.outputs.build-cache-key }}
           fail-on-cache-miss: true
 
       - name: Restore WAR cache

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -65,8 +65,10 @@ jobs:
         if: steps.skip-ci.outputs.skip != 'true'
         uses: actions/cache@v5
         with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
+          path: |
+            ~/.m2/repository/com/vaadin
+            vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/resources/META-INF/frontend/generated/
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/jsdom-exporter.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/customWidthsMap.js') }}
 
       - name: Setup JDK 21
         if: steps.skip-ci.outputs.skip != 'true' && steps.build-cache.outputs.cache-hit != 'true'
@@ -222,13 +224,15 @@ jobs:
         id: build-cache
         uses: actions/cache@v5
         with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
+          path: |
+            ~/.m2/repository/com/vaadin
+            vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/resources/META-INF/frontend/generated/
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/jsdom-exporter.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/customWidthsMap.js') }}
           fail-on-cache-miss: true
 
       - name: Run unit tests
         if: matrix.type == 'unit'
-        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 $MAVEN_ARGS
+        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 -DskipSvgChartsBuild $MAVEN_ARGS
 
       - name: Upload unit test reports
         if: always() && matrix.type == 'unit'
@@ -350,8 +354,10 @@ jobs:
       - name: Restore build cache
         uses: actions/cache@v5
         with:
-          path: ~/.m2/repository/com/vaadin
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**') }}
+          path: |
+            ~/.m2/repository/com/vaadin
+            vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/main/resources/META-INF/frontend/generated/
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/jsdom-exporter.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/customWidthsMap.js') }}
           fail-on-cache-miss: true
 
       - name: Restore WAR cache

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -321,7 +321,7 @@ jobs:
 
   its:
     name: ITs (${{ matrix.shard }})
-    needs: [fast-tests]
+    needs: [build, fast-tests]
     if: needs.fast-tests.outputs.has-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -65,7 +65,7 @@ jobs:
         id: build-key
         if: steps.skip-ci.outputs.skip != 'true'
         env:
-          KEY: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/*.js', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/package-lock.json') }}
+          KEY: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', '**/src/main/java/**', '**/src/main/resources/**', '!integration-tests/**', '!**/frontend/generated/**', 'vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/*.js') }}
         run: echo "key=$KEY" >> "$GITHUB_OUTPUT"
 
       - name: Restore build cache

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -61,6 +61,7 @@
                             <arguments>
                                 <argument>install</argument>
                             </arguments>
+                            <skip>${skipSvgChartsBuild}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -75,6 +76,7 @@
                                 <argument>run</argument>
                                 <argument>build</argument>
                             </arguments>
+                            <skip>${skipSvgChartsBuild}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -88,7 +90,7 @@
                             <arguments>
                                 <argument>test</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <skip>${skipSvgChartsBuild}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The \`vaadin-charts-flow-svg-generator\` module runs \`npm install\` + webpack on every Maven build via the \`validate\` phase, even in the unit test job where the bundle is already available from the build cache.

The generated \`jsdom-exporter-bundle.js\` is gitignored, so it must be produced by webpack. This change includes the bundle in the build cache so the unit test job can skip the npm steps.

Changes:
- Build cache path extended to include the svg generator bundle
- Build cache key updated to exclude \`**/frontend/generated/**\` (avoids hash mismatch since the bundle doesn't exist at key-computation time in non-build jobs) and include the JS source files that affect the bundle
- \`skipSvgChartsBuild\` property added to pom.xml to skip npm install, webpack, and mocha when the bundle is already cached
- Unit test job passes \`-DskipSvgChartsBuild\` since the build cache always hits there (\`fail-on-cache-miss: true\`)

Reduces unit test job duration by 15-20% about 40-55s