### PR TITLE
fix: respect visibility, enabled, and read-only state in the form AI

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -636,12 +636,13 @@ public class FormAIController implements AIController {
      * Builds the {@code fill_form} rejection reason for a write the LLM aimed
      * at a field it can read but not edit.
      *
-     * @param field
-     *            the disabled or read-only field that was targeted
+     * @param disabled
+     *            {@code true} when the field is disabled, {@code false} when it
+     *            is read-only
      * @return an LLM-facing reason explaining why the write was rejected
      */
-    private static String notWritableReason(FormFieldDescriptor field) {
-        if (field.disabled()) {
+    private static String notWritableReason(boolean disabled) {
+        if (disabled) {
             return "Field is disabled and cannot be filled. Set its "
                     + "controlling field to enable it, then re-read fill_form's "
                     + "response and fill it.";
@@ -735,9 +736,18 @@ public class FormAIController implements AIController {
                                     + "unknown field id."));
                     continue;
                 }
-                if (field.disabled() || field.readOnly()) {
+                // Re-evaluate the field's live writability rather than the
+                // verdict captured before this turn's writes: an earlier
+                // write in the same payload (e.g. via a value-change listener)
+                // can disable or enable a field that appears later. Using the
+                // pre-write snapshot would let a write land on a field the
+                // user can no longer edit, or reject one that just became
+                // writable.
+                var raw = field.field();
+                var disabled = isDisabled(raw);
+                if (disabled || isApplicationReadOnly(raw)) {
                     rejected.add(new RejectedEntry(id, value,
-                            notWritableReason(field)));
+                            notWritableReason(disabled)));
                     continue;
                 }
                 applyValue(field, value, rejected);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.ai.form.FormAITools.FormFieldDescriptor;
 import com.vaadin.flow.component.ai.form.FormValueConverter.RejectedValueException;
@@ -183,6 +184,13 @@ public class FormAIController implements AIController {
             - Fields the application has hidden via .ignore() (and password \
             fields) never appear in get_form_state and cannot be written by \
             fill_form. Do not try, even if the user message asks for them.
+            - get_form_state lists only the fields that are currently visible \
+            and enabled. Some fields appear or become editable only after a \
+            controlling field is set (e.g. a "Cost center" shown once trip \
+            type is "Business", or a date enabled by a checkbox). Set the \
+            controlling field first, then re-read the fill_form response: the \
+            newly revealed fields are now present and you can fill them in the \
+            same turn.
             - Numeric values are JSON numbers (no scientific notation for \
             integers); dates / date-times / times are ISO-8601 strings. \
             Empty string and null clear a field. Multi-select fields take a \
@@ -495,12 +503,37 @@ public class FormAIController implements AIController {
     /**
      * Returns the discovered fields the controller acts on — every
      * {@link HasValue} in the form tree minus those hidden via
-     * {@link #ignore(HasValue)}. Use this anywhere the LLM-visible field set
-     * matters (locking, tool inputs and outputs).
+     * {@link #ignore(HasValue)} and minus those that are not currently visible
+     * or not enabled. Use this anywhere the LLM-visible field set matters
+     * (locking, tool inputs and outputs).
      */
     private List<HasValue<?, ?>> collectActiveFields() {
         return FormFieldDiscovery.collectFields(form).stream()
-                .filter(field -> !isIgnored(field)).toList();
+                .filter(field -> !isIgnored(field)).filter(this::isAvailable)
+                .toList();
+    }
+
+    /**
+     * Whether a field is part of the surface the LLM may read and write right
+     * now. A field that the application has hidden ({@code setVisible(false)})
+     * or disabled ({@code setEnabled(false)}) is excluded, mirroring what the
+     * user can see and edit: a conditional field whose visibility or
+     * enabledness depends on another field only enters the tool surface once
+     * its controlling field is set, and the post-write {@code fill_form}
+     * snapshot is re-taken so such fields appear (or disappear) as the LLM's
+     * own writes cascade through value-change listeners.
+     *
+     * @param field
+     *            the discovered field to test, not {@code null}
+     * @return {@code true} when the field is currently visible and enabled (or
+     *         does not expose those states), {@code false} otherwise
+     */
+    private boolean isAvailable(HasValue<?, ?> field) {
+        if (field instanceof Component component && !component.isVisible()) {
+            return false;
+        }
+        return !(field instanceof HasEnabled hasEnabled)
+                || hasEnabled.isEnabled();
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -108,13 +108,14 @@ import tools.jackson.databind.JsonNode;
  *
  * <p>
  * <b>Field locking:</b> while a fill is in progress, every non-ignored field
- * that wasn't already read-only is set to read-only so the user cannot type
- * into a field the AI is about to overwrite. Locks are released when the turn
- * ends, successfully or otherwise. Application code that changes a field's
- * read-only state mid-turn (e.g. from a value-change listener reacting to the
- * LLM's writes) will be overridden when the controller releases its own locks
- * at turn end — applications should avoid toggling read-only state during a
- * fill turn, or reapply it after the turn completes.
+ * the user can currently edit (visible, enabled, and not already read-only) is
+ * set to read-only so the user cannot type into a field the AI is about to
+ * overwrite. Locks are released when the turn ends, successfully or otherwise.
+ * Application code that changes a field's read-only state mid-turn (e.g. from a
+ * value-change listener reacting to the LLM's writes) will be overridden when
+ * the controller releases its own locks at turn end — applications should avoid
+ * toggling read-only state during a fill turn, or reapply it after the turn
+ * completes.
  * </p>
  *
  * <p>
@@ -184,13 +185,15 @@ public class FormAIController implements AIController {
             - Fields the application has hidden via .ignore() (and password \
             fields) never appear in get_form_state and cannot be written by \
             fill_form. Do not try, even if the user message asks for them.
-            - get_form_state lists only the fields that are currently visible \
-            and enabled. Some fields appear or become editable only after a \
-            controlling field is set (e.g. a "Cost center" shown once trip \
-            type is "Business", or a date enabled by a checkbox). Set the \
-            controlling field first, then re-read the fill_form response: the \
-            newly revealed fields are now present and you can fill them in the \
-            same turn.
+            - get_form_state lists every visible field. A field tagged \
+            "disabled": true or "readOnly": true is context only — read its \
+            value, but fill_form will reject any write to it. Such a field \
+            usually becomes writable after a controlling field is set (e.g. a \
+            "Cost center" enabled once trip type is "Business", or a date \
+            enabled by a checkbox). Set the controlling field first, then \
+            re-read the fill_form response: the field is now writable and you \
+            can fill it in the same turn. Hidden fields are not listed at all; \
+            setting their controlling field reveals them on the next state read.
             - Numeric values are JSON numbers (no scientific notation for \
             integers); dates / date-times / times are ISO-8601 strings. \
             Empty string and null clear a field. Multi-select fields take a \
@@ -485,14 +488,15 @@ public class FormAIController implements AIController {
     }
 
     /**
-     * Puts every discovered, non-ignored, currently editable field into
+     * Puts every discovered, non-ignored, currently writable field into
      * read-only state so the user cannot type into a field the AI is about to
-     * overwrite. Fields that were already read-only when the turn started are
-     * left untouched and will not be unlocked at turn end.
+     * overwrite. Fields that are disabled or were already read-only when the
+     * turn started are not writable, so they are left untouched and will not be
+     * unlocked at turn end.
      */
     private void lockFields() {
         for (var field : collectActiveFields()) {
-            if (field.isReadOnly()) {
+            if (isDisabled(field) || isApplicationReadOnly(field)) {
                 continue;
             }
             field.setReadOnly(true);
@@ -503,37 +507,64 @@ public class FormAIController implements AIController {
     /**
      * Returns the discovered fields the controller acts on — every
      * {@link HasValue} in the form tree minus those hidden via
-     * {@link #ignore(HasValue)} and minus those that are not currently visible
-     * or not enabled. Use this anywhere the LLM-visible field set matters
-     * (locking, tool inputs and outputs).
+     * {@link #ignore(HasValue)} and minus those that are not currently visible.
+     * Disabled and read-only fields are kept: the LLM reads them as context but
+     * cannot write them (see {@link #isDisabled} /
+     * {@link #isApplicationReadOnly}). Use this anywhere the LLM-visible field
+     * set matters (locking, tool inputs and outputs).
      */
     private List<HasValue<?, ?>> collectActiveFields() {
         return FormFieldDiscovery.collectFields(form).stream()
-                .filter(field -> !isIgnored(field)).filter(this::isAvailable)
+                .filter(field -> !isIgnored(field)).filter(this::isVisible)
                 .toList();
     }
 
     /**
-     * Whether a field is part of the surface the LLM may read and write right
-     * now. A field that the application has hidden ({@code setVisible(false)})
-     * or disabled ({@code setEnabled(false)}) is excluded, mirroring what the
-     * user can see and edit: a conditional field whose visibility or
-     * enabledness depends on another field only enters the tool surface once
-     * its controlling field is set, and the post-write {@code fill_form}
-     * snapshot is re-taken so such fields appear (or disappear) as the LLM's
-     * own writes cascade through value-change listeners.
+     * Whether the field is currently visible. A field the application has
+     * hidden ({@code setVisible(false)}) is dropped from the LLM surface
+     * entirely: the user cannot see it, so its value is not exposed as context
+     * and it cannot be written. A conditional field hidden until a controlling
+     * field is set only enters the surface once it becomes visible and the next
+     * state read is taken.
      *
      * @param field
      *            the discovered field to test, not {@code null}
-     * @return {@code true} when the field is currently visible and enabled (or
-     *         does not expose those states), {@code false} otherwise
+     * @return {@code true} when the field is visible (or is not a
+     *         {@link Component} exposing visibility), {@code false} otherwise
      */
-    private boolean isAvailable(HasValue<?, ?> field) {
-        if (field instanceof Component component && !component.isVisible()) {
-            return false;
-        }
-        return !(field instanceof HasEnabled hasEnabled)
-                || hasEnabled.isEnabled();
+    private boolean isVisible(HasValue<?, ?> field) {
+        return !(field instanceof Component component) || component.isVisible();
+    }
+
+    /**
+     * Whether the field is disabled ({@code setEnabled(false)}). A disabled
+     * field is shown to the LLM as read-only context but cannot be written.
+     *
+     * @param field
+     *            the discovered field to test, not {@code null}
+     * @return {@code true} when the field exposes an enabled state and is
+     *         currently disabled, {@code false} otherwise
+     */
+    private boolean isDisabled(HasValue<?, ?> field) {
+        return field instanceof HasEnabled hasEnabled
+                && !hasEnabled.isEnabled();
+    }
+
+    /**
+     * Whether the application set the field read-only, as opposed to the
+     * controller's own turn lock. Between {@link #lockFields()} and
+     * {@link #unlockFields()} every writable field reports read-only, so a
+     * field counts as application-read-only only when it reports read-only yet
+     * is not one this controller locked (the {@code lockedFields} set). Such a
+     * field is shown to the LLM as read-only context but cannot be written.
+     *
+     * @param field
+     *            the discovered field to test, not {@code null}
+     * @return {@code true} when the field is read-only independently of the
+     *         controller's turn lock, {@code false} otherwise
+     */
+    private boolean isApplicationReadOnly(HasValue<?, ?> field) {
+        return field.isReadOnly() && !lockedFields.contains(field);
     }
 
     /**
@@ -595,6 +626,23 @@ public class FormAIController implements AIController {
         return stream.limit(limit).toList();
     }
 
+    /**
+     * Builds the {@code fill_form} rejection reason for a write the LLM aimed
+     * at a field it can read but not edit.
+     *
+     * @param field
+     *            the disabled or read-only field that was targeted
+     * @return an LLM-facing reason explaining why the write was rejected
+     */
+    private static String notWritableReason(FormFieldDescriptor field) {
+        if (field.disabled()) {
+            return "Field is disabled and cannot be filled. Set its "
+                    + "controlling field to enable it, then re-read fill_form's "
+                    + "response and fill it.";
+        }
+        return "Field is read-only and cannot be filled.";
+    }
+
     private final class ToolCallbacks implements FormAITools.Callbacks {
 
         @Override
@@ -607,8 +655,8 @@ public class FormAIController implements AIController {
                 if (type == FormFieldType.UNSUPPORTED) {
                     continue;
                 }
-                descriptors
-                        .add(new FormFieldDescriptor(id, field, type, hints));
+                descriptors.add(new FormFieldDescriptor(id, field, type, hints,
+                        isDisabled(field), isApplicationReadOnly(field)));
             }
             return descriptors;
         }
@@ -679,6 +727,11 @@ public class FormAIController implements AIController {
                                     + "the id list and retry only entries "
                                     + "that are rejected with the reason "
                                     + "unknown field id."));
+                    continue;
+                }
+                if (field.disabled() || field.readOnly()) {
+                    rejected.add(new RejectedEntry(id, value,
+                            notWritableReason(field)));
                     continue;
                 }
                 applyValue(field, value, rejected);
@@ -752,8 +805,7 @@ public class FormAIController implements AIController {
             var fieldsArr = root.putArray("fields");
             for (var d : postWrite) {
                 try {
-                    fieldsArr.add(FormFieldSchema.build(d.id(), d.field(),
-                            d.type(), d.hints()));
+                    fieldsArr.add(FormFieldSchema.build(d));
                 } catch (Exception ex) {
                     LOGGER.warn("fill_form field-state build failed for {}",
                             d.id(), ex);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -111,11 +111,13 @@ import tools.jackson.databind.JsonNode;
  * the user can currently edit (visible, enabled, and not already read-only) is
  * set to read-only so the user cannot type into a field the AI is about to
  * overwrite. Locks are released when the turn ends, successfully or otherwise.
- * Application code that changes a field's read-only state mid-turn (e.g. from a
- * value-change listener reacting to the LLM's writes) will be overridden when
- * the controller releases its own locks at turn end — applications should avoid
- * toggling read-only state during a fill turn, or reapply it after the turn
- * completes.
+ * Application code that turns a locked field read-only mid-turn (e.g. from a
+ * value-change listener reacting to the LLM's writes) is not honoured: the
+ * field already reports read-only because of the lock, so the controller cannot
+ * tell the application's toggle apart from its own lock. {@code fill_form}
+ * still writes the field, and the lock is released at turn end regardless.
+ * Applications should avoid toggling read-only state during a fill turn, or
+ * reapply it after the turn completes.
  * </p>
  *
  * <p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -520,30 +520,36 @@ public class FormAIController implements AIController {
     }
 
     /**
-     * Whether the field is currently visible. A field the application has
-     * hidden ({@code setVisible(false)}) is dropped from the LLM surface
-     * entirely: the user cannot see it, so its value is not exposed as context
-     * and it cannot be written. A conditional field hidden until a controlling
-     * field is set only enters the surface once it becomes visible and the next
-     * state read is taken.
+     * Whether the field is effectively visible — visible itself and not hidden
+     * by any ancestor. A field the application has hidden
+     * ({@code setVisible(false)}), or that sits inside a hidden container, is
+     * dropped from the LLM surface entirely: the user cannot see it, so its
+     * value is not exposed as context and it cannot be written. A conditional
+     * field hidden until a controlling field is set only enters the surface
+     * once it becomes visible and the next state read is taken.
      *
      * @param field
      *            the discovered field to test, not {@code null}
-     * @return {@code true} when the field is visible (or is not a
-     *         {@link Component} exposing visibility), {@code false} otherwise
+     * @return {@code true} when the field and all its ancestors are visible (or
+     *         it is not a {@link Component} exposing visibility), {@code false}
+     *         otherwise
      */
     private boolean isVisible(HasValue<?, ?> field) {
-        return !(field instanceof Component component) || component.isVisible();
+        return !(field instanceof Component component)
+                || ComponentUtil.isEffectivelyVisible(component);
     }
 
     /**
-     * Whether the field is disabled ({@code setEnabled(false)}). A disabled
-     * field is shown to the LLM as read-only context but cannot be written.
+     * Whether the field is effectively disabled — disabled itself
+     * ({@code setEnabled(false)}) or sitting inside a disabled container.
+     * Unlike visibility, {@link HasEnabled#isEnabled()} already reflects the
+     * ancestor chain, so no explicit walk is needed. A disabled field is shown
+     * to the LLM as read-only context but cannot be written.
      *
      * @param field
      *            the discovered field to test, not {@code null}
      * @return {@code true} when the field exposes an enabled state and is
-     *         currently disabled, {@code false} otherwise
+     *         effectively disabled, {@code false} otherwise
      */
     private boolean isDisabled(HasValue<?, ?> field) {
         return field instanceof HasEnabled hasEnabled

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
@@ -48,9 +48,15 @@ final class FormAITools {
      * at discovery time; the {@link FormFieldHints} reference is live so live
      * label, helper text, current value, and any post-construction hint updates
      * are read fresh on each tool call.
+     * <p>
+     * {@code disabled} and {@code readOnly} flag a field the user can see but
+     * not edit: the LLM reads it for context, while {@code fill_form} rejects
+     * any write to it. {@code readOnly} already excludes the controller's own
+     * turn lock, so it reflects only application-set read-only state.
      */
     record FormFieldDescriptor(String id, HasValue<?, ?> field,
-            FormFieldType type, FormFieldHints hints) {
+            FormFieldType type, FormFieldHints hints, boolean disabled,
+            boolean readOnly) {
     }
 
     /**
@@ -61,9 +67,12 @@ final class FormAITools {
 
         /**
          * Returns the descriptors the tools should expose to the LLM, in
-         * document order. Ignored fields and fields whose type is
-         * {@link FormFieldType#UNSUPPORTED} must be filtered out by the
-         * implementation.
+         * document order. Hidden fields, ignored fields, and fields whose type
+         * is {@link FormFieldType#UNSUPPORTED} must be filtered out by the
+         * implementation. Disabled and read-only fields are kept, with their
+         * {@link FormFieldDescriptor#disabled()} /
+         * {@link FormFieldDescriptor#readOnly()} flags set, so the LLM sees
+         * them as read-only context.
          *
          * @return the visible field descriptors in document order, never
          *         {@code null}
@@ -127,10 +136,12 @@ final class FormAITools {
             @Override
             public String getDescription() {
                 return """
-                        Returns the current form as JSON: every fillable field's id, \
+                        Returns the current form as JSON: every visible field's id, \
                         description, type metadata (type/format/pattern/enum/queryable/\
-                        array/items), and current value. Call this first so you know \
-                        which ids exist and what each one means.""";
+                        array/items), and current value. A field tagged "disabled" or \
+                        "readOnly" is context only — read it, but fill_form will reject \
+                        writing it. Call this first so you know which ids exist and what \
+                        each one means.""";
             }
 
             @Override
@@ -148,8 +159,7 @@ final class FormAITools {
                 var fields = root.putArray("fields");
                 for (var d : callbacks.visibleFields()) {
                     try {
-                        fields.add(FormFieldSchema.build(d.id(), d.field(),
-                                d.type(), d.hints()));
+                        fields.add(FormFieldSchema.build(d));
                     } catch (Exception ex) {
                         LOGGER.warn("get_form_state failed for field {}",
                                 d.id(), ex);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldSchema.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldSchema.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.ai.form.FormAITools.FormFieldDescriptor;
 import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.node.ObjectNode;
@@ -52,15 +53,29 @@ final class FormFieldSchema {
 
     /**
      * Builds a JSON node describing one form field: id, merged description,
-     * type metadata, and the current value.
+     * read-only/disabled status, type metadata, and the current value.
+     *
+     * @param descriptor
+     *            the field to describe, not {@code null}
+     * @return the field's metadata node
      */
-    static ObjectNode build(String id, HasValue<?, ?> field, FormFieldType type,
-            FormFieldHints hints) {
+    static ObjectNode build(FormFieldDescriptor descriptor) {
+        var field = descriptor.field();
+        var type = descriptor.type();
+        var hints = descriptor.hints();
         var node = JacksonUtils.createObjectNode();
-        node.put("id", id);
+        node.put("id", descriptor.id());
         var description = mergeDescription(field, hints);
         if (!description.isEmpty()) {
             node.put("description", description);
+        }
+        // A disabled or read-only field is shown for context only; the flags
+        // tell the LLM not to fill it (fill_form rejects writes to it).
+        if (descriptor.disabled()) {
+            node.put("disabled", true);
+        }
+        if (descriptor.readOnly()) {
+            node.put("readOnly", true);
         }
         applyType(node, field, type, hints);
         applyValue(node, field, type, hints);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -338,6 +338,71 @@ class FillFormToolTest {
     }
 
     @Test
+    void fillForm_rejectsWriteToDisabledFieldWithoutChangingIt() {
+        // A disabled field is shown to the LLM as context (with a "disabled"
+        // flag) but is not writable. A write to it must be rejected with a
+        // reason that points at enabling it, and the field must keep its value.
+        var disabled = new TestField();
+        disabled.setValue("orig");
+        disabled.setEnabled(false);
+        var controller = controllerFor(new TestField(), disabled);
+
+        var result = fillFormResult(controller, payload(disabled, "\"new\""));
+
+        Assertions.assertEquals("orig", disabled.getValue(),
+                "Disabled field must keep its value");
+        Assertions.assertEquals(List.of(idOf(disabled)), rejectedIds(result));
+        var reason = rejectionReason(result, idOf(disabled));
+        Assertions.assertTrue(reason.contains("disabled"),
+                "Reason must say the field is disabled; got: " + reason);
+    }
+
+    @Test
+    void fillForm_rejectsWriteToReadOnlyFieldWithoutChangingIt() {
+        // An application-read-only field is context only. A write to it must be
+        // rejected without changing it. The controller's own turn lock does not
+        // count as read-only here — that path is exercised by every happy-path
+        // fill test, which writes through the lock after onRequest().
+        var readOnly = new TestField();
+        readOnly.setValue("orig");
+        readOnly.setReadOnly(true);
+        var controller = controllerFor(new TestField(), readOnly);
+
+        var result = fillFormResult(controller, payload(readOnly, "\"new\""));
+
+        Assertions.assertEquals("orig", readOnly.getValue(),
+                "Read-only field must keep its value");
+        Assertions.assertEquals(List.of(idOf(readOnly)), rejectedIds(result));
+        var reason = rejectionReason(result, idOf(readOnly));
+        Assertions.assertTrue(reason.contains("read-only"),
+                "Reason must say the field is read-only; got: " + reason);
+    }
+
+    @Test
+    void fillForm_postWriteSnapshotDoesNotFlagTurnLockedFieldAsReadOnly() {
+        // The fill_form response re-snapshots the form AFTER the writes, while
+        // the controller's turn lock is still on. A locked-but-writable field
+        // must appear in that snapshot WITHOUT a readOnly flag — the lock is
+        // the controller's, not the application's — and must carry the value
+        // just written. Guards the formatResult() path the way
+        // get_form_state's own carve-out test guards the read path.
+        var field = new TestField();
+        var controller = controllerFor(field); // onRequest() locks the field
+
+        var result = fillFormResult(controller, payload(field, "\"filled\""));
+
+        var entry = fieldEntry(result, idOf(field));
+        Assertions.assertNotNull(entry,
+                "Locked field must appear in the post-write fields block; got: "
+                        + result);
+        Assertions.assertFalse(entry.has("readOnly"),
+                "Turn-locked field must not be flagged readOnly in the "
+                        + "fill_form post-write snapshot; got: " + entry);
+        Assertions.assertEquals("filled", field.getValue(),
+                "Write to a turn-locked (but app-writable) field must land");
+    }
+
+    @Test
     void fillForm_partialSuccessLeavesBadFieldOnPriorValue() {
         // Mixed payload: name converts cleanly, amount fails. The valid
         // field must land; the failed field must stay on its prior value.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -379,6 +379,38 @@ class FillFormToolTest {
     }
 
     @Test
+    void fillForm_rejectsWriteToFieldDisabledByEarlierWriteInSamePayload() {
+        // A field's availability can change mid-fill: writing a controlling
+        // field earlier in the same payload can disable a field that appears
+        // later. The not-writable check must re-evaluate each field's LIVE
+        // state at write time, not a snapshot taken before any writes —
+        // otherwise the write lands on a field the user can no longer edit.
+        var trigger = new TestField();
+        var dependent = new TestField();
+        dependent.setValue("orig");
+        // Writing the trigger disables the dependent field.
+        trigger.addValueChangeListener(e -> dependent.setEnabled(false));
+        var controller = controllerFor(trigger, dependent);
+
+        // Order matters: the trigger is written first so the dependent is
+        // already disabled by the time its entry is processed.
+        var args = JacksonUtils.createObjectNode();
+        args.put(idOf(trigger), "go");
+        args.put(idOf(dependent), "new");
+        var result = fillFormResult(controller, args);
+
+        Assertions.assertEquals("orig", dependent.getValue(),
+                "A field disabled by an earlier write in the same payload "
+                        + "must not be written");
+        Assertions.assertEquals(List.of(idOf(dependent)), rejectedIds(result),
+                "The write to the now-disabled field must be rejected; got: "
+                        + result);
+        var reason = rejectionReason(result, idOf(dependent));
+        Assertions.assertTrue(reason.contains("disabled"),
+                "Reason must say the field is disabled; got: " + reason);
+    }
+
+    @Test
     void fillForm_rejectsWriteToNowHiddenFieldAsUnknownId() {
         // The LLM may hold an id from an earlier get_form_state for a field
         // that has since been hidden. A hidden field is off the surface, so

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -379,6 +379,51 @@ class FillFormToolTest {
     }
 
     @Test
+    void fillForm_rejectsWriteToNowHiddenFieldAsUnknownId() {
+        // The LLM may hold an id from an earlier get_form_state for a field
+        // that has since been hidden. A hidden field is off the surface, so
+        // the write is rejected as an unknown id (which tells the LLM to
+        // refresh via get_form_state), and the field keeps its value.
+        var field = new TestField();
+        field.setValue("orig");
+        var controller = controllerFor(field); // id stamped while visible
+        field.setVisible(false); // hidden after the LLM saw it
+
+        var result = fillFormResult(controller, payload(field, "\"new\""));
+
+        Assertions.assertEquals("orig", field.getValue(),
+                "Hidden field must keep its value");
+        Assertions.assertEquals(List.of(idOf(field)), rejectedIds(result));
+        var reason = rejectionReason(result, idOf(field));
+        Assertions.assertTrue(reason.contains("Unknown field id"),
+                "A hidden field is off the surface, so the write must be "
+                        + "rejected as an unknown id; got: " + reason);
+    }
+
+    @Test
+    void fillForm_rejectsWriteToFieldUnderNowHiddenContainerAsUnknownId() {
+        // Same as above, but the field is hidden because an ancestor container
+        // is hidden rather than the field itself. Effective visibility keeps it
+        // off the surface, so the write is rejected as an unknown id.
+        var field = new TestField();
+        field.setValue("orig");
+        var container = new Div(field);
+        var controller = controllerFor(container); // id stamped while visible
+        container.setVisible(false); // ancestor hidden afterwards
+
+        var result = fillFormResult(controller, payload(field, "\"new\""));
+
+        Assertions.assertEquals("orig", field.getValue(),
+                "Field under a hidden container must keep its value");
+        Assertions.assertEquals(List.of(idOf(field)), rejectedIds(result));
+        var reason = rejectionReason(result, idOf(field));
+        Assertions.assertTrue(reason.contains("Unknown field id"),
+                "A field hidden by an ancestor is off the surface, so the "
+                        + "write must be rejected as an unknown id; got: "
+                        + reason);
+    }
+
+    @Test
     void fillForm_postWriteSnapshotDoesNotFlagTurnLockedFieldAsReadOnly() {
         // The fill_form response re-snapshots the form AFTER the writes, while
         // the controller's turn lock is still on. A locked-but-writable field

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -101,6 +101,65 @@ class FormStateToolTest {
     }
 
     @Test
+    void getFormStateOmitsHiddenFields() {
+        // A field the application has hidden with setVisible(false) is not
+        // something the user can see or edit, so it must not enter the LLM's
+        // tool surface either. This is how a conditionally-shown field (e.g.
+        // a "Cost center" revealed only for business trips) stays out of
+        // get_form_state until its controlling field reveals it.
+        var visible = new TestField();
+        var hidden = new TestField();
+        hidden.setVisible(false);
+        var controller = new FormAIController(new Div(visible, hidden));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(1, fields.size(),
+                "Hidden (setVisible(false)) field must be excluded, got: "
+                        + fields);
+        Assertions.assertEquals(idOf(visible),
+                fields.get(0).get("id").asString());
+    }
+
+    @Test
+    void getFormStateOmitsDisabledFields() {
+        // A disabled field cannot be edited by the user; the AI must not fill
+        // it either. Disabling is the typical way a field is gated on another
+        // field's value (a "Seat preference" enabled only for non-Economy
+        // cabins), so the disabled field re-enters the surface once the
+        // controlling field is set and the next state read is taken.
+        var enabled = new TestField();
+        var disabled = new TestField();
+        disabled.setEnabled(false);
+        var controller = new FormAIController(new Div(enabled, disabled));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(1, fields.size(),
+                "Disabled (setEnabled(false)) field must be excluded, got: "
+                        + fields);
+        Assertions.assertEquals(idOf(enabled),
+                fields.get(0).get("id").asString());
+    }
+
+    @Test
+    void getFormStateIncludesFieldOnceItBecomesVisible() {
+        // Fields are re-discovered on every state read, so a field hidden at
+        // one turn appears at the next once the controlling field reveals it.
+        var field = new TestField();
+        field.setVisible(false);
+        var controller = new FormAIController(new Div(field));
+
+        Assertions.assertEquals(0, formStateFields(controller).size(),
+                "Hidden field must be absent while invisible");
+
+        field.setVisible(true);
+
+        Assertions.assertEquals(1, formStateFields(controller).size(),
+                "Field must reappear once it is made visible again");
+    }
+
+    @Test
     void getFormStateReturnsEmptyFieldsArrayForEmptyForm() {
         var controller = new FormAIController(new Div());
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -122,6 +122,60 @@ class FormStateToolTest {
     }
 
     @Test
+    void getFormStateExcludesFieldInsideInvisibleContainer() {
+        // Hiding a container hides the fields inside it from the user. The
+        // field's own isVisible() is still true, so the controller must judge
+        // EFFECTIVE visibility (ancestors included) to keep such a field off
+        // the surface — otherwise the AI reads/writes a field nobody can see.
+        var field = new TestField();
+        var container = new Div(field);
+        container.setVisible(false);
+        var controller = new FormAIController(new Div(container));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(0, fields.size(),
+                "Field inside an invisible container must be excluded, got: "
+                        + fields);
+    }
+
+    @Test
+    void getFormStateExcludesFieldUnderInvisibleAncestor() {
+        // The hidden ancestor may be several levels up; effective-visibility
+        // must walk the whole chain, not just the immediate parent.
+        var field = new TestField();
+        var hiddenAncestor = new Div(new Div(new Div(field)));
+        hiddenAncestor.setVisible(false);
+        var controller = new FormAIController(new Div(hiddenAncestor));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(0, fields.size(),
+                "Field under an invisible ancestor must be excluded, got: "
+                        + fields);
+    }
+
+    @Test
+    void getFormStateLabelsFieldInsideDisabledContainerAsDisabled() {
+        // Disabling a container disables the fields inside it for the user.
+        // Such a field is read-only context: it must stay listed but carry the
+        // "disabled" flag so the AI does not try to fill it.
+        var field = new TestField();
+        var container = new Div(field);
+        container.setEnabled(false);
+        var controller = new FormAIController(new Div(container));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(1, fields.size(),
+                "Field inside a disabled container must still be listed, got: "
+                        + fields);
+        Assertions.assertTrue(fields.get(0).path("disabled").asBoolean(false),
+                "Field inside a disabled container must be flagged disabled, "
+                        + "got: " + fields.get(0));
+    }
+
+    @Test
     void getFormStateLabelsDisabledFieldsAsContext() {
         // A disabled field cannot be edited by the user, but the AI should
         // still see it (with its description) so it can reason about the form,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -122,12 +122,11 @@ class FormStateToolTest {
     }
 
     @Test
-    void getFormStateOmitsDisabledFields() {
-        // A disabled field cannot be edited by the user; the AI must not fill
-        // it either. Disabling is the typical way a field is gated on another
-        // field's value (a "Seat preference" enabled only for non-Economy
-        // cabins), so the disabled field re-enters the surface once the
-        // controlling field is set and the next state read is taken.
+    void getFormStateLabelsDisabledFieldsAsContext() {
+        // A disabled field cannot be edited by the user, but the AI should
+        // still see it (with its description) so it can reason about the form,
+        // e.g. set the controlling field that enables it. The "disabled" flag
+        // tells the AI it is read-only context; fill_form rejects writes to it.
         var enabled = new TestField();
         var disabled = new TestField();
         disabled.setEnabled(false);
@@ -135,11 +134,75 @@ class FormStateToolTest {
 
         var fields = formStateFields(controller);
 
-        Assertions.assertEquals(1, fields.size(),
-                "Disabled (setEnabled(false)) field must be excluded, got: "
+        Assertions.assertEquals(2, fields.size(),
+                "Disabled field must still be listed as context, got: "
                         + fields);
-        Assertions.assertEquals(idOf(enabled),
-                fields.get(0).get("id").asString());
+        var disabledNode = fields.get(1);
+        Assertions.assertEquals(idOf(disabled),
+                disabledNode.get("id").asString());
+        Assertions.assertTrue(disabledNode.path("disabled").asBoolean(false),
+                "Disabled field must carry \"disabled\": true, got: "
+                        + disabledNode);
+        Assertions.assertFalse(fields.get(0).has("disabled"),
+                "Enabled field must not carry a disabled flag, got: "
+                        + fields.get(0));
+    }
+
+    @Test
+    void getFormStateLabelsReadOnlyFieldsAsContext() {
+        // A read-only field is visible to the user but not editable; the AI
+        // sees it as context with a "readOnly" flag and fill_form rejects
+        // writes to it.
+        var editable = new TestField();
+        var readOnly = new TestField();
+        readOnly.setReadOnly(true);
+        var controller = new FormAIController(new Div(editable, readOnly));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(2, fields.size(),
+                "Read-only field must still be listed as context, got: "
+                        + fields);
+        var readOnlyNode = fields.get(1);
+        Assertions.assertEquals(idOf(readOnly),
+                readOnlyNode.get("id").asString());
+        Assertions.assertTrue(readOnlyNode.path("readOnly").asBoolean(false),
+                "Read-only field must carry \"readOnly\": true, got: "
+                        + readOnlyNode);
+        Assertions.assertFalse(fields.get(0).has("readOnly"),
+                "Editable field must not carry a readOnly flag, got: "
+                        + fields.get(0));
+    }
+
+    @Test
+    void getFormStateDoesNotFlagTurnLockedFieldsAsReadOnly() {
+        // During a turn the controller locks every writable field read-only so
+        // the user can't race the AI. That lock must not surface as a
+        // "readOnly" context flag: only application-set read-only counts. A
+        // field the application itself set read-only keeps its flag.
+        var editable = new TestField();
+        var readOnly = new TestField();
+        readOnly.setReadOnly(true);
+        var controller = new FormAIController(new Div(editable, readOnly));
+
+        controller.onRequest(); // locks the editable field read-only
+        try {
+            var fields = formStateFields(controller);
+
+            Assertions.assertEquals(2, fields.size());
+            var editableNode = fields.get(0);
+            Assertions.assertEquals(idOf(editable),
+                    editableNode.get("id").asString());
+            Assertions.assertFalse(editableNode.has("readOnly"),
+                    "Turn-locked editable field must not be flagged readOnly, "
+                            + "got: " + editableNode);
+            Assertions.assertTrue(
+                    fields.get(1).path("readOnly").asBoolean(false),
+                    "Application-read-only field must stay flagged, got: "
+                            + fields.get(1));
+        } finally {
+            controller.onResponse(null);
+        }
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormValueConverterTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormValueConverterTest.java
@@ -547,12 +547,14 @@ class FormValueConverterTest {
 
     private static FormFieldDescriptor wrap(HasValue<?, ?> field,
             FormFieldType type) {
-        return new FormFieldDescriptor("test-id", field, type, null);
+        return new FormFieldDescriptor("test-id", field, type, null, false,
+                false);
     }
 
     private static FormFieldDescriptor wrap(HasValue<?, ?> field,
             FormFieldType type, FormFieldHints hints) {
-        return new FormFieldDescriptor("test-id", field, type, hints);
+        return new FormFieldDescriptor("test-id", field, type, hints, false,
+                false);
     }
 
     private static FormFieldHints hintsWithToValue(


### PR DESCRIPTION
## Description
The form AI controller discovered every `HasValue` in the form and offered all of them to the model through `get_form_state`, no matter their state. A field the application had hidden, disabled, or set read-only was still readable — and writable through `fill_form`. So the AI could read values off fields the user cannot see and overwrite fields the user cannot edit.

For example, an expense form shows a read-only, computed "Total" and a "Cost center" field enabled only for business trips. Before this change, a prompt like "set the total to 0 and the cost center to X" was carried out even though the user can neither edit the total nor reach the cost center.

Changes:

- Hidden fields are excluded from `get_form_state` and `fill_form`.
- Disabled and read-only fields stay in `get_form_state` as read-only context, each carrying a `"disabled"` or `"readOnly"` flag alongside its description and current value. `fill_form` rejects writes to them with a reason. This keeps context the model may need to fill other fields, while preventing edits.
- During a fill turn the controller sets every writable field read-only so the user cannot race the AI. That turn lock is excluded from the `"readOnly"` flag, so a field the controller locked is never reported as read-only to the model — only application-set read-only is.
- The model instructions explain the flags and tell the model to set a controlling field first to unlock a disabled or read-only field.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)