### PR TITLE
fix: defer setSelectedCellAndRange until sheet layout is ready

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
@@ -366,14 +366,37 @@ export class VaadinSpreadsheet extends LitElement {
 
   setSelectedCellAndRange(name, col, row, c1, c2, r1, r2, scroll) {
     this._flush();
-    // The sheet widget's initial relayout is deferred via GWT's scheduler.
-    // If this RPC runs in the same task as the initial property batch (e.g.
-    // opening a Dialog that contains the Spreadsheet), `$scrollAreaIntoView`
-    // would dereference `definedRowHeights` before it exists. The server
-    // reissues this call once the spreadsheet has fully attached.
+    // The sheet widget's initial relayout is deferred via GWT's scheduler,
+    // so `definedRowHeights` may not yet exist when this RPC arrives in the
+    // same task as the initial property batch (e.g. opening a Dialog that
+    // contains the Spreadsheet). Calling `setSelectedCellAndRange` before
+    // it's populated would throw inside `$scrollAreaIntoView`. Re-queue the
+    // call until the layout state is ready; only the latest pending call is
+    // kept so rapid successive calls collapse to the final selection.
     if (!this.api.spreadsheetWidget.sheetWidget.definedRowHeights) {
+      this._pendingSelection = [name, col, row, c1, c2, r1, r2, scroll];
+      if (!this._pendingSelectionScheduled) {
+        this._pendingSelectionScheduled = true;
+        const applyPending = () => {
+          if (!this.isConnected || !this._pendingSelection) {
+            this._pendingSelectionScheduled = false;
+            this._pendingSelection = null;
+            return;
+          }
+          if (this.api.spreadsheetWidget.sheetWidget.definedRowHeights) {
+            const args = this._pendingSelection;
+            this._pendingSelection = null;
+            this._pendingSelectionScheduled = false;
+            this.api.setSelectedCellAndRange(...args);
+            return;
+          }
+          setTimeout(applyPending, 10);
+        };
+        setTimeout(applyPending, 10);
+      }
       return;
     }
+    this._pendingSelection = null;
     this.api.setSelectedCellAndRange(name, col, row, c1, c2, r1, r2, scroll);
   }
 


### PR DESCRIPTION
<!-- Why -->
Follow-up to #9333. The connector's `setSelectedCellAndRange` silently dropped calls when the sheet widget's `definedRowHeights` wasn't yet populated, on the assumption that Flow would reissue the call. That assumption only holds for the reload cycle path (`initialSheetSelection` set on the server, then `onSheetScroll` from the client triggering `reloadCurrentSelection`). For any other path — most notably the selection RPC sent when the user types a range into the address field — there is no reissue, so a call that loses the race against GWT's deferred initial relayout is lost permanently.

This caused the cherry-pick PRs (#9365, #9366, #9367) to consistently fail 20 selection-related tests (`NavigationIT`, `NamedRangeIT`, `ChartsIT`, `SheetTabSheetIT`, `PreserveOnRefreshIT`, and the new `SpreadsheetDialogIT`). The original PR happened to pass on main's CI agent timing, but the failure is deterministic on the cherry-pick branches' GWT 2.9 / older-Flow-SNAPSHOT environment.

<!-- Changes -->
Queue the latest call as `_pendingSelection` and poll `definedRowHeights` every 10 ms until it's set or the element is disconnected. Rapid successive calls collapse to the final selection (the array is overwritten, only one retry loop runs at a time).

Follow-up to #9333.

---

🤖 Generated with Claude Code