### PR TITLE
refactor: narrow combo box filter-mode flag to server-side intent

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -24,8 +24,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
@@ -42,7 +40,6 @@ import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasLazyDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.InMemoryDataProvider;
-import com.vaadin.flow.data.provider.ItemCountChangeEvent;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.dom.PropertyChangeEvent;
@@ -161,15 +158,10 @@ class ComboBoxDataController<TItem>
      * @param localeSupplier
      *            supplier for the current locale of the combo box
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     ComboBoxDataController(ComboBoxBase<?, TItem, ?> comboBox,
             SerializableSupplier<Locale> localeSupplier) {
         this.comboBox = comboBox;
         this.localeSupplier = localeSupplier;
-
-        // Update client side filtering when data provider size changes
-        ComponentUtil.addListener(comboBox, ItemCountChangeEvent.class,
-                (ComponentEventListener) (e -> updateClientSideFiltering()));
     }
 
     /**
@@ -205,7 +197,6 @@ class ComboBoxDataController<TItem>
             dataCommunicator.setPageSize(pageSize);
         }
         reset();
-        updateClientSideFiltering();
     }
 
     /**
@@ -558,7 +549,8 @@ class ComboBoxDataController<TItem>
         shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         setupDataProviderListener(dataProvider);
         reset();
-        updateClientSideFiltering();
+        comboBox.getElement().setProperty("_forceServerSideFilter",
+                shouldForceServerSideFiltering);
 
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
 
@@ -569,19 +561,6 @@ class ComboBoxDataController<TItem>
                     .addPropertyChangeListener("opened",
                             this::executeRegistration);
         }
-    }
-
-    private void updateClientSideFiltering() {
-        if (dataCommunicator != null) {
-            setClientSideFilter(
-                    !this.shouldForceServerSideFiltering && dataCommunicator
-                            .getItemCount() <= comboBox.getPageSize());
-        }
-    }
-
-    private void setClientSideFilter(boolean clientSideFilter) {
-        comboBox.getElement().setProperty("_clientSideFilter",
-                clientSideFilter);
     }
 
     private void clearFilterOnClose(PropertyChangeEvent event) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -17,6 +17,12 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   let lastFilter = '';
   const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
 
+  // Client-side filter applies when the full data set fits one page and the
+  // server hasn't requested server-side filtering (e.g. user-provided filter).
+  // Relies on comboBox.size being undefined until the first updateSize call.
+  const isClientSideFilter = () =>
+    !comboBox._forceServerSideFilter && comboBox.size <= comboBox.pageSize;
+
   const serverFacade = (() => {
     // Private variables
     let lastFilterSentToServer = '';
@@ -67,7 +73,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
       throw 'Invalid pageSize';
     }
 
-    if (comboBox._clientSideFilter) {
+    if (isClientSideFilter()) {
       // For clientside filter we first make sure we have all data which we also
       // filter based on comboBox.filter. While later we only filter clientside data.
 
@@ -201,17 +207,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   };
 
   comboBox.$connector.updateSize = function (newSize) {
-    if (!comboBox._clientSideFilter) {
-      // FIXME: It may be that this size set is unnecessary, since when
-      // providing data to combobox via callback we may use data's size.
-      // However, if this size reflect the whole data size, including
-      // data not fetched yet into client side, and combobox expect it
-      // to be set as such, the at least, we don't need it in case the
-      // filter is clientSide only, since it'll increase the height of
-      // the popup at only at first user filter to this size, while the
-      // filtered items count are less.
-      comboBox.size = newSize;
-    }
+    comboBox.size = newSize;
   };
 
   comboBox.$connector.reset = function () {
@@ -250,7 +246,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   const commitPage = function (page, callback) {
     let data = cache[page];
 
-    if (comboBox._clientSideFilter) {
+    if (isClientSideFilter()) {
       performClientSideFilter(data, comboBox.filter, callback);
     } else {
       // Remove the data if server-side filtering, but keep it for client-side

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxFilteringTest.java
@@ -30,7 +30,7 @@ class MultiSelectComboBoxFilteringTest {
     MockUIExtension ui = new MockUIExtension();
 
     @Test
-    void filter_addAndRefreshItems_doesNotToggleClientSideFiltering() {
+    void noUserProvidedFilter_doesNotForceServerSideFiltering() {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
         ui.add(comboBox);
 
@@ -41,13 +41,13 @@ class MultiSelectComboBoxFilteringTest {
         comboBox.getDataController().setViewportRange(0, 50, "foo");
         ui.fakeClientCommunication();
         Assertions.assertFalse((Boolean) comboBox.getElement()
-                .getPropertyRaw("_clientSideFilter"));
+                .getPropertyRaw("_forceServerSideFilter"));
 
         items.add("foo");
         comboBox.getDataProvider().refreshAll();
         comboBox.getDataController().setViewportRange(0, 50, "");
         ui.fakeClientCommunication();
         Assertions.assertFalse((Boolean) comboBox.getElement()
-                .getPropertyRaw("_clientSideFilter"));
+                .getPropertyRaw("_forceServerSideFilter"));
     }
 }


### PR DESCRIPTION
The combo box pushed a `_clientSideFilter` element property from the server that conflated two facts: whether the user supplied a filter callback (server-only knowledge) and whether the dataset fits one page (derivable on the client). The latter caused the server to re-evaluate and re-push the flag on every item count change.

Renames the property to `_forceServerSideFilter`, set once per data provider change. Moves the size comparison into the connector, which derives client-side filter mode from `!_forceServerSideFilter && comboBox.size <= comboBox.pageSize`.

The connector previously skipped assigning `comboBox.size` when client-side filtering was active to avoid a brief popup-height flash before the first filter keystroke. The original FIXME suspected this guard was unnecessary; it has been dropped so `comboBox.size` can serve as the authoritative total. Watch IT runs for any popup-height regressions.