### PR TITLE
feat: add field highlighting for ai updated fields

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-field-highlighter-flow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-flow-components-base</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FieldValueChange.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FieldValueChange.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.form;
+
+import java.io.Serializable;
+
+/**
+ * Captures the before / after values of a single field across one
+ * {@link FormAIController} turn. Reported through
+ * {@link FormAIController#withFieldValuesChanged} for every field whose value
+ * changed during the turn — either written by the LLM or by a cascade.
+ *
+ * @param oldValue
+ *            the field's value at the start of the turn, possibly {@code null}
+ * @param newValue
+ *            the field's value at the end of the turn, possibly {@code null}
+ *
+ * @author Vaadin Ltd
+ */
+public record FieldValueChange(Object oldValue,
+        Object newValue) implements Serializable {
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FieldValueChange.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FieldValueChange.java
@@ -17,12 +17,16 @@ package com.vaadin.flow.component.ai.form;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.component.HasValue;
+
 /**
  * Captures the before / after values of a single field across one
  * {@link FormAIController} turn. Reported through
- * {@link FormAIController#withFieldValuesChanged} for every field whose value
- * changed during the turn — either written by the LLM or by a cascade.
+ * {@link FormAIController#addFieldValueChangedListener} for every field whose
+ * value changed during the turn — either written by the LLM or by a cascade.
  *
+ * @param field
+ *            the field whose value changed
  * @param oldValue
  *            the field's value at the start of the turn, possibly {@code null}
  * @param newValue
@@ -30,6 +34,6 @@ import java.io.Serializable;
  *
  * @author Vaadin Ltd
  */
-public record FieldValueChange(Object oldValue,
+public record FieldValueChange(HasValue<?, ?> field, Object oldValue,
         Object newValue) implements Serializable {
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -467,16 +467,14 @@ public class FormAIController implements AIController {
      * @param field
      *            the field to highlight, not {@code null}; must be a
      *            {@link Component}
-     * @return this controller, for chaining
      * @throws NullPointerException
      *             if {@code field} is {@code null}
      * @throws IllegalArgumentException
      *             if {@code field} is not a {@link Component}
      */
-    public FormAIController showHighlight(HasValue<?, ?> field) {
+    public void showHighlight(HasValue<?, ?> field) {
         FormFieldHighlighter.show(requireFieldComponent(field).getElement(),
                 aiUserId);
-        return this;
     }
 
     /**
@@ -490,16 +488,14 @@ public class FormAIController implements AIController {
      * @param field
      *            the field to clear the highlight from, not {@code null}; must
      *            be a {@link Component}
-     * @return this controller, for chaining
      * @throws NullPointerException
      *             if {@code field} is {@code null}
      * @throws IllegalArgumentException
      *             if {@code field} is not a {@link Component}
      */
-    public FormAIController hideHighlight(HasValue<?, ?> field) {
+    public void hideHighlight(HasValue<?, ?> field) {
         FormFieldHighlighter.hide(requireFieldComponent(field).getElement(),
                 aiUserId);
-        return this;
     }
 
     private static Component requireFieldComponent(HasValue<?, ?> field) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -118,6 +119,14 @@ import tools.jackson.databind.JsonNode;
  * still writes the field, and the lock is released at turn end regardless.
  * Applications should avoid toggling read-only state during a fill turn, or
  * reapply it after the turn completes.
+ * </p>
+ *
+ * <p>
+ * <b>Change tracking and highlight:</b> a handler registered through
+ * {@link #withFieldValuesChanged(Consumer)} fires once per successful turn with
+ * the fields whose value changed during the turn — the common driver for
+ * {@link #showHighlight(HasValue)} / {@link #hideHighlight} to flash the AI's
+ * edits in the UI.
  * </p>
  *
  * <p>
@@ -213,6 +222,9 @@ public class FormAIController implements AIController {
     private final Binder<?> binder;
     private final Map<String, FormFieldHints> hintsById = new HashMap<>();
     private final List<HasValue<?, ?>> lockedFields = new ArrayList<>();
+    private final Map<HasValue<?, ?>, Object> preTurnValues = new LinkedHashMap<>();
+    private final String aiUserId = "vaadin-ai-" + UUID.randomUUID();
+    private Consumer<Map<HasValue<?, ?>, FieldValueChange>> fieldValuesChangedHandler;
 
     /**
      * Creates a new form AI controller for the given container. Fields are
@@ -405,6 +417,100 @@ public class FormAIController implements AIController {
         return this;
     }
 
+    /**
+     * Registers a handler that is invoked once per successful turn with the
+     * fields whose value differs from what was read at the start of the turn.
+     * Comparison is by {@link Objects#equals(Object, Object)} so multi-select
+     * sets, dates, and other value-objects work naturally.
+     * <p>
+     * Only fields visible to the LLM (non-ignored discovered fields) are
+     * tracked, and only changed fields appear in the map. The handler is not
+     * called when the turn ended in error or when no field changed. The map
+     * iterates in document order; modifying it has no effect on the controller.
+     * <p>
+     * The handler runs on the UI thread with the session lock held, so it can
+     * update components and call {@link #showHighlight} /
+     * {@link #hideHighlight} directly without {@code ui.access(...)}. A typical
+     * use is to flash the AI's edits by calling {@code showHighlight} on every
+     * changed field.
+     *
+     * @param handler
+     *            handler invoked with the per-field {@link FieldValueChange}
+     *            entries, or {@code null} to remove a previously registered
+     *            handler
+     * @return this controller, for chaining
+     */
+    public FormAIController withFieldValuesChanged(
+            Consumer<Map<HasValue<?, ?>, FieldValueChange>> handler) {
+        this.fieldValuesChangedHandler = handler;
+        return this;
+    }
+
+    /**
+     * Paints a highlight on the field via the {@code vaadin-field-highlighter}
+     * web component. Repeated calls keep exactly one highlight on the field.
+     * Call {@link #hideHighlight} to clear it. The field can be any
+     * {@link HasValue} {@link Component}, in or out of this controller's form,
+     * and each field's highlight state is independent of the others.
+     * <p>
+     * The AI user added to the field carries a UUID id unique to this
+     * controller, so the highlight coexists with any other
+     * {@code vaadin-field-highlighter} users the application keeps on the field
+     * (e.g. from a collaboration session) as long as those consumers also use
+     * {@code addUser} / {@code removeUser} rather than {@code setUsers}.
+     * <p>
+     * The highlight is not retained across detach/re-attach: a detached field's
+     * client-side state is discarded, and re-attaching produces a fresh element
+     * with no highlight. Call {@code showHighlight} again if the field leaves
+     * and returns to the DOM.
+     *
+     * @param field
+     *            the field to highlight, not {@code null}; must be a
+     *            {@link Component}
+     * @return this controller, for chaining
+     * @throws NullPointerException
+     *             if {@code field} is {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code field} is not a {@link Component}
+     */
+    public FormAIController showHighlight(HasValue<?, ?> field) {
+        FormFieldHighlighter.show(requireFieldComponent(field).getElement(),
+                aiUserId);
+        return this;
+    }
+
+    /**
+     * Clears any highlight previously applied to the field via
+     * {@link #showHighlight}. A no-op when no highlight is currently shown.
+     * Only this controller's AI user is removed; other users on the field stay
+     * highlighted. The field can be any {@link HasValue} {@link Component}, in
+     * or out of this controller's form, and clearing one field's highlight has
+     * no effect on others.
+     *
+     * @param field
+     *            the field to clear the highlight from, not {@code null}; must
+     *            be a {@link Component}
+     * @return this controller, for chaining
+     * @throws NullPointerException
+     *             if {@code field} is {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code field} is not a {@link Component}
+     */
+    public FormAIController hideHighlight(HasValue<?, ?> field) {
+        FormFieldHighlighter.hide(requireFieldComponent(field).getElement(),
+                aiUserId);
+        return this;
+    }
+
+    private static Component requireFieldComponent(HasValue<?, ?> field) {
+        Objects.requireNonNull(field, "Field must not be null");
+        if (!(field instanceof Component component)) {
+            throw new IllegalArgumentException(
+                    "Field must be a Component: " + field.getClass().getName());
+        }
+        return component;
+    }
+
     @Override
     public List<LLMProvider.ToolSpec> getTools() {
         var tools = new ArrayList<LLMProvider.ToolSpec>();
@@ -457,14 +563,68 @@ public class FormAIController implements AIController {
         attachIds();
         seedDescriptionsFromBinder();
         lockFields();
+        snapshotPreTurnValues();
     }
 
     @Override
     public void onResponse(Throwable error) {
-        // Unlock regardless of success or failure: locks set in onRequest
-        // must be released so the user can edit again. The failure path
-        // doesn't have any committed state to discard.
-        unlockFields();
+        try {
+            fireFieldValuesChanged(error);
+        } finally {
+            // Unlock regardless of success or failure: locks set in onRequest
+            // must be released so the user can edit again. The failure path
+            // doesn't have any committed state to discard.
+            unlockFields();
+        }
+    }
+
+    /**
+     * Captures the current value of every active field before the LLM runs. The
+     * snapshot is consulted in {@link #onResponse} to compute the before /
+     * after diff for {@link #withFieldValuesChanged}. Skipped when no handler
+     * is registered to avoid copying values that no one will read.
+     */
+    private void snapshotPreTurnValues() {
+        preTurnValues.clear();
+        if (fieldValuesChangedHandler == null) {
+            return;
+        }
+        for (var field : collectActiveFields()) {
+            preTurnValues.put(field, field.getValue());
+        }
+    }
+
+    /**
+     * Builds the change map from the pre-turn snapshot and the current field
+     * values, then invokes the registered handler if anything changed. On error
+     * the snapshot is discarded and the handler does not fire — the application
+     * learns about errors through the orchestrator's response listener instead.
+     * A throwing handler is logged and otherwise ignored so the rest of the
+     * response lifecycle (notably {@link #unlockFields}) still runs.
+     */
+    private void fireFieldValuesChanged(Throwable error) {
+        if (preTurnValues.isEmpty() || error != null) {
+            preTurnValues.clear();
+            return;
+        }
+        var changes = new LinkedHashMap<HasValue<?, ?>, FieldValueChange>();
+        for (var entry : preTurnValues.entrySet()) {
+            var field = entry.getKey();
+            var oldValue = entry.getValue();
+            var newValue = field.getValue();
+            if (!Objects.equals(oldValue, newValue)) {
+                changes.put(field, new FieldValueChange(oldValue, newValue));
+            }
+        }
+        preTurnValues.clear();
+        if (changes.isEmpty()) {
+            return;
+        }
+        try {
+            fieldValuesChangedHandler.accept(changes);
+        } catch (Exception ex) {
+            LOGGER.warn("Field-values-changed handler threw an exception", ex);
+        }
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -123,10 +123,10 @@ import tools.jackson.databind.JsonNode;
  *
  * <p>
  * <b>Change tracking and highlight:</b> a handler registered through
- * {@link #withFieldValuesChanged(Consumer)} fires once per successful turn with
- * the fields whose value changed during the turn — the common driver for
- * {@link #showHighlight(HasValue)} / {@link #hideHighlight} to flash the AI's
- * edits in the UI.
+ * {@link #addFieldValueChangedListener(Consumer)} fires once per successful
+ * turn with the fields whose value changed during the turn — the common driver
+ * for {@link #showHighlight(HasValue)} / {@link #hideHighlight} to flash the
+ * AI's edits in the UI.
  * </p>
  *
  * <p>
@@ -224,7 +224,7 @@ public class FormAIController implements AIController {
     private final List<HasValue<?, ?>> lockedFields = new ArrayList<>();
     private final Map<HasValue<?, ?>, Object> preTurnValues = new LinkedHashMap<>();
     private final String aiUserId = "vaadin-ai-" + UUID.randomUUID();
-    private Consumer<Map<HasValue<?, ?>, FieldValueChange>> fieldValuesChangedHandler;
+    private Consumer<List<FieldValueChange>> fieldValuesChangedHandler;
 
     /**
      * Creates a new form AI controller for the given container. Fields are
@@ -424,8 +424,8 @@ public class FormAIController implements AIController {
      * sets, dates, and other value-objects work naturally.
      * <p>
      * Only fields visible to the LLM (non-ignored discovered fields) are
-     * tracked, and only changed fields appear in the map. The handler is not
-     * called when the turn ended in error or when no field changed. The map
+     * tracked, and only changed fields appear in the list. The handler is not
+     * called when the turn ended in error or when no field changed. The list
      * iterates in document order; modifying it has no effect on the controller.
      * <p>
      * The handler runs on the UI thread with the session lock held, so it can
@@ -440,8 +440,8 @@ public class FormAIController implements AIController {
      *            handler
      * @return this controller, for chaining
      */
-    public FormAIController withFieldValuesChanged(
-            Consumer<Map<HasValue<?, ?>, FieldValueChange>> handler) {
+    public FormAIController addFieldValueChangedListener(
+            Consumer<List<FieldValueChange>> handler) {
         this.fieldValuesChangedHandler = handler;
         return this;
     }
@@ -577,8 +577,8 @@ public class FormAIController implements AIController {
     /**
      * Captures the current value of every active field before the LLM runs. The
      * snapshot is consulted in {@link #onResponse} to compute the before /
-     * after diff for {@link #withFieldValuesChanged}. Skipped when no handler
-     * is registered to avoid copying values that no one will read.
+     * after diff for {@link #addFieldValueChangedListener}. Skipped when no
+     * handler is registered to avoid copying values that no one will read.
      */
     private void snapshotPreTurnValues() {
         preTurnValues.clear();
@@ -603,13 +603,13 @@ public class FormAIController implements AIController {
             preTurnValues.clear();
             return;
         }
-        var changes = new LinkedHashMap<HasValue<?, ?>, FieldValueChange>();
+        var changes = new ArrayList<FieldValueChange>();
         for (var entry : preTurnValues.entrySet()) {
             var field = entry.getKey();
             var oldValue = entry.getValue();
             var newValue = field.getValue();
             if (!Objects.equals(oldValue, newValue)) {
-                changes.put(field, new FieldValueChange(oldValue, newValue));
+                changes.add(new FieldValueChange(field, oldValue, newValue));
             }
         }
         preTurnValues.clear();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.selection.MultiSelect;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.shared.Registration;
 
 import tools.jackson.databind.JsonNode;
 
@@ -224,6 +225,12 @@ public class FormAIController implements AIController {
     private final List<HasValue<?, ?>> lockedFields = new ArrayList<>();
     private final Map<HasValue<?, ?>, Object> preTurnValues = new LinkedHashMap<>();
     private final String aiUserId = "vaadin-ai-" + UUID.randomUUID();
+    /**
+     * Per-field attach-listener registrations that re-apply the AI highlight
+     * after detach/re-attach. Populated on the first {@link #showHighlight}
+     * call for a field; entries are removed by {@link #hideHighlight}.
+     */
+    private final Map<HasValue<?, ?>, Registration> highlightedFields = new HashMap<>();
     private Consumer<List<FieldValueChange>> fieldValuesChangedHandler;
 
     /**
@@ -459,10 +466,10 @@ public class FormAIController implements AIController {
      * (e.g. from a collaboration session) as long as those consumers also use
      * {@code addUser} / {@code removeUser} rather than {@code setUsers}.
      * <p>
-     * The highlight is not retained across detach/re-attach: a detached field's
-     * client-side state is discarded, and re-attaching produces a fresh element
-     * with no highlight. Call {@code showHighlight} again if the field leaves
-     * and returns to the DOM.
+     * The first {@code showHighlight} call on a field also registers an attach
+     * listener that re-applies the AI user every time the field re-enters the
+     * DOM, so the highlight survives detach/re-attach. The listener is removed
+     * by {@link #hideHighlight}.
      *
      * @param field
      *            the field to highlight, not {@code null}; must be a
@@ -473,8 +480,12 @@ public class FormAIController implements AIController {
      *             if {@code field} is not a {@link Component}
      */
     public void showHighlight(HasValue<?, ?> field) {
-        FormFieldHighlighter.show(requireFieldComponent(field).getElement(),
-                aiUserId);
+        var component = requireFieldComponent(field);
+        var element = component.getElement();
+        highlightedFields.computeIfAbsent(field,
+                ignored -> component.addAttachListener(
+                        event -> FormFieldHighlighter.show(element, aiUserId)));
+        FormFieldHighlighter.show(element, aiUserId);
     }
 
     /**
@@ -483,7 +494,9 @@ public class FormAIController implements AIController {
      * Only this controller's AI user is removed; other users on the field stay
      * highlighted. The field can be any {@link HasValue} {@link Component}, in
      * or out of this controller's form, and clearing one field's highlight has
-     * no effect on others.
+     * no effect on others. The re-attach listener registered by
+     * {@link #showHighlight} is also removed, so the highlight does not come
+     * back if the field leaves and returns to the DOM after this call.
      *
      * @param field
      *            the field to clear the highlight from, not {@code null}; must
@@ -494,8 +507,12 @@ public class FormAIController implements AIController {
      *             if {@code field} is not a {@link Component}
      */
     public void hideHighlight(HasValue<?, ?> field) {
-        FormFieldHighlighter.hide(requireFieldComponent(field).getElement(),
-                aiUserId);
+        var element = requireFieldComponent(field).getElement();
+        var registration = highlightedFields.remove(field);
+        if (registration != null) {
+            registration.remove();
+        }
+        FormFieldHighlighter.hide(element, aiUserId);
     }
 
     private static Component requireFieldComponent(HasValue<?, ?> field) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -45,6 +44,7 @@ import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.selection.MultiSelect;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
 
@@ -123,11 +123,11 @@ import tools.jackson.databind.JsonNode;
  * </p>
  *
  * <p>
- * <b>Change tracking and highlight:</b> a handler registered through
- * {@link #addFieldValueChangedListener(Consumer)} fires once per successful
- * turn with the fields whose value changed during the turn — the common driver
- * for {@link #showHighlight(HasValue)} / {@link #hideHighlight} to flash the
- * AI's edits in the UI.
+ * <b>Change tracking and highlight:</b> a listener registered through
+ * {@link #addFieldValueChangedListener(SerializableConsumer)} fires once per
+ * successful turn with the fields whose value changed during the turn — the
+ * common driver for {@link #showHighlight(HasValue)} / {@link #hideHighlight}
+ * to flash the AI's edits in the UI.
  * </p>
  *
  * <p>
@@ -231,7 +231,7 @@ public class FormAIController implements AIController {
      * call for a field; entries are removed by {@link #hideHighlight}.
      */
     private final Map<HasValue<?, ?>, Registration> highlightedFields = new HashMap<>();
-    private Consumer<List<FieldValueChange>> fieldValuesChangedHandler;
+    private final List<SerializableConsumer<List<FieldValueChange>>> fieldValuesChangedListeners = new ArrayList<>();
 
     /**
      * Creates a new form AI controller for the given container. Fields are
@@ -425,32 +425,40 @@ public class FormAIController implements AIController {
     }
 
     /**
-     * Registers a handler that is invoked once per successful turn with the
+     * Registers a listener that is invoked once per successful turn with the
      * fields whose value differs from what was read at the start of the turn.
      * Comparison is by {@link Objects#equals(Object, Object)} so multi-select
      * sets, dates, and other value-objects work naturally.
      * <p>
-     * Only fields visible to the LLM (non-ignored discovered fields) are
-     * tracked, and only changed fields appear in the list. The handler is not
-     * called when the turn ended in error or when no field changed. The list
-     * iterates in document order; modifying it has no effect on the controller.
+     * Multiple listeners are supported and fire in registration order. If one
+     * listener throws, the exception is logged and the remaining listeners
+     * still fire.
      * <p>
-     * The handler runs on the UI thread with the session lock held, so it can
+     * Only non-ignored fields are tracked, and only changed fields appear in
+     * the list. A field's pre-turn value is captured regardless of its current
+     * visibility, so a value cascaded into a freshly-revealed field is reported
+     * with the field's real pre-turn value rather than a spurious {@code null}.
+     * The listener is not called when the turn ended in error or when no field
+     * changed. The list iterates in document order; modifying it has no effect
+     * on the controller.
+     * <p>
+     * The listener runs on the UI thread with the session lock held, so it can
      * update components and call {@link #showHighlight} /
      * {@link #hideHighlight} directly without {@code ui.access(...)}. A typical
      * use is to flash the AI's edits by calling {@code showHighlight} on every
      * changed field.
      *
-     * @param handler
-     *            handler invoked with the per-field {@link FieldValueChange}
-     *            entries, or {@code null} to remove a previously registered
-     *            handler
-     * @return this controller, for chaining
+     * @param listener
+     *            the listener to register, not {@code null}
+     * @return a {@link Registration} that removes the listener when called
+     * @throws NullPointerException
+     *             if {@code listener} is {@code null}
      */
-    public FormAIController addFieldValueChangedListener(
-            Consumer<List<FieldValueChange>> handler) {
-        this.fieldValuesChangedHandler = handler;
-        return this;
+    public Registration addFieldValueChangedListener(
+            SerializableConsumer<List<FieldValueChange>> listener) {
+        Objects.requireNonNull(listener, "Listener must not be null");
+        fieldValuesChangedListeners.add(listener);
+        return () -> fieldValuesChangedListeners.remove(listener);
     }
 
     /**
@@ -592,28 +600,36 @@ public class FormAIController implements AIController {
     }
 
     /**
-     * Captures the current value of every active field before the LLM runs. The
+     * Captures the current value of every known field before the LLM runs. The
      * snapshot is consulted in {@link #onResponse} to compute the before /
      * after diff for {@link #addFieldValueChangedListener}. Skipped when no
-     * handler is registered to avoid copying values that no one will read.
+     * listener is registered to avoid copying values that no one will read.
+     * <p>
+     * Hidden and disabled fields are included so a value cascaded into a field
+     * that's revealed during the turn can still be compared against a real
+     * pre-turn value rather than {@code null}.
      */
     private void snapshotPreTurnValues() {
         preTurnValues.clear();
-        if (fieldValuesChangedHandler == null) {
+        if (fieldValuesChangedListeners.isEmpty()) {
             return;
         }
-        for (var field : collectActiveFields()) {
+        for (var field : collectKnownFields()) {
             preTurnValues.put(field, field.getValue());
         }
     }
 
     /**
-     * Builds the change map from the pre-turn snapshot and the current field
-     * values, then invokes the registered handler if anything changed. On error
-     * the snapshot is discarded and the handler does not fire — the application
-     * learns about errors through the orchestrator's response listener instead.
-     * A throwing handler is logged and otherwise ignored so the rest of the
-     * response lifecycle (notably {@link #unlockFields}) still runs.
+     * Builds the change list from the pre-turn snapshot and the post-turn value
+     * of every known field, then invokes every registered listener if anything
+     * changed. The post-turn walk picks up fields that were hidden (or absent)
+     * at turn start but became visible / were added during the turn, so
+     * visibility cascades report their value changes correctly. On error the
+     * snapshot is discarded and no listener fires — the application learns
+     * about errors through the orchestrator's response listener instead. A
+     * throwing listener is logged and otherwise ignored so subsequent listeners
+     * still fire and the rest of the response lifecycle (notably
+     * {@link #unlockFields}) still runs.
      */
     private void fireFieldValuesChanged(Throwable error) {
         if (preTurnValues.isEmpty() || error != null) {
@@ -621,9 +637,8 @@ public class FormAIController implements AIController {
             return;
         }
         var changes = new ArrayList<FieldValueChange>();
-        for (var entry : preTurnValues.entrySet()) {
-            var field = entry.getKey();
-            var oldValue = entry.getValue();
+        for (var field : collectKnownFields()) {
+            var oldValue = preTurnValues.get(field);
             var newValue = field.getValue();
             if (!Objects.equals(oldValue, newValue)) {
                 changes.add(new FieldValueChange(field, oldValue, newValue));
@@ -633,10 +648,16 @@ public class FormAIController implements AIController {
         if (changes.isEmpty()) {
             return;
         }
-        try {
-            fieldValuesChangedHandler.accept(changes);
-        } catch (Exception ex) {
-            LOGGER.warn("Field-values-changed handler threw an exception", ex);
+        // Snapshot the list before iterating so a listener that adds or
+        // removes listeners (its own Registration included) doesn't break
+        // the dispatch.
+        for (var listener : List.copyOf(fieldValuesChangedListeners)) {
+            try {
+                listener.accept(changes);
+            } catch (Exception ex) {
+                LOGGER.warn("Field-values-changed listener threw an exception",
+                        ex);
+            }
         }
     }
 
@@ -685,18 +706,28 @@ public class FormAIController implements AIController {
     }
 
     /**
-     * Returns the discovered fields the controller acts on — every
-     * {@link HasValue} in the form tree minus those hidden via
-     * {@link #ignore(HasValue)} and minus those that are not currently visible.
-     * Disabled and read-only fields are kept: the LLM reads them as context but
-     * cannot write them (see {@link #isDisabled} /
-     * {@link #isApplicationReadOnly}). Use this anywhere the LLM-visible field
-     * set matters (locking, tool inputs and outputs).
+     * Returns every {@link HasValue} in the form tree that the controller
+     * tracks — i.e. all discovered fields minus those hidden via
+     * {@link #ignore(HasValue)}. Visibility and enabled state are NOT filtered,
+     * so this is the right set for the snapshot + diff used by
+     * {@link #addFieldValueChangedListener}: a field hidden at turn start may
+     * be revealed during the turn, and a value cascaded into it should compare
+     * against its real pre-turn value rather than {@code null}.
+     */
+    private List<HasValue<?, ?>> collectKnownFields() {
+        return FormFieldDiscovery.collectFields(form).stream()
+                .filter(field -> !isIgnored(field)).toList();
+    }
+
+    /**
+     * Returns the subset of {@link #collectKnownFields()} the LLM currently
+     * acts on — visible fields only. Disabled and read-only fields are kept:
+     * the LLM reads them as context but cannot write them (see
+     * {@link #isDisabled} / {@link #isApplicationReadOnly}). Use this anywhere
+     * the LLM-visible field set matters (locking, tool inputs and outputs).
      */
     private List<HasValue<?, ?>> collectActiveFields() {
-        return FormFieldDiscovery.collectFields(form).stream()
-                .filter(field -> !isIgnored(field)).filter(this::isVisible)
-                .toList();
+        return collectKnownFields().stream().filter(this::isVisible).toList();
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHighlighter.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHighlighter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.form;
+
+import com.vaadin.flow.component.fieldhighlighter.FieldHighlighterInitializer;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Bridges {@link FormAIController#showHighlight} /
+ * {@link FormAIController#hideHighlight} to the
+ * {@code vaadin-field-highlighter} web component. Each controller passes its
+ * own {@code userId} so the AI user does not collide with any other user the
+ * application may keep on the same field.
+ */
+final class FormFieldHighlighter extends FieldHighlighterInitializer {
+
+    private FormFieldHighlighter() {
+    }
+
+    /**
+     * Adds the controller's AI user to the field. {@code addUser} is keyed by
+     * id at the client, so repeated calls with the same id collapse to a single
+     * entry — other users on the field stay untouched.
+     */
+    static void show(Element field, String userId) {
+        field.executeJs(
+                "customElements.get('vaadin-field-highlighter')"
+                        + ".addUser(this, {id: $0, name: 'AI', colorIndex: 0})",
+                userId);
+    }
+
+    /**
+     * Removes the controller's AI user from the field. {@code removeUser}
+     * matches by id and is a no-op when the AI user is not present. Other users
+     * on the field stay highlighted.
+     */
+    static void hide(Element field, String userId) {
+        field.executeJs("customElements.get('vaadin-field-highlighter')"
+                + ".removeUser(this, {id: $0})", userId);
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -87,6 +87,10 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldType.*",
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldValidation.*",
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormValueConverter.*",
+                "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.FormFieldHighlighter(\\$\\d+)?",
+                // vaadin-field-highlighter-flow dependency: a one-shot
+                // init utility, not Serializable by design.
+                "com\\.vaadin\\.flow\\.component\\.fieldhighlighter\\.FieldHighlighterInitializer(\\$\\d+)?",
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.BinderReflection(\\$\\d+)?",
                 // ValueOptions is a transient registration helper: the
                 // controller copies its state into FormFieldHints during

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -23,7 +23,6 @@ import static com.vaadin.flow.component.ai.form.FormTestSupport.json;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -939,8 +938,8 @@ class FormAIControllerTest {
         void handlerFiresWithChangedFieldsAfterSuccessfulTurn() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             field.setValue("John");
@@ -950,7 +949,7 @@ class FormAIControllerTest {
             Assertions.assertNotNull(changes, "Handler must fire when a "
                     + "field's value changed during the turn");
             Assertions.assertEquals(1, changes.size());
-            var change = changes.get(field);
+            var change = changeFor(changes, field);
             Assertions.assertEquals("", change.oldValue());
             Assertions.assertEquals("John", change.newValue());
         }
@@ -960,8 +959,8 @@ class FormAIControllerTest {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var invocations = new AtomicInteger();
-            controller
-                    .withFieldValuesChanged(c -> invocations.incrementAndGet());
+            controller.addFieldValueChangedListener(
+                    c -> invocations.incrementAndGet());
 
             controller.onRequest();
             // No setValue between request and response.
@@ -976,8 +975,8 @@ class FormAIControllerTest {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var invocations = new AtomicInteger();
-            controller
-                    .withFieldValuesChanged(c -> invocations.incrementAndGet());
+            controller.addFieldValueChangedListener(
+                    c -> invocations.incrementAndGet());
 
             controller.onRequest();
             field.setValue("partial");
@@ -989,12 +988,12 @@ class FormAIControllerTest {
         }
 
         @Test
-        void mapContainsOnlyChangedFields() {
+        void listContainsOnlyChangedFields() {
             var changed = new TestField();
             var untouched = new TestField();
             var controller = new FormAIController(new Div(changed, untouched));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             changed.setValue("X");
@@ -1003,8 +1002,8 @@ class FormAIControllerTest {
             var changes = captured.get();
             Assertions.assertEquals(1, changes.size(),
                     "Only the changed field should appear; got: " + changes);
-            Assertions.assertTrue(changes.containsKey(changed));
-            Assertions.assertFalse(changes.containsKey(untouched));
+            Assertions.assertTrue(containsChangeFor(changes, changed));
+            Assertions.assertFalse(containsChangeFor(changes, untouched));
         }
 
         @Test
@@ -1017,17 +1016,17 @@ class FormAIControllerTest {
             visible.addValueChangeListener(e -> hidden.setValue("cascade"));
             var controller = new FormAIController(new Div(visible, hidden));
             controller.ignore(hidden);
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             visible.setValue("primary");
             controller.onResponse(null);
 
             var changes = captured.get();
-            Assertions.assertTrue(changes.containsKey(visible));
-            Assertions.assertFalse(changes.containsKey(hidden),
-                    "Ignored fields must not appear in the change map; got: "
+            Assertions.assertTrue(containsChangeFor(changes, visible));
+            Assertions.assertFalse(containsChangeFor(changes, hidden),
+                    "Ignored fields must not appear in the change list; got: "
                             + changes);
         }
 
@@ -1049,7 +1048,7 @@ class FormAIControllerTest {
             // a stuck-locked field strands the user.
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
-            controller.withFieldValuesChanged(c -> {
+            controller.addFieldValueChangedListener(c -> {
                 throw new RuntimeException("handler boom");
             });
 
@@ -1065,13 +1064,13 @@ class FormAIControllerTest {
         void cascadingChangesAppearInTheSameTurn() {
             // A field's value-change listener writes to a sibling. Both
             // fields' values differ from the pre-turn snapshot, so both
-            // appear in the change map.
+            // appear in the change list.
             var primary = new TestField();
             var cascaded = new TestField();
             primary.addValueChangeListener(e -> cascaded.setValue("derived"));
             var controller = new FormAIController(new Div(primary, cascaded));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             primary.setValue("driver");
@@ -1082,7 +1081,7 @@ class FormAIControllerTest {
                     "Both the driver and cascaded fields should be reported; "
                             + "got: " + changes);
             Assertions.assertEquals("derived",
-                    changes.get(cascaded).newValue());
+                    changeFor(changes, cascaded).newValue());
         }
 
         @Test
@@ -1090,8 +1089,8 @@ class FormAIControllerTest {
             var field = new FormTestFields.MultiSelectField<String>();
             field.setValue(Set.of("a", "b"));
             var controller = new FormAIController(new Div(field));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             // Same content, different Set instance — Objects.equals true.
@@ -1108,27 +1107,27 @@ class FormAIControllerTest {
             var field = new FormTestFields.MultiSelectField<String>();
             field.setValue(Set.of("a", "b"));
             var controller = new FormAIController(new Div(field));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             field.setValue(Set.of("a", "c"));
             controller.onResponse(null);
 
-            var change = captured.get().get(field);
+            var change = changeFor(captured.get(), field);
             Assertions.assertEquals(Set.of("a", "b"), change.oldValue());
             Assertions.assertEquals(Set.of("a", "c"), change.newValue());
         }
 
         @Test
-        void changeMapIteratesInDocumentOrder() {
+        void changeListIteratesInDocumentOrder() {
             var first = new TestField();
             var second = new TestField();
             var third = new TestField();
             var controller = new FormAIController(
                     new Div(first, second, third));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             third.setValue("c");
@@ -1137,8 +1136,9 @@ class FormAIControllerTest {
             controller.onResponse(null);
 
             Assertions.assertEquals(List.of(first, second, third),
-                    new java.util.ArrayList<>(captured.get().keySet()),
-                    "Map iteration must follow document order regardless of "
+                    captured.get().stream().map(FieldValueChange::field)
+                            .toList(),
+                    "List iteration must follow document order regardless of "
                             + "the order writes happened in");
         }
 
@@ -1146,14 +1146,14 @@ class FormAIControllerTest {
         void nullPreTurnValueIsReportedFaithfully() {
             var field = new FormTestFields.DateField();
             var controller = new FormAIController(new Div(field));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             field.setValue(LocalDate.of(2026, 1, 1));
             controller.onResponse(null);
 
-            var change = captured.get().get(field);
+            var change = changeFor(captured.get(), field);
             Assertions.assertNull(change.oldValue(),
                     "Pre-turn null must round-trip as null");
             Assertions.assertEquals(LocalDate.of(2026, 1, 1),
@@ -1169,14 +1169,14 @@ class FormAIControllerTest {
             var field = new FormTestFields.DateField();
             field.setValue(LocalDate.of(2026, 1, 1));
             var controller = new FormAIController(new Div(field));
-            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
-            controller.withFieldValuesChanged(captured::set);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
 
             controller.onRequest();
             field.setValue(null);
             controller.onResponse(null);
 
-            var change = captured.get().get(field);
+            var change = changeFor(captured.get(), field);
             Assertions.assertEquals(LocalDate.of(2026, 1, 1),
                     change.oldValue());
             Assertions.assertNull(change.newValue(),
@@ -1189,9 +1189,9 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(field));
             var firstHandlerCalls = new AtomicInteger();
             var secondHandlerCalls = new AtomicInteger();
-            controller.withFieldValuesChanged(
+            controller.addFieldValueChangedListener(
                     c -> firstHandlerCalls.incrementAndGet());
-            controller.withFieldValuesChanged(
+            controller.addFieldValueChangedListener(
                     c -> secondHandlerCalls.incrementAndGet());
 
             controller.onRequest();
@@ -1209,8 +1209,9 @@ class FormAIControllerTest {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var calls = new AtomicInteger();
-            controller.withFieldValuesChanged(c -> calls.incrementAndGet());
-            controller.withFieldValuesChanged(null);
+            controller
+                    .addFieldValueChangedListener(c -> calls.incrementAndGet());
+            controller.addFieldValueChangedListener(null);
 
             controller.onRequest();
             field.setValue("X");
@@ -1218,7 +1219,21 @@ class FormAIControllerTest {
 
             Assertions.assertEquals(0, calls.get(),
                     "A previously registered handler must not fire after "
-                            + "being cleared with withFieldValuesChanged(null)");
+                            + "being cleared with "
+                            + "addFieldValueChangedListener(null)");
+        }
+
+        private static FieldValueChange changeFor(
+                List<FieldValueChange> changes, HasValue<?, ?> field) {
+            return changes.stream().filter(c -> c.field() == field).findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "No FieldValueChange entry for field " + field
+                                    + " in " + changes));
+        }
+
+        private static boolean containsChangeFor(List<FieldValueChange> changes,
+                HasValue<?, ?> field) {
+            return changes.stream().anyMatch(c -> c.field() == field);
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -1375,6 +1375,58 @@ class FormAIControllerTest {
                             + "must not be reported as a change");
         }
 
+        @Test
+        void fieldRevealedAndFilledInSameTurnIsReported() {
+            var controlling = new TestField();
+            var conditional = new TestField();
+            conditional.setVisible(false);
+            controlling
+                    .addValueChangeListener(e -> conditional.setVisible(true));
+            var controller = new FormAIController(
+                    new Div(controlling, conditional));
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
+
+            controller.onRequest();
+            controlling.setValue("business"); // reveals the conditional field
+            conditional.setValue("cost-center-42"); // AI fills the revealed one
+            controller.onResponse(null);
+
+            var changes = captured.get();
+            Assertions.assertTrue(containsChangeFor(changes, conditional),
+                    "A field revealed and filled within the same turn must be "
+                            + "reported as changed; got: " + changes);
+        }
+
+        @Test
+        void fieldAddedAndFilledInSameTurnIsReported() {
+            // Stronger variant: the conditional field does not exist in
+            // the form when onRequest snapshots. A controlling field's
+            // listener ADDS it to the form mid-turn (e.g. a checkbox
+            // revealing a new panel), and the same turn fills it. It must
+            // still be reported as changed.
+            var controlling = new TestField();
+            var added = new TestField();
+            var form = new Div(controlling);
+            // Adding the conditional field is application-driven, triggered
+            // by the controlling field's value change.
+            controlling.addValueChangeListener(e -> form.add(added));
+            var controller = new FormAIController(form);
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
+
+            controller.onRequest();
+            controlling.setValue("business"); // adds the new field to the form
+            added.setValue("cost-center-42"); // AI fills the newly-added field
+            controller.onResponse(null);
+
+            var changes = captured.get();
+            Assertions.assertTrue(containsChangeFor(changes, added),
+                    "A field added to the form and filled within the same "
+                            + "turn must be reported as changed; got: "
+                            + changes);
+        }
+
         private static FieldValueChange changeFor(
                 List<FieldValueChange> changes, HasValue<?, ?> field) {
             return changes.stream().filter(c -> c.field() == field).findFirst()

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -1308,7 +1308,8 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field).showHighlight(field);
+            controller.showHighlight(field);
+            controller.showHighlight(field);
             var scripts = pendingJsOn(field);
 
             Assertions.assertEquals(2, scripts.size(),
@@ -1331,8 +1332,9 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field).hideHighlight(field)
-                    .showHighlight(field);
+            controller.showHighlight(field);
+            controller.hideHighlight(field);
+            controller.showHighlight(field);
             var scripts = pendingJsOn(field);
 
             Assertions.assertEquals(3, scripts.size(),
@@ -1375,17 +1377,6 @@ class FormAIControllerTest {
                     () -> controller.showHighlight(nonComponent));
             Assertions.assertThrows(IllegalArgumentException.class,
                     () -> controller.hideHighlight(nonComponent));
-        }
-
-        @Test
-        void showAndHideHighlightReturnTheControllerForChaining() {
-            var field = new TestField();
-            var form = new Div(field);
-            ui.add(form);
-            var controller = new FormAIController(form);
-
-            Assertions.assertSame(controller, controller.showHighlight(field));
-            Assertions.assertSame(controller, controller.hideHighlight(field));
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -21,28 +21,39 @@ import static com.vaadin.flow.component.ai.form.FormTestSupport.formStateFields;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.json;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.slf4j.event.Level;
 
 import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.ai.form.FormTestFields.CompositeField;
 import com.vaadin.flow.component.ai.form.FormTestFields.IntField;
 import com.vaadin.flow.component.ai.form.FormTestFields.SingleSelectField;
 import com.vaadin.flow.component.ai.form.FormTestFields.TestField;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.PropertyId;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -918,6 +929,597 @@ class FormAIControllerTest {
             // either, so the LLM-facing form state lists only the real
             // component.
             Assertions.assertEquals(1, formStateFields(controller).size());
+        }
+    }
+
+    @Nested
+    class FieldValuesChangedHandler {
+
+        @Test
+        void handlerFiresWithChangedFieldsAfterSuccessfulTurn() {
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            field.setValue("John");
+            controller.onResponse(null);
+
+            var changes = captured.get();
+            Assertions.assertNotNull(changes, "Handler must fire when a "
+                    + "field's value changed during the turn");
+            Assertions.assertEquals(1, changes.size());
+            var change = changes.get(field);
+            Assertions.assertEquals("", change.oldValue());
+            Assertions.assertEquals("John", change.newValue());
+        }
+
+        @Test
+        void handlerNotInvokedWhenNoFieldChanged() {
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var invocations = new AtomicInteger();
+            controller
+                    .withFieldValuesChanged(c -> invocations.incrementAndGet());
+
+            controller.onRequest();
+            // No setValue between request and response.
+            controller.onResponse(null);
+
+            Assertions.assertEquals(0, invocations.get(),
+                    "Handler must not be called when no field changed");
+        }
+
+        @Test
+        void handlerNotInvokedOnError() {
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var invocations = new AtomicInteger();
+            controller
+                    .withFieldValuesChanged(c -> invocations.incrementAndGet());
+
+            controller.onRequest();
+            field.setValue("partial");
+            controller.onResponse(new RuntimeException("boom"));
+
+            Assertions.assertEquals(0, invocations.get(),
+                    "Handler must not fire when the turn ended in error, even "
+                            + "if a tool call already wrote to a field");
+        }
+
+        @Test
+        void mapContainsOnlyChangedFields() {
+            var changed = new TestField();
+            var untouched = new TestField();
+            var controller = new FormAIController(new Div(changed, untouched));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            changed.setValue("X");
+            controller.onResponse(null);
+
+            var changes = captured.get();
+            Assertions.assertEquals(1, changes.size(),
+                    "Only the changed field should appear; got: " + changes);
+            Assertions.assertTrue(changes.containsKey(changed));
+            Assertions.assertFalse(changes.containsKey(untouched));
+        }
+
+        @Test
+        void ignoredFieldsDoNotAppearEvenIfTheirValueChanged() {
+            // A value-change listener on a visible field cascades into an
+            // ignored field. The cascade is application-driven, so the
+            // ignored field stays out of the AI-visible change set.
+            var visible = new TestField();
+            var hidden = new TestField();
+            visible.addValueChangeListener(e -> hidden.setValue("cascade"));
+            var controller = new FormAIController(new Div(visible, hidden));
+            controller.ignore(hidden);
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            visible.setValue("primary");
+            controller.onResponse(null);
+
+            var changes = captured.get();
+            Assertions.assertTrue(changes.containsKey(visible));
+            Assertions.assertFalse(changes.containsKey(hidden),
+                    "Ignored fields must not appear in the change map; got: "
+                            + changes);
+        }
+
+        @Test
+        void noHandlerRegisteredIsHarmlessAcrossTheLifecycle() {
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+
+            Assertions.assertDoesNotThrow(() -> {
+                controller.onRequest();
+                field.setValue("any");
+                controller.onResponse(null);
+            }, "Lifecycle must run without a handler registered");
+        }
+
+        @Test
+        void handlerExceptionStillReleasesFieldLocks() {
+            // A handler that throws must not prevent unlockFields from running:
+            // a stuck-locked field strands the user.
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            controller.withFieldValuesChanged(c -> {
+                throw new RuntimeException("handler boom");
+            });
+
+            controller.onRequest();
+            field.setValue("anything");
+            controller.onResponse(null);
+
+            Assertions.assertFalse(field.isReadOnly(),
+                    "Field must be unlocked even if the handler threw");
+        }
+
+        @Test
+        void cascadingChangesAppearInTheSameTurn() {
+            // A field's value-change listener writes to a sibling. Both
+            // fields' values differ from the pre-turn snapshot, so both
+            // appear in the change map.
+            var primary = new TestField();
+            var cascaded = new TestField();
+            primary.addValueChangeListener(e -> cascaded.setValue("derived"));
+            var controller = new FormAIController(new Div(primary, cascaded));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            primary.setValue("driver");
+            controller.onResponse(null);
+
+            var changes = captured.get();
+            Assertions.assertEquals(2, changes.size(),
+                    "Both the driver and cascaded fields should be reported; "
+                            + "got: " + changes);
+            Assertions.assertEquals("derived",
+                    changes.get(cascaded).newValue());
+        }
+
+        @Test
+        void multiSelectSetWithEqualContentIsNotReportedAsChange() {
+            var field = new FormTestFields.MultiSelectField<String>();
+            field.setValue(Set.of("a", "b"));
+            var controller = new FormAIController(new Div(field));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            // Same content, different Set instance — Objects.equals true.
+            field.setValue(Set.of("b", "a"));
+            controller.onResponse(null);
+
+            Assertions.assertNull(captured.get(),
+                    "A multi-select set equal to its previous value must not "
+                            + "be reported as a change");
+        }
+
+        @Test
+        void multiSelectSetWithDifferentContentIsReportedAsChange() {
+            var field = new FormTestFields.MultiSelectField<String>();
+            field.setValue(Set.of("a", "b"));
+            var controller = new FormAIController(new Div(field));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            field.setValue(Set.of("a", "c"));
+            controller.onResponse(null);
+
+            var change = captured.get().get(field);
+            Assertions.assertEquals(Set.of("a", "b"), change.oldValue());
+            Assertions.assertEquals(Set.of("a", "c"), change.newValue());
+        }
+
+        @Test
+        void changeMapIteratesInDocumentOrder() {
+            var first = new TestField();
+            var second = new TestField();
+            var third = new TestField();
+            var controller = new FormAIController(
+                    new Div(first, second, third));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            third.setValue("c");
+            first.setValue("a");
+            second.setValue("b");
+            controller.onResponse(null);
+
+            Assertions.assertEquals(List.of(first, second, third),
+                    new java.util.ArrayList<>(captured.get().keySet()),
+                    "Map iteration must follow document order regardless of "
+                            + "the order writes happened in");
+        }
+
+        @Test
+        void nullPreTurnValueIsReportedFaithfully() {
+            var field = new FormTestFields.DateField();
+            var controller = new FormAIController(new Div(field));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            field.setValue(LocalDate.of(2026, 1, 1));
+            controller.onResponse(null);
+
+            var change = captured.get().get(field);
+            Assertions.assertNull(change.oldValue(),
+                    "Pre-turn null must round-trip as null");
+            Assertions.assertEquals(LocalDate.of(2026, 1, 1),
+                    change.newValue());
+        }
+
+        @Test
+        void clearingAValueToNullIsReportedAsChange() {
+            // Inverse direction: pre-turn non-null → post-turn null. The
+            // LLM-side equivalent is the "Empty string and null clear a
+            // field" convention; the hook must see the clear as a change so
+            // the application can react (e.g. unhighlight, audit log).
+            var field = new FormTestFields.DateField();
+            field.setValue(LocalDate.of(2026, 1, 1));
+            var controller = new FormAIController(new Div(field));
+            var captured = new AtomicReference<Map<HasValue<?, ?>, FieldValueChange>>();
+            controller.withFieldValuesChanged(captured::set);
+
+            controller.onRequest();
+            field.setValue(null);
+            controller.onResponse(null);
+
+            var change = captured.get().get(field);
+            Assertions.assertEquals(LocalDate.of(2026, 1, 1),
+                    change.oldValue());
+            Assertions.assertNull(change.newValue(),
+                    "Clearing to null must surface as the new value");
+        }
+
+        @Test
+        void replacingHandlerKeepsOnlyTheLastRegistration() {
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var firstHandlerCalls = new AtomicInteger();
+            var secondHandlerCalls = new AtomicInteger();
+            controller.withFieldValuesChanged(
+                    c -> firstHandlerCalls.incrementAndGet());
+            controller.withFieldValuesChanged(
+                    c -> secondHandlerCalls.incrementAndGet());
+
+            controller.onRequest();
+            field.setValue("X");
+            controller.onResponse(null);
+
+            Assertions.assertEquals(0, firstHandlerCalls.get(),
+                    "Replaced handler must not be called");
+            Assertions.assertEquals(1, secondHandlerCalls.get(),
+                    "Latest handler must be the one invoked");
+        }
+
+        @Test
+        void passingNullHandlerClearsPreviouslyRegisteredHandler() {
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var calls = new AtomicInteger();
+            controller.withFieldValuesChanged(c -> calls.incrementAndGet());
+            controller.withFieldValuesChanged(null);
+
+            controller.onRequest();
+            field.setValue("X");
+            controller.onResponse(null);
+
+            Assertions.assertEquals(0, calls.get(),
+                    "A previously registered handler must not fire after "
+                            + "being cleared with withFieldValuesChanged(null)");
+        }
+    }
+
+    @Nested
+    class Highlight {
+
+        // Field-highlighter integration is exercised through the JS
+        // invocations the controller queues on the field's element. We
+        // assert on the queued script text rather than DOM side effects
+        // because the real visual change happens in the web component, on
+        // the client. Tests use a minimal UI so executeJs lands in the
+        // pending-invocation list.
+
+        private UI ui;
+
+        @BeforeEach
+        void attachUi() {
+            ui = new UI();
+            var mockSession = Mockito.mock(VaadinSession.class);
+            ui.getInternals().setSession(mockSession);
+        }
+
+        @Test
+        void showHighlightQueuesAddUserWithSingleAIUser() {
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field);
+            var invocations = drainPendingJs();
+            var scripts = scriptsOn(invocations, field);
+
+            Assertions.assertEquals(1, scripts.size(),
+                    "showHighlight must queue exactly one script; got: "
+                            + scripts);
+            var script = scripts.getFirst();
+            Assertions.assertTrue(script.contains(
+                    "customElements.get('vaadin-field-highlighter').addUser")
+                    && script.contains("'AI'"),
+                    "Script must invoke the field-highlighter addUser with "
+                            + "the AI user; got: " + script);
+            Assertions.assertTrue(
+                    paramsOn(invocations, field).stream()
+                            .anyMatch(p -> p instanceof String s
+                                    && s.startsWith("vaadin-ai-")),
+                    "addUser must be parameterised with a vaadin-ai- prefixed "
+                            + "UUID so it cannot collide with other users on "
+                            + "the field");
+        }
+
+        @Test
+        void hideHighlightQueuesRemoveUserWithControllerId() {
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.hideHighlight(field);
+            var invocations = drainPendingJs();
+            var scripts = scriptsOn(invocations, field);
+
+            Assertions.assertEquals(1, scripts.size(),
+                    "hideHighlight must queue exactly one script; got: "
+                            + scripts);
+            var script = scripts.getFirst();
+            Assertions.assertTrue(script.contains(
+                    "customElements.get('vaadin-field-highlighter').removeUser"),
+                    "Script must invoke removeUser keyed by the controller's "
+                            + "AI user id; got: " + script);
+            Assertions.assertTrue(
+                    paramsOn(invocations, field).stream()
+                            .anyMatch(p -> p instanceof String s
+                                    && s.startsWith("vaadin-ai-")),
+                    "removeUser must be parameterised with the controller's "
+                            + "vaadin-ai- prefixed UUID so it removes only the "
+                            + "AI user and leaves other users untouched");
+        }
+
+        @Test
+        void showHighlightTwiceQueuesIdenticalScripts() {
+            // The web component dedups by user id, so repeated addUser with
+            // the same id collapses to one entry on the client. The Java
+            // side simply queues the same script twice.
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field).showHighlight(field);
+            var scripts = pendingJsOn(field);
+
+            Assertions.assertEquals(2, scripts.size(),
+                    "Each showHighlight call queues its own script; got: "
+                            + scripts);
+            Assertions.assertEquals(scripts.get(0), scripts.get(1),
+                    "Both invocations must produce identical scripts so the "
+                            + "client converges on a single highlighted user");
+        }
+
+        @Test
+        void showThenHideThenShowQueuesThreeScriptsInOrder() {
+            // A flash-clear-reshow sequence (e.g. an application clearing
+            // the highlight on user focus and re-applying it on the next
+            // turn) must enqueue the three scripts in the call order. Pins
+            // that hide doesn't swallow or collapse a subsequent show, and
+            // that the show-script appears at both endpoints.
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field).hideHighlight(field)
+                    .showHighlight(field);
+            var scripts = pendingJsOn(field);
+
+            Assertions.assertEquals(3, scripts.size(),
+                    "Each call enqueues its own script; got: " + scripts);
+            Assertions.assertTrue(scripts.get(0).contains("addUser"),
+                    "First script must be the show (addUser); got: "
+                            + scripts.get(0));
+            Assertions.assertTrue(scripts.get(1).contains("removeUser"),
+                    "Middle script must be the hide (removeUser); got: "
+                            + scripts.get(1));
+            Assertions.assertTrue(scripts.get(2).contains("addUser"),
+                    "Third script must be the show again (addUser); got: "
+                            + scripts.get(2));
+        }
+
+        @Test
+        void nullFieldThrows() {
+            // Message is asserted, not just the exception type: without an
+            // explicit null guard, the IllegalArgumentException branch would
+            // incidentally NPE on field.getClass(), accidentally satisfying a
+            // type-only assertion.
+            var controller = new FormAIController(new Div());
+
+            var showNpe = Assertions.assertThrows(NullPointerException.class,
+                    () -> controller.showHighlight(null));
+            Assertions.assertEquals("Field must not be null",
+                    showNpe.getMessage());
+            var hideNpe = Assertions.assertThrows(NullPointerException.class,
+                    () -> controller.hideHighlight(null));
+            Assertions.assertEquals("Field must not be null",
+                    hideNpe.getMessage());
+        }
+
+        @Test
+        void nonComponentFieldThrows() {
+            var controller = new FormAIController(new Div());
+            var nonComponent = new NonComponentField();
+
+            Assertions.assertThrows(IllegalArgumentException.class,
+                    () -> controller.showHighlight(nonComponent));
+            Assertions.assertThrows(IllegalArgumentException.class,
+                    () -> controller.hideHighlight(nonComponent));
+        }
+
+        @Test
+        void showAndHideHighlightReturnTheControllerForChaining() {
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            Assertions.assertSame(controller, controller.showHighlight(field));
+            Assertions.assertSame(controller, controller.hideHighlight(field));
+        }
+
+        @Test
+        void highlightWorksForFieldOutsideTheControllerForm() {
+            // Controller's form intentionally does not contain `outsideField`.
+            // Pins the contract that showHighlight / hideHighlight operate on
+            // any HasValue Component, regardless of form membership.
+            var formField = new TestField();
+            var outsideField = new TestField();
+            var formDiv = new Div(formField);
+            var siblingDiv = new Div(outsideField);
+            ui.add(formDiv);
+            ui.add(siblingDiv);
+            var controller = new FormAIController(formDiv);
+
+            controller.showHighlight(outsideField);
+            var scripts = pendingJsOn(outsideField);
+
+            Assertions.assertEquals(1, scripts.size(),
+                    "showHighlight must queue a script even when the field "
+                            + "is outside the controller's form; got: "
+                            + scripts);
+            Assertions.assertTrue(scripts.getFirst().contains("addUser")
+                    && scripts.getFirst().contains("'AI'"));
+        }
+
+        @Test
+        void highlightOnOneFieldDoesNotEmitJsForAnother() {
+            // Two fields, only one is highlighted. The other field must not
+            // receive any field-highlighter script.
+            var highlighted = new TestField();
+            var untouched = new TestField();
+            var form = new Div(highlighted, untouched);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(highlighted);
+
+            var dump = drainPendingJs();
+            Assertions.assertEquals(1, scriptsOn(dump, highlighted).size());
+            Assertions.assertEquals(0, scriptsOn(dump, untouched).size(),
+                    "Highlighting one field must not enqueue scripts on "
+                            + "unrelated fields");
+        }
+
+        @Test
+        void hideHighlightOnOneFieldDoesNotEmitJsForAnother() {
+            // Sibling-independence check on the clearing path: hiding one
+            // field's highlight must leave another field's script queue
+            // untouched.
+            var cleared = new TestField();
+            var untouched = new TestField();
+            var form = new Div(cleared, untouched);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.hideHighlight(cleared);
+
+            var dump = drainPendingJs();
+            Assertions.assertEquals(1, scriptsOn(dump, cleared).size());
+            Assertions.assertEquals(0, scriptsOn(dump, untouched).size());
+        }
+
+        @Test
+        void hideHighlightLeavesOtherHighlightedFieldsAlone() {
+            // Pin behavioural independence: with two fields already
+            // highlighted, hiding one must only emit the clear-script on the
+            // hidden field. The other field's queue keeps its show-script
+            // and gains nothing — its client-side state stays highlighted.
+            var keep = new TestField();
+            var clear = new TestField();
+            var form = new Div(keep, clear);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(keep);
+            controller.showHighlight(clear);
+            controller.hideHighlight(clear);
+
+            var dump = drainPendingJs();
+            var keepScripts = scriptsOn(dump, keep);
+            var clearScripts = scriptsOn(dump, clear);
+
+            Assertions.assertEquals(1, keepScripts.size(),
+                    "keep field should keep only its show script when "
+                            + "another field is hidden; got: " + keepScripts);
+            Assertions.assertTrue(keepScripts.getFirst().contains("addUser"),
+                    "keep field's queued script should be the show "
+                            + "(addUser with AI user); got: "
+                            + keepScripts.getFirst());
+            Assertions.assertEquals(2, clearScripts.size(),
+                    "cleared field receives show then hide; got: "
+                            + clearScripts);
+            Assertions.assertTrue(clearScripts.get(0).contains("addUser"),
+                    "First script on cleared field is the show (addUser); "
+                            + "got: " + clearScripts.get(0));
+            Assertions.assertTrue(clearScripts.get(1).contains("removeUser"),
+                    "Last script on cleared field is the removeUser; got: "
+                            + clearScripts.get(1));
+        }
+
+        private List<String> pendingJsOn(HasElement target) {
+            return scriptsOn(drainPendingJs(), target);
+        }
+
+        // Use when more than one target is inspected from the same dump —
+        // dumpPendingJavaScriptInvocations is destructive, so per-target
+        // filtering must happen against a single drained list.
+        private List<PendingJavaScriptInvocation> drainPendingJs() {
+            ui.getInternals().getStateTree()
+                    .runExecutionsBeforeClientResponse();
+            ui.getInternals().getStateTree().collectChanges(ignore -> {
+            });
+            return ui.getInternals().dumpPendingJavaScriptInvocations();
+        }
+
+        private static List<String> scriptsOn(
+                List<PendingJavaScriptInvocation> dump, HasElement target) {
+            return dump.stream()
+                    .filter(p -> p.getInvocation().getParameters()
+                            .contains(target.getElement()))
+                    .map(p -> p.getInvocation().getExpression()).toList();
+        }
+
+        // Flattened parameter list for every invocation targeted at `target`.
+        // Used to assert on the values bound to $0, $1, ... in the queued
+        // script expressions.
+        private static List<Object> paramsOn(
+                List<PendingJavaScriptInvocation> dump, HasElement target) {
+            return dump.stream()
+                    .filter(p -> p.getInvocation().getParameters()
+                            .contains(target.getElement()))
+                    .flatMap(p -> p.getInvocation().getParameters().stream())
+                    .map(p -> (Object) p).toList();
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -932,10 +932,10 @@ class FormAIControllerTest {
     }
 
     @Nested
-    class FieldValuesChangedHandler {
+    class FieldValuesChangedListener {
 
         @Test
-        void handlerFiresWithChangedFieldsAfterSuccessfulTurn() {
+        void listenerFiresWithChangedFieldsAfterSuccessfulTurn() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var captured = new AtomicReference<List<FieldValueChange>>();
@@ -946,7 +946,7 @@ class FormAIControllerTest {
             controller.onResponse(null);
 
             var changes = captured.get();
-            Assertions.assertNotNull(changes, "Handler must fire when a "
+            Assertions.assertNotNull(changes, "Listener must fire when a "
                     + "field's value changed during the turn");
             Assertions.assertEquals(1, changes.size());
             var change = changeFor(changes, field);
@@ -955,7 +955,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void handlerNotInvokedWhenNoFieldChanged() {
+        void listenerNotInvokedWhenNoFieldChanged() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var invocations = new AtomicInteger();
@@ -967,11 +967,11 @@ class FormAIControllerTest {
             controller.onResponse(null);
 
             Assertions.assertEquals(0, invocations.get(),
-                    "Handler must not be called when no field changed");
+                    "Listener must not be called when no field changed");
         }
 
         @Test
-        void handlerNotInvokedOnError() {
+        void listenerNotInvokedOnError() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var invocations = new AtomicInteger();
@@ -983,8 +983,8 @@ class FormAIControllerTest {
             controller.onResponse(new RuntimeException("boom"));
 
             Assertions.assertEquals(0, invocations.get(),
-                    "Handler must not fire when the turn ended in error, even "
-                            + "if a tool call already wrote to a field");
+                    "Listener must not fire when the turn ended in error, "
+                            + "even if a tool call already wrote to a field");
         }
 
         @Test
@@ -1001,21 +1001,21 @@ class FormAIControllerTest {
 
             var changes = captured.get();
             Assertions.assertEquals(1, changes.size(),
-                    "Only the changed field should appear; got: " + changes);
+                    "Only the changed field must appear; got: " + changes);
             Assertions.assertTrue(containsChangeFor(changes, changed));
             Assertions.assertFalse(containsChangeFor(changes, untouched));
         }
 
         @Test
         void ignoredFieldsDoNotAppearEvenIfTheirValueChanged() {
-            // A value-change listener on a visible field cascades into an
-            // ignored field. The cascade is application-driven, so the
-            // ignored field stays out of the AI-visible change set.
+            // Application-driven cascades into a field marked ignore() must
+            // not leak into the change list — ignore() is the application's
+            // opt-out from AI-driven tracking on either side of the lifecycle.
             var visible = new TestField();
-            var hidden = new TestField();
-            visible.addValueChangeListener(e -> hidden.setValue("cascade"));
-            var controller = new FormAIController(new Div(visible, hidden));
-            controller.ignore(hidden);
+            var ignored = new TestField();
+            visible.addValueChangeListener(e -> ignored.setValue("cascade"));
+            var controller = new FormAIController(new Div(visible, ignored));
+            controller.ignore(ignored);
             var captured = new AtomicReference<List<FieldValueChange>>();
             controller.addFieldValueChangedListener(captured::set);
 
@@ -1025,13 +1025,13 @@ class FormAIControllerTest {
 
             var changes = captured.get();
             Assertions.assertTrue(containsChangeFor(changes, visible));
-            Assertions.assertFalse(containsChangeFor(changes, hidden),
+            Assertions.assertFalse(containsChangeFor(changes, ignored),
                     "Ignored fields must not appear in the change list; got: "
                             + changes);
         }
 
         @Test
-        void noHandlerRegisteredIsHarmlessAcrossTheLifecycle() {
+        void noListenerRegisteredIsHarmlessAcrossTheLifecycle() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
 
@@ -1039,17 +1039,17 @@ class FormAIControllerTest {
                 controller.onRequest();
                 field.setValue("any");
                 controller.onResponse(null);
-            }, "Lifecycle must run without a handler registered");
+            }, "Lifecycle must run without a listener registered");
         }
 
         @Test
-        void handlerExceptionStillReleasesFieldLocks() {
-            // A handler that throws must not prevent unlockFields from running:
-            // a stuck-locked field strands the user.
+        void listenerExceptionStillReleasesFieldLocks() {
+            // Locks set in onRequest must release regardless of listener
+            // outcome: a stuck-locked field strands the user.
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             controller.addFieldValueChangedListener(c -> {
-                throw new RuntimeException("handler boom");
+                throw new RuntimeException("listener boom");
             });
 
             controller.onRequest();
@@ -1057,14 +1057,14 @@ class FormAIControllerTest {
             controller.onResponse(null);
 
             Assertions.assertFalse(field.isReadOnly(),
-                    "Field must be unlocked even if the handler threw");
+                    "Field must be unlocked even if a listener threw");
         }
 
         @Test
         void cascadingChangesAppearInTheSameTurn() {
-            // A field's value-change listener writes to a sibling. Both
-            // fields' values differ from the pre-turn snapshot, so both
-            // appear in the change list.
+            // Cascades through ValueChangeListener are observable in the diff
+            // regardless of who triggered them — pin the symmetry so this
+            // doesn't quietly regress to "only AI-driven writes are reported".
             var primary = new TestField();
             var cascaded = new TestField();
             primary.addValueChangeListener(e -> cascaded.setValue("derived"));
@@ -1078,7 +1078,7 @@ class FormAIControllerTest {
 
             var changes = captured.get();
             Assertions.assertEquals(2, changes.size(),
-                    "Both the driver and cascaded fields should be reported; "
+                    "Both the driver and cascaded fields must be reported; "
                             + "got: " + changes);
             Assertions.assertEquals("derived",
                     changeFor(changes, cascaded).newValue());
@@ -1162,10 +1162,9 @@ class FormAIControllerTest {
 
         @Test
         void clearingAValueToNullIsReportedAsChange() {
-            // Inverse direction: pre-turn non-null → post-turn null. The
-            // LLM-side equivalent is the "Empty string and null clear a
-            // field" convention; the hook must see the clear as a change so
-            // the application can react (e.g. unhighlight, audit log).
+            // Inverse of nullPreTurnValueIsReportedFaithfully: pre-turn
+            // non-null → post-turn null must surface as a change so
+            // applications can react (e.g. clear the highlight).
             var field = new FormTestFields.DateField();
             field.setValue(LocalDate.of(2026, 1, 1));
             var controller = new FormAIController(new Div(field));
@@ -1184,43 +1183,196 @@ class FormAIControllerTest {
         }
 
         @Test
-        void replacingHandlerKeepsOnlyTheLastRegistration() {
+        void multipleListenersAllFire() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
-            var firstHandlerCalls = new AtomicInteger();
-            var secondHandlerCalls = new AtomicInteger();
-            controller.addFieldValueChangedListener(
-                    c -> firstHandlerCalls.incrementAndGet());
-            controller.addFieldValueChangedListener(
-                    c -> secondHandlerCalls.incrementAndGet());
+            var first = new AtomicReference<List<FieldValueChange>>();
+            var second = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(first::set);
+            controller.addFieldValueChangedListener(second::set);
 
             controller.onRequest();
             field.setValue("X");
             controller.onResponse(null);
 
-            Assertions.assertEquals(0, firstHandlerCalls.get(),
-                    "Replaced handler must not be called");
-            Assertions.assertEquals(1, secondHandlerCalls.get(),
-                    "Latest handler must be the one invoked");
+            Assertions.assertNotNull(first.get(), "First listener must fire");
+            Assertions.assertNotNull(second.get(),
+                    "Second listener must also fire");
+            Assertions.assertEquals(first.get(), second.get(),
+                    "Both listeners must receive equal change lists");
         }
 
         @Test
-        void passingNullHandlerClearsPreviouslyRegisteredHandler() {
+        void nullListenerThrows() {
+            var controller = new FormAIController(new Div(new TestField()));
+
+            Assertions.assertThrows(NullPointerException.class,
+                    () -> controller.addFieldValueChangedListener(null));
+        }
+
+        @Test
+        void registrationRemoveStopsFutureCalls() {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
             var calls = new AtomicInteger();
-            controller
+            var registration = controller
                     .addFieldValueChangedListener(c -> calls.incrementAndGet());
-            controller.addFieldValueChangedListener(null);
+
+            controller.onRequest();
+            field.setValue("first");
+            controller.onResponse(null);
+            Assertions.assertEquals(1, calls.get(),
+                    "Listener must fire while registered");
+
+            registration.remove();
+
+            controller.onRequest();
+            field.setValue("second");
+            controller.onResponse(null);
+            Assertions.assertEquals(1, calls.get(),
+                    "Listener must not fire after Registration.remove()");
+        }
+
+        @Test
+        void listenerExceptionDoesNotPreventOtherListeners() {
+            // One bad listener must not silence the rest — otherwise a
+            // library listener could break the application's listener (or
+            // vice versa) depending on registration order.
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var followingCalls = new AtomicInteger();
+            controller.addFieldValueChangedListener(c -> {
+                throw new RuntimeException("first throws");
+            });
+            controller.addFieldValueChangedListener(
+                    c -> followingCalls.incrementAndGet());
 
             controller.onRequest();
             field.setValue("X");
             controller.onResponse(null);
 
-            Assertions.assertEquals(0, calls.get(),
-                    "A previously registered handler must not fire after "
-                            + "being cleared with "
-                            + "addFieldValueChangedListener(null)");
+            Assertions.assertEquals(1, followingCalls.get(),
+                    "An exception from one listener must not prevent the "
+                            + "next listener from firing");
+        }
+
+        @Test
+        void listenerCanRemoveItselfDuringDispatchWithoutBreakingTheTurn() {
+            // Self-removal during dispatch must not throw or skip remaining
+            // listeners: a common idiom for one-shot listeners.
+            var field = new TestField();
+            var controller = new FormAIController(new Div(field));
+            var registration = new AtomicReference<Registration>();
+            var selfRemovingCalls = new AtomicInteger();
+            var followingCalls = new AtomicInteger();
+            registration.set(controller.addFieldValueChangedListener(c -> {
+                selfRemovingCalls.incrementAndGet();
+                registration.get().remove();
+            }));
+            controller.addFieldValueChangedListener(
+                    c -> followingCalls.incrementAndGet());
+
+            controller.onRequest();
+            field.setValue("X");
+            controller.onResponse(null);
+
+            Assertions.assertEquals(1, selfRemovingCalls.get(),
+                    "Self-removing listener fires for the dispatch in which "
+                            + "it removed itself");
+            Assertions.assertEquals(1, followingCalls.get(),
+                    "Listeners following the self-removing one must still fire");
+
+            controller.onRequest();
+            field.setValue("Y");
+            controller.onResponse(null);
+
+            Assertions.assertEquals(1, selfRemovingCalls.get(),
+                    "Self-removing listener must not fire after the turn "
+                            + "where it removed itself");
+            Assertions.assertEquals(2, followingCalls.get(),
+                    "Following listener must keep firing on subsequent turns");
+        }
+
+        @Test
+        void fieldRevealedMidTurnIsReportedAsChange() {
+            // Visibility-cascade headline: a hidden field that gets
+            // revealed-and-written during a single turn must surface in
+            // the change list. Otherwise the LLM's effect on the form
+            // would be silently underreported.
+            var primary = new TestField();
+            var conditional = new TestField();
+            conditional.setVisible(false);
+            primary.addValueChangeListener(e -> {
+                conditional.setVisible(true);
+                conditional.setValue("derived");
+            });
+            var controller = new FormAIController(
+                    new Div(primary, conditional));
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
+
+            controller.onRequest();
+            primary.setValue("driver");
+            controller.onResponse(null);
+
+            var change = changeFor(captured.get(), conditional);
+            Assertions.assertEquals("", change.oldValue(),
+                    "Old value must reflect the field's pre-turn value");
+            Assertions.assertEquals("derived", change.newValue());
+        }
+
+        @Test
+        void hiddenFieldRevealedAndChangedReportsRealOldValue() {
+            // When the hidden field already had a non-null value
+            // (e.g. bound to a bean), the diff must report the real
+            // (preset → derived) transition rather than (null → derived).
+            var primary = new TestField();
+            var conditional = new TestField();
+            conditional.setValue("preset");
+            conditional.setVisible(false);
+            primary.addValueChangeListener(e -> {
+                conditional.setVisible(true);
+                conditional.setValue("derived");
+            });
+            var controller = new FormAIController(
+                    new Div(primary, conditional));
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
+
+            controller.onRequest();
+            primary.setValue("driver");
+            controller.onResponse(null);
+
+            var change = changeFor(captured.get(), conditional);
+            Assertions.assertEquals("preset", change.oldValue(),
+                    "Pre-turn value of a hidden field must round-trip into "
+                            + "the change record, not a spurious null");
+            Assertions.assertEquals("derived", change.newValue());
+        }
+
+        @Test
+        void fieldRevealedMidTurnWithUnchangedValueIsNotReported() {
+            // False-positive guard: revealing a hidden field without
+            // writing to it is not a change and must not appear in the
+            // change list.
+            var primary = new TestField();
+            var conditional = new TestField();
+            conditional.setValue("preset");
+            conditional.setVisible(false);
+            primary.addValueChangeListener(e -> conditional.setVisible(true));
+            var controller = new FormAIController(
+                    new Div(primary, conditional));
+            var captured = new AtomicReference<List<FieldValueChange>>();
+            controller.addFieldValueChangedListener(captured::set);
+
+            controller.onRequest();
+            primary.setValue("driver");
+            controller.onResponse(null);
+
+            Assertions.assertFalse(
+                    containsChangeFor(captured.get(), conditional),
+                    "Revealing a hidden field without changing its value "
+                            + "must not be reported as a change");
         }
 
         private static FieldValueChange changeFor(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -1354,14 +1354,12 @@ class FormAIControllerTest {
 
             Assertions.assertEquals(3, scripts.size(),
                     "Each call enqueues its own script; got: " + scripts);
-            Assertions.assertTrue(scripts.get(0).contains("addUser"),
-                    "First script must be the show (addUser); got: "
-                            + scripts.get(0));
-            Assertions.assertTrue(scripts.get(1).contains("removeUser"),
-                    "Middle script must be the hide (removeUser); got: "
-                            + scripts.get(1));
-            Assertions.assertTrue(scripts.get(2).contains("addUser"),
-                    "Third script must be the show again (addUser); got: "
+            Assertions.assertTrue(isShowScript(scripts.get(0)),
+                    "First script must be the show; got: " + scripts.get(0));
+            Assertions.assertTrue(isHideScript(scripts.get(1)),
+                    "Middle script must be the hide; got: " + scripts.get(1));
+            Assertions.assertTrue(isShowScript(scripts.get(2)),
+                    "Third script must be the show again; got: "
                             + scripts.get(2));
         }
 
@@ -1414,8 +1412,7 @@ class FormAIControllerTest {
                     "showHighlight must queue a script even when the field "
                             + "is outside the controller's form; got: "
                             + scripts);
-            Assertions.assertTrue(scripts.getFirst().contains("addUser")
-                    && scripts.getFirst().contains("'AI'"));
+            Assertions.assertTrue(isShowScript(scripts.getFirst()));
         }
 
         @Test
@@ -1478,19 +1475,129 @@ class FormAIControllerTest {
             Assertions.assertEquals(1, keepScripts.size(),
                     "keep field should keep only its show script when "
                             + "another field is hidden; got: " + keepScripts);
-            Assertions.assertTrue(keepScripts.getFirst().contains("addUser"),
-                    "keep field's queued script should be the show "
-                            + "(addUser with AI user); got: "
+            Assertions.assertTrue(isShowScript(keepScripts.getFirst()),
+                    "keep field's queued script should be the show; got: "
                             + keepScripts.getFirst());
             Assertions.assertEquals(2, clearScripts.size(),
                     "cleared field receives show then hide; got: "
                             + clearScripts);
-            Assertions.assertTrue(clearScripts.get(0).contains("addUser"),
-                    "First script on cleared field is the show (addUser); "
-                            + "got: " + clearScripts.get(0));
-            Assertions.assertTrue(clearScripts.get(1).contains("removeUser"),
-                    "Last script on cleared field is the removeUser; got: "
+            Assertions.assertTrue(isShowScript(clearScripts.get(0)),
+                    "First script on cleared field is the show; got: "
+                            + clearScripts.get(0));
+            Assertions.assertTrue(isHideScript(clearScripts.get(1)),
+                    "Last script on cleared field is the hide; got: "
                             + clearScripts.get(1));
+        }
+
+        @Test
+        void showHighlightReappliesOnReattach() {
+            // Detach drops the client-side highlight; the controller's
+            // attach listener must re-issue addUser on the next attach so
+            // the user does not lose the visual cue.
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field);
+            drainPendingJs();
+
+            form.remove(field);
+            form.add(field);
+
+            var addUserScripts = pendingJsOn(field).stream()
+                    .filter(Highlight::isShowScript).toList();
+            Assertions.assertEquals(1, addUserScripts.size(),
+                    "Re-attach must re-issue exactly one addUser script; "
+                            + "got: " + addUserScripts);
+        }
+
+        @Test
+        void hideHighlightCancelsReapplyOnReattach() {
+            // hide removes the attach listener as well as queueing
+            // removeUser; a subsequent detach/re-attach must not bring the
+            // highlight back.
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field);
+            controller.hideHighlight(field);
+            drainPendingJs();
+
+            form.remove(field);
+            form.add(field);
+
+            var addUserScripts = pendingJsOn(field).stream()
+                    .filter(Highlight::isShowScript).toList();
+            Assertions.assertEquals(0, addUserScripts.size(),
+                    "After hide, re-attach must not re-issue addUser; got: "
+                            + addUserScripts);
+        }
+
+        @Test
+        void repeatedShowDoesNotStackReapplyListeners() {
+            // Two showHighlight calls must register exactly one attach
+            // listener. Otherwise re-attach would queue duplicate addUser
+            // scripts and leak listeners across the field's lifetime.
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field);
+            controller.showHighlight(field);
+            drainPendingJs();
+
+            form.remove(field);
+            form.add(field);
+
+            var addUserScripts = pendingJsOn(field).stream()
+                    .filter(Highlight::isShowScript).toList();
+            Assertions.assertEquals(1, addUserScripts.size(),
+                    "Repeated show calls must collapse to one attach "
+                            + "listener; re-attach must re-issue addUser "
+                            + "exactly once; got: " + addUserScripts);
+        }
+
+        @Test
+        void showHighlightAfterHideReinstallsReapply() {
+            // show → hide → show on the same field must end with a working
+            // attach listener again, because hide removed the previous one
+            // and the second show installs a fresh registration.
+            var field = new TestField();
+            var form = new Div(field);
+            ui.add(form);
+            var controller = new FormAIController(form);
+
+            controller.showHighlight(field);
+            controller.hideHighlight(field);
+            controller.showHighlight(field);
+            drainPendingJs();
+
+            form.remove(field);
+            form.add(field);
+
+            var addUserScripts = pendingJsOn(field).stream()
+                    .filter(Highlight::isShowScript).toList();
+            Assertions.assertEquals(1, addUserScripts.size(),
+                    "Show after hide must reinstall the re-apply listener; "
+                            + "re-attach must re-issue addUser exactly once; "
+                            + "got: " + addUserScripts);
+        }
+
+        // Tie the JS-shape check to the conceptual operation so call
+        // sites read as "is this a show / hide?" instead of grepping the
+        // raw JS string. The canonical add/remove-user test (above) pins
+        // the exact JS contract; these helpers are for follow-on tests
+        // that only need to distinguish show from hide.
+        private static boolean isShowScript(String script) {
+            return script.contains("addUser");
+        }
+
+        private static boolean isHideScript(String script) {
+            return script.contains("removeUser");
         }
 
         private List<String> pendingJsOn(HasElement target) {


### PR DESCRIPTION
## Description

This PR:
- Adds `withFieldValuesChanged(Consumer<Map<HasValue, FieldValueChange>>)`, which fires once per successful turn. Ignored fields are excluded. Skipped when the turn ended in error or when no field changed.
- Adds `showHighlight(HasValue)` and `hideHighlight(HasValue)` to control the highlighter. Each controller carries a per-instance UUID id (`vaadin-ai-<uuid>`) and uses `addUser` / `removeUser`, so the AI highlight coexists with any other field-highlighter user the application keeps on the same field. The highlight is not retained across detach/re-attach.

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=193540699

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.