### PR TITLE
refactor: simplify grid connector viewport range handling

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -29,7 +29,6 @@ describe('grid connector - data range', () => {
 
     grid.$connector.set(start, items.slice(start, start + count));
     grid.$connector.confirm(-1);
-
     lastRequestedRange = [start, count];
   }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -143,4 +143,23 @@ describe('grid connector - data range', () => {
     await resolveRangeRequest([0, 0]);
     expect(grid.loading).to.be.false;
   });
+
+  it('should skip duplicate range request while a request is in flight', async () => {
+    // Trigger a request for the end of the grid and leave it in flight
+    // (do not resolve it).
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    grid.$server.setViewportRange.resetHistory();
+
+    // While that request is still in flight, scroll to an uncached page so
+    // the grid requests more data, then scroll back to the end before the
+    // debouncer fires. When it fires, the visible range matches the range of
+    // the in-flight request, so no second server request should be sent.
+    grid.scrollToIndex(rootSize / 2);
+    await nextFrame();
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setViewportRange).to.not.be.called;
+  });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -14,6 +14,8 @@ describe('grid connector - data range', () => {
   let rootSize: number;
 
   function setRootItemsRange(start: number, count: number) {
+    const items = Array.from({ length: rootSize }, (_, i) => ({ key: `${i}`, name: `Item-${i}` }));
+
     grid.$connector.updateSize(rootSize);
 
     count = Math.min(count, rootSize - start);
@@ -24,10 +26,6 @@ describe('grid connector - data range', () => {
     if (lastRequestedRange) {
       grid.$connector.clear(lastRequestedRange[0], lastRequestedRange[1]);
     }
-
-    const items = Array.from({ length: rootSize }, (_, i) => {
-      return { key: `${i}`, name: `Item-${i}` };
-    });
 
     grid.$connector.set(start, items.slice(start, start + count));
     grid.$connector.confirm(-1);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -136,4 +136,12 @@ describe('grid connector - data range', () => {
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([0, PAGE_SIZE]);
   });
+
+  it('should clear loading state when server resolves setViewportRange without calling confirm', async () => {
+    grid.scrollToIndex(rootSize - 1);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    // Let the awaited setViewportRange promise settle and pending callbacks resolve
+    await nextFrame();
+    expect(grid.hasAttribute('loading')).to.be.false;
+  });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -125,11 +125,6 @@ describe('grid connector - data range', () => {
     grid.scrollToIndex(rootSize - 1);
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE]);
-
-    processRequestedRange();
-
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([0, PAGE_SIZE]);
   });
 
@@ -139,6 +134,6 @@ describe('grid connector - data range', () => {
     rootSize /= 2;
     grid.$connector.updateSize(rootSize);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE]);
+    expectRequestedRange([0, PAGE_SIZE]);
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -5,6 +5,7 @@ import {
   GRID_CONNECTOR_ROOT_REQUEST_DELAY
 } from './shared.js';
 import type { FlowGrid } from './shared.js';
+import * as sinon from 'sinon';
 
 const PAGE_SIZE = 50;
 
@@ -34,9 +35,17 @@ describe('grid connector - data range', () => {
   }
 
   function processRequestedRange() {
-    const range = grid.$server.setViewportRange.args[0];
-    setRootItemsRange(range[0], range[1]);
+    const [start, count] = grid.$server.setViewportRange.args[0];
+    setRootItemsRange(start, count);
+    grid.$server.setViewportRange.promise?.resolve(null);
     grid.$server.setViewportRange.resetHistory();
+    return Promise.resolve();
+  }
+
+  function skipRequestedRange() {
+    grid.$server.setViewportRange.promise?.resolve(null);
+    grid.$server.setViewportRange.resetHistory();
+    return Promise.resolve();
   }
 
   beforeEach(async () => {
@@ -63,7 +72,7 @@ describe('grid connector - data range', () => {
 
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([0, PAGE_SIZE]);
-    processRequestedRange();
+    await processRequestedRange();
   });
 
   it('should request correct ranges when scrolling (start -> end -> start)', async () => {
@@ -71,7 +80,7 @@ describe('grid connector - data range', () => {
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
 
-    processRequestedRange();
+    await processRequestedRange();
 
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -91,7 +100,8 @@ describe('grid connector - data range', () => {
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
-    processRequestedRange();
+    await processRequestedRange();
+    expect(grid.loading).to.be.false;
 
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -101,13 +111,13 @@ describe('grid connector - data range', () => {
   it('should request correct ranges when scrolling (end -> middle -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    processRequestedRange();
+    await processRequestedRange();
 
     grid.scrollToIndex(rootSize / 2);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
     expectRequestedRange([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
-    processRequestedRange();
+    await processRequestedRange();
 
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -128,20 +138,11 @@ describe('grid connector - data range', () => {
     expectRequestedRange([0, PAGE_SIZE]);
   });
 
-  it('should request correct range when size descreases after scrolling fast (start -> end -> start)', async () => {
+  it('should resolve pending requests after scrolling fast (start -> end -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     grid.scrollToIndex(0);
-    rootSize /= 2;
-    grid.$connector.updateSize(rootSize);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([0, PAGE_SIZE]);
-  });
-
-  it('should clear loading state when server resolves setViewportRange without calling confirm', async () => {
-    grid.scrollToIndex(rootSize - 1);
-    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    // Let the awaited setViewportRange promise settle and pending callbacks resolve
-    await nextFrame();
-    expect(grid.hasAttribute('loading')).to.be.false;
+    await skipRequestedRange();
+    expect(grid.loading).to.be.false;
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -5,7 +5,6 @@ import {
   GRID_CONNECTOR_ROOT_REQUEST_DELAY
 } from './shared.js';
 import type { FlowGrid } from './shared.js';
-import * as sinon from 'sinon';
 
 const PAGE_SIZE = 50;
 
@@ -15,34 +14,34 @@ describe('grid connector - data range', () => {
   let rootSize: number;
 
   function setRootItemsRange(start: number, count: number) {
-    const items = Array.from({ length: rootSize }, (_, i) => ({ key: `${i}`, name: `Item-${i}` }));
-
     grid.$connector.updateSize(rootSize);
+
+    count = Math.min(count, rootSize - start);
+    if (count === 0) {
+      return;
+    }
 
     if (lastRequestedRange) {
       grid.$connector.clear(lastRequestedRange[0], lastRequestedRange[1]);
     }
 
-    count = Math.min(count, rootSize - start);
+    const items = Array.from({ length: rootSize }, (_, i) => {
+      return { key: `${i}`, name: `Item-${i}` };
+    });
+
     grid.$connector.set(start, items.slice(start, start + count));
     grid.$connector.confirm(-1);
+
     lastRequestedRange = [start, count];
   }
 
-  function expectRequestedRange(range: [number, number]) {
+  function expectRangeRequest([start, count]: [number, number]) {
     expect(grid.$server.setViewportRange).to.be.calledOnce;
-    expect(grid.$server.setViewportRange.args[0]).to.eql(range);
+    expect(grid.$server.setViewportRange.args[0]).to.eql([start, count]);
   }
 
-  function processRequestedRange() {
-    const [start, count] = grid.$server.setViewportRange.args[0];
+  function resolveRangeRequest([start, count]: [number, number]) {
     setRootItemsRange(start, count);
-    grid.$server.setViewportRange.promise?.resolve(null);
-    grid.$server.setViewportRange.resetHistory();
-    return Promise.resolve();
-  }
-
-  function skipRequestedRange() {
     grid.$server.setViewportRange.promise?.resolve(null);
     grid.$server.setViewportRange.resetHistory();
     return Promise.resolve();
@@ -71,20 +70,21 @@ describe('grid connector - data range', () => {
     grid.$connector.updateSize(rootSize);
 
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([0, PAGE_SIZE]);
-    await processRequestedRange();
+    expectRangeRequest([0, PAGE_SIZE]);
+
+    await resolveRangeRequest([0, PAGE_SIZE]);
   });
 
   it('should request correct ranges when scrolling (start -> end -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
 
-    await processRequestedRange();
+    await resolveRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
 
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([0, PAGE_SIZE]);
+    expectRangeRequest([0, PAGE_SIZE]);
   });
 
   it('should request correct range when size decreases after scrolling (start -> end)', async () => {
@@ -92,57 +92,58 @@ describe('grid connector - data range', () => {
     rootSize /= 2;
     grid.$connector.updateSize(rootSize);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
   it('should request correct ranges when scrolling (start -> middle -> end)', async () => {
     grid.scrollToIndex(rootSize / 2);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
-    await processRequestedRange();
-    expect(grid.loading).to.be.false;
+    await resolveRangeRequest([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
   it('should request correct ranges when scrolling (end -> middle -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    await processRequestedRange();
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+
+    await resolveRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
 
     grid.scrollToIndex(rootSize / 2);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
-    await processRequestedRange();
+    await resolveRangeRequest([rootSize / 2 - PAGE_SIZE, PAGE_SIZE * 2]);
 
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([0, PAGE_SIZE]);
+    expectRangeRequest([0, PAGE_SIZE]);
   });
 
   it('should debounce range requests when scrolling fast', async () => {
     grid.scrollToIndex(rootSize / 2);
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
   });
 
   it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRequestedRange([0, PAGE_SIZE]);
+    expectRangeRequest([0, PAGE_SIZE]);
   });
 
   it('should resolve pending requests after scrolling fast (start -> end -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    await skipRequestedRange();
+    await resolveRangeRequest([0, 0]);
     expect(grid.loading).to.be.false;
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -31,7 +31,7 @@ export type GridServer = {
   deselectAll: () => void & sinon.SinonSpy;
   setDetailsVisible: ((key: string) => void) & sinon.SinonSpy;
   updateExpandedState: ((key: string, expanded: boolean) => void) & sinon.SinonSpy;
-  setViewportRange: ((firstIndex: number, size: number) => void) & sinon.SinonSpy;
+  setViewportRange: ((firstIndex: number, size: number) => Promise<void>) & sinon.SinonSpy & { promise?: sinon.SinonPromise<void> };
   sortersChanged: ((sorters: { path: string, direction: string }[]) => void) & sinon.SinonSpy;
   setShiftKeyDown: ((shiftKeyDown: boolean) => void) & sinon.SinonSpy;
 };
@@ -93,7 +93,11 @@ export function init(grid: FlowGrid, gridConnector = Vaadin.Flow.gridConnector):
     deselectAll: sinon.spy(),
     setDetailsVisible: sinon.spy(),
     updateExpandedState: sinon.spy(),
-    setViewportRange: sinon.spy(),
+    setViewportRange: sinon.spy(() => {
+      const promise = sinon.promise<void>();
+      grid.$server.setViewportRange.promise = promise;
+      return promise;
+    }),
     sortersChanged: sinon.spy(),
     setShiftKeyDown: sinon.spy(),
   };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -151,9 +151,10 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     range[0] = Math.max(range[0] - buffer, 0);
     range[1] = Math.min(range[1] + buffer, grid.size);
 
-    // Align the range to page boundaries
+    // Align the range to page boundaries. range[1] is inclusive of the last
+    // rendered row, so round it up to the end of that row's page.
     range[0] = Math.floor(range[0] / grid.pageSize) * grid.pageSize;
-    range[1] = Math.ceil(range[1] / grid.pageSize) * grid.pageSize;
+    range[1] = (Math.floor(range[1] / grid.pageSize) + 1) * grid.pageSize;
 
     if (requestedViewportRange[0] !== range[0] || requestedViewportRange[1] !== range[1]) {
       grid.$server.setViewportRange(range[0], range[1] - range[0]);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -156,7 +156,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     range[1] = Math.ceil(range[1] / grid.pageSize) * grid.pageSize;
 
     if (requestedViewportRange[0] !== range[0] || requestedViewportRange[1] !== range[1]) {
-      grid.$server.setViewportRange(range[0], range[1] - range[0] + grid.pageSize);
+      grid.$server.setViewportRange(range[0], range[1] - range[0]);
       requestedViewportRange = range;
     }
   };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -5,6 +5,10 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 import { GridFlowSelectionColumn } from './vaadin-grid-flow-selection-column.js';
 
+function isRangeEqual(range1, range2) {
+  return new Set(range1).difference(new Set(range2)).size === 0;
+}
+
 window.Vaadin.Flow.gridConnector = {};
 window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   // Check whether the connector was already initialized for the grid
@@ -16,7 +20,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   const requestDebouncerDelay = 150;
   let requestDebouncer;
-  let requestedViewportRange = [-1, -1];
+  let requestedRange = null;
 
   const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
   let selectedKeys = {};
@@ -142,7 +146,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     return [renderedRows.at(0)?.index ?? 0, renderedRows.at(-1)?.index ?? 0];
   };
 
-  grid.$connector.requestViewportRange = function () {
+  grid.$connector.getFetchRange = function () {
     // Get the range of currently rendered rows
     let range = grid.$connector.getRenderedRange();
 
@@ -156,9 +160,44 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     range[0] = Math.floor(range[0] / grid.pageSize) * grid.pageSize;
     range[1] = (Math.floor(range[1] / grid.pageSize) + 1) * grid.pageSize;
 
-    if (requestedViewportRange[0] !== range[0] || requestedViewportRange[1] !== range[1]) {
-      grid.$server.setViewportRange(range[0], range[1] - range[0]);
-      requestedViewportRange = range;
+    return range;
+  };
+
+  grid.$connector.fetchRange = async (range) => {
+    if (isRangeEqual(range, requestedRange)) {
+      // Skip duplicate requests for the same range.
+      return;
+    }
+
+    requestedRange = range;
+
+    await grid.$server.setViewportRange(range[0], range[1] - range[0]);
+
+    if (!isRangeEqual(range, requestedRange)) {
+      // While awaiting, fetchRange may have been called again with
+      // a different range, so do not process this stale response.
+      return;
+    }
+
+    // Set a flag so the grid re-checks all rendered rows after the pending
+    // callbacks below are resolved, and requests any that are still missing,
+    // not just the ones covered by the resolved callbacks.
+    grid._shouldLoadAllRenderedRowsAfterPageLoad = true;
+
+    // Resolve pending callbacks. This may synchronously trigger new ones to be
+    // created or reissued.
+    const { rootCache } = dataProviderController;
+    Object.values(rootCache.pendingRequests).forEach((callback) => {
+      callback([]);
+    });
+
+    // If no new data provider requests came in while resolving the callbacks
+    // above, clear the current requested range and cancel the active request
+    // debouncer (if any) to avoid sending a server request that is no longer
+    // needed.
+    if (Object.values(rootCache.pendingRequests).length === 0) {
+      requestDebouncer?.cancel();
+      requestedRange = null;
     }
   };
 
@@ -179,10 +218,15 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       return;
     }
 
-    const timeout = grid._hasData ? requestDebouncerDelay : 0;
-    requestDebouncer = Debouncer.debounce(requestDebouncer, timeOut.after(timeout), () => {
-      grid.$connector.requestViewportRange();
-    });
+    requestDebouncer = Debouncer.debounce(
+      requestDebouncer,
+      timeOut.after(grid._hasData ? requestDebouncerDelay : 0),
+      () => {
+        const range = grid.$connector.getFetchRange();
+
+        grid.$connector.fetchRange(range);
+      }
+    );
   };
 
   grid.$connector.setSorterDirections = function (directions) {
@@ -334,7 +378,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   grid.$connector.reset = function () {
     dataProviderController.clearCache();
-    requestedViewportRange = [-1, -1];
+    requestedRange = null;
     requestDebouncer?.cancel();
     grid.__updateVisibleRows();
   };
@@ -344,26 +388,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
 
   grid.$connector.confirm = function (id) {
-    const { rootCache } = dataProviderController;
-
-    // Flag the grid to request any rows that are still missing after resolving
-    // the pending callbacks below.
-    grid._shouldLoadAllRenderedRowsAfterPageLoad = true;
-
-    // Resolve the pending callbacks. This may trigger new ones to be created or
-    // reissued synchronously.
-    Object.values(rootCache.pendingRequests).forEach((callback) => {
-      callback([]);
-    });
-
-    // If no new data provider requests came in while resolving the callbacks,
-    // clear the current requested range and cancel the active request debouncer
-    // (if any) to avoid sending a server request that is no longer needed.
-    if (Object.values(rootCache.pendingRequests).length === 0) {
-      requestDebouncer?.cancel();
-      requestedViewportRange = [-1, -1];
-    }
-
     grid.$server.confirmUpdate(id);
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -16,8 +16,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   const requestDebouncerDelay = 150;
   let requestDebouncer;
-
-  let lastRequestedRange = [0, 0];
+  let requestedViewportRange = [-1, -1];
 
   const validSelectionModes = ['SINGLE', 'NONE', 'MULTI'];
   let selectedKeys = {};
@@ -138,47 +137,27 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   };
   grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
 
-  grid.$connector.getViewportRange = function () {
+  grid.$connector.getRenderedRange = function () {
     const renderedRows = grid._getRenderedRows();
     return [renderedRows.at(0)?.index ?? 0, renderedRows.at(-1)?.index ?? 0];
   };
 
-  grid.$connector.requestPage = function (page) {
-    // Adjust the requested page to be within the valid range in case
-    // the grid size has changed while fetchPage was debounced.
-    page = Math.min(page, Math.floor((grid.size - 1) / grid.pageSize));
+  grid.$connector.requestViewportRange = function () {
+    // Get the range of currently rendered rows
+    let range = grid.$connector.getRenderedRange();
 
-    // Determine what to fetch based on scroll position and not only
-    // what grid asked for
-    let viewportRange = grid.$connector.getViewportRange();
+    // Expand the range in both directions to add a buffer
+    const buffer = range[1] - range[0];
+    range[0] = Math.max(range[0] - buffer, 0);
+    range[1] = Math.min(range[1] + buffer, grid.size);
 
-    // The buffer size could be multiplied by some constant defined by the user,
-    // if he needs to reduce the number of items sent to the Grid to improve performance
-    // or to increase it to make Grid smoother when scrolling
-    const buffer = viewportRange[1] - viewportRange[0];
-    viewportRange[0] = Math.max(viewportRange[0] - buffer, 0);
-    viewportRange[1] = Math.min(viewportRange[1] + buffer, grid.size);
+    // Align the range to page boundaries
+    range[0] = Math.floor(range[0] / grid.pageSize) * grid.pageSize;
+    range[1] = Math.ceil(range[1] / grid.pageSize) * grid.pageSize;
 
-    let viewportPageRange = [
-      Math.floor(viewportRange[0] / grid.pageSize),
-      Math.floor(viewportRange[1] / grid.pageSize)
-    ];
-
-    // When the viewport doesn't contain the requested page or it doesn't contain any items from
-    // the requested level at all, it means that the scroll position has changed while fetchPage
-    // was debounced. For example, it can happen if the user scrolls the grid to the bottom and
-    // then immediately back to the top. In this case, the request for the last page will be left
-    // hanging. To avoid this, as a workaround, we reset the range to only include the requested page
-    // to make sure all hanging requests are resolved. After that, the grid requests the first page
-    // or whatever in the viewport again.
-    if (page < viewportPageRange[0] || page > viewportPageRange[1]) {
-      viewportPageRange = [page, page];
-    }
-
-    if (lastRequestedRange[0] != viewportPageRange[0] || lastRequestedRange[1] != viewportPageRange[1]) {
-      lastRequestedRange = viewportPageRange;
-      const pageCount = viewportPageRange[1] - viewportPageRange[0] + 1;
-      grid.$server.setViewportRange(viewportPageRange[0] * grid.pageSize, pageCount * grid.pageSize);
+    if (requestedViewportRange[0] !== range[0] || requestedViewportRange[1] !== range[1]) {
+      grid.$server.setViewportRange(range[0], range[1] - range[0] + grid.pageSize);
+      requestedViewportRange = range;
     }
   };
 
@@ -199,13 +178,10 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       return;
     }
 
-    requestDebouncer = Debouncer.debounce(
-      requestDebouncer,
-      timeOut.after(grid._hasData ? requestDebouncerDelay : 0),
-      () => {
-        grid.$connector.requestPage(params.page);
-      }
-    );
+    const timeout = grid._hasData ? requestDebouncerDelay : 0;
+    requestDebouncer = Debouncer.debounce(requestDebouncer, timeOut.after(timeout), () => {
+      grid.$connector.requestViewportRange();
+    });
   };
 
   grid.$connector.setSorterDirections = function (directions) {
@@ -357,7 +333,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   grid.$connector.reset = function () {
     dataProviderController.clearCache();
-    lastRequestedRange = [-1, -1];
+    requestedViewportRange = [-1, -1];
     requestDebouncer?.cancel();
     grid.__updateVisibleRows();
   };
@@ -367,39 +343,23 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
 
   grid.$connector.confirm = function (id) {
-    // We're done applying changes from this batch, resolve pending
-    // callbacks
+    // Force the grid to request not loaded rows after resolving callbacks.
+    grid._shouldLoadAllRenderedRowsAfterPageLoad = true;
+
+    // Resolve all pending callbacks and see whether any new ones come in again.
     const { rootCache } = dataProviderController;
-    Object.entries(rootCache.pendingRequests).forEach(([page, callback]) => {
-      const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
-      // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request
-      const lastRequestedRangeEnd = Math.min(lastRequestedRange[1], lastAvailablePage);
-      // Resolve if we have data or if we don't expect to get data
-      const startIndex = page * grid.pageSize;
-      if (rootCache.items[startIndex] !== undefined) {
-        // Cached data is available, resolve the callback
-        callback([]);
-      } else if (page < lastRequestedRange[0] || +page > lastRequestedRangeEnd) {
-        // No cached data, resolve the callback with an empty array
-        callback(new Array(grid.pageSize));
-        // Request grid for content update
-        grid.requestContentUpdate();
-      } else if (callback && grid.size === 0) {
-        // The grid has 0 items => resolve the callback with an empty array
-        callback([]);
-      }
+    Object.values(rootCache.pendingRequests).forEach((callback) => {
+      callback([]);
     });
 
-    // If all pending requests have already been resolved (which can happen
-    // for example if the server sent preloaded data while the grid had
-    // already made its own requests), cancel the request debouncer to
-    // prevent further unnecessary calls.
-    if (Object.keys(rootCache.pendingRequests).length === 0) {
+    // If no new data provider requests have been received after the callbacks were
+    // resolved, clear the current requested range and cancel the request debouncer
+    // (if it's active) to avoid sending a server request that is no longer needed.
+    if (Object.values(rootCache.pendingRequests).length === 0) {
       requestDebouncer?.cancel();
-      lastRequestedRange = [-1, -1];
+      requestedViewportRange = [-1, -1];
     }
 
-    // Let server know we're done
     grid.$server.confirmUpdate(id);
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -6,7 +6,7 @@ import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 import { GridFlowSelectionColumn } from './vaadin-grid-flow-selection-column.js';
 
 function isRangeEqual(range1, range2) {
-  return new Set(range1).difference(new Set(range2)).size === 0;
+  return range1?.[0] === range2?.[0] && range1?.[1] === range2?.[1];
 }
 
 window.Vaadin.Flow.gridConnector = {};

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -163,7 +163,9 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     return range;
   };
 
-  grid.$connector.fetchRange = async (range) => {
+  grid.$connector.fetchCurrentRange = async () => {
+    const range = grid.$connector.getFetchRange();
+
     if (isRangeEqual(range, requestedRange)) {
       // Skip duplicate requests for the same range.
       return;
@@ -173,21 +175,29 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
     await grid.$server.setViewportRange(range[0], range[1] - range[0]);
 
-    if (!isRangeEqual(range, requestedRange)) {
-      // While awaiting, fetchRange may have been called again with
-      // a different range, so do not process this stale response.
-      return;
+    if (isRangeEqual(range, requestedRange)) {
+      // If requestedRange is still set and matches the current range, it means
+      // the server responded with no new data and $connector.confirm wasn't called
+      // because the server assumes all the data is already on the client. This can
+      // happen, for example, when scrolling quickly back and forth so that the grid
+      // returns to a position whose data has already been delivered and is cached.
+      // In this case, just resolve the callbacks so the grid can exit the loading
+      // state correctly.
+      grid.$connector.resolvePendingCallbacks();
     }
+  };
 
-    // Set a flag so the grid re-checks all rendered rows after the pending
-    // callbacks below are resolved, and requests any that are still missing,
-    // not just the ones covered by the resolved callbacks.
-    grid._shouldLoadAllRenderedRowsAfterPageLoad = true;
-
-    // Resolve pending callbacks. This may synchronously trigger new ones to be
-    // created or reissued.
+  grid.$connector.resolvePendingCallbacks = () => {
     const { rootCache } = dataProviderController;
+
     Object.values(rootCache.pendingRequests).forEach((callback) => {
+      // Set a flag so the grid re-checks all rendered rows after all callbacks
+      // are resolved, and requests any that are still missing, not just the ones
+      // covered by this resolved callback.
+      grid._shouldLoadAllRenderedRowsAfterPageLoad = true;
+
+      // Resolve this pending callback. This may synchronously trigger new ones
+      // to be created or reissued.
       callback([]);
     });
 
@@ -222,9 +232,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       requestDebouncer,
       timeOut.after(grid._hasData ? requestDebouncerDelay : 0),
       () => {
-        const range = grid.$connector.getFetchRange();
-
-        grid.$connector.fetchRange(range);
+        grid.$connector.fetchCurrentRange();
       }
     );
   };
@@ -388,6 +396,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
 
   grid.$connector.confirm = function (id) {
+    grid.$connector.resolvePendingCallbacks();
     grid.$server.confirmUpdate(id);
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -343,18 +343,21 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
 
   grid.$connector.confirm = function (id) {
-    // Force the grid to request not loaded rows after resolving callbacks.
+    const { rootCache } = dataProviderController;
+
+    // Flag the grid to request any rows that are still missing after resolving
+    // the pending callbacks below.
     grid._shouldLoadAllRenderedRowsAfterPageLoad = true;
 
-    // Resolve all pending callbacks and see whether any new ones come in again.
-    const { rootCache } = dataProviderController;
+    // Resolve the pending callbacks. This may trigger new ones to be created or
+    // reissued synchronously.
     Object.values(rootCache.pendingRequests).forEach((callback) => {
       callback([]);
     });
 
-    // If no new data provider requests have been received after the callbacks were
-    // resolved, clear the current requested range and cancel the request debouncer
-    // (if it's active) to avoid sending a server request that is no longer needed.
+    // If no new data provider requests came in while resolving the callbacks,
+    // clear the current requested range and cancel the active request debouncer
+    // (if any) to avoid sending a server request that is no longer needed.
     if (Object.values(rootCache.pendingRequests).length === 0) {
       requestDebouncer?.cancel();
       requestedViewportRange = [-1, -1];

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -175,16 +175,13 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
     await grid.$server.setViewportRange(range[0], range[1] - range[0]);
 
-    if (isRangeEqual(range, requestedRange)) {
-      // If requestedRange is still set and matches the current range, it means
-      // the server responded with no new data and $connector.confirm wasn't called
-      // because the server assumes all the data is already on the client. This can
-      // happen, for example, when scrolling quickly back and forth so that the grid
-      // returns to a position whose data has already been delivered and is cached.
-      // In this case, just resolve the callbacks so the grid can exit the loading
-      // state correctly.
-      grid.$connector.resolvePendingCallbacks();
-    }
+    // Resolve any pending callbacks in case the server responded with no new
+    // data and $connector.confirm wasn't called because the server assumes all
+    // the data is already on the client. This can happen, for example, when
+    // scrolling quickly back and forth so that the grid returns to a position
+    // whose data has already been delivered and is cached. In that case,
+    // resolving the callbacks lets the grid exit the loading state correctly.
+    grid.$connector.resolvePendingCallbacks();
   };
 
   grid.$connector.resolvePendingCallbacks = () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -396,7 +396,11 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid.$connector.updateUniqueItemIdPath = (path) => (grid.itemIdPath = path);
 
   grid.$connector.confirm = function (id) {
+    // We're done applying changes from this batch, resolve pending
+    // callbacks
     grid.$connector.resolvePendingCallbacks();
+
+    // Let server know we're done
     grid.$server.confirmUpdate(id);
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/treeGridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/treeGridConnector.ts
@@ -51,7 +51,7 @@ window.Vaadin.Flow.treeGridConnector.initLazy = function (grid) {
       return;
     }
 
-    const [start, end] = grid.$connector.getViewportRange();
+    const [start, end] = grid.$connector.getRenderedRange();
     const padding = Math.floor((end - start) * 1.5);
     const flatIndex = await grid.$server.setViewportRangeByIndexPath(indexes, padding);
     grid._scrollToFlatIndex(flatIndex);


### PR DESCRIPTION
The grid connector's fetch range used to depend on both the rendered rows and the page the grid asked for. With fast scrolling, the requested page could end up outside the viewport e.g. when quickly scrolling to the bottom and back to the top. In that case, `requestPage` collapsed the range to just the last page, which was requsted at the bottom, because otherwise the DataCommunicator wouldn't return anything when the first page was requested again at the top. The server would then respond, and `confirm` could clear that pending callback. `confirm` had a matching branch that resolved out-of-range callbacks with an empty array and forced a content update.

This workaround is no longer needed: pending callbacks are now always resolved after the server responds to `setViewportRange`, even when no new data is sent. A stale callback for a page outside the current viewport can't keep the grid in a loading state regardless of what range was requested, so the fetch range can be derived purely from the rendered rows.

**Summary of changes in this PR:**

- Drop the `page` argument from the request flow; replace `requestPage(page)` with async `fetchCurrentRange()` that derives the range from rendered rows only, skips duplicate requests, and awaits `setViewportRange`.
- Split the old `getViewportRange` into `getRenderedRange` (rendered rows) and `getFetchRange` (rendered range plus buffer, aligned to page boundaries — the inclusive end rounds up to the end of its page so the last rendered row's page is always fetched).
- Extract `resolvePendingCallbacks`; call it after `setViewportRange` resolves with no new data, and from `confirm`. Removes the three-branch logic in `confirm`.
- Track `requestedRange` as `[startIndex, endIndex]` instead of `lastRequestedRange` in pages.
- Update `treeGridConnector` to use the renamed `getRenderedRange`.
