### PR TITLE
fix: clear only the column's own filters in spreadsheet popup

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFilterTable.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFilterTable.java
@@ -159,11 +159,32 @@ public class SpreadsheetFilterTable extends SpreadsheetTable {
     }
 
     /**
+     * Clears the filters of the column the given pop-up button belongs to.
+     * Other columns' filters are left intact.
+     *
+     * @param popupButton
+     *            The pop-up button whose column filters should be cleared
+     */
+    public void clearFilters(PopupButton popupButton) {
+        HashSet<SpreadsheetFilter> filters = popupButtonToFiltersMap
+                .get(popupButton);
+        if (filters != null) {
+            for (SpreadsheetFilter filter : filters) {
+                filter.clearFilter();
+            }
+        }
+        // Recomputes hidden rows from the remaining filters and updates the
+        // pop-up button / clear button states.
+        onFiltersUpdated();
+    }
+
+    /**
      * Creates the "Clear filters" buttons for the pop-ups.
      */
     protected void initClearAllButtons() {
         for (PopupButton popupButton : getPopupButtons()) {
             Button clearButton = createClearButton();
+            clearButton.addClickListener(event -> clearFilters(popupButton));
             addComponentToPopup(popupButton, clearButton);
             popupButtonToClearButtonMap.put(popupButton, clearButton);
         }
@@ -206,7 +227,9 @@ public class SpreadsheetFilterTable extends SpreadsheetTable {
 
     /**
      * Creates a "Clear filters" button. It has the
-     * {@value #CLEAR_FILTERS_BUTTON_CLASSNAME} class name.
+     * {@value #CLEAR_FILTERS_BUTTON_CLASSNAME} class name. The click listener
+     * that clears the column's filters is attached in
+     * {@link #initClearAllButtons()}.
      *
      * @return Button for clearing the filters
      */
@@ -217,7 +240,6 @@ public class SpreadsheetFilterTable extends SpreadsheetTable {
         button.addThemeVariants(ButtonVariant.LUMO_TERTIARY,
                 ButtonVariant.SMALL);
         button.addClassName(CLEAR_FILTERS_BUTTON_CLASSNAME);
-        button.addClickListener(event -> clearAllFilters());
         return button;
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
@@ -120,6 +120,27 @@ class FilterTableTest {
     }
 
     @Test
+    void filterTwoColumns_clearOneColumn_otherColumnFilterRetained() {
+        // Column 1 value "3" is in row 2, column 2 value "7" is in row 5
+        getFilterCheckboxGroup(1).deselect("3");
+        getFilterCheckboxGroup(2).deselect("7");
+
+        getClearButton(1).click();
+
+        // Column 1 filter is cleared
+        Assertions.assertEquals(0, getItemFilter(1).getFilteredRows().size());
+        Assertions.assertFalse(spreadsheet.isRowHidden(2));
+        Assertions.assertFalse(getClearButton(1).isEnabled());
+        Assertions.assertFalse(getPopupButton(1).isActive());
+
+        // Column 2 filter is retained
+        Assertions.assertEquals(1, getItemFilter(2).getFilteredRows().size());
+        Assertions.assertTrue(spreadsheet.isRowHidden(5));
+        Assertions.assertTrue(getClearButton(2).isEnabled());
+        Assertions.assertTrue(getPopupButton(2).isActive());
+    }
+
+    @Test
     void filter_clearAndReload_filtersCleared() {
         getFilterCheckboxGroup().deselect("4");
         table.clear();
@@ -158,25 +179,41 @@ class FilterTableTest {
     }
 
     private CheckboxGroup<String> getFilterCheckboxGroup() {
-        return (CheckboxGroup<String>) getItemFilter().getChildren()
+        return getFilterCheckboxGroup(1);
+    }
+
+    private CheckboxGroup<String> getFilterCheckboxGroup(int column) {
+        return (CheckboxGroup<String>) getItemFilter(column).getChildren()
                 .filter(component -> component instanceof CheckboxGroup)
                 .findFirst().get();
     }
 
     private ItemFilter getItemFilter() {
-        return (ItemFilter) getPopupButtonChildren().get(0);
+        return getItemFilter(1);
+    }
+
+    private ItemFilter getItemFilter(int column) {
+        return (ItemFilter) getPopupButtonChildren(column).get(0);
     }
 
     private Button getClearButton() {
-        return (Button) getPopupButtonChildren().get(1);
+        return getClearButton(1);
     }
 
-    private List<Component> getPopupButtonChildren() {
-        return getPopupButton().getContent().getChildren()
+    private Button getClearButton(int column) {
+        return (Button) getPopupButtonChildren(column).get(1);
+    }
+
+    private List<Component> getPopupButtonChildren(int column) {
+        return getPopupButton(column).getContent().getChildren()
                 .collect(Collectors.toList());
     }
 
     private PopupButton getPopupButton() {
-        return table.getPopupButton(1);
+        return getPopupButton(1);
+    }
+
+    private PopupButton getPopupButton(int column) {
+        return table.getPopupButton(column);
     }
 }


### PR DESCRIPTION
The "Clear filters" button shown inside a column's filter pop-up cleared the filters of every column, not just the column it belongs to. The class already documents the per-column behavior ("clears all the filters for that column"), so the button was not doing what it promised.

## Reproduction

1. Add a `SpreadsheetFilterTable` spanning several columns.
2. Filter column A and, separately, filter column B.
3. Open column A's pop-up and click "Clear filters".

Both columns' filters are cleared. Only column A's filter should be.

## Changes

- Add `clearFilters(PopupButton)` that clears only the filters of the column the given pop-up belongs to, then recomputes the hidden rows from the remaining filters via `onFiltersUpdated()`.
- Wire each column's clear button to this method in `initClearAllButtons()`. `createClearButton()` no longer attaches the listener.
- `clearAllFilters()` is unchanged and still used by `Spreadsheet.deleteTable`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)