### PR TITLE
fix: focus selected item with wrapped in-memory data providers

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -422,7 +422,12 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         }
         Integer index;
         if (dataProvider.isInMemory()) {
-            index = getListDataView().getItemIndex(getValue()).orElse(null);
+            // Use the generic data view rather than the list data view: it
+            // resolves the item index through the data communicator and works
+            // for any in-memory provider, including wrapped ones (e.g. from
+            // ListDataProvider.withConvertedFilter) that are not a
+            // ListDataProvider and would fail the list data view's cast.
+            index = getGenericDataView().getItemIndex(getValue()).orElse(null);
         } else {
             index = getLazyDataView().getItemIndex(getValue()).orElse(null);
         }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.combobox;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -29,9 +30,12 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.Unit;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.InputField;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 
@@ -251,6 +255,31 @@ class ComboBoxTest extends ComboBoxBaseTest {
         Assertions.assertTrue(comboBox.isFocusSelectedItem());
         comboBox.setFocusSelectedItem(false);
         Assertions.assertFalse(comboBox.isFocusSelectedItem());
+    }
+
+    @Test
+    void focusSelectedItem_convertedFilterListDataProvider_scrollsToSelectedItem() {
+        // withConvertedFilter wraps the ListDataProvider in a provider that is
+        // in-memory but not a ListDataProvider. Opening the dropdown must
+        // resolve the selected item's index without failing.
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        ListDataProvider<String> dataProvider = DataProvider
+                .ofCollection(List.of("A", "B", "C", "D"));
+        comboBox.setItems(dataProvider.withConvertedFilter(
+                filterText -> item -> item.contains(filterText)));
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("C");
+        comboBox.setOpened(true);
+
+        var invocations = ui.dumpPendingJavaScriptInvocations().stream()
+                .map(PendingJavaScriptInvocation::getInvocation)
+                .filter(invocation -> invocation.getExpression()
+                        .contains("scrollToIndex"))
+                .toList();
+        Assertions.assertEquals(1, invocations.size());
+        // Parameter 0 is the target element, parameter 1 is the item index
+        Assertions.assertEquals(2, invocations.get(0).getParameters().get(1));
     }
 
     @Test


### PR DESCRIPTION
A `ComboBox` with `setFocusSelectedItem(true)` throws a `ClassCastException` when opening the dropdown if its items come from a `ListDataProvider` wrapped with `withConvertedFilter(...)`. `scrollToSelectedItem()` resolved the selected item's index through the list data view, which casts the provider to `ListDataProvider`. The wrapper is in-memory but not a `ListDataProvider`, so the cast fails.

```java
ComboBox<String> comboBox = new ComboBox<>();
ListDataProvider<String> dataProvider = DataProvider
        .ofCollection(List.of("A", "B", "C", "D"));
comboBox.setItems(dataProvider.withConvertedFilter(
        filterText -> item -> item.contains(filterText)));
comboBox.setFocusSelectedItem(true);
comboBox.setValue("C");
comboBox.setOpened(true); // throws ClassCastException
```

`scrollToSelectedItem()` now resolves the index through the generic data view (`ComboBoxDataView`) for in-memory providers instead of the list data view. The generic data view reads items from the data communicator and works for any in-memory provider, wrapped or not, so the list data view is no longer used for providers that aren't a `ListDataProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
