### PR TITLE
feat: add binder integration to form ai controller

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/BinderReflection.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/BinderReflection.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.ai.form;
 
 import java.lang.reflect.Field;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,14 +31,13 @@ import com.vaadin.flow.data.binder.Binder.Binding;
 /**
  * Reflection access to {@link Binder} internals.
  * <p>
- * {@link FormAIController} needs two pieces of information that {@link Binder}
- * does not expose publicly: the property name supplied when a binding was
- * created, and the binding instance for a given {@link HasValue}. Both live in
- * private fields ({@code boundProperties} and {@code bindings}); this class
- * reads them reflectively and caches the {@link Field} references at static
- * init. If a future {@code Binder} renames or removes either field, the helper
- * logs a warning and returns empty results so callers degrade to the non-binder
- * code path rather than throwing.
+ * {@link FormAIController} needs the property name supplied when a binding was
+ * created, which {@link Binder} does not expose publicly. The property names
+ * live in a private {@code boundProperties} field; this class reads it
+ * reflectively and caches the {@link Field} reference at static init. If a
+ * future {@code Binder} renames or removes the field, the helper logs a warning
+ * and returns an empty map so callers degrade to the non-binder code path
+ * rather than throwing.
  * </p>
  */
 final class BinderReflection {
@@ -48,7 +46,6 @@ final class BinderReflection {
             .getLogger(BinderReflection.class);
 
     private static final Field BOUND_PROPERTIES_FIELD = getBoundPropertiesField();
-    private static final Field BINDINGS_FIELD = getBindingsField();
 
     private BinderReflection() {
     }
@@ -77,29 +74,6 @@ final class BinderReflection {
         return Collections.emptyMap();
     }
 
-    /**
-     * Returns the {@link Binding} registered for the given field, or
-     * {@code null} if no binding matches. Matches by reference equality so the
-     * same {@code HasValue} added to two binders does not cross-pollute.
-     *
-     * @param binder
-     *            the binder, not {@code null}
-     * @param field
-     *            the field, not {@code null}
-     * @return the matching binding, or {@code null}
-     */
-    @SuppressWarnings("unchecked")
-    static Binding<?, ?> findBinding(Binder<?> binder, HasValue<?, ?> field) {
-        try {
-            return ((Collection<Binding<?, ?>>) BINDINGS_FIELD.get(binder))
-                    .stream().filter(binding -> binding.getField() == field)
-                    .findFirst().orElse(null);
-        } catch (Exception ex) {
-            LOGGER.warn("Could not read bindings from Binder.", ex);
-        }
-        return null;
-    }
-
     private static Field getBoundPropertiesField() {
         try {
             var field = Binder.class.getDeclaredField("boundProperties");
@@ -107,21 +81,8 @@ final class BinderReflection {
             return field;
         } catch (Exception e) {
             LOGGER.warn("Could not access Binder.boundProperties; bound "
-                    + "fields will not contribute a property-name alias to "
-                    + "the LLM's view of the form.", e);
-        }
-        return null;
-    }
-
-    private static Field getBindingsField() {
-        try {
-            var field = Binder.class.getDeclaredField("bindings");
-            field.setAccessible(true);
-            return field;
-        } catch (Exception e) {
-            LOGGER.warn("Could not access Binder.bindings; "
-                    + "FormAIController.findBinding(...) will always return "
-                    + "empty.", e);
+                    + "fields will not seed the LLM-facing description from "
+                    + "their bean property name.", e);
         }
         return null;
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/BinderReflection.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/BinderReflection.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.form;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.Binder.Binding;
+
+/**
+ * Reflection access to {@link Binder} internals.
+ * <p>
+ * {@link FormAIController} needs two pieces of information that {@link Binder}
+ * does not expose publicly: the property name supplied when a binding was
+ * created, and the binding instance for a given {@link HasValue}. Both live in
+ * private fields ({@code boundProperties} and {@code bindings}); this class
+ * reads them reflectively and caches the {@link Field} references at static
+ * init. If a future {@code Binder} renames or removes either field, the helper
+ * logs a warning and returns empty results so callers degrade to the non-binder
+ * code path rather than throwing.
+ * </p>
+ */
+final class BinderReflection {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(BinderReflection.class);
+
+    private static final Field BOUND_PROPERTIES_FIELD = getBoundPropertiesField();
+    private static final Field BINDINGS_FIELD = getBindingsField();
+
+    private BinderReflection() {
+    }
+
+    /**
+     * Builds a {@code HasValue → propertyName} map of every binding that
+     * carries a property name. Lambda-bound bindings are excluded because the
+     * binder records no name for them.
+     *
+     * @param binder
+     *            the binder, not {@code null}
+     * @return the map, never {@code null}; empty if reflection is unavailable
+     */
+    @SuppressWarnings("unchecked")
+    static Map<HasValue<?, ?>, String> collectPropertyNames(Binder<?> binder) {
+        try {
+            return ((Map<String, Binding<?, ?>>) BOUND_PROPERTIES_FIELD
+                    .get(binder))
+                    .entrySet().stream()
+                    .collect(Collectors.toMap(e -> e.getValue().getField(),
+                            Map.Entry::getKey, (x, y) -> y,
+                            LinkedHashMap::new));
+        } catch (Exception ex) {
+            LOGGER.warn("Could not extract property names from Binder.", ex);
+        }
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Returns the {@link Binding} registered for the given field, or
+     * {@code null} if no binding matches. Matches by reference equality so the
+     * same {@code HasValue} added to two binders does not cross-pollute.
+     *
+     * @param binder
+     *            the binder, not {@code null}
+     * @param field
+     *            the field, not {@code null}
+     * @return the matching binding, or {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    static Binding<?, ?> findBinding(Binder<?> binder, HasValue<?, ?> field) {
+        try {
+            return ((Collection<Binding<?, ?>>) BINDINGS_FIELD.get(binder))
+                    .stream().filter(binding -> binding.getField() == field)
+                    .findFirst().orElse(null);
+        } catch (Exception ex) {
+            LOGGER.warn("Could not read bindings from Binder.", ex);
+        }
+        return null;
+    }
+
+    private static Field getBoundPropertiesField() {
+        try {
+            var field = Binder.class.getDeclaredField("boundProperties");
+            field.setAccessible(true);
+            return field;
+        } catch (Exception e) {
+            LOGGER.warn("Could not access Binder.boundProperties; bound "
+                    + "fields will not contribute a property-name alias to "
+                    + "the LLM's view of the form.", e);
+        }
+        return null;
+    }
+
+    private static Field getBindingsField() {
+        try {
+            var field = Binder.class.getDeclaredField("bindings");
+            field.setAccessible(true);
+            return field;
+        } catch (Exception e) {
+            LOGGER.warn("Could not access Binder.bindings; "
+                    + "FormAIController.findBinding(...) will always return "
+                    + "empty.", e);
+        }
+        return null;
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -317,9 +317,6 @@ public class FormAIController implements AIController {
      * always wins because the seeding only fills in nulls.
      */
     private void seedDescriptionsFromBinder() {
-        if (binder == null) {
-            return;
-        }
         var propertyNames = BinderReflection.collectPropertyNames(binder);
         for (var entry : propertyNames.entrySet()) {
             var field = entry.getKey();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -35,7 +34,6 @@ import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.data.binder.Binder;
-import com.vaadin.flow.data.binder.Binder.Binding;
 
 /**
  * Populates a layout's fields with values an LLM extracts from a user prompt or
@@ -150,26 +148,6 @@ public class FormAIController implements AIController {
         Objects.requireNonNull(binder, "Binder must not be null");
         this.form = form;
         this.binder = binder;
-    }
-
-    /**
-     * Returns the {@link Binding} registered for the given field on the binder
-     * supplied to this controller. Returns an empty optional for unbound fields
-     * and for controllers constructed without a binder. The lookup is live
-     * against the binder's current state, not a snapshot taken at construction.
-     *
-     * @param field
-     *            the field, not {@code null}
-     * @return the binding, or empty if the field is not bound
-     * @throws NullPointerException
-     *             if {@code field} is {@code null}
-     */
-    Optional<Binding<?, ?>> findBinding(HasValue<?, ?> field) {
-        Objects.requireNonNull(field, "Field must not be null");
-        if (binder == null) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(BinderReflection.findBinding(binder, field));
     }
 
     /**
@@ -345,13 +323,12 @@ public class FormAIController implements AIController {
         var propertyNames = BinderReflection.collectPropertyNames(binder);
         for (var entry : propertyNames.entrySet()) {
             var field = entry.getKey();
-            var name = entry.getValue();
-            if (name == null || !(field instanceof Component)) {
+            if (!(field instanceof Component)) {
                 continue;
             }
             var hints = hintsFor(field);
             if (hints.description == null) {
-                hints.description = name;
+                hints.description = entry.getValue();
             }
         }
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -33,6 +34,8 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.Binder.Binding;
 
 /**
  * Populates a layout's fields with values an LLM extracts from a user prompt or
@@ -48,6 +51,26 @@ import com.vaadin.flow.component.ai.provider.LLMProvider;
  * </p>
  *
  * <p>
+ * <b>Field identifiers:</b> the controller assigns an opaque UUID to each field
+ * at discovery time and uses that UUID as the field's id in every tool call the
+ * LLM makes. Developers never see UUIDs; the LLM never sees field labels in the
+ * id slot. Semantic meaning travels through each field's <i>description</i> —
+ * the field's label, helper text, and the {@link #describe(HasValue, String)}
+ * hint.
+ * </p>
+ *
+ * <p>
+ * <b>Binder integration:</b> the two-argument constructor accepts a
+ * {@link Binder}. For every named binding ({@code bind("propertyName")},
+ * {@code bindInstanceFields(this)}, or {@code @PropertyId}) the property name
+ * is used as a default field description so the LLM can refer to the field by
+ * its bean-side name. The default only applies when no explicit
+ * {@link #describe(HasValue, String)} has been registered; calling
+ * {@code describe(...)} always wins. Lambda-bound bindings carry no property
+ * name and contribute no default.
+ * </p>
+ *
+ * <p>
  * <b>Field locking:</b> while a fill is in progress, every non-ignored field
  * that wasn't already read-only is set to read-only so the user cannot type
  * into a field the AI is about to overwrite. Locks are released when the turn
@@ -60,7 +83,8 @@ import com.vaadin.flow.component.ai.provider.LLMProvider;
  *
  * <p>
  * <b>Serialization:</b> the controller is not serialized with the orchestrator.
- * After deserialization, create a new controller against the same form and call
+ * After deserialization, create a new controller against the same form (and
+ * binder, if any) and call
  * {@code orchestrator.reconnect(provider).withController(controller).apply()}.
  * </p>
  *
@@ -76,6 +100,7 @@ public class FormAIController implements AIController {
     static final String FIELD_ID_KEY = "vaadin.ai.form.fieldId";
 
     private final Component form;
+    private final Binder<?> binder;
     private final Map<String, FormFieldHints> hintsById = new HashMap<>();
     private final List<HasValue<?, ?>> lockedFields = new ArrayList<>();
 
@@ -94,6 +119,57 @@ public class FormAIController implements AIController {
     public <T extends Component & HasComponents> FormAIController(T form) {
         Objects.requireNonNull(form, "Form must not be null");
         this.form = form;
+        this.binder = null;
+    }
+
+    /**
+     * Creates a new form AI controller for the given container and binder. For
+     * every named binding on the binder, the bean property name is used as a
+     * default {@link #describe(HasValue, String) description} when the
+     * developer has not registered one explicitly; the controller itself still
+     * uses an opaque UUID as the field's tool-call id. Lambda-bound bindings
+     * carry no property name and contribute no default. A field that is part of
+     * the layout but not bound to the supplied binder behaves the same as in
+     * the no-binder constructor.
+     *
+     * @param form
+     *            the container whose fields the LLM may populate, not
+     *            {@code null}
+     * @param binder
+     *            the binder whose property names default the field
+     *            descriptions, not {@code null}; use the single-argument
+     *            constructor for the no-binder case
+     * @param <T>
+     *            the container type
+     * @throws NullPointerException
+     *             if {@code form} or {@code binder} is {@code null}
+     */
+    public <T extends Component & HasComponents> FormAIController(T form,
+            Binder<?> binder) {
+        Objects.requireNonNull(form, "Form must not be null");
+        Objects.requireNonNull(binder, "Binder must not be null");
+        this.form = form;
+        this.binder = binder;
+    }
+
+    /**
+     * Returns the {@link Binding} registered for the given field on the binder
+     * supplied to this controller. Returns an empty optional for unbound fields
+     * and for controllers constructed without a binder. The lookup is live
+     * against the binder's current state, not a snapshot taken at construction.
+     *
+     * @param field
+     *            the field, not {@code null}
+     * @return the binding, or empty if the field is not bound
+     * @throws NullPointerException
+     *             if {@code field} is {@code null}
+     */
+    Optional<Binding<?, ?>> findBinding(HasValue<?, ?> field) {
+        Objects.requireNonNull(field, "Field must not be null");
+        if (binder == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(BinderReflection.findBinding(binder, field));
     }
 
     /**
@@ -241,6 +317,7 @@ public class FormAIController implements AIController {
         // Refresh the field set so fields added or removed between turns
         // are picked up.
         attachIds();
+        seedDescriptionsFromBinder();
         lockFields();
     }
 
@@ -252,6 +329,31 @@ public class FormAIController implements AIController {
     @Override
     public void onResponseFailed(Throwable error) {
         unlockFields();
+    }
+
+    /**
+     * Walks the binder's property names and defaults {@code hints.description}
+     * for any bound field that does not already have an explicit description.
+     * Called at the start of every turn so bindings added or removed between
+     * turns are reflected; an explicit {@link #describe(HasValue, String)}
+     * always wins because the seeding only fills in nulls.
+     */
+    private void seedDescriptionsFromBinder() {
+        if (binder == null) {
+            return;
+        }
+        var propertyNames = BinderReflection.collectPropertyNames(binder);
+        for (var entry : propertyNames.entrySet()) {
+            var field = entry.getKey();
+            var name = entry.getValue();
+            if (name == null || !(field instanceof Component)) {
+                continue;
+            }
+            var hints = hintsFor(field);
+            if (hints.description == null) {
+                hints.description = name;
+            }
+        }
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -85,7 +85,8 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldHints.*",
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldSchema.*",
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldType.*",
-                "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormValueConverter.*"));
+                "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormValueConverter.*",
+                "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.BinderReflection(\\$\\d+)?"));
     }
 
     @BeforeEach

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -28,11 +28,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.HasLabel;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.ai.form.FormTestFields.CompositeField;
 import com.vaadin.flow.component.ai.form.FormTestFields.IntField;
 import com.vaadin.flow.component.ai.form.FormTestFields.SingleSelectField;
 import com.vaadin.flow.component.ai.form.FormTestFields.TestField;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.internal.JacksonUtils;
 
 /**
@@ -43,6 +47,46 @@ import com.vaadin.flow.internal.JacksonUtils;
  * stays focused on controller behaviour rather than schema details.
  */
 class FormAIControllerTest {
+
+    /** {@link TestField} variant that also exposes a label. */
+    @Tag("labeled-field")
+    private static class LabeledField
+            extends AbstractField<LabeledField, String> implements HasLabel {
+        LabeledField(String label) {
+            super("");
+            setLabel(label);
+        }
+
+        @Override
+        protected void setPresentationValue(String value) {
+        }
+    }
+
+    /** Bean used by binder integration tests. */
+    private static class TestBean {
+        private String name;
+        private String email;
+
+        @SuppressWarnings("unused")
+        public String getName() {
+            return name;
+        }
+
+        @SuppressWarnings("unused")
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @SuppressWarnings("unused")
+        public String getEmail() {
+            return email;
+        }
+
+        @SuppressWarnings("unused")
+        public void setEmail(String email) {
+            this.email = email;
+        }
+    }
 
     @Nested
     class Construction {
@@ -57,6 +101,27 @@ class FormAIControllerTest {
         void nullFormThrows() {
             Assertions.assertThrows(NullPointerException.class,
                     () -> new FormAIController(null));
+        }
+
+        @Test
+        void constructionWithBinderSucceeds() {
+            var form = new Div(new TestField());
+            var binder = new Binder<>(TestBean.class);
+            Assertions.assertDoesNotThrow(
+                    () -> new FormAIController(form, binder));
+        }
+
+        @Test
+        void nullFormForBinderConstructorThrows() {
+            Assertions.assertThrows(NullPointerException.class,
+                    () -> new FormAIController(null,
+                            new Binder<>(TestBean.class)));
+        }
+
+        @Test
+        void nullBinderForBinderConstructorThrows() {
+            Assertions.assertThrows(NullPointerException.class,
+                    () -> new FormAIController(new Div(), null));
         }
     }
 
@@ -434,6 +499,76 @@ class FormAIControllerTest {
             Assertions.assertTrue(field.path("enum").isMissingNode(),
                     "Stale enum block must not survive re-registration with "
                             + "a BiFunction, got: " + field);
+        }
+    }
+
+    @Nested
+    class FindBinding {
+
+        @Test
+        void findBindingReturnsBindingForBoundField() {
+            // Pins that findBinding resolves a named binding via reflection.
+            // The returned Binding's getField() must be the same reference the
+            // caller passed in.
+            var field = new LabeledField("Name");
+            var binder = new Binder<>(TestBean.class);
+            binder.forField(field).bind("name");
+            var controller = new FormAIController(new Div(field), binder);
+
+            var binding = controller.findBinding(field);
+
+            Assertions.assertTrue(binding.isPresent(),
+                    "findBinding should resolve a bound field's binding");
+            Assertions.assertSame(field, binding.get().getField(),
+                    "Resolved binding must reference the same field instance");
+        }
+
+        @Test
+        void findBindingReturnsEmptyForUnboundField() {
+            var bound = new LabeledField("Name");
+            var unbound = new LabeledField("Email");
+            var binder = new Binder<>(TestBean.class);
+            binder.forField(bound).bind("name");
+            var controller = new FormAIController(new Div(bound, unbound),
+                    binder);
+
+            Assertions.assertTrue(controller.findBinding(unbound).isEmpty());
+        }
+
+        @Test
+        void findBindingReturnsEmptyWhenNoBinderSupplied() {
+            // No-binder constructor: findBinding always returns empty so
+            // downstream callers cleanly skip fields with no binding.
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+
+            Assertions.assertTrue(controller.findBinding(field).isEmpty());
+        }
+
+        @Test
+        void findBindingRejectsNullField() {
+            var controller = new FormAIController(new Div(new TestField()),
+                    new Binder<>(TestBean.class));
+            Assertions.assertThrows(NullPointerException.class,
+                    () -> controller.findBinding(null));
+        }
+
+        @Test
+        void findBindingIsLiveAfterRebinding() {
+            // findBinding reflects the binder's current state, not a
+            // construction-time snapshot. A field bound after the controller
+            // is created shows up; a field whose binding is removed
+            // disappears.
+            var field = new LabeledField("Name");
+            var binder = new Binder<>(TestBean.class);
+            var controller = new FormAIController(new Div(field), binder);
+
+            Assertions.assertTrue(controller.findBinding(field).isEmpty(),
+                    "Pre-bind: no binding");
+
+            binder.forField(field).bind("name");
+            Assertions.assertTrue(controller.findBinding(field).isPresent(),
+                    "Post-bind: binding resolved");
         }
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.ai.form;
 
 import static com.vaadin.flow.component.ai.form.FormTestSupport.executeQueryFieldOptions;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.findTool;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.formStateFields;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.json;
 
 import java.util.Collection;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasLabel;
+import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.ai.form.FormTestFields.CompositeField;
 import com.vaadin.flow.component.ai.form.FormTestFields.IntField;
@@ -37,7 +40,9 @@ import com.vaadin.flow.component.ai.form.FormTestFields.SingleSelectField;
 import com.vaadin.flow.component.ai.form.FormTestFields.TestField;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.PropertyId;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * Tests covering {@link FormAIController}'s construction, container traversal,
@@ -503,72 +508,250 @@ class FormAIControllerTest {
     }
 
     @Nested
-    class FindBinding {
+    class BinderDescriptionSeeding {
 
         @Test
-        void findBindingReturnsBindingForBoundField() {
-            // Pins that findBinding resolves a named binding via reflection.
-            // The returned Binding's getField() must be the same reference the
-            // caller passed in.
-            var field = new LabeledField("Name");
+        void boundFieldPropertyNameSurfacesInDescription() {
+            // A named binding contributes the bean property name as the
+            // default description; with no label or helper text, that's the
+            // entire description string the LLM sees.
+            var field = new TestField();
             var binder = new Binder<>(TestBean.class);
             binder.forField(field).bind("name");
             var controller = new FormAIController(new Div(field), binder);
 
-            var binding = controller.findBinding(field);
+            controller.onRequestStart();
+            var entry = formStateFields(controller).get(0);
 
-            Assertions.assertTrue(binding.isPresent(),
-                    "findBinding should resolve a bound field's binding");
-            Assertions.assertSame(field, binding.get().getField(),
-                    "Resolved binding must reference the same field instance");
+            Assertions.assertEquals("name",
+                    entry.path("description").asString(),
+                    "Bean property name should default the description");
         }
 
         @Test
-        void findBindingReturnsEmptyForUnboundField() {
-            var bound = new LabeledField("Name");
-            var unbound = new LabeledField("Email");
+        void labelAndPropertyNameMergeInDescription() {
+            // When both label and property name are available, the merged
+            // description is `label | propertyName`, in that order.
+            var field = new LabeledField("Customer Name");
+            var binder = new Binder<>(TestBean.class);
+            binder.forField(field).bind("name");
+            var controller = new FormAIController(new Div(field), binder);
+
+            controller.onRequestStart();
+            var entry = formStateFields(controller).get(0);
+
+            Assertions.assertEquals("Customer Name | name",
+                    entry.path("description").asString());
+        }
+
+        @Test
+        void describeOverridesBinderSeeding() {
+            // Explicit describe() always wins: seeding only fills nulls, so
+            // a developer's description suppresses the bean property name.
+            var field = new LabeledField("Customer Name");
+            var binder = new Binder<>(TestBean.class);
+            binder.forField(field).bind("name");
+            var controller = new FormAIController(new Div(field), binder);
+            controller.describe(field, "Full legal name");
+
+            controller.onRequestStart();
+            var entry = formStateFields(controller).get(0);
+
+            var description = entry.path("description").asString();
+            Assertions.assertEquals("Customer Name | Full legal name",
+                    description);
+            Assertions.assertFalse(description.contains("name | "),
+                    "Property name must not appear when describe() set "
+                            + "the description explicitly, got: "
+                            + description);
+        }
+
+        @Test
+        void lambdaBoundFieldHasNoSeededDescription() {
+            // Lambda-bound bindings carry no property name; the description
+            // falls back to whatever label/helper/describe() provides — here
+            // just the label.
+            var field = new LabeledField("Email");
+            var binder = new Binder<>(TestBean.class);
+            binder.forField(field).bind(TestBean::getEmail, TestBean::setEmail);
+            var controller = new FormAIController(new Div(field), binder);
+
+            controller.onRequestStart();
+            var entry = formStateFields(controller).get(0);
+
+            Assertions.assertEquals("Email",
+                    entry.path("description").asString(),
+                    "Lambda-bound field has no property name to seed; "
+                            + "description should be the label alone");
+        }
+
+        @Test
+        void unboundFieldHasNoSeededDescription() {
+            // A field present in the form but not registered with the binder
+            // contributes no seeded property name. With no label either, the
+            // description is omitted entirely from the JSON.
+            var bound = new LabeledField("Customer Name");
+            var unbound = new TestField();
             var binder = new Binder<>(TestBean.class);
             binder.forField(bound).bind("name");
             var controller = new FormAIController(new Div(bound, unbound),
                     binder);
 
-            Assertions.assertTrue(controller.findBinding(unbound).isEmpty());
+            controller.onRequestStart();
+            var entries = formStateFields(controller);
+            var unboundEntry = entries.stream()
+                    .filter(e -> e.path("id").asString().equals(idOf(unbound)))
+                    .findFirst().orElseThrow();
+
+            Assertions.assertTrue(
+                    unboundEntry.path("description").isMissingNode(),
+                    "Unbound field with no label / helper / describe() must "
+                            + "have no description, got: " + unboundEntry);
         }
 
         @Test
-        void findBindingReturnsEmptyWhenNoBinderSupplied() {
-            // No-binder constructor: findBinding always returns empty so
-            // downstream callers cleanly skip fields with no binding.
+        void bindInstanceFieldsWithPropertyIdSurfacesPropertyName() {
+            // bindInstanceFields walks the holder's declared fields and binds
+            // each to the matching bean property. @PropertyId re-targets a
+            // Java field whose name doesn't match the bean property —
+            // emailField → "email". The seeded description should reflect
+            // the bean property name, not the Java field name.
+            var holder = new InstanceFieldsHolder();
+            var binder = new Binder<>(TestBean.class);
+            binder.bindInstanceFields(holder);
+            var controller = new FormAIController(holder, binder);
+
+            controller.onRequestStart();
+            var entries = formStateFields(controller);
+
+            var nameEntry = entries.stream().filter(
+                    e -> e.path("id").asString().equals(idOf(holder.name)))
+                    .findFirst().orElseThrow();
+            var emailEntry = entries.stream()
+                    .filter(e -> e.path("id").asString()
+                            .equals(idOf(holder.emailField)))
+                    .findFirst().orElseThrow();
+
+            Assertions.assertEquals("Customer Name | name",
+                    nameEntry.path("description").asString());
+            var emailDescription = emailEntry.path("description").asString();
+            Assertions.assertEquals("Address Of Email | email",
+                    emailDescription,
+                    "@PropertyId should surface the bean property name "
+                            + "(\"email\"), not the Java field name "
+                            + "(\"emailField\")");
+            Assertions.assertFalse(emailDescription.contains("emailField"),
+                    "Java field name must not leak into the description");
+        }
+
+        @Test
+        void bindingsAddedBetweenTurnsAppearOnNextRequest() {
+            // Seeding runs every turn, so a binding added after the
+            // controller is constructed surfaces in the next get_form_state.
             var field = new TestField();
-            var controller = new FormAIController(new Div(field));
-
-            Assertions.assertTrue(controller.findBinding(field).isEmpty());
-        }
-
-        @Test
-        void findBindingRejectsNullField() {
-            var controller = new FormAIController(new Div(new TestField()),
-                    new Binder<>(TestBean.class));
-            Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.findBinding(null));
-        }
-
-        @Test
-        void findBindingIsLiveAfterRebinding() {
-            // findBinding reflects the binder's current state, not a
-            // construction-time snapshot. A field bound after the controller
-            // is created shows up; a field whose binding is removed
-            // disappears.
-            var field = new LabeledField("Name");
             var binder = new Binder<>(TestBean.class);
             var controller = new FormAIController(new Div(field), binder);
 
-            Assertions.assertTrue(controller.findBinding(field).isEmpty(),
-                    "Pre-bind: no binding");
+            controller.onRequestStart();
+            Assertions.assertTrue(
+                    formStateFields(controller).get(0).path("description")
+                            .isMissingNode(),
+                    "First turn: not yet bound, no seeded description");
 
             binder.forField(field).bind("name");
-            Assertions.assertTrue(controller.findBinding(field).isPresent(),
-                    "Post-bind: binding resolved");
+            controller.onRequestStart();
+
+            Assertions.assertEquals("name",
+                    formStateFields(controller).get(0).path("description")
+                            .asString(),
+                    "Second turn: binding added between turns surfaces as "
+                            + "the seeded description");
+        }
+
+        @Test
+        void seedingSkipsNonComponentHasValue() {
+            // Binder.forField accepts any HasValue, including custom
+            // adapters that aren't Components. Such fields cannot carry the
+            // controller's UUID id and cannot appear in the LLM-facing
+            // tools, so the seeding skips them silently rather than throwing
+            // out of the per-turn lifecycle. Pins that contract: a
+            // non-Component bound HasValue must not break onRequestStart.
+            var nonComponentField = new NonComponentField();
+            var formField = new TestField();
+            var binder = new Binder<>(TestBean.class);
+            binder.forField(nonComponentField).bind("name");
+            var controller = new FormAIController(new Div(formField), binder);
+
+            Assertions.assertDoesNotThrow(controller::onRequestStart,
+                    "Seeding must not crash on a non-Component bound field");
+            // The non-Component field never participates in discovery
+            // either, so the LLM-facing form state lists only the real
+            // component.
+            Assertions.assertEquals(1, formStateFields(controller).size());
+        }
+    }
+
+    /**
+     * Minimal {@link HasValue} implementation that is <strong>not</strong> a
+     * {@link Component}. Used to pin the seeding contract for bound HasValues
+     * that can't carry the controller's UUID id.
+     */
+    private static class NonComponentField
+            implements HasValue<HasValue.ValueChangeEvent<String>, String> {
+
+        private String value = "";
+
+        @Override
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public Registration addValueChangeListener(
+                ValueChangeListener<? super ValueChangeEvent<String>> listener) {
+            return () -> {
+            };
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) {
+            // No-op; the controller does not lock a non-Component field.
+        }
+
+        @Override
+        public boolean isRequiredIndicatorVisible() {
+            return false;
+        }
+
+        @Override
+        public void setRequiredIndicatorVisible(boolean visible) {
+            // No-op; not exercised by these tests.
+        }
+    }
+
+    /**
+     * Form-holder used by {@code bindInstanceFields} tests. {@link PropertyId}
+     * on {@code emailField} re-targets the binding to the bean's {@code email}
+     * property; without it the Java field name {@code emailField} would not
+     * match any bean property.
+     */
+    private static class InstanceFieldsHolder extends Div {
+        final LabeledField name = new LabeledField("Customer Name");
+        @PropertyId("email")
+        final LabeledField emailField = new LabeledField("Address Of Email");
+
+        InstanceFieldsHolder() {
+            add(name, emailField);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR:
- Adds a `FormAIController(container, Binder<?>)` overload.                                                                                                                
  - Property-named bindings (`bind("name")`, `bindInstanceFields(this)`, `@PropertyId(...)`) contribute the bean property name as a default for the field's description — surfaced to the LLM alongside the field's label and helper text. The field's tool-call id stays an opaque UUID assigned at discovery time; the property name is description-side metadata only.
  - Seeding only fills nulls: an explicit `describe(field, "...")` always wins. Lambda-bound bindings and unbound fields contribute no default.
- Adds a package-private `findBinding(field)` returning the live binding for any field on the supplied binder, or an empty optional for unbound fields and for controllers constructed without a binder. 

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=186542732

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.