### PR TITLE
ci: run nightly validation against local web-components checkout

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -187,7 +187,7 @@ jobs:
           node-version: '24'
 
       - name: Checkout web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule'
+        if: matrix.type != 'unit' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6
         with:
           repository: vaadin/web-components
@@ -195,12 +195,12 @@ jobs:
           path: web-components
 
       - name: Install web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule'
+        if: matrix.type != 'unit' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: yarn install --ignore-engines
         working-directory: web-components
 
       - name: Configure local web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule'
+        if: matrix.type != 'unit' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: echo "LOCAL_WEB_COMPONENTS_PATH=web-components" > .env
 
       - name: npm install

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,6 +16,11 @@ on:
         description: 'Number of parallel IT shards'
         required: false
         default: '5'
+      local-wc-validation:
+        description: 'Run validation against local web-components checkout'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
@@ -187,7 +192,7 @@ jobs:
           node-version: '24'
 
       - name: Checkout web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
         uses: actions/checkout@v6
         with:
           repository: vaadin/web-components
@@ -195,12 +200,12 @@ jobs:
           path: web-components
 
       - name: Install web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
         run: yarn install --ignore-engines
         working-directory: web-components
 
       - name: Configure local web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
         run: echo "LOCAL_WEB_COMPONENTS_PATH=web-components" > .env
 
       - name: npm install

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,7 +2,7 @@ name: Validation
 
 on:
   schedule:
-    - cron: '14 10 * * *'
+    - cron: '30 23 * * *'
   pull_request:
     branches: ['main', '25.*']
   merge_group:
@@ -201,7 +201,7 @@ jobs:
 
       - name: Install web-components
         if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
-        run: yarn install --ignore-engines
+        run: yarn install --ignore-engines --ignore-scripts
         working-directory: web-components
 
       - name: Configure local web-components

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,6 +1,8 @@
 name: Validation
 
 on:
+  schedule:
+    - cron: '30 23 * * *'
   pull_request:
     branches: ['main', '25.*']
   merge_group:
@@ -183,6 +185,23 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+
+      - name: Checkout web-components
+        if: matrix.type != 'unit' && github.event_name == 'schedule'
+        uses: actions/checkout@v6
+        with:
+          repository: vaadin/web-components
+          ref: main
+          path: web-components
+
+      - name: Install web-components
+        if: matrix.type != 'unit' && github.event_name == 'schedule'
+        run: yarn install --ignore-engines
+        working-directory: web-components
+
+      - name: Configure local web-components
+        if: matrix.type != 'unit' && github.event_name == 'schedule'
+        run: echo "LOCAL_WEB_COMPONENTS_PATH=web-components" > .env
 
       - name: npm install
         if: matrix.type != 'unit'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,7 +2,7 @@ name: Validation
 
 on:
   schedule:
-    - cron: '30 23 * * *'
+    - cron: '14 10 * * *'
   pull_request:
     branches: ['main', '25.*']
   merge_group:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -188,6 +188,15 @@ jobs:
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
 
+      - name: Detect @NpmPackage version changes
+        if: matrix.type != 'unit'
+        run: |
+          base="${{ github.base_ref || 'main' }}"
+          if git fetch --depth=1 origin "$base" 2>/dev/null && \
+             git diff FETCH_HEAD -- '*.java' | grep -q '@NpmPackage'; then
+            echo "MAVEN_OPTS=${MAVEN_OPTS} -Dvaadin.npm.minimumFrontendPackageAgeDays=0" >> "$GITHUB_ENV"
+          fi
+
       - name: Merge ITs
         if: matrix.type == 'war'
         run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}


### PR DESCRIPTION
Adds a nightly cron trigger to the Validation workflow that runs the full test suite against a local checkout of `vaadin/web-components@main` instead of the published npm packages.

When triggered by the cron schedule (or manually with the `local-wc-validation` input enabled), the `fast-tests` job (WTR and WAR matrix types) will:
1. Check out `vaadin/web-components` at `main` into a `web-components/` subdirectory
2. Install its dependencies with `yarn install --ignore-engines --ignore-scripts`
3. Write `LOCAL_WEB_COMPONENTS_PATH=web-components` to `.env`, so the Vite plugin resolves all `@vaadin/*` packages from the local checkout

PR and merge_group runs are not affected.