### PR TITLE
test: fix compilation errors due to ambiguous setAriaLabelledBy(null)

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -624,7 +624,7 @@ class CheckboxGroupTest {
         Assertions.assertEquals("aria-labelledby",
                 group.getAriaLabelledBy().get());
 
-        group.setAriaLabelledBy(null);
+        group.setAriaLabelledBy((String) null);
         Assertions.assertTrue(group.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
@@ -143,7 +143,7 @@ class CheckboxUnitTest {
         Assertions.assertEquals("aria-labelledby",
                 checkbox.getAriaLabelledBy().get());
 
-        checkbox.setAriaLabelledBy(null);
+        checkbox.setAriaLabelledBy((String) null);
         Assertions.assertTrue(checkbox.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -372,7 +372,7 @@ abstract class ComboBoxBaseTest {
         Assertions.assertEquals("aria-labelledby",
                 comboBox.getAriaLabelledBy().get());
 
-        comboBox.setAriaLabelledBy(null);
+        comboBox.setAriaLabelledBy((String) null);
         Assertions.assertTrue(comboBox.getAriaLabelledBy().isEmpty());
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTest.java
@@ -84,7 +84,7 @@ class MenuItemTest {
         Assertions.assertEquals("aria-labelledby",
                 item.getAriaLabelledBy().get());
 
-        item.setAriaLabelledBy(null);
+        item.setAriaLabelledBy((String) null);
         Assertions.assertTrue(item.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -318,7 +318,7 @@ class DatePickerTest {
         Assertions.assertEquals("aria-labelledby",
                 datePicker.getAriaLabelledBy().get());
 
-        datePicker.setAriaLabelledBy(null);
+        datePicker.setAriaLabelledBy((String) null);
         Assertions.assertTrue(datePicker.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -215,7 +215,7 @@ class ListBoxUnitTest {
         Assertions.assertEquals("aria-labelledby",
                 listBox.getAriaLabelledBy().get());
 
-        listBox.setAriaLabelledBy(null);
+        listBox.setAriaLabelledBy((String) null);
 
         Assertions.assertTrue(listBox.getAriaLabelledBy().isEmpty());
     }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
@@ -360,7 +360,7 @@ class MultiSelectListBoxTest {
         Assertions.assertEquals("aria-labelledby",
                 listBox.getAriaLabelledBy().get());
 
-        listBox.setAriaLabelledBy(null);
+        listBox.setAriaLabelledBy((String) null);
 
         Assertions.assertTrue(listBox.getAriaLabelledBy().isEmpty());
     }

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverTest.java
@@ -229,7 +229,7 @@ class PopoverTest {
         Assertions.assertEquals("aria-labelledby",
                 popover.getAriaLabelledBy().get());
 
-        popover.setAriaLabelledBy(null);
+        popover.setAriaLabelledBy((String) null);
         Assertions.assertTrue(popover.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -493,7 +493,7 @@ class RadioButtonGroupTest {
         Assertions.assertEquals("aria-labelledby",
                 group.getAriaLabelledBy().get());
 
-        group.setAriaLabelledBy(null);
+        group.setAriaLabelledBy((String) null);
         Assertions.assertTrue(group.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -861,7 +861,7 @@ class SelectTest {
         Assertions.assertEquals("aria-labelledby",
                 select.getAriaLabelledBy().get());
 
-        select.setAriaLabelledBy(null);
+        select.setAriaLabelledBy((String) null);
         Assertions.assertTrue(select.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/AbstractSliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/AbstractSliderTest.java
@@ -58,7 +58,7 @@ abstract class AbstractSliderTest<TComponent extends NumberSlider<TComponent, TV
         Assertions.assertEquals("aria-labelledby",
                 slider.getAriaLabelledBy().get());
 
-        slider.setAriaLabelledBy(null);
+        slider.setAriaLabelledBy((String) null);
         Assertions.assertTrue(slider.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabTest.java
@@ -87,7 +87,7 @@ class TabTest {
         Assertions.assertEquals("aria-labelledby",
                 tab.getAriaLabelledBy().get());
 
-        tab.setAriaLabelledBy(null);
+        tab.setAriaLabelledBy((String) null);
         Assertions.assertTrue(tab.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -188,7 +188,7 @@ class BigDecimalFieldTest extends TextFieldTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -158,7 +158,7 @@ class EmailFieldTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -247,7 +247,7 @@ class IntegerFieldTest extends TextFieldTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -297,7 +297,7 @@ class NumberFieldTest extends TextFieldTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -184,7 +184,7 @@ class PasswordFieldTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -200,7 +200,7 @@ class TextAreaTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -191,7 +191,7 @@ class TextFieldTest {
         Assertions.assertEquals("aria-labelledby",
                 field.getAriaLabelledBy().get());
 
-        field.setAriaLabelledBy(null);
+        field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
     }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -323,7 +323,7 @@ class TimePickerTest {
         Assertions.assertEquals("aria-labelledby",
                 timePicker.getAriaLabelledBy().get());
 
-        timePicker.setAriaLabelledBy(null);
+        timePicker.setAriaLabelledBy((String) null);
         Assertions.assertTrue(timePicker.getAriaLabelledBy().isEmpty());
     }
 


### PR DESCRIPTION
After bumping to Flow 25.3-SNAPSHOT, `vaadin/flow#24425` added `setAriaLabelledBy(Component)` to `HasAriaLabel`. The new overload made every `component.setAriaLabelledBy(null)` call site ambiguous between `setAriaLabelledBy(String)` and `setAriaLabelledBy(Component)`, breaking CI on at least `vaadin-date-picker-flow` and `vaadin-time-picker-flow`.

```
reference to setAriaLabelledBy is ambiguous
  both method setAriaLabelledBy(com.vaadin.flow.component.Component) in com.vaadin.flow.component.HasAriaLabel
  and method setAriaLabelledBy(java.lang.String) in com.vaadin.flow.component.datepicker.DatePicker match
```

Cast the literal `null` to `(String)` to keep these tests exercising the `String` overload. Applied across all 20 affected test files — the two reported in CI plus 18 sibling tests with the same pattern that would fail as soon as their reactor slot reached `testCompile`.

Related to vaadin/flow#24425

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)