### PR TITLE
refactor: remove serverFacade abstraction from comboBoxConnector

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixtureSync } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
 import { comboBoxConnector, FlowComboBox, init } from './shared.ts';
 import '@vaadin/combo-box';
 import * as sinon from 'sinon';
@@ -97,37 +98,38 @@ describe('combo-box connector', () => {
   describe('filter debouncing', () => {
     let clock: sinon.SinonFakeTimers;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       clock = sinon.useFakeTimers({
         toFake: ['setTimeout', 'clearTimeout']
       });
+      comboBox.inputElement.focus();
     });
 
     afterEach(() => {
       clock.restore();
     });
 
-    it('should debounce filter requests with default timeout', () => {
-      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'a' }, () => {});
+    it('should debounce filter requests with default timeout', async () => {
+      await sendKeys({ type: 'a' });
       expect(comboBox.$server.setViewportRange).to.be.not.called;
       clock.tick(500);
       expect(comboBox.$server.setViewportRange).to.be.calledOnce;
 
       comboBox.$server.setViewportRange.resetHistory();
 
-      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'ab' }, () => {});
+      await sendKeys({ type: 'b' });
       clock.tick(250);
-      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'abc' }, () => {});
+      await sendKeys({ type: 'c' });
       clock.tick(250);
       expect(comboBox.$server.setViewportRange).to.be.not.called;
       clock.tick(250);
       expect(comboBox.$server.setViewportRange).to.be.calledOnce;
     });
 
-    it('should debounce filter requests with custom timeout', () => {
+    it('should debounce filter requests with custom timeout', async () => {
       comboBox._filterTimeout = 1000;
 
-      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'a' }, () => {});
+      await sendKeys({ type: 'a' });
       expect(comboBox.$server.setViewportRange).to.be.not.called;
       clock.tick(500);
       expect(comboBox.$server.setViewportRange).to.be.not.called;
@@ -135,16 +137,16 @@ describe('combo-box connector', () => {
       expect(comboBox.$server.setViewportRange).to.be.calledOnce;
     });
 
-    it('should cancel filter request when the connector is reset', () => {
-      comboBox.dataProvider!({ page: 0, pageSize: comboBox.pageSize, filter: 'test' }, () => {});
-      expect(comboBox._filterDebouncer).to.exist;
+    it('should cancel filter request when the connector is reset', async () => {
+      await sendKeys({ type: 'test' });
+      expect(comboBox.$server.setViewportRange).to.be.not.called;
 
       comboBox.$connector.reset();
-      expect(comboBox._filterDebouncer).to.not.exist;
-
       clock.tick(600);
 
-      expect(comboBox.$server.setViewportRange).to.not.be.called;
+      // Reset triggers a single fresh fetch; the cancelled debounced fetch
+      // must not also fire.
+      expect(comboBox.$server.setViewportRange).to.be.calledOnce;
     });
   });
 });

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -17,6 +17,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   let lastTypedFilter = '';
   let lastRequestedRange = [-1, -1];
   let lastRequestedFilter = '';
+  let needsDataCommunicatorReset = false;
 
   comboBox.dataProvider = function (params, callback) {
     if (params.pageSize != comboBox.pageSize) {
@@ -42,6 +43,11 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
         comboBox._filterDebouncer,
         timeOut.after(comboBox._filterTimeout ?? 500),
         () => {
+          // Filter cycled back to what server last received — force re-emit.
+          if (params.filter === lastRequestedFilter) {
+            needsDataCommunicatorReset = true;
+          }
+
           comboBox.clearCache();
         }
       );
@@ -95,14 +101,15 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
       const startIndex = viewportPageRange[0] * comboBox.pageSize;
       const endIndex = (viewportPageRange[1] + 1) * comboBox.pageSize;
       comboBox.$server.setViewportRange(startIndex, endIndex - startIndex, filter);
-
-      if (lastRequestedFilter === filter) {
-        comboBox.$server.resetDataCommunicator();
-      }
-
-      lastRequestedRange = viewportPageRange;
-      lastRequestedFilter = filter;
     }
