### PR TITLE
feat: implement BreadcrumbsItem constructors, text, path, and prefix

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -114,7 +114,7 @@ public class BreadcrumbsItem extends Component
      */
     public BreadcrumbsItem(String text, String path,
             Component prefixComponent) {
-        super(text, path);
+        this(text, path);
         setPrefixComponent(prefixComponent);
     }
 
@@ -131,7 +131,7 @@ public class BreadcrumbsItem extends Component
      */
     public BreadcrumbsItem(String text, Class<? extends Component> view,
             Component prefixComponent) {
-        super(text, view);
+        this(text, view);
         setPrefixComponent(prefixComponent);
     }
 
@@ -150,7 +150,7 @@ public class BreadcrumbsItem extends Component
      */
     public BreadcrumbsItem(String text, Class<? extends Component> view,
             RouteParameters params, Component prefixComponent) {
-        super(text, view, params);
+        this(text, view, params);
         setPrefixComponent(prefixComponent);
     }
 

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -16,16 +16,26 @@
 package com.vaadin.flow.component.breadcrumbs;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteParameters;
 
 /**
  * An item of the {@link Breadcrumbs} component, representing a single entry in
  * the navigation trail.
+ * <p>
+ * An item carries the text shown in the trail and, optionally, a {@code path}
+ * it links to. An item without a path is the current page and is rendered as a
+ * non-link. The link target can be set as a plain URL string via
+ * {@link #setPath(String)} or resolved from a Flow route class via
+ * {@link #setPath(Class)} / {@link #setPath(Class, RouteParameters)}. An
+ * optional prefix component (typically an icon) can be shown before the text.
  *
  * @author Vaadin Ltd
  */
