### PR TITLE
feat: lock form fields during AI fill turn

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -44,6 +44,17 @@ import com.vaadin.flow.component.ai.provider.LLMProvider;
  * </p>
  *
  * <p>
+ * <b>Field locking:</b> while a fill is in progress, every non-ignored field
+ * that wasn't already read-only is set to read-only so the user cannot type
+ * into a field the AI is about to overwrite. Locks are released when the turn
+ * ends, successfully or otherwise. Application code that changes a field's
+ * read-only state mid-turn (e.g. from a value-change listener reacting to the
+ * LLM's writes) will be overridden when the controller releases its own locks
+ * at turn end — applications should avoid toggling read-only state during a
+ * fill turn, or reapply it after the turn completes.
+ * </p>
+ *
+ * <p>
  * <b>Serialization:</b> the controller is not serialized with the orchestrator.
  * After deserialization, create a new controller against the same form and call
  * {@code orchestrator.reconnect(provider).withController(controller).apply()}.
@@ -62,6 +73,7 @@ public class FormAIController implements AIController {
 
     private final Component form;
     private final Map<String, FormFieldHints> hintsById = new HashMap<>();
+    private final List<HasValue<?, ?>> lockedFields = new ArrayList<>();
 
     /**
      * Creates a new form AI controller for the given container. Fields are
@@ -144,10 +156,65 @@ public class FormAIController implements AIController {
         // Refresh the field set so fields added or removed between turns
         // are picked up.
         attachIds();
+        lockFields();
     }
 
     @Override
     public void onResponseComplete() {
+        unlockFields();
+    }
+
+    @Override
+    public void onResponseFailed(Throwable error) {
+        unlockFields();
+    }
+
+    /**
+     * Puts every discovered, non-ignored, currently editable field into
+     * read-only state so the user cannot type into a field the AI is about to
+     * overwrite. Fields that were already read-only when the turn started are
+     * left untouched and will not be unlocked at turn end.
+     */
+    private void lockFields() {
+        for (var field : collectActiveFields()) {
+            if (field.isReadOnly()) {
+                continue;
+            }
+            field.setReadOnly(true);
+            lockedFields.add(field);
+        }
+    }
+
+    /**
+     * Returns the discovered fields the controller acts on — every
+     * {@link HasValue} in the form tree minus those hidden via
+     * {@link #ignore(HasValue)}. Use this anywhere the LLM-visible field set
+     * matters (locking, tool inputs and outputs).
+     */
+    private List<HasValue<?, ?>> collectActiveFields() {
+        return FormFieldDiscovery.collectFields(form).stream()
+                .filter(field -> !isIgnored(field)).toList();
+    }
+
+    /**
+     * Restores fields locked by {@link #lockFields()} to read-write. Fields the
+     * application set to read-only before the turn started are not touched
+     * (they were skipped at lock time).
+     */
+    private void unlockFields() {
+        for (var field : lockedFields) {
+            field.setReadOnly(false);
+        }
+        lockedFields.clear();
+    }
+
+    private boolean isIgnored(HasValue<?, ?> field) {
+        if (!(field instanceof Component component)) {
+            return false;
+        }
+        var id = (String) ComponentUtil.getData(component, FIELD_ID_KEY);
+        var hints = hintsById.get(id);
+        return hints != null && hints.ignored;
     }
 
     private FormFieldHints hintsFor(HasValue<?, ?> field) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -209,10 +209,8 @@ public class FormAIController implements AIController {
     }
 
     private boolean isIgnored(HasValue<?, ?> field) {
-        if (!(field instanceof Component component)) {
-            return false;
-        }
-        var id = (String) ComponentUtil.getData(component, FIELD_ID_KEY);
+        var id = (String) ComponentUtil.getData((Component) field,
+                FIELD_ID_KEY);
         var hints = hintsById.get(id);
         return hints != null && hints.ignored;
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -169,6 +169,170 @@ class FormAIControllerTest {
     }
 
     @Nested
+    class FieldLocking {
+
+        @Test
+        void onRequestStartLocksAllDiscoveredFields() {
+            var a = new TestField();
+            var b = new TestField();
+            var nested = new TestField();
+            var form = new Div(a, new Div(b, nested));
+            var controller = new FormAIController(form);
+
+            controller.onRequestStart();
+
+            Assertions.assertTrue(a.isReadOnly());
+            Assertions.assertTrue(b.isReadOnly());
+            Assertions.assertTrue(nested.isReadOnly());
+        }
+
+        @Test
+        void onResponseCompleteReleasesLockedFields() {
+            var a = new TestField();
+            var b = new TestField();
+            var controller = new FormAIController(new Div(a, b));
+
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            Assertions.assertFalse(a.isReadOnly());
+            Assertions.assertFalse(b.isReadOnly());
+        }
+
+        @Test
+        void onResponseFailedReleasesLockedFields() {
+            var a = new TestField();
+            var b = new TestField();
+            var controller = new FormAIController(new Div(a, b));
+
+            controller.onRequestStart();
+            controller.onResponseFailed(new RuntimeException("boom"));
+
+            Assertions.assertFalse(a.isReadOnly());
+            Assertions.assertFalse(b.isReadOnly());
+        }
+
+        @Test
+        void ignoredFieldsAreNotLocked() {
+            var visible = new TestField();
+            var hidden = new TestField();
+            var controller = new FormAIController(new Div(visible, hidden));
+            controller.ignore(hidden);
+
+            controller.onRequestStart();
+
+            Assertions.assertTrue(visible.isReadOnly());
+            Assertions.assertFalse(hidden.isReadOnly(),
+                    "Ignored fields must not be locked during a fill");
+        }
+
+        @Test
+        void preexistingReadOnlyFieldsStayReadOnlyAfterRelease() {
+            // A field the application put into read-only state before the
+            // turn started must remain read-only after the turn ends —
+            // unlocking should only revert fields the controller itself
+            // locked.
+            var editable = new TestField();
+            var preReadOnly = new TestField();
+            preReadOnly.setReadOnly(true);
+            var controller = new FormAIController(
+                    new Div(editable, preReadOnly));
+
+            controller.onRequestStart();
+            Assertions.assertTrue(editable.isReadOnly());
+            Assertions.assertTrue(preReadOnly.isReadOnly());
+
+            controller.onResponseComplete();
+            Assertions.assertFalse(editable.isReadOnly());
+            Assertions.assertTrue(preReadOnly.isReadOnly(),
+                    "A field that was already read-only before the fill "
+                            + "must remain read-only after the fill ends");
+        }
+
+        @Test
+        void describedFieldIsLocked() {
+            // describe() registers a hint but does not ignore the field;
+            // the controller must distinguish "has a hint entry" from "is
+            // ignored". If they collapse, every described or
+            // valueOptions-bound field would silently escape locking.
+            var described = new TestField();
+            var controller = new FormAIController(new Div(described));
+            controller.describe(described, "the merchant name");
+
+            controller.onRequestStart();
+
+            Assertions.assertTrue(described.isReadOnly(),
+                    "A field with a description hint but no ignore() call "
+                            + "must still be locked during a fill");
+        }
+
+        @Test
+        void appReadOnlyBetweenTurnsSurvivesNextRelease() {
+            // The application may legitimately switch a field to
+            // read-only between turns. The next turn's unlock must only
+            // release fields locked by *that* turn — leftover tracking
+            // from a previous turn would clobber the app's state.
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            field.setReadOnly(true);
+
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            Assertions.assertTrue(field.isReadOnly(),
+                    "A field the application set read-only between turns "
+                            + "must stay read-only after a subsequent "
+                            + "fill releases its own locks");
+        }
+
+        @Test
+        void fieldAddedBetweenTurnsIsLockedOnNextRequest() {
+            var initial = new TestField();
+            var form = new Div(initial);
+            var controller = new FormAIController(form);
+
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            var added = new TestField();
+            form.add(added);
+
+            controller.onRequestStart();
+
+            Assertions.assertTrue(initial.isReadOnly());
+            Assertions.assertTrue(added.isReadOnly(),
+                    "Fields added between turns must be locked on the "
+                            + "next request");
+        }
+
+        @Test
+        void fieldIgnoredBetweenTurnsIsNotLockedOnNextRequest() {
+            // The application may flag a field as ignored after the
+            // controller has been wired up — e.g., a feature toggle
+            // hides PII from the AI. The next turn must respect that.
+            // Today this works only because discovery re-evaluates each
+            // request; if anyone caches the active set "for performance",
+            // this regression slips through.
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+
+            controller.onRequestStart();
+            controller.onResponseComplete();
+
+            controller.ignore(field);
+            controller.onRequestStart();
+
+            Assertions.assertFalse(field.isReadOnly(),
+                    "A field ignored after a previous turn must not be "
+                            + "locked by the next turn");
+        }
+    }
+
+    @Nested
     class HintApi {
 
         @Test


### PR DESCRIPTION
## Summary
- Prevent the user from typing into a field the AI is about to overwrite by switching every non-ignored, currently-editable field to read-only for the duration of a fill turn, releasing on success, failure, or timeout.
- Document the limitation that application code which toggles a field's read-only state mid-turn (e.g. a value-change listener reacting to the LLM's writes) will be overridden when the controller releases its locks — applications should avoid mid-turn toggling, or reapply state after the turn completes.

Related to https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=186543521

🤖 Generated with [Claude Code](https://claude.com/claude-code)