### PR TITLE
fix!: remove not working helper-above variants from CheckboxVariant

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
@@ -21,13 +21,7 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-checkbox} component.
  */
 public enum CheckboxVariant implements ThemeVariant {
-    LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
-    /**
-     * @deprecated Use {@link #HELPER_ABOVE} instead.
-     */
-    @Deprecated
-    AURA_HELPER_ABOVE_FIELD("helper-above-field"),
-    HELPER_ABOVE("helper-above-field");
+    AURA_SMALL("small");
 
     private final String variant;
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11750

The only variant in `CheckboxVariant` is `helper-above-field` and it does nothing. Let's remove it as agreed.

## Type of change

- Behavior altering change