@@ -36,12 +46,180 @@ public class BreadcrumbsItem extends Component
         implements HasText, HasEnabled, HasPrefix {
 
     /**
-     * Creates a breadcrumbs item with the given text.
+     * Creates a breadcrumbs item with the given text and no path. An item
+     * without a path represents the current page and is rendered as a non-link.
      *
      * @param text
      *            the text of the item
      */
     public BreadcrumbsItem(String text) {
         setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text that links to the given
+     * path.
+     *
+     * @param text
+     *            the text of the item
+     * @param path
+     *            the path to link to
+     */
+    public BreadcrumbsItem(String text, String path) {
+        setPath(path);
+        setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text that links to the given
+     * view.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view) {
+        setPath(view);
+        setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text that links to the given
+     * view using the given route parameters.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     * @param params
+     *            the route parameters
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view,
+            RouteParameters params) {
+        setPath(view, params);
+        setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text and prefix component (like
+     * an icon) that links to the given path.
+     *
+     * @param text
+     *            the text of the item
+     * @param path
+     *            the path to link to
+     * @param prefixComponent
+     *            the prefix component for the item (usually an icon)
+     */
+    public BreadcrumbsItem(String text, String path,
+            Component prefixComponent) {
+        super(text, path);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text and prefix component (like
+     * an icon) that links to the given view.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     * @param prefixComponent
+     *            the prefix component for the item (usually an icon)
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view,
+            Component prefixComponent) {
+        super(text, view);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text and prefix component (like
+     * an icon) that links to the given view using the given route parameters.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     * @param params
+     *            the route parameters
+     * @param prefixComponent
+     *            the prefix component for the item (usually an icon)
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view,
+            RouteParameters params, Component prefixComponent) {
+        super(text, view, params);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Gets the path this item links to.
+     *
+     * @return the path this item links to, or {@code null} if the item has no
+     *         path
+     */
+    public String getPath() {
+        return getElement().getAttribute("path");
+    }
+
+    /**
+     * Sets the path, as a URL string, this item links to.
+     * <p>
+     * Note that there is also an alternative way of setting the link path via
+     * {@link #setPath(Class)}.
+     *
+     * @param path
+     *            the path to link to, or {@code null} to remove the path and
+     *            render the item as the current page (a non-link)
+     *
+     * @see #setPath(Class)
+     */
+    public void setPath(String path) {
+        if (path == null) {
+            getElement().removeAttribute("path");
+        } else {
+            getElement().setAttribute("path", path);
+        }
+    }
+
+    /**
+     * Resolves the URL of the given view via the Vaadin router and sets it as
+     * the path this item links to.
+     *
+     * @param view
+     *            the view to link to. The view should be annotated with the
+     *            {@link com.vaadin.flow.router.Route} annotation. Set to
+     *            {@code null} to remove the path.
+     *
+     * @see #setPath(String)
+     */
+    public void setPath(Class<? extends Component> view) {
+        setPath(view, RouteParameters.empty());
+    }
+
+    /**
+     * Resolves the URL of the given view via the Vaadin router using the given
+     * route parameters and sets it as the path this item links to.
+     *
+     * @param view
+     *            the view to link to. The view should be annotated with the
+     *            {@link com.vaadin.flow.router.Route} annotation. Set to
+     *            {@code null} to remove the path.
+     * @param parameters
+     *            the route parameters
+     *
+     * @see #setPath(String)
+     */
+    public void setPath(Class<? extends Component> view,
+            RouteParameters parameters) {
+        if (view == null) {
+            setPath((String) null);
+        } else {
+            RouteConfiguration routeConfiguration = RouteConfiguration
+                    .forRegistry(ComponentUtil.getRouter(this).getRegistry());
+            setPath(routeConfiguration.getUrl(view, parameters));
+        }
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
+
+class BreadcrumbsItemTest {
+
+    // CONSTRUCTOR TESTS
+
+    @Test
+    void allConstructorsArePresent() {
+        new BreadcrumbsItem("Text");
+        new BreadcrumbsItem("Text", "/path");
+        new BreadcrumbsItem("Text", "/path", new Div());
+        runWithMockRouter(() -> {
+            new BreadcrumbsItem("Text", TestRoute.class);
+            new BreadcrumbsItem("Text", TestRoute.class,
+                    RouteParameters.empty());
+            new BreadcrumbsItem("Text", TestRoute.class, new Div());
+            new BreadcrumbsItem("Text", TestRoute.class,
+                    RouteParameters.empty(), new Div());
+        }, TestRoute.class);
+    }
+
+    @Test
+    void createWithText_textSetAndNoPath() {
+        var item = new BreadcrumbsItem("Home");
+
+        Assertions.assertEquals("Home", item.getText());
+        Assertions.assertNull(item.getPath());
+        Assertions.assertFalse(item.getElement().hasAttribute("path"));
+    }
+
+    @Test
+    void createWithPath_pathAttributeSet() {
+        var item = new BreadcrumbsItem("Docs", "/docs");
+
+        Assertions.assertEquals("/docs", item.getPath());
+        Assertions.assertEquals("/docs",
+                item.getElement().getAttribute("path"));
+    }
+
+    @Test
+    void createWithViewAndPrefix_pathAndPrefixSet() {
+        runWithMockRouter(() -> {
+            var homeIcon = new Div();
+            var item = new BreadcrumbsItem("Home", TestRoute.class, homeIcon);
+
+            Assertions.assertEquals("foo/bar", item.getPath());
+            Assertions.assertEquals(homeIcon, item.getPrefixComponent());
+        }, TestRoute.class);
+    }
+
+    // PATH TESTS
+
+    @Test
+    void setStringPath_pathAttributeSet() {
+        var item = new BreadcrumbsItem("Docs");
+        item.setPath("/docs");
+
+        Assertions.assertEquals("/docs", item.getPath());
+        Assertions.assertEquals("/docs",
+                item.getElement().getAttribute("path"));
+    }
+
+    @Test
+    void setNullStringPath_pathAttributeRemoved() {
+        var item = new BreadcrumbsItem("Docs", "/docs");
+        item.setPath((String) null);
+
+        Assertions.assertNull(item.getPath());
+        Assertions.assertFalse(item.getElement().hasAttribute("path"));
+    }
+
+    @Test
+    void setViewPath_pathAttributeSetToViewUrl() {
+        runWithMockRouter(() -> {
+            var item = new BreadcrumbsItem("Foo");
+            item.setPath(TestRoute.class);
+
+            Assertions.assertEquals("foo/bar", item.getPath());
+        }, TestRoute.class);
+    }
+
+    @Test
+    void setViewPathWithRouteParameters_pathAttributeSetToParameterisedUrl() {
+        runWithMockRouter(() -> {
+            var item = new BreadcrumbsItem("Foo");
+            item.setPath(TestRouteWithRouteParams.class,
+                    new RouteParameters(Map.of("k1", "v1", "k2", "v2")));
+
+            Assertions.assertEquals("foo/v1/v2/bar", item.getPath());
+        }, TestRouteWithRouteParams.class);
+    }
+
+    @Test
+    void setNullViewPath_pathAttributeRemoved() {
+        var item = new BreadcrumbsItem("Docs", "/docs");
+        item.setPath((Class<? extends Component>) null);
+
+        Assertions.assertNull(item.getPath());
+        Assertions.assertFalse(item.getElement().hasAttribute("path"));
+    }
+
+    // PREFIX TESTS
+
+    @Test
+    void setPrefixComponent_getPrefixComponentReturnsSame() {
+        var item = new BreadcrumbsItem("Home");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
+    // ENABLED TESTS
+
+    @Test
+    void setEnabledFalse_disabledAttributeReflected() {
+        UI ui = new UI();
+        var item = new BreadcrumbsItem("Home");
+        ui.add(item);
+
+        item.setEnabled(false);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        Assertions.assertFalse(item.isEnabled());
+        Assertions.assertTrue(item.getElement().hasAttribute("disabled"));
+    }
+
+    @SafeVarargs
+    private void runWithMockRouter(Runnable test,
+            Class<? extends Component>... routes) {
+        Router router = mockRouter(routes);
+        try (MockedStatic<ComponentUtil> mockComponentUtil = Mockito
+                .mockStatic(ComponentUtil.class)) {
+            mockComponentUtil.when(() -> ComponentUtil.getRouter(Mockito.any()))
+                    .thenReturn(router);
+            test.run();
+        }
+    }
+
+    @SafeVarargs
+    private Router mockRouter(Class<? extends Component>... navigationTargets) {
+        VaadinContext mockContext = Mockito.mock(VaadinContext.class);
+        ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
+                .getInstance(mockContext);
+        Router router = new Router(routeRegistry);
+
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(routeRegistry);
+        for (Class<? extends Component> navigationTarget : navigationTargets) {
+            routeConfiguration.setAnnotatedRoute(navigationTarget);
+        }
+        return router;
+    }
+
+    @Route("foo/bar")
+    private static class TestRoute extends Component {
+    }
+
+    @Route("foo/:k1/:k2/bar")
+    private static class TestRouteWithRouteParams extends Component {
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
@@ -24,7 +24,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
@@ -136,27 +135,12 @@ class BreadcrumbsItemTest {
     // PREFIX TESTS
 
     @Test
-    void setPrefixComponent_getPrefixComponentReturnsSame() {
+    void setPrefixComponent_getPrefixComponent() {
         var item = new BreadcrumbsItem("Home");
         var prefix = new Div();
         item.setPrefixComponent(prefix);
 
         Assertions.assertEquals(prefix, item.getPrefixComponent());
-    }
-
-    // ENABLED TESTS
-
-    @Test
-    void setEnabledFalse_disabledAttributeReflected() {
-        UI ui = new UI();
-        var item = new BreadcrumbsItem("Home");
-        ui.add(item);
-
-        item.setEnabled(false);
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-
-        Assertions.assertFalse(item.isEnabled());
-        Assertions.assertTrue(item.getElement().hasAttribute("disabled"));
     }
 
     @SafeVarargs


### PR DESCRIPTION
Implements `BreadcrumbsItem`: the seven constructors mirroring `SideNavItem`'s overload set, the `path` accessors (`getPath()`, `setPath(String)`, `setPath(Class<? extends Component>)`, `setPath(Class, RouteParameters)` — the class overloads resolve via `RouteConfiguration` exactly like `SideNavItem`), and the inherited `HasText` / `HasEnabled` / `HasPrefix` surface.

Stacked on #9379 (scaffolding) — base branch is `breadcrumbs-flow-scaffolding`, so review/merge that first. Kept as a draft until the base PR lands and this can retarget `main`.

Closes #9378

🤖 Generated with [Claude Code](https://claude.com/claude-code)