+
+    if (needsDataCommunicatorReset) {
+      comboBox.$server.resetDataCommunicator();
+      needsDataCommunicatorReset = false;
+    }
+
+    lastRequestedRange = viewportPageRange;
+    lastRequestedFilter = filter;
   };
 
   comboBox.$connector.clear = (start, length) => {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -13,35 +13,10 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
 
   let cache = {};
   const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
+
+  let lastTypedFilter = '';
   let lastRequestedRange = [-1, -1];
-  let lastFilter = '';
-
-  const serverFacade = (() => {
-    // Private variables
-    let lastFilterSentToServer = '';
-    let dataCommunicatorResetNeeded = false;
-
-    // Public methods
-    const needsDataCommunicatorReset = () => (dataCommunicatorResetNeeded = true);
-    const getLastFilterSentToServer = () => lastFilterSentToServer;
-    const requestData = (startIndex, endIndex, params) => {
-      const count = endIndex - startIndex;
-      const filter = params.filter;
-
-      comboBox.$server.setViewportRange(startIndex, count, filter);
-      lastFilterSentToServer = filter;
-      if (dataCommunicatorResetNeeded) {
-        comboBox.$server.resetDataCommunicator();
-        dataCommunicatorResetNeeded = false;
-      }
-    };
-
-    return {
-      needsDataCommunicatorReset,
-      getLastFilterSentToServer,
-      requestData
-    };
-  })();
+  let lastRequestedFilter = '';
 
   comboBox.dataProvider = function (params, callback) {
     if (params.pageSize != comboBox.pageSize) {
@@ -53,25 +28,19 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
         performClientSideFilter(cache[0], params.filter, callback);
         return;
       }
+
       // First fetch: ignore the typed filter so we get the full dataset
       params = { ...params, filter: '' };
     }
 
-    if (params.filter !== lastFilter) {
-      lastFilter = params.filter;
+    if (lastTypedFilter !== params.filter) {
       cache = {};
+      lastTypedFilter = params.filter;
       lastRequestedRange = [-1, -1];
-      comboBox._filterDebouncer = Debouncer.debounce(
-        comboBox._filterDebouncer,
-        timeOut.after(comboBox._filterTimeout ?? 500),
-        () => {
-          // Filter cycled back to previously sent value — force re-emit.
-          if (params.filter === serverFacade.getLastFilterSentToServer()) {
-            serverFacade.needsDataCommunicatorReset();
-          }
-          comboBox.$connector.requestPage(params.page, params.filter);
-        }
-      );
+
+      comboBox._filterDebouncer = Debouncer.debounce(comboBox._filterDebouncer, timeOut.after(comboBox._filterTimeout ?? 500), () => {
+        comboBox.clearCache();
+      });
       return;
     }
 
@@ -119,10 +88,16 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
     }
 
     if (lastRequestedRange[0] != viewportPageRange[0] || lastRequestedRange[1] != viewportPageRange[1]) {
-      lastRequestedRange = viewportPageRange;
       const startIndex = viewportPageRange[0] * comboBox.pageSize;
       const endIndex = (viewportPageRange[1] + 1) * comboBox.pageSize;
-      serverFacade.requestData(startIndex, endIndex, { filter });
+      comboBox.$server.setViewportRange(startIndex, endIndex - startIndex, filter);
+
+      if (lastRequestedFilter === filter) {
+        comboBox.$server.resetDataCommunicator();
+      }
+
+      lastRequestedRange = viewportPageRange;
+      lastRequestedFilter = filter;
     }
   };
 
@@ -148,7 +123,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   };
 
   comboBox.$connector.set = (index, items, filter) => {
-    if (filter !== lastFilter) {
+    if (filter !== lastTypedFilter) {
       return;
     }
 
@@ -202,12 +177,12 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
     comboBox._filterDebouncer = null;
     cache = {};
     lastRequestedRange = [-1, -1];
-    lastFilter = '';
+    lastTypedFilter = '';
     comboBox.clearCache();
   };
 
   comboBox.$connector.confirm = function (id, filter) {
-    if (filter !== lastFilter) {
+    if (filter !== lastTypedFilter) {
       return;
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -38,9 +38,13 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
       lastTypedFilter = params.filter;
       lastRequestedRange = [-1, -1];
 
-      comboBox._filterDebouncer = Debouncer.debounce(comboBox._filterDebouncer, timeOut.after(comboBox._filterTimeout ?? 500), () => {
-        comboBox.clearCache();
-      });
+      comboBox._filterDebouncer = Debouncer.debounce(
+        comboBox._filterDebouncer,
+        timeOut.after(comboBox._filterTimeout ?? 500),
+        () => {
+          comboBox.clearCache();
+        }
+      );
       return;
     }
 


### PR DESCRIPTION
The PR simplifies the `comboBoxConnector` logic by removing the `serverFacade` abstraction. This abstraction has become diluted over time and now just adds unnecessary complexity without any clear benefit.