### PR TITLE
chore: replace pull_request_target with pull_request in Sonar workflow

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,7 +1,7 @@
 name: Sonar Scan
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     branches: [ main ]
 
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   sonar-scan:
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external-checks' || '' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup JDK 21
         if: steps.skip-check.outputs.skip != 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Replaces `pull_request_target` with `pull_request` in `sonar-scan.yml`.

Removes the `environment: external-checks` gate. The Sonar scan job skips entirely for fork PRs since `SONAR_TOKEN` is not available in that context. Bumps `actions/checkout` and `actions/setup-java` from v4 to v5.