### PR TITLE
chore: move web-test-runner CI reporters into shared config

### DIFF
--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -83,36 +83,19 @@ async function runTests() {
         stdio: 'inherit'
       });
 
-      // Generate a CI config that adds the JUnit reporter on top of the existing config
-      const hasBaseConfig = fs.existsSync(`${itFolder}/web-test-runner.config.mjs`);
-      const ciConfigPath = `${itFolder}/wtr-ci.config.mjs`;
-      fs.writeFileSync(ciConfigPath, [
-        `import { defaultReporter, summaryReporter } from '@web/test-runner';`,
-        `import { junitReporter } from '@web/test-runner-junit-reporter';`,
-        hasBaseConfig ? `import baseConfig from './web-test-runner.config.mjs';` : '',
-        `export default {`,
-        hasBaseConfig ? `  ...baseConfig,` : '',
-        `  reporters: [defaultReporter(), summaryReporter(), junitReporter({ outputPath: 'wtr-results.xml', reportLogs: true })],`,
-        `};`,
-      ].filter(Boolean).join('\n'));
-
       // Run the tests
       console.log(`Running tests in ${itFolder}`);
-      let wtrError = null;
       try {
-        execSync(`npx web-test-runner --playwright ${wtrTestsFolderName}/**/*.test.ts --node-resolve --config wtr-ci.config.mjs`, {
+        execSync(`npx web-test-runner --playwright ${wtrTestsFolderName}/**/*.test.ts --node-resolve`, {
           cwd: itFolder,
           stdio: 'inherit'
         });
       } catch (e) {
-        wtrError = e;
-      } finally {
-        fs.unlinkSync(ciConfigPath);
-      }
+        if (process.env.GITHUB_ACTIONS) {
+          await appendSessionError(`${itFolder}/wtr-results.xml`, e);
+        }
 
-      if (wtrError) {
-        await appendSessionError(`${itFolder}/wtr-results.xml`, wtrError);
-        throw wtrError;
+        throw e;
       }
     }
   }

--- a/shared/shared-web-test-runner-config.mjs
+++ b/shared/shared-web-test-runner-config.mjs
@@ -1,4 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
+import { defaultReporter, summaryReporter } from '@web/test-runner';
+import { junitReporter } from '@web/test-runner-junit-reporter';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export const sharedConfig = {
@@ -8,5 +10,14 @@ export const sharedConfig = {
       ui: 'bdd',
       timeout: '10000'
     }
-  }
+  },
+  ...(process.env.GITHUB_ACTIONS
+    ? {
+        reporters: [
+          defaultReporter(),
+          summaryReporter(),
+          junitReporter({ outputPath: 'wtr-results.xml', reportLogs: true })
+        ]
+      }
+    : {})
 };


### PR DESCRIPTION
The wtr JUnit reporter setup lived in `scripts/wtr.js`, which wrote a temporary `wtr-ci.config.mjs` next to each IT module's `web-test-runner.config.mjs` and deleted it after the run. Config was split between a script and a generated file, and local runs left behind `wtr-results.xml` files that are only useful in CI.

Reporters now live in `shared-web-test-runner-config.mjs` and only attach when `GITHUB_ACTIONS` is set. IT modules with wtr tests already import `sharedConfig`, so CI picks the reporters up on its own. `scripts/wtr.js` runs wtr against the module's own config and only appends the session-error testsuite when running under CI.

Follow-up to #9349
