### PR TITLE
ci: disable pnpm minimumReleaseAge when @NpmPackage versions changed

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -188,6 +188,15 @@ jobs:
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
 
+      - name: Detect @NpmPackage version changes
+        if: matrix.type != 'unit'
+        run: |
+          base="${{ github.base_ref || 'main' }}"
+          if git fetch --depth=1 origin "$base" 2>/dev/null && \
+             git diff FETCH_HEAD -- '*.java' | grep -q '@NpmPackage'; then
+            echo "MAVEN_OPTS=${MAVEN_OPTS} -Dvaadin.npm.minimumFrontendPackageAgeDays=0" >> "$GITHUB_ENV"
+          fi
+
       - name: Merge ITs
         if: matrix.type == 'war'
         run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}


### PR DESCRIPTION
When bumping @NpmPackage versions, the new alpha packages are published minutes before CI runs and pnpm/npm reject them with minimumReleaseAge.

For both the WAR build (pnpm) and WTR tests (npm via flow:build-frontend): fetch the PR target branch, diff against HEAD, and if any Java file containing @NpmPackage changed, set minimumFrontendPackageAgeDays=0 via MAVEN_OPTS so the Flow plugin disables the age check for that run.

No GH token needed: pure git fetch + diff + grep.

