### PR TITLE
refactor: extract shared web-test-runner config

### DIFF
--- a/shared/shared-web-test-runner-config.mjs
+++ b/shared/shared-web-test-runner-config.mjs
@@ -1,0 +1,12 @@
+import { esbuildPlugin } from '@web/dev-server-esbuild';
+
+/** @type {import('@web/test-runner').TestRunnerConfig} */
+export const sharedConfig = {
+  plugins: [esbuildPlugin({ ts: true })],
+  testFramework: {
+    config: {
+      ui: 'bdd',
+      timeout: '10000'
+    }
+  }
+};

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
@@ -1,11 +1,6 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
+/** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  plugins: [esbuildPlugin({ ts: true })],
-  testFramework: {
-    config: {
-      ui: 'bdd',
-      timeout: '10000',
-    },
-  },
+  ...sharedConfig
 };

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
@@ -1,11 +1,6 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
+/** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  plugins: [esbuildPlugin({ ts: true })],
-  testFramework: {
-    config: {
-      ui: 'bdd',
-      timeout: '10000',
-    },
-  },
+  ...sharedConfig
 };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/web-test-runner.config.mjs
@@ -1,11 +1,6 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
+/** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  plugins: [esbuildPlugin({ ts: true })],
-  testFramework: {
-    config: {
-      ui: 'bdd',
-      timeout: '10000',
-    },
-  },
+  ...sharedConfig
 };

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/web-test-runner.config.mjs
@@ -1,11 +1,6 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
+/** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  plugins: [esbuildPlugin({ ts: true })],
-  testFramework: {
-    config: {
-      ui: 'bdd',
-      timeout: '10000',
-    },
-  },
+  ...sharedConfig
 };


### PR DESCRIPTION
Several integration-test modules duplicate the same web-test-runner config (esbuild plugin + mocha BDD/timeout). Extract it once so future tweaks live in one place.

- New `shared/shared-web-test-runner-config.mjs` exporting `sharedConfig`.
- combo-box, date-picker, grid, and renderer IT modules now spread `sharedConfig` instead of redefining it.