### PR TITLE
fix: No ItemClickListener for component with overlay

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewClickListenersPage.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
@@ -61,6 +62,15 @@ public class GridViewClickListenersPage extends LegacyTestView {
         grid.addColumn(new ComponentRenderer<>(person -> {
             return new Button(VaadinIcon.PENCIL.create());
         })).setHeader("Button");
+        grid.addColumn(new ComponentRenderer<>(person -> {
+            Select<String> select = new Select<>();
+            select.setItems("Most recent first", "Rating: high to low",
+                    "Rating: low to high", "Price: high to low",
+                    "Price: low to high");
+            select.setValue("Most recent first");
+            return select;
+
+        })).setHeader("Select");
 
         // Disable selection: will receive only click events instead
         grid.setSelectionMode(SelectionMode.NONE);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewClickListenersIT.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.flow.component.select.testbench.SelectElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
 
@@ -91,6 +92,25 @@ public class GridViewClickListenersIT extends AbstractComponentIT {
         WebElement icon = cell.getContext()
                 .findElement(By.tagName("vaadin-icon"));
         icon.click();
+
+        WebElement clickInfo = findElement(By.id("clicked-item"));
+
+        Assert.assertEquals("", clickInfo.getText());
+    }
+
+    @Test
+    public void itemClickListener_singleClick_overlaySelectElementClickIgnored() {
+        GridElement grid = $(GridElement.class).id("item-click-listener");
+        scrollToElement(grid);
+        waitUntil(driver -> grid.getRowCount() > 0);
+
+        GridTRElement row = grid.getRow(0);
+        GridTHTDElement cell = row.getCell(grid.getColumn("Select"));
+
+        SelectElement select = cell.$(SelectElement.class).all().getFirst();
+        select.selectByText("Rating: high to low");
+
+        Assert.assertEquals("Rating: high to low", select.getSelectedText());
 
         WebElement clickInfo = findElement(By.id("clicked-item"));
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -624,6 +624,15 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     const cell = path[idx];
     const content = path.slice(0, idx);
 
+    // Do not fire item click event if the click originated inside a Vaadin overlay
+    // (Select, ComboBox, DatePicker, MenuBar, ContextMenu, ...). The overlay's
+    // menu/list lives in the host component's light DOM, so its clicks bubble
+    // through the cell — but by the time we get here, the overlay has typically
+    // been hidden synchronously, defeating the offsetParent-based isFocusable check.
+    if (content.some((node) => typeof node.localName === 'string' && node.localName.endsWith('-overlay'))) {
+      return;
+    }
+
     // Do not fire item click event if cell content contains focusable elements.
     // Use this instead of event.target to detect cases like icon inside button.
     // See https://github.com/vaadin/flow-components/issues/4065


### PR DESCRIPTION
Do not fire ItemClickEvent if
the click originated inside a Vaadin overlay
of a component inside a Grid cell.

Fixes #9288
Closes vaadin/flow#17821
