### PR TITLE
fix: update method call in ComboBox to `__focusIndex`

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -170,7 +170,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         getElement().addPropertyChangeListener("opened", event -> {
             var isOpened = (boolean) event.getValue();
             if (isOpened && focusSelectedItem) {
-                scrollToSelectedItem();
+                focusOnSelectedItem();
             }
         });
     }
@@ -412,7 +412,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         return focusSelectedItem;
     }
 
-    private void scrollToSelectedItem() {
+    private void focusOnSelectedItem() {
         if (getValue() == null) {
             return;
         }
@@ -434,7 +434,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         if (index == null || index < 0) {
             return;
         }
-        getElement().callJsFunction("scrollToIndex", index);
+        getElement().callJsFunction("__focusIndex", index);
     }
 
     /**


### PR DESCRIPTION
## Description

After https://github.com/vaadin/web-components/pull/11862, the feature moved from the public method `scrollToIndex` to the private `__focusIndex`. Also renamed the private method name to align with the web-component's method.

> [!NOTE]
> Keeping it as draft until the next web-components version is released

## Type of change

- Bugfix