### PR TITLE
fix!: prevent initial OpenedChangeEvent, set isFromClient correctly (CP: 25.0)

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/src/test/java/com/vaadin/flow/component/accordion/tests/BasicIT.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/src/test/java/com/vaadin/flow/component/accordion/tests/BasicIT.java
@@ -35,10 +35,6 @@ public class BasicIT extends AbstractComponentIT {
     @Before
     public void init() {
         open();
-        // Close the initially opened panel, otherwise the panel can fire a
-        // close event after opening a different panel, breaking some assertions
-        $(AccordionElement.class).first().$(AccordionPanelElement.class).first()
-                .click();
     }
 
     @Test
@@ -47,7 +43,14 @@ public class BasicIT extends AbstractComponentIT {
     }
 
     @Test
+    public void noInitialOpenedChangeEvent() {
+        Assert.assertEquals(0, $(TestBenchElement.class).id(ACCORDION_EVENTS)
+                .$("span").all().size());
+    }
+
+    @Test
     public void programmaticOpenByIndex() {
+        closeInitialPanel();
         getTestButton("1").click();
         Assert.assertEquals(1, $(AccordionElement.class).first()
                 .getOpenedIndex().orElseThrow());
@@ -63,6 +66,7 @@ public class BasicIT extends AbstractComponentIT {
 
     @Test
     public void programmaticOpenByPanel() {
+        closeInitialPanel();
         getTestButton("green").click();
 
         final AccordionPanelElement secondPanel = $(AccordionElement.class)
@@ -88,6 +92,7 @@ public class BasicIT extends AbstractComponentIT {
 
     @Test
     public void userOpen() {
+        closeInitialPanel();
         $(AccordionElement.class).first().$(AccordionPanelElement.class).last()
                 .click();
         Assert.assertEquals("Panel Blue opened", getLastEvent(PANEL_EVENTS));
@@ -162,6 +167,14 @@ public class BasicIT extends AbstractComponentIT {
                 .$(AccordionPanelElement.class).all().size());
         Assert.assertEquals("Disabled", $(AccordionElement.class).first()
                 .$(AccordionPanelElement.class).last().getSummaryText());
+    }
+
+    private void closeInitialPanel() {
+        // Close the initially opened panel, otherwise the panel can fire a
+        // close event after opening a different panel, breaking some
+        // assertions.
+        $(AccordionElement.class).first().$(AccordionPanelElement.class).first()
+                .click();
     }
 
     private ButtonElement getTestButton(String id) {

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
@@ -10,6 +10,9 @@
     <packaging>jar</packaging>
     <name>Vaadin Accordion</name>
     <description>Vaadin Accordion</description>
+    <properties>
+        <surefire.argLine>-javaagent:${org.mockito:mockito-core:jar}</surefire.argLine>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -32,6 +35,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-flow-components-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <scope>test</scope>
@@ -43,6 +52,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -22,9 +22,6 @@ import java.util.OptionalInt;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
@@ -58,6 +55,21 @@ public class Accordion extends Component implements HasSize, HasStyle {
 
     private static final String OPENED_PROPERTY = "opened";
     private static final String OPENED_CHANGED_DOM_EVENT = "opened-changed";
+
+    /**
+     * Initializes a new Accordion component.
+     */
+    public Accordion() {
+        if (getElement().getPropertyRaw(OPENED_PROPERTY) == null) {
+            getElement().setProperty(OPENED_PROPERTY, 0);
+        }
+
+        getElement().addPropertyChangeListener(OPENED_PROPERTY, event -> {
+            OptionalInt openedIndex = getOpenedIndex();
+            fireEvent(new OpenedChangeEvent(this, event.isUserOriginated(),
+                    openedIndex.isPresent() ? openedIndex.getAsInt() : null));
+        });
+    }
 
     /**
      * Adds a panel created from the given title and content.
@@ -214,15 +226,12 @@ public class Accordion extends Component implements HasSize, HasStyle {
      */
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent> listener) {
-
-        return ComponentUtil.addListener(this, OpenedChangeEvent.class,
-                listener);
+        return addListener(OpenedChangeEvent.class, listener);
     }
 
     /**
      * An event fired when an Accordion is opened or closed.
      */
-    @DomEvent(OPENED_CHANGED_DOM_EVENT)
     public static class OpenedChangeEvent extends ComponentEvent<Accordion> {
 
         private final Integer index;
@@ -240,7 +249,7 @@ public class Accordion extends Component implements HasSize, HasStyle {
          *            closed
          */
         public OpenedChangeEvent(Accordion source, boolean fromClient,
-                @EventData("event.detail.value") Integer index) {
+                Integer index) {
             super(source, fromClient);
             this.index = index;
         }

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/test/java/com/vaadin/flow/component/accordion/AccordionOpenedChangeListenerTest.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/test/java/com/vaadin/flow/component/accordion/AccordionOpenedChangeListenerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.accordion;
+
+import java.io.Serializable;
+import java.util.OptionalInt;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.accordion.Accordion.OpenedChangeEvent;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
+import com.vaadin.flow.internal.nodefeature.PropertyChangeDeniedException;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.tests.dataprovider.MockUI;
+
+public class AccordionOpenedChangeListenerTest {
+
+    private MockUI ui;
+
+    @SuppressWarnings("unchecked")
+    private ComponentEventListener<OpenedChangeEvent> mockListener = Mockito
+            .mock(ComponentEventListener.class);
+
+    private ArgumentCaptor<OpenedChangeEvent> eventCaptor = ArgumentCaptor
+            .forClass(OpenedChangeEvent.class);
+
+    private Accordion accordion;
+
+    @Before
+    public void setup() {
+        ui = new MockUI();
+        accordion = new Accordion();
+        accordion.add("Panel 0", new Span("Content 0"));
+        accordion.add("Panel 1", new Span("Content 1"));
+        accordion.add("Panel 2", new Span("Content 2"));
+        accordion.addOpenedChangeListener(mockListener);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
+        VaadinSession.setCurrent(null);
+    }
+
+    @Test
+    public void openFromClient() {
+        fakeClientPropertyChange("opened", 2);
+
+        Mockito.verify(mockListener).onComponentEvent(eventCaptor.capture());
+        OpenedChangeEvent event = eventCaptor.getValue();
+        Assert.assertTrue(event.isFromClient());
+        Assert.assertEquals(OptionalInt.of(2), event.getOpenedIndex());
+    }
+
+    @Test
+    public void closeFromClient() {
+        fakeClientPropertyChange("opened", 2);
+        Mockito.reset(mockListener);
+
+        fakeClientPropertyChange("opened", null);
+
+        Mockito.verify(mockListener).onComponentEvent(eventCaptor.capture());
+        OpenedChangeEvent event = eventCaptor.getValue();
+        Assert.assertTrue(event.isFromClient());
+        Assert.assertEquals(OptionalInt.empty(), event.getOpenedIndex());
+    }
+
+    @Test
+    public void openFromServer() {
+        accordion.open(1);
+
+        Mockito.verify(mockListener).onComponentEvent(eventCaptor.capture());
+        OpenedChangeEvent event = eventCaptor.getValue();
+        Assert.assertFalse(event.isFromClient());
+        Assert.assertEquals(OptionalInt.of(1), event.getOpenedIndex());
+    }
+
+    @Test
+    public void closeFromServer() {
+        accordion.open(1);
+        Mockito.reset(mockListener);
+
+        accordion.close();
+
+        Mockito.verify(mockListener).onComponentEvent(eventCaptor.capture());
+        OpenedChangeEvent event = eventCaptor.getValue();
+        Assert.assertFalse(event.isFromClient());
+        Assert.assertEquals(OptionalInt.empty(), event.getOpenedIndex());
+    }
+
+    private void fakeClientPropertyChange(String property, Serializable value) {
+        try {
+            accordion.getElement().getNode()
+                    .getFeature(ElementPropertyMap.class)
+                    .deferredUpdateFromClient(property, value).run();
+        } catch (PropertyChangeDeniedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9267 to branch 25.0.

---

> `Accordion` had two issues with its `OpenedChangeEvent`:
> 
> 1. The event fired on initial attach, even though no user interaction occurred.
> 2. `isFromClient()` always returned `true`, including for server-side changes.
> 
> Both broke listeners that branch on `isFromClient()`.
> 
> ```java
> Accordion accordion = new Accordion();
> accordion.add("1", new Span("Panel 1"));
> accordion.addOpenedChangeListener(e -> {
>     if (e.isFromClient())
>         Notification.show("Client opened accordion panel");
> });
> ```
> 
> The PR replaces the `@DomEvent("opened-changed")` listener with a property change listener that fires the `OpenedChangeEvent` with the correct `isFromClient()` value, and initializes the `opened` property properly to prevent the unwanted initial event.
> 
> Fixes #2301
> 
> 🤖 Generated with Claude Code