### PR TITLE
feat: expose per-turn session metadata to the LLM

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -619,7 +619,7 @@ public class AIOrchestrator implements Serializable {
             .ofPattern("yyyy-MM-dd'T'HH:mmXXX");
 
     /**
-     * Default supplier installed when {@link Builder#withContext} has not been
+     * Default supplier installed when {@link Builder#withMetadata} has not been
      * called. Renders the server clock as e.g.
      * {@code "Current server date and time: 2026-05-28T17:42+03:00 (Friday, Europe/Helsinki)"}
      * so the LLM can interpret relative date references without guessing.
@@ -901,7 +901,7 @@ public class AIOrchestrator implements Serializable {
      * <li>{@link #withHistory(List, Map)} – restores a previously saved
      * conversation history with attachments (from
      * {@link AIOrchestrator#getHistory()}).</li>
-     * <li>{@link #withContext(SerializableSupplier)} – sets a supplier the
+     * <li>{@link #withMetadata(SerializableSupplier)} – sets a supplier the
      * orchestrator invokes on every turn; the returned string is exposed to the
      * LLM as the description of a built-in {@code get_session_context} tool.
      * Defaults to a current-date-and-time supplier so the LLM can interpret
@@ -1268,7 +1268,7 @@ public class AIOrchestrator implements Serializable {
          *            to disable the tool entirely
          * @return this builder
          */
-        public Builder withContext(
+        public Builder withMetadata(
                 SerializableSupplier<String> contextSupplier) {
             if (contextSupplierSet) {
                 LOGGER.warn("Context supplier was already set on the "

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -902,12 +902,11 @@ public class AIOrchestrator implements Serializable {
      * conversation history with attachments (from
      * {@link AIOrchestrator#getHistory()}).</li>
      * <li>{@link #withMetadata(SerializableSupplier)} – sets a supplier the
-     * orchestrator invokes on every turn; the returned string is exposed to the
-     * LLM as the description of a built-in {@code get_session_context} tool.
-     * Defaults to a current-date-and-time supplier so the LLM can interpret
-     * relative date/time references; pass {@code null} to disable, or a custom
-     * supplier to include tenant, locale, page state, or anything else worth
-     * keeping out of the system prompt.</li>
+     * orchestrator invokes on every turn to give the LLM free-form session
+     * context. Defaults to a current-date-and-time supplier so the LLM can
+     * interpret relative date/time references; pass {@code null} to disable, or
+     * a custom supplier to include tenant, locale, page state, or anything else
+     * worth keeping out of the system prompt.</li>
      * </ul>
      * <p>
      * Both Flow components ({@link MessageInput}, {@link MessageList},
@@ -1233,39 +1232,33 @@ public class AIOrchestrator implements Serializable {
         /**
          * Sets the supplier of free-form session context the LLM sees on every
          * turn. The supplier is invoked once per turn on the UI thread when the
-         * request is being built; its return value is exposed to the LLM as the
-         * description of a built-in {@code get_session_context} tool. Because
-         * the content lives in the tool's description, a tool call is not
-         * required for the LLM to read it.
+         * request is being built.
          * <p>
          * The supplier may return any string the application wants the LLM to
          * have on hand — current date and time, the active tenant, the user's
          * locale, the page the user is on, feature flags. Compose multiple
          * pieces of context with plain string concatenation.
          * <p>
-         * If the supplier returns {@code null} or an empty/blank string, the
-         * tool is omitted for that turn — useful for "context only when X"
+         * If the supplier returns {@code null} or an empty/blank string, no
+         * context is added for that turn — useful for "context only when X"
          * patterns. If the supplier throws, the turn is aborted via the normal
          * error path: the assistant placeholder is updated to a generic error
          * message, {@link AIController#onResponse(Throwable)} fires with the
          * thrown exception, and the exception propagates to the caller of the
          * prompt entry point.
          * <p>
-         * Passing {@code null} disables the tool entirely, including the
+         * Passing {@code null} disables session context entirely, including the
          * built-in default. By default, the orchestrator installs a supplier
          * that yields the current date and time so the LLM can interpret
          * relative date/time references ("show me sales from the past two
          * months") without having to guess.
          * <p>
          * The supplier runs on the UI thread, so it can read
-         * {@link UI#getCurrent()} and session-scoped state. The resolved string
-         * is captured in the per-turn tool instance, so an LLM-driven
-         * {@code execute()} call returns the same content without re-invoking
-         * the supplier.
+         * {@link UI#getCurrent()} and session-scoped state.
          *
          * @param contextSupplier
          *            supplier of the per-turn context string, or {@code null}
-         *            to disable the tool entirely
+         *            to disable session context entirely
          * @return this builder
          */
         public Builder withMetadata(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -727,6 +727,11 @@ public class AIOrchestrator implements Serializable {
                                 + "(pattern: "
                                 + VALID_TOOL_NAME_PATTERN.pattern() + ").");
             }
+            if (SESSION_CONTEXT_TOOL_NAME.equals(name)) {
+                LOGGER.warn(
+                        "Tool name '{}' is reserved for the built-in session context tool",
+                        name);
+            }
             if (!seen.add(name)) {
                 LOGGER.warn(
                         "Duplicate tool name '{}': previous tool will be replaced",

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -18,10 +18,15 @@ package com.vaadin.flow.component.ai.orchestrator;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -53,7 +58,10 @@ import com.vaadin.flow.component.upload.Receiver;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadHelper;
 import com.vaadin.flow.component.upload.UploadManager;
+import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.server.streams.UploadHandler;
+
+import tools.jackson.databind.JsonNode;
 
 /**
  * Orchestrator for AI-powered chat interfaces.
@@ -162,6 +170,13 @@ public class AIOrchestrator implements Serializable {
         }
     }
 
+    /**
+     * Name of the built-in tool that exposes per-turn session context to the
+     * LLM. Reserved — applications should not register their own tool with this
+     * name.
+     */
+    static final String SESSION_CONTEXT_TOOL_NAME = "get_session_context";
+
     private transient LLMProvider provider;
     private final String systemPrompt;
     private AIMessageList messageList;
@@ -174,6 +189,7 @@ public class AIOrchestrator implements Serializable {
     private RequestListener requestListener;
     private AttachmentClickListener attachmentClickListener;
     private ResponseListener responseListener;
+    private SerializableSupplier<String> contextSupplier;
     private final Map<AIMessage, String> itemToMessageId = new HashMap<>();
     private final List<ChatMessage> conversationHistory = new CopyOnWriteArrayList<>();
 
@@ -528,6 +544,7 @@ public class AIOrchestrator implements Serializable {
         var controllerTools = controller != null
                 && controller.getTools() != null ? controller.getTools()
                         : List.<LLMProvider.ToolSpec> of();
+        final var explicitTools = mergeWithContextTool(controllerTools);
         return new LLMProvider.LLMRequest() {
 
             @Override
@@ -552,9 +569,112 @@ public class AIOrchestrator implements Serializable {
 
             @Override
             public List<LLMProvider.ToolSpec> explicitTools() {
-                return controllerTools;
+                return explicitTools;
             }
         };
+    }
+
+    /**
+     * Resolves the configured {@link Supplier} for session context and, if it
+     * returns non-empty content, prepends a {@value #SESSION_CONTEXT_TOOL_NAME}
+     * tool that carries that content in its description. The resolved string is
+     * captured in the per-turn tool instance so {@code execute()} can return it
+     * without re-invoking the supplier off the UI thread.
+     * <p>
+     * A supplier that throws aborts the turn — the exception propagates through
+     * {@link #buildRequest} and is handled by the existing error path in
+     * {@link #processUserInput}.
+     */
+    private List<LLMProvider.ToolSpec> mergeWithContextTool(
+            List<LLMProvider.ToolSpec> controllerTools) {
+        if (contextSupplier == null) {
+            return controllerTools;
+        }
+        var resolved = contextSupplier.get();
+        if (resolved == null || resolved.isBlank()) {
+            return controllerTools;
+        }
+        var contextTool = buildSessionContextTool(resolved);
+        var merged = new ArrayList<LLMProvider.ToolSpec>(
+                controllerTools.size() + 1);
+        merged.add(contextTool);
+        merged.addAll(controllerTools);
+        return List.copyOf(merged);
+    }
+
+    /**
+     * Builds the per-turn {@value #SESSION_CONTEXT_TOOL_NAME} tool. The
+     * resolved content is baked into the description so the LLM sees it just
+     * from listing the available tools — no separate call is normally needed.
+     * {@link LLMProvider.ToolSpec#execute} returns the same content so a model
+     * that does call the tool gets exactly what the description already
+     * carries.
+     */
+    private static LLMProvider.ToolSpec buildSessionContextTool(
+            String content) {
+        return new SessionContextTool(content);
+    }
+
+    private static final DateTimeFormatter DEFAULT_CONTEXT_DATE_TIME_FORMAT = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mmXXX");
+
+    /**
+     * Default supplier installed when {@link Builder#withContext} has not been
+     * called. Renders the server clock as e.g.
+     * {@code "Current server date and time: 2026-05-28T17:42+03:00 (Friday, Europe/Helsinki)"}
+     * so the LLM can interpret relative date references without guessing.
+     */
+    private static SerializableSupplier<String> defaultContextSupplier() {
+        return () -> {
+            var now = ZonedDateTime.now();
+            var dayOfWeek = now.getDayOfWeek().getDisplayName(TextStyle.FULL,
+                    Locale.ENGLISH);
+            return String.format("Current server date and time: %s (%s, %s)",
+                    now.format(DEFAULT_CONTEXT_DATE_TIME_FORMAT), dayOfWeek,
+                    now.getZone().getId());
+        };
+    }
+
+    /**
+     * Per-turn {@link LLMProvider.ToolSpec} that surfaces the resolved session
+     * context. {@link Serializable} so the orchestrator's per-turn explicit
+     * tools list does not break the serialization round-trip test even though
+     * tools themselves are rebuilt on every turn.
+     */
+    private static final class SessionContextTool
+            implements LLMProvider.ToolSpec, Serializable {
+        private final String content;
+        private final String description;
+
+        SessionContextTool(String content) {
+            this.content = content;
+            this.description = """
+                    Read for current session context (e.g. date and time, user \
+                    locale). The content below is captured at the start of \
+                    this turn:
+
+                    """ + content;
+        }
+
+        @Override
+        public String getName() {
+            return SESSION_CONTEXT_TOOL_NAME;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public String getParametersSchema() {
+            return null;
+        }
+
+        @Override
+        public String execute(JsonNode arguments) {
+            return content;
+        }
     }
 
     private void fireResponseListener(String responseText, Throwable error,
@@ -781,6 +901,13 @@ public class AIOrchestrator implements Serializable {
      * <li>{@link #withHistory(List, Map)} – restores a previously saved
      * conversation history with attachments (from
      * {@link AIOrchestrator#getHistory()}).</li>
+     * <li>{@link #withContext(SerializableSupplier)} – sets a supplier the
+     * orchestrator invokes on every turn; the returned string is exposed to the
+     * LLM as the description of a built-in {@code get_session_context} tool.
+     * Defaults to a current-date-and-time supplier so the LLM can interpret
+     * relative date/time references; pass {@code null} to disable, or a custom
+     * supplier to include tenant, locale, page state, or anything else worth
+     * keeping out of the system prompt.</li>
      * </ul>
      * <p>
      * Both Flow components ({@link MessageInput}, {@link MessageList},
@@ -804,6 +931,8 @@ public class AIOrchestrator implements Serializable {
         private ResponseListener responseListener;
         private List<ChatMessage> history;
         private Map<String, List<AIAttachment>> historyAttachments;
+        private SerializableSupplier<String> contextSupplier;
+        private boolean contextSupplierSet;
 
         private Builder(LLMProvider provider, String systemPrompt) {
             Objects.requireNonNull(provider, "Provider cannot be null");
@@ -1102,6 +1231,55 @@ public class AIOrchestrator implements Serializable {
         }
 
         /**
+         * Sets the supplier of free-form session context the LLM sees on every
+         * turn. The supplier is invoked once per turn on the UI thread when the
+         * request is being built; its return value is exposed to the LLM as the
+         * description of a built-in {@code get_session_context} tool. Because
+         * the content lives in the tool's description, a tool call is not
+         * required for the LLM to read it.
+         * <p>
+         * The supplier may return any string the application wants the LLM to
+         * have on hand — current date and time, the active tenant, the user's
+         * locale, the page the user is on, feature flags. Compose multiple
+         * pieces of context with plain string concatenation.
+         * <p>
+         * If the supplier returns {@code null} or an empty/blank string, the
+         * tool is omitted for that turn — useful for "context only when X"
+         * patterns. If the supplier throws, the turn is aborted via the normal
+         * error path: the assistant placeholder is updated to a generic error
+         * message, {@link AIController#onResponse(Throwable)} fires with the
+         * thrown exception, and the exception propagates to the caller of the
+         * prompt entry point.
+         * <p>
+         * Passing {@code null} disables the tool entirely, including the
+         * built-in default. By default, the orchestrator installs a supplier
+         * that yields the current date and time so the LLM can interpret
+         * relative date/time references ("show me sales from the past two
+         * months") without having to guess.
+         * <p>
+         * The supplier runs on the UI thread, so it can read
+         * {@link UI#getCurrent()} and session-scoped state. The resolved string
+         * is captured in the per-turn tool instance, so an LLM-driven
+         * {@code execute()} call returns the same content without re-invoking
+         * the supplier.
+         *
+         * @param contextSupplier
+         *            supplier of the per-turn context string, or {@code null}
+         *            to disable the tool entirely
+         * @return this builder
+         */
+        public Builder withContext(
+                SerializableSupplier<String> contextSupplier) {
+            if (contextSupplierSet) {
+                LOGGER.warn("Context supplier was already set on the "
+                        + "builder and will be replaced");
+            }
+            this.contextSupplier = contextSupplier;
+            this.contextSupplierSet = true;
+            return this;
+        }
+
+        /**
          * Sets the conversation history and associated attachments to restore
          * when the orchestrator is built. This restores the LLM provider's
          * conversation context (including multimodal content), the message list
@@ -1151,6 +1329,8 @@ public class AIOrchestrator implements Serializable {
             orchestrator.requestListener = requestListener;
             orchestrator.attachmentClickListener = attachmentClickListener;
             orchestrator.responseListener = responseListener;
+            orchestrator.contextSupplier = contextSupplierSet ? contextSupplier
+                    : defaultContextSupplier();
             try {
                 if (input != null) {
                     input.addSubmitListener(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -332,7 +332,7 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
         var tool1 = createToolSpec("originalTool", "Original");
         AIController originalController = createController(tool1);
 
-        // Build without mocks (no message list) so it can serialize
+        // Build without mocks (no message list) so it can serialize.
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withController(originalController).build();
 
@@ -347,9 +347,14 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(newProvider).stream(captor.capture());
-        var explicitTools = captor.getValue().explicitTools();
-        Assertions.assertEquals(1, explicitTools.size());
-        Assertions.assertEquals("newTool", explicitTools.getFirst().getName());
+        var toolNames = captor.getValue().explicitTools().stream()
+                .map(LLMProvider.ToolSpec::getName).toList();
+        Assertions.assertTrue(toolNames.contains("newTool"),
+                "Reconnect should install the new controller's tool; got: "
+                        + toolNames);
+        Assertions.assertFalse(toolNames.contains("originalTool"),
+                "Reconnect should drop the previous controller's tool; got: "
+                        + toolNames);
     }
 
     private static AIController createController(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2715,6 +2715,22 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void withController_reservedSessionContextToolName_logsWarning() {
+        var reserved = createToolSpec("get_session_context", "Clashing tool");
+        AIController controller = createController(reserved);
+
+        AIOrchestrator.builder(mockProvider, null).withController(controller);
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage().equals(
+                        "Tool name '{}' is reserved for the built-in session context tool"))
+                .findFirst();
+
+        Assertions.assertTrue(warning.isPresent(),
+                "Using the reserved tool name should log a warning");
+    }
+
+    @Test
     void builder_withNullToolName_throwsIllegalArgumentException() {
         var controller = createController(createToolSpec(null, "A tool"));
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -443,7 +443,7 @@ class AIOrchestratorTest {
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList).withController(controller)
-                .build();
+                .withContext(null).build();
         orchestrator.prompt("do it");
 
         Mockito.verify(fakeTool).execute(Mockito.any());
@@ -1957,7 +1957,7 @@ class AIOrchestratorTest {
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList).withController(controller)
-                .build();
+                .withContext(null).build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
@@ -2485,7 +2485,171 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withNoControllers_explicitToolsIsEmpty() {
+    void prompt_byDefault_includesSessionContextToolWithCurrentDateTime() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var tools = captor.getValue().explicitTools();
+        Assertions.assertEquals(1, tools.size());
+        var contextTool = tools.get(0);
+        Assertions.assertEquals("get_session_context", contextTool.getName());
+        Assertions.assertTrue(
+                contextTool.getDescription()
+                        .contains("Current server date and time:"),
+                "Default supplier should render a date/time line; got: "
+                        + contextTool.getDescription());
+    }
+
+    @Test
+    void prompt_withCustomContextSupplier_replacesDefaultAndExposesContent() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withContext(() -> "Tenant: acme").build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var tools = captor.getValue().explicitTools();
+        Assertions.assertEquals(1, tools.size());
+        var contextTool = tools.get(0);
+        Assertions.assertTrue(
+                contextTool.getDescription().contains("Tenant: acme"),
+                "Custom supplier value should appear in the description; got: "
+                        + contextTool.getDescription());
+        Assertions.assertFalse(
+                contextTool.getDescription()
+                        .contains("Current server date and time:"),
+                "Custom supplier should fully replace the default; got: "
+                        + contextTool.getDescription());
+        Assertions.assertEquals("Tenant: acme", contextTool.execute(null),
+                "execute should return the same content the description shows");
+    }
+
+    @Test
+    void prompt_withNullContext_omitsSessionContextTool() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withContext(null).build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
+                "withContext(null) should suppress the built-in tool");
+    }
+
+    @Test
+    void prompt_withContextSupplierReturningBlank_omitsSessionContextTool() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withContext(() -> "   ")
+                .build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
+                "Empty/blank supplier output should suppress the tool for that turn");
+    }
+
+    @Test
+    void prompt_withContextAndController_mergesContextFirst() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var tool1 = createToolSpec("tool1", "First controller tool");
+        var controller = createController(tool1);
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withController(controller)
+                .withContext(() -> "Tenant: acme").build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var tools = captor.getValue().explicitTools();
+        Assertions.assertEquals(2, tools.size());
+        Assertions.assertEquals("get_session_context", tools.get(0).getName());
+        Assertions.assertEquals("tool1", tools.get(1).getName());
+    }
+
+    @Test
+    void prompt_withContextSupplier_invokedOncePerTurn() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var callCount = new AtomicInteger();
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withContext(() -> {
+                    callCount.incrementAndGet();
+                    return "tick " + callCount.get();
+                }).build();
+
+        orchestrator.prompt("first");
+        orchestrator.prompt("second");
+
+        Assertions.assertEquals(2, callCount.get(),
+                "Supplier should be invoked once per prompt");
+    }
+
+    @Test
+    void prompt_withContextSupplierThrowing_abortsTurn() {
+        stubAddMessage();
+        var thrown = new RuntimeException("context supplier failed");
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withContext(() -> {
+                    throw thrown;
+                }).build();
+
+        var caught = Assertions.assertThrows(RuntimeException.class,
+                () -> orchestrator.prompt("Hello"));
+        Assertions.assertSame(thrown, caught);
+
+        Mockito.verify(mockProvider, Mockito.never())
+                .stream(Mockito.any(LLMProvider.LLMRequest.class));
+        Assertions.assertTrue(orchestrator.getHistory().isEmpty(),
+                "Aborted turn must not leave the user message in history");
+    }
+
+    @Test
+    void builder_withContextCalledTwice_logsWarning() {
+        AIOrchestrator.builder(mockProvider, null).withContext(() -> "first")
+                .withContext(() -> "second");
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(e -> e.getMessage()
+                        .contains("Context supplier was already set"))
+                .findFirst();
+        Assertions.assertTrue(warning.isPresent(),
+                "Second withContext call should log a replacement warning");
+    }
+
+    @Test
+    void builder_withNoControllersAndNoContext_explicitToolsIsEmpty() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))
@@ -2495,7 +2659,7 @@ class AIOrchestratorTest {
                 .thenReturn(Flux.just("Response"));
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).build();
+                .withMessageList(mockMessageList).withContext(null).build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
@@ -2711,7 +2875,7 @@ class AIOrchestratorTest {
         Set<String> nonResourceSetters = Set.of("withTools", "withUserName",
                 "withAssistantName", "withRequestListener",
                 "withAttachmentClickListener", "withResponseListener",
-                "withHistory");
+                "withHistory", "withContext");
 
         // Provider is set via the factory method, not a with-method.
         assertClaimed(null, LLMProvider.class);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -443,7 +443,7 @@ class AIOrchestratorTest {
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList).withController(controller)
-                .withContext(null).build();
+                .withMetadata(null).build();
         orchestrator.prompt("do it");
 
         Mockito.verify(fakeTool).execute(Mockito.any());
@@ -1957,7 +1957,7 @@ class AIOrchestratorTest {
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList).withController(controller)
-                .withContext(null).build();
+                .withMetadata(null).build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
@@ -2517,7 +2517,7 @@ class AIOrchestratorTest {
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList)
-                .withContext(() -> "Tenant: acme").build();
+                .withMetadata(() -> "Tenant: acme").build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
@@ -2546,24 +2546,24 @@ class AIOrchestratorTest {
                 .thenReturn(Flux.just("Response"));
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withContext(null).build();
+                .withMessageList(mockMessageList).withMetadata(null).build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
         Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
-                "withContext(null) should suppress the built-in tool");
+                "withMetadata(null) should suppress the built-in tool");
     }
 
     @Test
-    void prompt_withContextSupplierReturningBlank_omitsSessionContextTool() {
+    void prompt_withMetadataSupplierReturningBlank_omitsSessionContextTool() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
                 .thenReturn(Flux.just("Response"));
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withContext(() -> "   ")
+                .withMessageList(mockMessageList).withMetadata(() -> "   ")
                 .build();
         orchestrator.prompt("Hello");
 
@@ -2574,7 +2574,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void prompt_withContextAndController_mergesContextFirst() {
+    void prompt_withMetadataAndController_mergesContextFirst() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2584,7 +2584,7 @@ class AIOrchestratorTest {
         var controller = createController(tool1);
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList).withController(controller)
-                .withContext(() -> "Tenant: acme").build();
+                .withMetadata(() -> "Tenant: acme").build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
@@ -2596,7 +2596,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void prompt_withContextSupplier_invokedOncePerTurn() {
+    void prompt_withMetadataSupplier_invokedOncePerTurn() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2604,7 +2604,7 @@ class AIOrchestratorTest {
 
         var callCount = new AtomicInteger();
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withContext(() -> {
+                .withMessageList(mockMessageList).withMetadata(() -> {
                     callCount.incrementAndGet();
                     return "tick " + callCount.get();
                 }).build();
@@ -2617,11 +2617,11 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void prompt_withContextSupplierThrowing_abortsTurn() {
+    void prompt_withMetadataSupplierThrowing_abortsTurn() {
         stubAddMessage();
         var thrown = new RuntimeException("context supplier failed");
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withContext(() -> {
+                .withMessageList(mockMessageList).withMetadata(() -> {
                     throw thrown;
                 }).build();
 
@@ -2636,16 +2636,16 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void builder_withContextCalledTwice_logsWarning() {
-        AIOrchestrator.builder(mockProvider, null).withContext(() -> "first")
-                .withContext(() -> "second");
+    void builder_withMetadataCalledTwice_logsWarning() {
+        AIOrchestrator.builder(mockProvider, null).withMetadata(() -> "first")
+                .withMetadata(() -> "second");
 
         var warning = logger.getLoggingEvents().stream()
                 .filter(e -> e.getMessage()
                         .contains("Context supplier was already set"))
                 .findFirst();
         Assertions.assertTrue(warning.isPresent(),
-                "Second withContext call should log a replacement warning");
+                "Second withMetadata call should log a replacement warning");
     }
 
     @Test
@@ -2659,7 +2659,7 @@ class AIOrchestratorTest {
                 .thenReturn(Flux.just("Response"));
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withContext(null).build();
+                .withMessageList(mockMessageList).withMetadata(null).build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
@@ -2875,7 +2875,7 @@ class AIOrchestratorTest {
         Set<String> nonResourceSetters = Set.of("withTools", "withUserName",
                 "withAssistantName", "withRequestListener",
                 "withAttachmentClickListener", "withResponseListener",
-                "withHistory", "withContext");
+                "withHistory", "withMetadata");
 
         // Provider is set via the factory method, not a with-method.
         assertClaimed(null, LLMProvider.class);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2574,6 +2574,24 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void prompt_withMetadataSupplierReturningNull_omitsSessionContextTool() {
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withMetadata(() -> null)
+                .build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
+                "Null supplier output should suppress the tool for that turn");
+    }
+
+    @Test
     void prompt_withMetadataAndController_mergesContextFirst() {
         stubAddMessage();
         Mockito.when(


### PR DESCRIPTION
## Summary
- The LLM needs ambient session context — current date/time, and optionally tenant, locale, or view state — to interpret relative references like "sales from the past two months" instead of guessing. Putting that in the system prompt would invalidate its cache every turn, so it rides on a built-in get_session_context tool whose description carries the content, keeping the (potentially large) system prompt cacheable.
- The orchestrator installs a default supplier that provides the current server date and time; withMetadata lets apps replace or extend it with their own context, or pass null to disable the tool entirely.

Closes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=193058102

🤖 Generated with [Claude Code](https://claude.com/claude-code)