### PR TITLE
chore: upgrade spring-ai to 2.0.0-M8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <spring-data-commons.version>4.0.5</spring-data-commons.version>
         <reactor-core.version>3.8.5</reactor-core.version>
         <langchain4j.version>1.14.1</langchain4j.version>
-        <spring-ai.version>2.0.0-M5</spring-ai.version>
+        <spring-ai.version>2.0.0-M7</spring-ai.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <spring-data-commons.version>4.0.5</spring-data-commons.version>
         <reactor-core.version>3.8.5</reactor-core.version>
         <langchain4j.version>1.14.1</langchain4j.version>
-        <spring-ai.version>2.0.0-M7</spring-ai.version>
+        <spring-ai.version>2.0.0-M8</spring-ai.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -105,8 +106,8 @@ public class SpringAILLMProvider implements LLMProvider {
         chatMemory = MessageWindowChatMemory.builder().maxMessages(MAX_MESSAGES)
                 .build();
         chatClient = ChatClient.builder(chatModel)
-                .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory)
-                        .conversationId(CONVERSATION_ID).build())
+                .defaultAdvisors(
+                        MessageChatMemoryAdvisor.builder(chatMemory).build())
                 .build();
         hasManagedMemory = true;
     }
@@ -259,6 +260,10 @@ public class SpringAILLMProvider implements LLMProvider {
 
     private ChatClient.ChatClientRequestSpec getPromptSpec(LLMRequest request) {
         var promptSpec = chatClient.prompt();
+        if (hasManagedMemory) {
+            promptSpec = promptSpec.advisors(a -> a
+                    .param(ChatMemory.CONVERSATION_ID, CONVERSATION_ID));
+        }
         promptSpec = promptSpec.user(userSpec -> {
             userSpec.text(request.userMessage());
             var media = buildMedia(request);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -261,8 +261,8 @@ public class SpringAILLMProvider implements LLMProvider {
     private ChatClient.ChatClientRequestSpec getPromptSpec(LLMRequest request) {
         var promptSpec = chatClient.prompt();
         if (hasManagedMemory) {
-            promptSpec = promptSpec.advisors(a -> a
-                    .param(ChatMemory.CONVERSATION_ID, CONVERSATION_ID));
+            promptSpec = promptSpec.advisors(
+                    a -> a.param(ChatMemory.CONVERSATION_ID, CONVERSATION_ID));
         }
         promptSpec = promptSpec.user(userSpec -> {
             userSpec.text(request.userMessage());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -828,11 +828,18 @@ class SpringAILLMProviderTest {
     @Test
     void stream_streamingCompletesEmptyWithNoChunks_logsWarning() {
         // Zero-chunk stream: nothing ever flips the terminal gate.
+        // Uses the ChatClient constructor so no MessageChatMemoryAdvisor
+        // sits on the chain. The advisor's stream aggregation requires
+        // at least one emitted chunk to propagate the conversation id,
+        // which would fail an empty-flux test before the warn-on-no-
+        // terminal logic could run.
+        var chatClient = ChatClient.builder(mockChatModel).build();
+        var chatClientProvider = new SpringAILLMProvider(chatClient);
         var request = createSimpleRequest("Hello");
         Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
                 .thenReturn(Flux.empty());
 
-        provider.stream(request).collectList().block();
+        chatClientProvider.stream(request).collectList().block();
 
         assertAbnormalTerminationWarningLogged();
     }


### PR DESCRIPTION
MessageChatMemoryAdvisor.Builder.conversationId(String) is gone in M8; the conversation id is now passed per request via the advisor params (ChatMemory.CONVERSATION_ID).
