### PR TITLE
feat: add prompt overload accepting attachments

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -465,11 +465,7 @@ public class AIOrchestrator implements Serializable {
         var ui = UI.getCurrentOrThrow();
         checkFeatureFlag(ui);
 
-        // Explicit list wins; the receiver buffer stays untouched in that
-        // case (see prompt(String, List) JavaDoc).
-        var attachments = explicitAttachments != null ? explicitAttachments
-                : fileReceiver != null ? fileReceiver.takeAttachments()
-                        : List.<AIAttachment> of();
+        var attachments = getAttachmentsToProcess(explicitAttachments);
         var userAIMessage = messageList == null ? null
                 : messageList.addMessage(userMessage, userName, attachments);
         var assistantMessage = createAssistantMessagePlaceholder();
@@ -510,6 +506,19 @@ public class AIOrchestrator implements Serializable {
             }
             throw t;
         }
+    }
+
+    private List<AIAttachment> getAttachmentsToProcess(
+            List<AIAttachment> explicitAttachments) {
+        // Explicit list wins; the receiver buffer stays untouched in that
+        // case (see prompt(String, List) JavaDoc).
+        if (explicitAttachments != null) {
+            return explicitAttachments;
+        }
+        if (fileReceiver != null) {
+            return fileReceiver.takeAttachments();
+        }
+        return List.of();
     }
 
     private LLMProvider.LLMRequest buildRequest(String userMessage,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -220,8 +220,13 @@ public class AIOrchestrator implements Serializable {
      * component.
      * </p>
      * <p>
-     * If a request is already being processed, this method will log a warning
-     * and return without processing the new prompt.
+     * Attachments are taken from a configured {@link AIFileReceiver} (if any).
+     * To send a prompt with caller-supplied attachments, use
+     * {@link #prompt(String, List)}.
+     * </p>
+     * <p>
+     * If a request is already being processed, this method logs a warning and
+     * returns without processing the new prompt.
      * </p>
      *
      * @param userMessage
@@ -232,7 +237,50 @@ public class AIOrchestrator implements Serializable {
      *             {@link #reconnect(LLMProvider)})
      */
     public void prompt(String userMessage) {
-        doPrompt(userMessage);
+        doPrompt(userMessage, null);
+    }
+
+    /**
+     * Sends a prompt with caller-supplied attachments. Useful for programmatic
+     * flows where attachments are produced server-side — generated files,
+     * fetched data, content from non-Upload sources — rather than uploaded
+     * through a UI component.
+     * <p>
+     * Behaves like {@link #prompt(String)} otherwise: the message and
+     * attachments appear in the message list, the request listener fires with
+     * the {@code messageId} also recorded in the conversation history, and the
+     * attachments are forwarded to the {@link LLMProvider.LLMRequest}.
+     * </p>
+     * <p>
+     * <b>Interaction with a configured {@link AIFileReceiver}:</b> this
+     * overload uses only the supplied list and does <b>not</b> drain the
+     * receiver. Attachments pending in the receiver stay there for the next
+     * call to {@link #prompt(String)} (or the user's next submit through a
+     * connected input). To merge UI-driven and programmatic attachments, the
+     * caller must drain the receiver explicitly and pass the combined list.
+     * </p>
+     * <p>
+     * If a request is already being processed, this method logs a warning and
+     * returns without processing the new prompt.
+     * </p>
+     *
+     * @param userMessage
+     *            the prompt to send to the AI
+     * @param attachments
+     *            the attachments to send with the prompt; pass an empty list
+     *            for none. Copied defensively — subsequent mutations of the
+     *            caller's list have no effect.
+     * @throws NullPointerException
+     *             if {@code attachments} is {@code null} or contains
+     *             {@code null} elements
+     * @throws IllegalStateException
+     *             if no UI context is available, or if the orchestrator needs
+     *             to be reconnected after deserialization (see
+     *             {@link #reconnect(LLMProvider)})
+     */
+    public void prompt(String userMessage, List<AIAttachment> attachments) {
+        Objects.requireNonNull(attachments, "attachments cannot be null");
+        doPrompt(userMessage, List.copyOf(attachments));
     }
 
     /**
@@ -376,7 +424,8 @@ public class AIOrchestrator implements Serializable {
         });
     }
 
-    private void doPrompt(String userMessage) {
+    private void doPrompt(String userMessage,
+            List<AIAttachment> explicitAttachments) {
         if (userMessage == null || userMessage.isBlank()) {
             return;
         }
@@ -391,7 +440,7 @@ public class AIOrchestrator implements Serializable {
             return;
         }
         try {
-            processUserInput(userMessage);
+            processUserInput(userMessage, explicitAttachments);
         } catch (Throwable t) { // NOSONAR — Throwable for cleanup-then-rethrow
             // Reset the flag before firing the hook so a controller can
             // retry from onResponse, matching the async paths where
@@ -411,12 +460,16 @@ public class AIOrchestrator implements Serializable {
         }
     }
 
-    private void processUserInput(String userMessage) {
+    private void processUserInput(String userMessage,
+            List<AIAttachment> explicitAttachments) {
         var ui = UI.getCurrentOrThrow();
         checkFeatureFlag(ui);
 
-        var attachments = fileReceiver != null ? fileReceiver.takeAttachments()
-                : List.<AIAttachment> of();
+        // Explicit list wins; the receiver buffer stays untouched in that
+        // case (see prompt(String, List) JavaDoc).
+        var attachments = explicitAttachments != null ? explicitAttachments
+                : fileReceiver != null ? fileReceiver.takeAttachments()
+                        : List.<AIAttachment> of();
         var userAIMessage = messageList == null ? null
                 : messageList.addMessage(userMessage, userName, attachments);
         var assistantMessage = createAssistantMessagePlaceholder();
@@ -1091,7 +1144,8 @@ public class AIOrchestrator implements Serializable {
             orchestrator.responseListener = responseListener;
             try {
                 if (input != null) {
-                    input.addSubmitListener(orchestrator::doPrompt);
+                    input.addSubmitListener(
+                            msg -> orchestrator.doPrompt(msg, null));
                 }
 
                 if (attachmentClickListener != null && messageList != null) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -702,6 +702,226 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void prompt_withExplicitAttachments_includesAttachmentsInRequest() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello",
+                List.of(createAttachment("a.txt"), createAttachment("b.png")));
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var attachments = captor.getValue().attachments();
+        Assertions.assertEquals(2, attachments.size());
+        Assertions.assertEquals("a.txt", attachments.getFirst().name());
+        Assertions.assertEquals("b.png", attachments.get(1).name());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void prompt_withExplicitAttachments_rendersInUserMessageList() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+        var attachment = createAttachment("a.txt");
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello", List.of(attachment));
+
+        var attachmentsCaptor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(mockMessageList).addMessage(Mockito.eq("Hello"),
+                Mockito.eq("You"), attachmentsCaptor.capture());
+        var rendered = (List<AIAttachment>) attachmentsCaptor.getValue();
+        Assertions.assertEquals(1, rendered.size());
+        Assertions.assertEquals("a.txt", rendered.getFirst().name());
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_firesRequestListenerWithAttachments() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+        var receivedEvent = new AtomicReference<RequestListener.RequestEvent>();
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withRequestListener(receivedEvent::set).build();
+        orchestrator.prompt("Hello", List.of(createAttachment("a.txt")));
+
+        var event = receivedEvent.get();
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals("Hello", event.getUserMessage());
+        Assertions.assertNotNull(event.getMessageId());
+        Assertions.assertEquals(1, event.getAttachments().size());
+        Assertions.assertEquals("a.txt",
+                event.getAttachments().getFirst().name());
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_doesNotDrainFileReceiver() {
+        // The two-arg overload must leave the configured receiver alone so
+        // any pending UI uploads stay buffered for the next prompt(String).
+        // Pins the "Replace (don't drain)" semantic from the JavaDoc.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello", List.of(createAttachment("a.txt")));
+
+        Mockito.verify(mockFileReceiver, Mockito.never()).takeAttachments();
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_ignoresPendingReceiverAttachments() {
+        // Even if the receiver has files buffered, the explicit list wins
+        // and the receiver's content does not leak into this turn.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+        Mockito.when(mockFileReceiver.takeAttachments())
+                .thenReturn(List.of(createAttachment("from-receiver.txt")));
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello", List.of(createAttachment("explicit.txt")));
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var attachments = captor.getValue().attachments();
+        Assertions.assertEquals(1, attachments.size());
+        Assertions.assertEquals("explicit.txt", attachments.getFirst().name());
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_nullListThrowsNullPointerException() {
+        var orchestrator = getSimpleOrchestrator();
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> orchestrator.prompt("Hello", null));
+        Mockito.verify(mockProvider, Mockito.never())
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_nullElementThrowsNullPointerException() {
+        var listWithNull = new ArrayList<AIAttachment>();
+        listWithNull.add(null);
+        var orchestrator = getSimpleOrchestrator();
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> orchestrator.prompt("Hello", listWithNull));
+        Mockito.verify(mockProvider, Mockito.never())
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_emptyListSendsNoAttachments() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello", List.of());
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        Assertions.assertTrue(captor.getValue().attachments().isEmpty());
+        // Empty explicit list is still an explicit list, so we still don't
+        // fall back to draining the receiver.
+        Mockito.verify(mockFileReceiver, Mockito.never()).takeAttachments();
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_nullUserMessageIsIgnored() {
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt(null, List.of(createAttachment("a.txt")));
+
+        Mockito.verify(mockProvider, Mockito.never())
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_blankUserMessageIsIgnored() {
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("   ", List.of(createAttachment("a.txt")));
+
+        Mockito.verify(mockProvider, Mockito.never())
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_listIsCopiedDefensively() {
+        // Without a defensive copy, the caller mutating their list during
+        // the streamed response would silently desync the LLMRequest, the
+        // user message list, and the history snapshot. Pin that mutations
+        // after prompt() can't affect what the provider sees.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+        var mutable = new ArrayList<AIAttachment>();
+        mutable.add(createAttachment("a.txt"));
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello", mutable);
+        mutable.add(createAttachment("b.txt"));
+        mutable.clear();
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var attachments = captor.getValue().attachments();
+        Assertions.assertEquals(1, attachments.size());
+        Assertions.assertEquals("a.txt", attachments.getFirst().name());
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_addsUserMessageToHistory() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = getSimpleOrchestrator();
+        orchestrator.prompt("Hello", List.of(createAttachment("a.txt")));
+
+        var history = orchestrator.getHistory();
+        Assertions.assertFalse(history.isEmpty());
+        var user = history.getFirst();
+        Assertions.assertEquals(ChatMessage.Role.USER, user.role());
+        Assertions.assertEquals("Hello", user.content());
+        Assertions.assertNotNull(user.messageId());
+    }
+
+    @Test
+    void prompt_withExplicitAttachments_listenerAndHistoryShareMessageId() {
+        // The request listener and the conversation history record the
+        // turn under the same messageId — that's the correlation handle
+        // external storage (e.g. attachment maps keyed by messageId) relies
+        // on, so it can't drift between the two surfaces.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+        var receivedEvent = new AtomicReference<RequestListener.RequestEvent>();
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withRequestListener(receivedEvent::set).build();
+        orchestrator.prompt("Hello", List.of(createAttachment("a.txt")));
+
+        Assertions.assertEquals(receivedEvent.get().getMessageId(),
+                orchestrator.getHistory().getFirst().messageId());
+    }
+
+    @Test
     void prompt_withTimeout_setsTimeoutErrorMessage() throws Exception {
         var mockMessage = createMockMessage();
         var latch = new CountDownLatch(1);


### PR DESCRIPTION
## Description

This PR adds `prompt(String, List<AIAttachment>)` overload to `AIOrchestrator`.

The overload uses only the supplied list and does not drain a configured `AIFileReceiver`; pending uploads stay in the receiver for the next call to `prompt(String)` or the user's next submit. An empty list is still "explicit" — it does not fall back to the receiver.

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=189945711

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.