### PR TITLE
refactor: add missing checkbox import to GridFlowSelectionColumn

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -3,8 +3,6 @@ import '@vaadin/grid/src/all-imports.js';
 import '../frontend/generated/jar-resources/gridConnector.ts';
 import '../frontend/generated/jar-resources/treeGridConnector.ts';
 import '../frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
-// For some reason vaadin-grid-flow-selection-column doesn't import vaadin-checkbox
-import '@vaadin/checkbox/src/vaadin-checkbox.js';
 import sinon from 'sinon';
 import type { Grid, GridColumn } from '@vaadin/grid';
 import type {} from '@web/test-runner-mocha';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -1,5 +1,5 @@
-import '@vaadin/grid/src/vaadin-grid-column.js';
 import '@vaadin/checkbox/src/vaadin-checkbox.js';
+import '@vaadin/grid/src/vaadin-grid-column.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import { GridSelectionColumnBaseMixin } from '@vaadin/grid/src/vaadin-grid-selection-column-base-mixin.js';
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.js
@@ -1,4 +1,5 @@
 import '@vaadin/grid/src/vaadin-grid-column.js';
+import '@vaadin/checkbox/src/vaadin-checkbox.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import { GridSelectionColumnBaseMixin } from '@vaadin/grid/src/vaadin-grid-selection-column-base-mixin.js';
 


### PR DESCRIPTION
The `vaadin-grid-flow-selection-column` component should import `@vaadin/checkbox` since it's used by `GridSelectionColumnBaseMixin`.