### PR TITLE
fix: discard pending states on failed request

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -62,6 +62,13 @@ import tools.jackson.databind.JsonNode;
  * {@link Chart} component, so it survives serialization.
  * </p>
  * <p>
+ * If the LLM turn fails, the orchestrator fires
+ * {@link #onResponseFailed(Throwable)} instead — pending configuration is
+ * discarded and queries set during the failed turn are rolled back to the
+ * snapshot taken in {@link #onRequestStart()}, so the chart keeps its last
+ * successfully-rendered state.
+ * </p>
+ * <p>
  * Data conversion from SQL query results to chart series is handled by a
  * {@link DataConverter}. A default implementation is used unless overridden via
  * {@link #setDataConverter(DataConverter)}.
@@ -138,6 +145,7 @@ public class ChartAIController implements AIController {
     private final DatabaseProvider databaseProvider;
     private final List<SerializableConsumer<ChartState>> stateChangeListeners = new ArrayList<>();
     private DataConverter dataConverter;
+    private List<String> queriesBeforeTurn;
 
     /**
      * Creates a new AI chart controller.
@@ -301,6 +309,16 @@ public class ChartAIController implements AIController {
     }
 
     @Override
+    public void onRequestStart() {
+        var entry = ChartEntry.get(chart);
+        // Snapshot queries at the start of every turn so a failed turn can roll
+        // the entry back instead of leaving the chart pointing at queries the
+        // LLM never finished configuring.
+        queriesBeforeTurn = entry == null ? List.of()
+                : List.copyOf(entry.getQueries());
+    }
+
+    @Override
     public void onResponseComplete() {
         ChartEntry entry = ChartEntry.get(chart);
         if (entry == null || !entry.hasPendingState()) {
@@ -322,6 +340,17 @@ public class ChartAIController implements AIController {
         // is not required: Configuration is server-side state and any JS
         // calls are queued by Flow until the chart attaches.
         render(entry, queries, configJson, true);
+    }
+
+    @Override
+    public void onResponseFailed(Throwable error) {
+        var entry = ChartEntry.get(chart);
+        if (entry != null) {
+            if (queriesBeforeTurn != null) {
+                entry.setQueries(queriesBeforeTurn);
+            }
+            entry.clearPendingState();
+        }
     }
 
     private void render(ChartEntry entry, List<String> queries,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -63,10 +63,8 @@ import tools.jackson.databind.JsonNode;
  * </p>
  * <p>
  * If the LLM turn fails, the orchestrator fires
- * {@link #onResponseFailed(Throwable)} instead — pending configuration is
- * discarded and queries set during the failed turn are rolled back to the
- * snapshot taken in {@link #onRequestStart()}, so the chart keeps its last
- * successfully-rendered state.
+ * {@link #onResponseFailed(Throwable)} instead — pending changes are discarded
+ * and the chart keeps its last successfully-rendered state.
  * </p>
  * <p>
  * Data conversion from SQL query results to chart series is handled by a
@@ -145,7 +143,6 @@ public class ChartAIController implements AIController {
     private final DatabaseProvider databaseProvider;
     private final List<SerializableConsumer<ChartState>> stateChangeListeners = new ArrayList<>();
     private DataConverter dataConverter;
-    private List<String> queriesBeforeTurn;
 
     /**
      * Creates a new AI chart controller.
@@ -207,9 +204,8 @@ public class ChartAIController implements AIController {
                 for (String q : queries) {
                     databaseProvider.executeQuery(q);
                 }
-                ChartEntry entry = ChartEntry.getOrCreate(chart, chartId);
-                entry.setQueries(queries);
-                entry.setPendingDataUpdate(true);
+                ChartEntry.getOrCreate(chart, chartId)
+                        .setPendingQueries(queries);
             }
 
             @Override
@@ -309,28 +305,23 @@ public class ChartAIController implements AIController {
     }
 
     @Override
-    public void onRequestStart() {
-        var entry = ChartEntry.get(chart);
-        // Snapshot queries at the start of every turn so a failed turn can roll
-        // the entry back instead of leaving the chart pointing at queries the
-        // LLM never finished configuring.
-        queriesBeforeTurn = entry == null ? List.of()
-                : List.copyOf(entry.getQueries());
-    }
-
-    @Override
     public void onResponseComplete() {
         ChartEntry entry = ChartEntry.get(chart);
         if (entry == null || !entry.hasPendingState()) {
             return;
         }
 
-        List<String> queries = entry.getQueries();
-        if (queries.isEmpty()) {
-            // Config-only: no queries to render yet. Clear only the
-            // data flag but keep pendingConfigurationJson so it's used
-            // when data arrives in a later request.
-            entry.setPendingDataUpdate(false);
+        // Pending queries staged this turn replace the current set; if the
+        // turn only updated config, re-render with the current queries.
+        var queriesToRender = entry.getPendingQueries() != null
+                ? entry.getPendingQueries()
+                : entry.getQueries();
+
+        if (queriesToRender.isEmpty()) {
+            // Nothing to render. Consume any empty pending queries (rare:
+            // LLM staged an empty list) but keep pendingConfigurationJson
+            // so it applies when data arrives in a later request.
+            entry.setPendingQueries(null);
             return;
         }
 
@@ -339,16 +330,13 @@ public class ChartAIController implements AIController {
         // which runs this on the UI thread under session lock. Attachment
         // is not required: Configuration is server-side state and any JS
         // calls are queued by Flow until the chart attaches.
-        render(entry, queries, configJson, true);
+        render(entry, queriesToRender, configJson, true);
     }
 
     @Override
     public void onResponseFailed(Throwable error) {
         var entry = ChartEntry.get(chart);
         if (entry != null) {
-            if (queriesBeforeTurn != null) {
-                entry.setQueries(queriesBeforeTurn);
-            }
             entry.clearPendingState();
         }
     }
@@ -358,6 +346,7 @@ public class ChartAIController implements AIController {
         try {
             ChartRenderer.renderChart(chart, databaseProvider, dataConverter,
                     queries, configJson);
+            entry.setQueries(queries);
             if (fireListeners) {
                 fireStateChangeListeners();
             }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartEntry.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartEntry.java
@@ -40,8 +40,8 @@ class ChartEntry implements Serializable {
 
     private final String id;
     private List<String> queries = new ArrayList<>();
+    private List<String> pendingQueries;
     private String pendingConfigurationJson;
-    private boolean pendingDataUpdate;
 
     /**
      * Gets the {@link ChartEntry} for the given chart, or {@code null} if none
@@ -137,32 +137,34 @@ class ChartEntry implements Serializable {
     }
 
     /**
-     * Returns whether a data update is pending.
+     * Returns the staged SQL queries waiting to be committed by the next
+     * successful {@code onResponseComplete}, or {@code null} if none.
      *
-     * @return {@code true} if queries were changed and the chart needs
-     *         re-rendering
+     * @return the pending SQL queries, or {@code null}
      */
-    public boolean isPendingDataUpdate() {
-        return pendingDataUpdate;
+    public List<String> getPendingQueries() {
+        return pendingQueries == null ? null
+                : Collections.unmodifiableList(pendingQueries);
     }
 
     /**
-     * Marks or clears the pending data update flag.
+     * Stages SQL queries to be applied on the next successful
+     * {@code onResponseComplete}. Pass {@code null} to clear.
      *
-     * @param pendingDataUpdate
-     *            {@code true} if the chart data needs re-rendering
+     * @param queries
+     *            the SQL queries to stage, or {@code null}
      */
-    public void setPendingDataUpdate(boolean pendingDataUpdate) {
-        this.pendingDataUpdate = pendingDataUpdate;
+    public void setPendingQueries(List<String> queries) {
+        this.pendingQueries = queries == null ? null : new ArrayList<>(queries);
     }
 
     /**
      * Returns whether this entry has pending state waiting to be applied.
      *
-     * @return {@code true} if there is pending configuration or data update
+     * @return {@code true} if there is pending configuration or pending queries
      */
     public boolean hasPendingState() {
-        return pendingConfigurationJson != null || pendingDataUpdate;
+        return pendingConfigurationJson != null || pendingQueries != null;
     }
 
     /**
@@ -170,7 +172,7 @@ class ChartEntry implements Serializable {
      */
     public void clearPendingState() {
         pendingConfigurationJson = null;
-        pendingDataUpdate = false;
+        pendingQueries = null;
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -71,6 +71,11 @@ import tools.jackson.databind.JsonNode;
  * {@link Grid} component, so it survives serialization.
  * </p>
  * <p>
+ * If the LLM turn fails, the orchestrator fires
+ * {@link #onResponseFailed(Throwable)} instead — pending changes are discarded
+ * and the grid keeps its last successfully-rendered state.
+ * </p>
+ * <p>
  * <b>Serialization:</b> This controller is not serialized with the
  * orchestrator. After deserialization, create a new controller and restore
  * transient dependencies via {@link AIOrchestrator#reconnect(LLMProvider)
@@ -220,6 +225,14 @@ public class GridAIController implements AIController {
         // server-side and syncs to the client on attach.
         render(entry, query, true);
         LOGGER.info("Grid updated successfully");
+    }
+
+    @Override
+    public void onResponseFailed(Throwable error) {
+        var entry = GridEntry.get(grid);
+        if (entry != null) {
+            entry.clearPendingState();
+        }
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -417,10 +417,6 @@ public class AIOrchestrator implements Serializable {
         var ui = UI.getCurrentOrThrow();
         checkFeatureFlag(ui);
 
-        if (controller != null) {
-            controller.onRequestStart();
-        }
-
         var attachments = fileReceiver != null ? fileReceiver.takeAttachments()
                 : List.<AIAttachment> of();
         var userAIMessage = messageList == null ? null
@@ -497,19 +493,6 @@ public class AIOrchestrator implements Serializable {
                 return controllerTools;
             }
         };
-    }
-
-    private void fireResponseFailed(Throwable error, UI ui) {
-        if (controller == null) {
-            return;
-        }
-        ui.access(() -> {
-            try {
-                controller.onResponseFailed(error);
-            } catch (Exception e) {
-                LOGGER.error("Error in controller onResponseFailed", e);
-            }
-        });
     }
 
     private void fireResponseFailed(Throwable error, UI ui) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -417,6 +417,10 @@ public class AIOrchestrator implements Serializable {
         var ui = UI.getCurrentOrThrow();
         checkFeatureFlag(ui);
 
+        if (controller != null) {
+            controller.onRequestStart();
+        }
+
         var attachments = fileReceiver != null ? fileReceiver.takeAttachments()
                 : List.<AIAttachment> of();
         var userAIMessage = messageList == null ? null
@@ -493,6 +497,19 @@ public class AIOrchestrator implements Serializable {
                 return controllerTools;
             }
         };
+    }
+
+    private void fireResponseFailed(Throwable error, UI ui) {
+        if (controller == null) {
+            return;
+        }
+        ui.access(() -> {
+            try {
+                controller.onResponseFailed(error);
+            } catch (Exception e) {
+                LOGGER.error("Error in controller onResponseFailed", e);
+            }
+        });
     }
 
     private void fireResponseFailed(Throwable error, UI ui) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -610,6 +610,88 @@ class ChartAIControllerTest {
     }
 
     @Nested
+    class OnResponseFailed {
+
+        @Test
+        void failedFirstTurnDoesNotEstablishState() {
+            databaseProvider.results = List
+                    .of(Map.of("category", "A", "value", 10));
+            var tools = controller.getTools();
+
+            controller.onRequestStart();
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
+            findTool(tools, "update_chart_data_source")
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
+            controller.onResponseFailed(new RuntimeException("stream error"));
+
+            // A subsequent successful turn with no tool calls must not
+            // pick up the failed turn's staged configuration or queries.
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            Assertions.assertNull(controller.getState());
+        }
+
+        @Test
+        void failedTurnStagedConfigurationDoesNotLeakIntoNextTurn() {
+            // Establish a baseline turn with chart type "bar".
+            databaseProvider.results = List
+                    .of(Map.of("category", "A", "value", 10));
+            var tools = controller.getTools();
+            controller.onRequestStart();
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
+            findTool(tools, "update_chart_data_source")
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
+            controller.onResponseComplete();
+
+            var baselineType = chart.getConfiguration().getChart().getType();
+
+            // Second turn stages a different chart type, then fails.
+            controller.onRequestStart();
+            findTool(tools, "update_chart_configuration").execute(json(
+                    "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
+            controller.onResponseFailed(new RuntimeException("stream error"));
+
+            // Third turn fires onResponseComplete with no tool calls.
+            // The failed turn's chart type must not be applied.
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            Assertions.assertEquals(baselineType,
+                    chart.getConfiguration().getChart().getType());
+        }
+
+        @Test
+        void failedTurnRollsBackToPreviousSuccessfulQueries() {
+            databaseProvider.results = List
+                    .of(Map.of("category", "A", "value", 10));
+            var tools = controller.getTools();
+
+            controller.onRequestStart();
+            findTool(tools, "update_chart_data_source").execute(
+                    json("{\"queries\": [\"SELECT good FROM baseline\"]}"));
+            controller.onResponseComplete();
+
+            controller.onRequestStart();
+            findTool(tools, "update_chart_data_source").execute(
+                    json("{\"queries\": [\"SELECT bad FROM half_baked\"]}"));
+            controller.onResponseFailed(new RuntimeException("stream error"));
+
+            // A third turn fires onResponseComplete with nothing staged.
+            // The bad query must not bleed through; the baseline stands.
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            var state = controller.getState();
+            Assertions.assertNotNull(state);
+            Assertions.assertEquals(List.of("SELECT good FROM baseline"),
+                    state.queries());
+        }
+    }
+
+    @Nested
     class DetachedChart {
 
         @BeforeEach

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -238,23 +238,20 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void updateData_setsPendingDataUpdate() {
+        void updateData_stagesQueriesAppliedOnResponseComplete() {
             databaseProvider.results = List.of(Map.of("x", 1, "y", 2));
 
             var tools = controller.getTools();
-            var dataTool = tools.stream()
-                    .filter(t -> t.getName().equals("update_chart_data_source"))
-                    .findFirst().get();
-
-            String result = dataTool
+            String result = findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             Assertions.assertTrue(result.contains("updated"));
 
-            // Verify queries are stored via get_chart_state
-            var stateTool = tools.stream()
-                    .filter(t -> t.getName().equals("get_chart_state"))
-                    .findFirst().get();
-            String state = stateTool.execute(json("{}"));
+            // Queries are committed only after onResponseComplete; before
+            // that, get_chart_state returns the previously-committed view.
+            controller.onResponseComplete();
+
+            String state = findTool(tools, "get_chart_state")
+                    .execute(json("{}"));
             Assertions.assertTrue(state.contains("SELECT 1"));
         }
     }
@@ -326,6 +323,23 @@ class ChartAIControllerTest {
             Assertions.assertEquals(
                     chart.getConfiguration().getChart().getType(),
                     state.configuration().getChart().getType());
+        }
+
+        @Test
+        void afterFailedRender_returnsNull() {
+            databaseProvider.results = List
+                    .of(Map.of("category", "A", "value", 10));
+            var tools = controller.getTools();
+            findTool(tools, "update_chart_data_source")
+                    .execute(json("{\"queries\": [\"SELECT 1\"]}"));
+
+            databaseProvider.throwOnExecute = new RuntimeException("DB error");
+            Assertions.assertThrows(RuntimeException.class,
+                    () -> controller.onResponseComplete());
+
+            // Render threw before setQueries could commit, so the chart
+            // stays in its previous (uninitialized) state.
+            Assertions.assertNull(controller.getState());
         }
 
         @Test
@@ -618,16 +632,14 @@ class ChartAIControllerTest {
                     .of(Map.of("category", "A", "value", 10));
             var tools = controller.getTools();
 
-            controller.onRequestStart();
             findTool(tools, "update_chart_configuration").execute(json(
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
             controller.onResponseFailed(new RuntimeException("stream error"));
 
-            // A subsequent successful turn with no tool calls must not
-            // pick up the failed turn's staged configuration or queries.
-            controller.onRequestStart();
+            // Subsequent successful turn with no tool calls must not pick
+            // up the failed turn's staged configuration or queries.
             controller.onResponseComplete();
 
             Assertions.assertNull(controller.getState());
@@ -635,11 +647,9 @@ class ChartAIControllerTest {
 
         @Test
         void failedTurnStagedConfigurationDoesNotLeakIntoNextTurn() {
-            // Establish a baseline turn with chart type "bar".
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
             var tools = controller.getTools();
-            controller.onRequestStart();
             findTool(tools, "update_chart_configuration").execute(json(
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
@@ -648,15 +658,12 @@ class ChartAIControllerTest {
 
             var baselineType = chart.getConfiguration().getChart().getType();
 
-            // Second turn stages a different chart type, then fails.
-            controller.onRequestStart();
             findTool(tools, "update_chart_configuration").execute(json(
                     "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
             controller.onResponseFailed(new RuntimeException("stream error"));
 
-            // Third turn fires onResponseComplete with no tool calls.
-            // The failed turn's chart type must not be applied.
-            controller.onRequestStart();
+            // Subsequent successful turn with no tool calls — the failed
+            // turn's pending chart type must not be applied.
             controller.onResponseComplete();
 
             Assertions.assertEquals(baselineType,
@@ -664,24 +671,21 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void failedTurnRollsBackToPreviousSuccessfulQueries() {
+        void failedTurnDoesNotLeakPendingQueriesIntoNextOnResponseComplete() {
             databaseProvider.results = List
                     .of(Map.of("category", "A", "value", 10));
             var tools = controller.getTools();
 
-            controller.onRequestStart();
             findTool(tools, "update_chart_data_source").execute(
                     json("{\"queries\": [\"SELECT good FROM baseline\"]}"));
             controller.onResponseComplete();
 
-            controller.onRequestStart();
             findTool(tools, "update_chart_data_source").execute(
                     json("{\"queries\": [\"SELECT bad FROM half_baked\"]}"));
             controller.onResponseFailed(new RuntimeException("stream error"));
 
-            // A third turn fires onResponseComplete with nothing staged.
-            // The bad query must not bleed through; the baseline stands.
-            controller.onRequestStart();
+            // Subsequent successful turn with no tool calls — the failed
+            // turn's staged queries must not bleed through.
             controller.onResponseComplete();
 
             var state = controller.getState();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -224,6 +224,43 @@ class GridAIControllerTest {
                 stateTool.execute(json("{}")).contains("SELECT a FROM t"));
     }
 
+    @Nested
+    class OnResponseFailed {
+
+        @Test
+        void failedTurnDoesNotLeakPendingQueryIntoNextOnResponseComplete() {
+            // Establish a baseline successful turn.
+            dbProvider.queryResults = List.of(row("a", 1));
+            simulateUpdate("SELECT a FROM good");
+
+            // A second turn stages a query, then fails before completion.
+            findTool("update_grid_data")
+                    .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
+            controller.onResponseFailed(new RuntimeException("stream error"));
+
+            // A third turn fires onResponseComplete without staging anything
+            // (LLM responded conversationally). The bad query must not be
+            // rendered.
+            controller.onResponseComplete();
+
+            Assertions.assertEquals("SELECT a FROM good",
+                    controller.getState().query());
+        }
+
+        @Test
+        void failedFirstTurnDoesNotEstablishState() {
+            // No prior successful turn — the failed turn is the first one.
+            dbProvider.queryResults = List.of(row("a", 1));
+            findTool("update_grid_data")
+                    .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
+            controller.onResponseFailed(new RuntimeException("stream error"));
+
+            controller.onResponseComplete();
+
+            Assertions.assertNull(controller.getState());
+        }
+    }
+
     // --- GridState serialization ---
 
     @Test


### PR DESCRIPTION
## Description

This PR updates the `GridAIController` and `ChartAIController` to use the `AIController` hooks `onRequestStart` and `onResponseFailed` in order to discard pending states on failed requests.

No related issue.

Follow-up to https://github.com/vaadin/flow-components/pull/9274.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.