### PR TITLE
feat: add FormAIController skeleton

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.form;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.ai.orchestrator.AIController;
+import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
+import com.vaadin.flow.component.ai.provider.LLMProvider;
+
+/**
+ * Populates a layout's fields with values an LLM extracts from a user prompt or
+ * attached files. Attach it to an {@link AIOrchestrator} via
+ * {@link AIOrchestrator.Builder#withController(AIController)
+ * withController(...)}.
+ *
+ * <p>
+ * The controller accepts any {@link HasComponents} container. It discovers
+ * fields by walking the container's component tree and collecting every
+ * component that implements {@link HasValue}. The walk recurses into nested
+ * {@link HasComponents} children so layouts containing layouts are handled.
+ * </p>
+ *
+ * <p>
+ * <b>Serialization:</b> the controller is not serialized with the orchestrator.
+ * After deserialization, create a new controller against the same form and call
+ * {@code orchestrator.reconnect(provider).withController(controller).apply()}.
+ * </p>
+ *
+ * @author Vaadin Ltd
+ */
+public class FormAIController implements AIController {
+
+    /**
+     * Key under which a field's opaque id is stored on the field component via
+     * {@link ComponentUtil#setData(Component, String, Object)}. The id survives
+     * removing and re-adding the field within a session.
+     */
+    private static final String FIELD_ID_KEY = "vaadin.ai.form.fieldId";
+
+    private final Component form;
+
+    /**
+     * Creates a new form AI controller for the given container. Fields are
+     * discovered by walking the container's component tree each time the
+     * controller is asked for tools, so fields added or removed between turns
+     * are picked up automatically.
+     *
+     * @param form
+     *            the container whose fields the LLM may populate, not
+     *            {@code null}
+     * @param <T>
+     *            the container type
+     */
+    public <T extends Component & HasComponents> FormAIController(T form) {
+        Objects.requireNonNull(form, "Form must not be null");
+        this.form = form;
+    }
+
+    @Override
+    public List<LLMProvider.ToolSpec> getTools() {
+        // Refresh the field set so fields added or removed between turns
+        // are picked up.
+        attachIds();
+        return List.of();
+    }
+
+    @Override
+    public void onResponseComplete() {
+    }
+
+    /**
+     * Walks the form tree and ensures every discovered field has an id
+     * attached. Ids already attached are left untouched so they stay stable
+     * across removals, re-additions, and discovery walks.
+     */
+    private void attachIds() {
+        FormFieldDiscovery.collectFields(form)
+                .forEach(FormAIController::getOrCreateId);
+    }
+
+    private static String getOrCreateId(HasValue<?, ?> field) {
+        if (!(field instanceof Component component)) {
+            throw new IllegalArgumentException(
+                    "Field must be a Component to carry an attached id: "
+                            + field.getClass().getName());
+        }
+        var id = (String) ComponentUtil.getData(component, FIELD_ID_KEY);
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+            ComponentUtil.setData(component, FIELD_ID_KEY, id);
+        }
+        return id;
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -78,10 +78,14 @@ public class FormAIController implements AIController {
 
     @Override
     public List<LLMProvider.ToolSpec> getTools() {
+        return List.of();
+    }
+
+    @Override
+    public void onRequestStart() {
         // Refresh the field set so fields added or removed between turns
         // are picked up.
         attachIds();
-        return List.of();
     }
 
     @Override
@@ -95,20 +99,15 @@ public class FormAIController implements AIController {
      */
     private void attachIds() {
         FormFieldDiscovery.collectFields(form)
-                .forEach(FormAIController::getOrCreateId);
+                .forEach(FormAIController::attachId);
     }
 
-    private static String getOrCreateId(HasValue<?, ?> field) {
-        if (!(field instanceof Component component)) {
-            throw new IllegalArgumentException(
-                    "Field must be a Component to carry an attached id: "
-                            + field.getClass().getName());
+    private static void attachId(HasValue<?, ?> field) {
+        // Fields come from Component.getChildren(), so the cast is safe.
+        var component = (Component) field;
+        if (ComponentUtil.getData(component, FIELD_ID_KEY) == null) {
+            ComponentUtil.setData(component, FIELD_ID_KEY,
+                    UUID.randomUUID().toString());
         }
-        var id = (String) ComponentUtil.getData(component, FIELD_ID_KEY);
-        if (id == null) {
-            id = UUID.randomUUID().toString();
-            ComponentUtil.setData(component, FIELD_ID_KEY, id);
-        }
-        return id;
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldDiscovery.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldDiscovery.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.form;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasValue;
+
+/**
+ * Walks a form's component tree and collects every {@link HasValue} component
+ * into a flat list in document order.
+ *
+ * @author Vaadin Ltd
+ */
+final class FormFieldDiscovery {
+
+    private FormFieldDiscovery() {
+    }
+
+    /**
+     * Collects every {@link HasValue} component reachable from the given root,
+     * recursing through any {@link HasComponents} children so layouts
+     * containing layouts are handled.
+     *
+     * @param root
+     *            the component to walk, not {@code null}
+     * @return the discovered fields in document order
+     */
+    static List<HasValue<?, ?>> collectFields(Component root) {
+        Objects.requireNonNull(root, "Root must not be null");
+        var sink = new ArrayList<HasValue<?, ?>>();
+        collect(root, sink);
+        return sink;
+    }
+
+    private static void collect(Component component,
+            List<HasValue<?, ?>> sink) {
+        component.getChildren().forEach(child -> {
+            if (child instanceof HasValue<?, ?> hv) {
+                sink.add(hv);
+            }
+            if (child instanceof HasComponents) {
+                collect(child, sink);
+            }
+        });
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldDiscovery.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldDiscovery.java
@@ -53,10 +53,12 @@ final class FormFieldDiscovery {
     private static void collect(Component component,
             List<HasValue<?, ?>> sink) {
         component.getChildren().forEach(child -> {
+            // A component that is both HasValue and HasComponents is treated
+            // as a leaf field — its children are considered part of the
+            // field's internal composition, not separate form fields.
             if (child instanceof HasValue<?, ?> hv) {
                 sink.add(hv);
-            }
-            if (child instanceof HasComponents) {
+            } else if (child instanceof HasComponents) {
                 collect(child, sink);
             }
         });

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -76,7 +76,11 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 // restored via reconnect()
                 "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.ChartAIController(\\$\\d+)?",
                 // Build-time generator — not a runtime component
-                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.PlotOptionsSchemaGenerator"));
+                "com\\.vaadin\\.flow\\.component\\.ai\\.chart\\.PlotOptionsSchemaGenerator",
+                // FormAIController — intentionally not serializable;
+                // restored via reconnect()
+                "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormAIController(\\$\\d+)?",
+                "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldDiscovery(\\$\\d+)?"));
     }
 
     @BeforeEach

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.form;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Div;
+
+class FormAIControllerTest {
+
+    /**
+     * Minimal {@link com.vaadin.flow.component.HasValue} component used by the
+     * discovery tests. {@link AbstractField} ships with flow-server, so
+     * exercising discovery does not require any concrete Vaadin input component
+     * module.
+     */
+    @Tag("test-field")
+    private static class TestField extends AbstractField<TestField, String> {
+        TestField() {
+            super("");
+        }
+
+        @Override
+        protected void setPresentationValue(String value) {
+        }
+    }
+
+    @Nested
+    class Construction {
+
+        @Test
+        void constructionWithFieldsSucceeds() {
+            var form = new Div(new TestField(), new TestField());
+            Assertions.assertDoesNotThrow(() -> new FormAIController(form));
+        }
+
+        @Test
+        void nullFormThrows() {
+            Assertions.assertThrows(NullPointerException.class,
+                    () -> new FormAIController(null));
+        }
+    }
+
+    @Nested
+    class Traversal {
+
+        @Test
+        void deeplyNestedFieldsAreAllDiscoveredInDocumentOrder() {
+            var l0 = new TestField();
+            var l1 = new TestField();
+            var l2 = new TestField();
+            var l3 = new TestField();
+            var l4 = new TestField();
+
+            var deepest = new Div(l4);
+            var deep = new Div(l3, deepest);
+            var middle = new Div(l2, deep);
+            var inner = new Div(l1, middle);
+            var form = new Div(l0, inner);
+
+            Assertions.assertEquals(List.of(l0, l1, l2, l3, l4),
+                    FormFieldDiscovery.collectFields(form),
+                    "Every nested field should appear once, in document "
+                            + "order, regardless of depth");
+        }
+
+        @Test
+        void siblingContainersEachContributeTheirFields() {
+            var a1 = new TestField();
+            var a2 = new TestField();
+            var b1 = new TestField();
+            var b2 = new TestField();
+
+            var sideA = new Div(a1, a2);
+            var sideB = new Div(b1, b2);
+            var form = new Div(sideA, sideB);
+
+            Assertions.assertEquals(List.of(a1, a2, b1, b2),
+                    FormFieldDiscovery.collectFields(form));
+        }
+
+        @Test
+        void fieldsAndContainersInterleavedAreAllDiscovered() {
+            var direct1 = new TestField();
+            var nested = new TestField();
+            var direct2 = new TestField();
+
+            var sub = new Div(nested);
+            // Layout children: field, container, field — interleaved.
+            var form = new Div(direct1, sub, direct2);
+
+            Assertions.assertEquals(List.of(direct1, nested, direct2),
+                    FormFieldDiscovery.collectFields(form));
+        }
+
+        @Test
+        void emptyContainersDoNotBreakTheWalk() {
+            var empty1 = new Div();
+            var empty2 = new Div();
+            var field = new TestField();
+            var form = new Div(empty1, field, empty2);
+
+            Assertions.assertEquals(List.of(field),
+                    FormFieldDiscovery.collectFields(form));
+        }
+
+        @Test
+        void formWithNoFieldsProducesEmptyList() {
+            var emptyChild = new Div(new Div(), new Div());
+            var form = new Div(emptyChild);
+
+            Assertions.assertEquals(List.of(),
+                    FormFieldDiscovery.collectFields(form));
+        }
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.html.Div;
 
@@ -37,6 +39,24 @@ class FormAIControllerTest {
     private static class TestField extends AbstractField<TestField, String> {
         TestField() {
             super("");
+        }
+
+        @Override
+        protected void setPresentationValue(String value) {
+        }
+    }
+
+    /**
+     * Composite field that is both {@link com.vaadin.flow.component.HasValue}
+     * and {@link HasComponents} — used to verify that discovery stops at the
+     * field and does not descend into the field's internal composition.
+     */
+    @Tag("composite-field")
+    private static class CompositeField extends
+            AbstractField<CompositeField, String> implements HasComponents {
+        CompositeField(Component... children) {
+            super("");
+            add(children);
         }
 
         @Override
@@ -121,6 +141,21 @@ class FormAIControllerTest {
 
             Assertions.assertEquals(List.of(field),
                     FormFieldDiscovery.collectFields(form));
+        }
+
+        @Test
+        void compositeFieldIsTreatedAsLeafAndItsChildrenAreNotDiscovered() {
+            var innerChild = new TestField();
+            var composite = new CompositeField(innerChild);
+            var sibling = new TestField();
+            var form = new Div(composite, sibling);
+
+            Assertions.assertEquals(List.of(composite, sibling),
+                    FormFieldDiscovery.collectFields(form),
+                    "A component that is both HasValue and HasComponents "
+                            + "should be discovered as a single field; its "
+                            + "internal children should not be exposed as "
+                            + "separate form fields");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Adds the discovery slice of `FormAIController`: walks any `HasComponents` container, recursively, and stamps each discovered `HasValue` with an opaque UUID id stored on the field component via `ComponentUtil.setData`.
- Ids are plain `String`s — no wrapper class, no per-controller cache. The id survives removing and re-adding a field within a session, and future hint state can key off it.
- No tools yet — `getTools()` returns an empty list. The LLM-facing surface lands in follow-up PRs.

Closes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=186538897

🤖 Generated with [Claude Code](https://claude.com/claude-code)