### PR TITLE
refactor: remove unused getViewportRange in treeGridConnector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/treeGridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/treeGridConnector.ts
@@ -34,11 +34,6 @@ window.Vaadin.Flow.treeGridConnector.initLazy = function (grid) {
 
   window.Vaadin.Flow.gridConnector.initLazy(grid);
 
-  function getViewportRange() {
-    const renderedRows = grid._getRenderedRows();
-    return [renderedRows[0]?.index ?? 0, renderedRows[renderedRows.length - 1]?.index ?? 0];
-  }
-
   grid._dataProviderController._shouldLoadCachePage = function (cache, page) {
     // `$server.setViewportRangeByIndexPath` sends a preloaded viewport range based on
     // the provided index path and `padding` parameter. Applying the new range clears


### PR DESCRIPTION
In https://github.com/vaadin/flow-components/pull/9147, the calls to the `getViewportRange` function were replaced with `$connector.getViewportRange()`, but the function itself was never removed. This PR removes it.