### PR TITLE
fix: init Spreadsheet api on connect to avoid undefined api in Dialog

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetDialogPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/SpreadsheetDialogPage.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import java.util.GregorianCalendar;
+
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.DataFormat;
+import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFRichTextString;
+
+import com.vaadin.flow.component.ModalityMode;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet.SpreadsheetTheme;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetFilterTable;
+import com.vaadin.flow.component.spreadsheet.framework.Action;
+import com.vaadin.flow.component.spreadsheet.framework.Action.Handler;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@Route("spreadsheet-dialog")
+@PageTitle("Demo")
+public class SpreadsheetDialogPage extends VerticalLayout {
+
+    public SpreadsheetDialogPage() {
+        Spreadsheet spreadsheet = new Spreadsheet();
+        spreadsheet.setTheme(SpreadsheetTheme.LUMO);
+        spreadsheet.setHeight("400px");
+        spreadsheet.createFreezePane(2, 1);
+        spreadsheet.setSheetName(0, "First");
+
+        Drawing<?> drawing = spreadsheet.getActiveSheet()
+                .createDrawingPatriarch();
+        CreationHelper factory = spreadsheet.getActiveSheet().getWorkbook()
+                .getCreationHelper();
+
+        ClientAnchor anchor = factory.createClientAnchor();
+        Comment comment = drawing.createCellComment(anchor);
+        comment.setString(new XSSFRichTextString("First cell comment"));
+
+        spreadsheet.createCell(0, 0, "cell").setCellComment(comment);
+
+        // Define a cell style for dates
+        CellStyle dateStyle = spreadsheet.getWorkbook().createCellStyle();
+        DataFormat format = spreadsheet.getWorkbook().createDataFormat();
+        dateStyle.setDataFormat(format.getFormat("yyyy-mm-dd"));
+
+        // Add some data rows
+        spreadsheet.createCell(1, 0, "Nicolaus");
+        spreadsheet.createCell(1, 1, "Copernicus");
+        spreadsheet.createCell(1, 2,
+                new GregorianCalendar(1999, 2, 19).getTime());
+
+        // Style the date cell
+        spreadsheet.getCell(1, 2).setCellStyle(dateStyle);
+
+        spreadsheet.createNewSheet("Second", 10, 10);
+
+        int maxColumns = 5;
+        int maxRows = 5;
+
+        for (int column = 1; column < maxColumns + 1; column++) {
+            spreadsheet.createCell(1, column, "Column " + column);
+        }
+
+        for (int row = 2; row < maxRows + 2; row++) {
+            for (int col = 1; col < maxColumns + 1; col++) {
+                spreadsheet.createCell(row, col, row + col);
+            }
+        }
+        CellRangeAddress range = new CellRangeAddress(1, maxRows, 1,
+                maxColumns);
+        SpreadsheetFilterTable table = new SpreadsheetFilterTable(spreadsheet,
+                range);
+        spreadsheet.registerTable(table);
+        spreadsheet.refreshAllCellValues();
+
+        spreadsheet.setSelectionRange(2, 7, 2 + 5, 7 + 3);
+
+        Div lastAction = new Div();
+        lastAction.setId("last-action");
+
+        var action0 = new Action("Test", VaadinIcon.ABACUS.create());
+        var action1 = new Action("Other", VaadinIcon.CARET_DOWN.create());
+        spreadsheet.getContextMenuManager().addActionHandler(new Handler() {
+
+            @Override
+            public Action[] getActions(Object target, Object sender) {
+                Action[] actions = new Action[2];
+                actions[0] = action0;
+                actions[1] = action1;
+                return actions;
+            }
+
+            @Override
+            public void handleAction(Action action, Object sender,
+                    Object target) {
+                lastAction.setText(action.getCaption());
+            }
+
+        });
+
+        Dialog dialog = new Dialog();
+        dialog.add(spreadsheet);
+        dialog.setSizeFull();
+
+        Button openDialog = new Button("Open dialog", e -> dialog.open());
+        openDialog.setId("open-dialog");
+
+        Button toggleModality = new Button("Toggle modality",
+                e -> dialog
+                        .setModality(dialog.getModality() == ModalityMode.STRICT
+                                ? ModalityMode.MODELESS
+                                : ModalityMode.STRICT));
+        toggleModality.setId("toggle-modality");
+
+        add(openDialog, toggleModality, lastAction);
+    }
+
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SpreadsheetDialogIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/SpreadsheetDialogIT.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("spreadsheet-dialog")
+public class SpreadsheetDialogIT extends AbstractSpreadsheetIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void openDialog_noConsoleErrors_initialSelectionApplied() {
+        $(TestBenchElement.class).id("open-dialog").click();
+
+        SpreadsheetElement spreadsheet = $(SpreadsheetElement.class)
+                .waitForFirst();
+        Assert.assertEquals("H3",
+                spreadsheet.getAddressField().getPropertyString("value"));
+
+        checkLogsForErrors();
+    }
+
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
@@ -162,6 +162,21 @@ export class VaadinSpreadsheet extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     spreadsheetResizeObserver.observe(this);
+    if (!this.api) {
+      this._overlays = document.getElementById('spreadsheet-overlays');
+      if (!this._overlays) {
+        this._overlays = document.createElement('div');
+        this._overlays.id = 'spreadsheet-overlays';
+        document.body.appendChild(this._overlays);
+      }
+
+      this.api = new Spreadsheet(this, this.renderRoot);
+      this.api.setHeight('100%');
+      this.api.setWidth('100%');
+      this.createCallbacks();
+
+      this._firstUpdate = true;
+    }
   }
 
   disconnectedCallback() {
@@ -171,23 +186,7 @@ export class VaadinSpreadsheet extends LitElement {
 
   updated(_changedProperties) {
     super.updated(_changedProperties);
-    let initial = false;
-    let overlays = document.getElementById('spreadsheet-overlays');
-    if (!this.api) {
-      if (!overlays) {
-        overlays = document.createElement('div');
-        overlays.id = 'spreadsheet-overlays';
-        document.body.appendChild(overlays);
-      }
-
-      this.api = new Spreadsheet(this, this.renderRoot);
-      this.api.setHeight('100%');
-      this.api.setWidth('100%');
-      this.createCallbacks();
-
-      initial = true;
-    }
-    overlays.setAttribute('theme', this.getAttribute('theme'));
+    this._overlays.setAttribute('theme', this.getAttribute('theme'));
     let propNames = [];
     let dirty = false;
     _changedProperties.forEach((oldValue, name) => {
@@ -309,74 +308,107 @@ export class VaadinSpreadsheet extends LitElement {
       }
       propNames.push(name);
     });
-    this.api.notifyStateChanges(propNames, initial);
-    if (initial) {
+    this.api.notifyStateChanges(propNames, this._firstUpdate);
+    if (this._firstUpdate) {
       this.api.relayout();
+      this._firstUpdate = false;
     }
+  }
+
+  // Flow can send RPC calls in the same task as the property writes that
+  // configure the api, before Lit's microtask-scheduled `updated()` runs to
+  // propagate those properties to the api. Calling `performUpdate()` flushes
+  // the pending update synchronously so the api state is ready.
+  _flush() {
+    this.performUpdate();
   }
 
   /* CLIENT SIDE RPC METHODS */
   updateBottomRightCellValues(cellData) {
+    this._flush();
     this.api.updateBottomRightCellValues(cellData);
   }
 
   updateTopLeftCellValues(cellData) {
+    this._flush();
     this.api.updateTopLeftCellValues(cellData);
   }
 
   updateTopRightCellValues(cellData) {
+    this._flush();
     this.api.updateTopRightCellValues(cellData);
   }
 
   updateBottomLeftCellValues(cellData) {
+    this._flush();
     this.api.updateBottomLeftCellValues(cellData);
   }
 
   updateFormulaBar(possibleName, col, row) {
+    this._flush();
     this.api.updateFormulaBar(possibleName, col, row);
   }
 
   invalidCellAddress() {
+    this._flush();
     this.api.invalidCellAddress();
   }
 
   showSelectedCell(name, col, row, cellValue, formula, locked, initialSelection) {
+    this._flush();
     this.api.showSelectedCell(name, col, row, cellValue, formula, locked, initialSelection);
   }
 
   showActions(actionDetails) {
+    this._flush();
     this.api.showActions(actionDetails);
   }
 
   setSelectedCellAndRange(name, col, row, c1, c2, r1, r2, scroll) {
+    this._flush();
+    // The sheet widget's initial relayout is deferred via GWT's scheduler.
+    // If this RPC runs in the same task as the initial property batch (e.g.
+    // opening a Dialog that contains the Spreadsheet), `$scrollAreaIntoView`
+    // would dereference `definedRowHeights` before it exists. The server
+    // reissues this call once the spreadsheet has fully attached.
+    if (!this.api.spreadsheetWidget.sheetWidget.definedRowHeights) {
+      return;
+    }
     this.api.setSelectedCellAndRange(name, col, row, c1, c2, r1, r2, scroll);
   }
 
   cellsUpdated(updatedCellData) {
-    if (this.api) this.api.cellsUpdated(updatedCellData);
+    this._flush();
+    this.api.cellsUpdated(updatedCellData);
   }
 
   refreshCellStyles() {
-    if (this.api) this.api.refreshCellStyles();
+    this._flush();
+    this.api.refreshCellStyles();
   }
 
   editCellComment(col, row) {
+    this._flush();
     this.api.editCellComment(col, row);
   }
 
   onPopupButtonOpen(row, column, contentId, appId) {
+    this._flush();
     this.api.onPopupButtonOpened(row, column, contentId, appId);
   }
 
   closePopup(row, column) {
+    this._flush();
     this.api.closePopup(row, column);
   }
 
   addPopupButton(rawState) {
+    this._flush();
     this.api.addPopupButton(rawState);
   }
 
   removePopupButton(rawState) {
+    this._flush();
     this.api.removePopupButton(rawState);
   }
 


### PR DESCRIPTION
When a Spreadsheet is attached inside a closed Dialog and the Dialog later opens, Flow flushes its buffered property writes and `callJsFunction` calls in the same task. The connector created its api lazily inside Lit's microtask-scheduled `updated()`, so the RPC methods ran first — eleven of them threw `Cannot read properties of undefined`, and the initial selection was silently dropped.

```java
Spreadsheet spreadsheet = new Spreadsheet();
spreadsheet.setSelectionRange(2, 7, 7, 10);
Dialog dialog = new Dialog();
dialog.add(spreadsheet);
dialog.open(); // console floods with errors, selection not applied
```

The api is now created eagerly in `connectedCallback` (Lit 3 sets up `renderRoot` in `super.connectedCallback()`), and each RPC method calls `performUpdate()` at the top so pending property writes have propagated to the api before it's used.

One symptom remains structurally async: GWT schedules the initial `relayout()` via `setTimeout(1ms)`, so the sheet widget's layout state isn't yet populated when the first `setSelectedCellAndRange` arrives. That call would dereference `definedRowHeights` and throw inside `\$scrollAreaIntoView`. Flow reissues `setSelectedCellAndRange` after the spreadsheet has fully attached, so the connector skips the first call when the layout state isn't ready and lets the second one apply the selection.

---

🤖 Generated with Claude Code