### PR TITLE
test: avoid explicitly adding context menu to IT page

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipPage.java
@@ -68,6 +68,6 @@ public class ContextMenuTooltipPage extends Div {
         });
         updateTooltips.setId("update-tooltips");
 
-        add(attach, detach, updateTooltips, target, contextMenu);
+        add(attach, detach, updateTooltips, target);
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/ContextMenuTooltipIT.java
@@ -28,87 +28,90 @@ import com.vaadin.tests.AbstractComponentIT;
 public class ContextMenuTooltipIT extends AbstractComponentIT {
 
     private TestBenchElement target;
-    private ContextMenuElement contextMenu;
-    private TestBenchElement contextMenuTooltip;
 
     @Before
     public void init() {
         open();
         target = $(TestBenchElement.class).id("target");
-        contextMenu = $(ContextMenuElement.class).single();
-        contextMenuTooltip = contextMenu.$("vaadin-tooltip").single();
     }
 
     @Test
     public void openMenu_hoverOverRootItems_tooltipDisplayed() {
-        ContextMenuElement.openByRightClick(target);
+        var contextMenu = ContextMenuElement.openByRightClick(target);
 
         var items = contextMenu.getMenuItems();
 
         items.get(0).hover();
-        Assert.assertEquals("Item 0 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("Item 0 / Tooltip", getTooltipText(contextMenu));
 
         items.get(1).hover();
-        Assert.assertEquals("Item 1 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("Item 1 / Tooltip", getTooltipText(contextMenu));
 
         items.get(2).hover();
-        Assert.assertEquals("Item 2 / Tooltip", contextMenuTooltip.getText());
-        Assert.assertEquals("top",
-                contextMenuTooltip.getDomProperty("_position"));
+        Assert.assertEquals("Item 2 / Tooltip", getTooltipText(contextMenu));
+        Assert.assertEquals("top", getTooltipPosition(contextMenu));
     }
 
     @Test
     public void openMenu_hoverOverSubMenuItems_tooltipDisplayed() {
-        ContextMenuElement.openByRightClick(target);
+        var contextMenu = ContextMenuElement.openByRightClick(target);
 
         var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
         var subMenuItems = subMenu.getMenuItems();
 
         subMenuItems.get(0).hover();
-        Assert.assertEquals("Item 0-0 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("Item 0-0 / Tooltip", getTooltipText(contextMenu));
 
         subMenuItems.get(1).hover();
-        Assert.assertEquals("Item 0-1 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("Item 0-1 / Tooltip", getTooltipText(contextMenu));
 
         subMenuItems.get(2).hover();
-        Assert.assertEquals("Item 0-2 / Tooltip", contextMenuTooltip.getText());
-        Assert.assertEquals("top",
-                contextMenuTooltip.getDomProperty("_position"));
+        Assert.assertEquals("Item 0-2 / Tooltip", getTooltipText(contextMenu));
+        Assert.assertEquals("top", getTooltipPosition(contextMenu));
     }
 
     @Test
     public void updateTooltip_openMenu_hoverOverItems_updatedTooltipDisplayed() {
         clickElementWithJs("update-tooltips");
 
-        ContextMenuElement.openByRightClick(target);
+        var contextMenu = ContextMenuElement.openByRightClick(target);
 
         contextMenu.getMenuItems().get(0).hover();
         Assert.assertEquals("Item 0 / Updated Tooltip",
-                contextMenuTooltip.getText());
+                getTooltipText(contextMenu));
 
         var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
         subMenu.getMenuItems().get(0).hover();
         Assert.assertEquals("Item 0-0 / Updated Tooltip",
-                contextMenuTooltip.getText());
+                getTooltipText(contextMenu));
     }
 
     @Test
     public void detachAndAttach_openMenu_hoverOverItems_tooltipDisplayed() {
         detachAndAttach();
 
-        ContextMenuElement.openByRightClick(target);
+        var contextMenu = ContextMenuElement.openByRightClick(target);
 
         contextMenu.getMenuItems().get(0).hover();
-        Assert.assertEquals("Item 0 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("Item 0 / Tooltip", getTooltipText(contextMenu));
 
         var subMenu = contextMenu.getMenuItems().get(0).openSubMenu();
         subMenu.getMenuItems().get(0).hover();
-        Assert.assertEquals("Item 0-0 / Tooltip", contextMenuTooltip.getText());
+        Assert.assertEquals("Item 0-0 / Tooltip", getTooltipText(contextMenu));
     }
 
     private void detachAndAttach() {
         clickElementWithJs("detach");
         clickElementWithJs("attach");
         target = $(TestBenchElement.class).id("target");
+    }
+
+    private String getTooltipText(ContextMenuElement contextMenu) {
+        return contextMenu.$("vaadin-tooltip").single().getText();
+    }
+
+    private String getTooltipPosition(ContextMenuElement contextMenu) {
+        return contextMenu.$("vaadin-tooltip").single()
+                .getDomProperty("_position");
     }
 }


### PR DESCRIPTION
The PR makes it possible to unskip the previously flaky `detachAndAttach_openMenu_hoverOverItems_tooltipDisplayed` integration test by not adding the context menu to the DOM in `ContextMenuTooltipPage` explicitly.

The issue was that after detach and reattach, the target button ended up positioned after the `<vaadin-context-menu>` element, which was rendered in the DOM due to display: block, pushing the button onto the next line. As a result, hovering the root item left its tooltip with no room on the left, so it rendered on top of the first submenu item. That broke the next step, which tried to hover the submenu item: the pointer landed on the tooltip itself instead of the submenu item, causing the tooltip to close