### PR TITLE
chore: remove MDL feature flag from the IT package

### DIFF
--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
@@ -1,1 +1,0 @@
-com.vaadin.experimental.masterDetailLayoutComponent=true


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/flow-components/pull/9315

I didn't remove this in the above PR because the build was failing due to legacy feature flag in Flow.
That one was later removed in https://github.com/vaadin/flow/pull/24427, so we can remove this file now.

## Type of change

- Internal change