### PR TITLE
fix: restore and deprecate CheckboxVariant helper variants

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
@@ -22,17 +22,20 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  */
 public enum CheckboxVariant implements ThemeVariant {
     /**
-     * @deprecated This variant is not working and will be removed in the next major.
+     * @deprecated This variant is not working and will be removed in the next
+     *             major.
      */
     @Deprecated(since = "25.2", forRemoval = true)
     LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
     /**
-     * @deprecated This variant is not working and will be removed in the next major.
+     * @deprecated This variant is not working and will be removed in the next
+     *             major.
      */
     @Deprecated(since = "25.2", forRemoval = true)
     AURA_HELPER_ABOVE_FIELD("helper-above-field"),
     /**
-     * @deprecated This variant is not working and will be removed in the next major.
+     * @deprecated This variant is not working and will be removed in the next
+     *             major.
      */
     @Deprecated(since = "25.2", forRemoval = true)
     HELPER_ABOVE("helper-above-field"),

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
@@ -21,6 +21,21 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-checkbox} component.
  */
 public enum CheckboxVariant implements ThemeVariant {
+    /**
+     * @deprecated This variant is not working and will be removed in the next major.
+     */
+    @Deprecated(since = "25.2", forRemoval = true)
+    LUMO_HELPER_ABOVE_FIELD("helper-above-field"),
+    /**
+     * @deprecated This variant is not working and will be removed in the next major.
+     */
+    @Deprecated(since = "25.2", forRemoval = true)
+    AURA_HELPER_ABOVE_FIELD("helper-above-field"),
+    /**
+     * @deprecated This variant is not working and will be removed in the next major.
+     */
+    @Deprecated(since = "25.2", forRemoval = true)
+    HELPER_ABOVE("helper-above-field"),
     AURA_SMALL("small");
 
     private final String variant;


### PR DESCRIPTION
## Description

Restored variants removed in https://github.com/vaadin/flow-components/pull/9293 and marked as deprecated for removal.

Related to https://github.com/mstahv/vaadin-ecosystem-build/issues/131

## Type of change

- Bugfix