### PR TITLE
fix: do not include flow-server packages from OSGI manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,14 +319,9 @@
 
                           dash: -
                           packageNameWithoutDash: ${replacestring;${packageNameWithDash};${dash};}
+                          packageName: ${replacestring;${packageNameWithoutDash};icons;icon}
 
-                          packageNameTmp: ${replacestring;${packageNameWithoutDash};icons;icon}
-
-                          isDemoPattern: .*-flow-demo
-                          isDemo: ${matches;${project.artifactId};${isDemoPattern}}
-                          packageName: ${packageNameTmp}${if;${isDemo};.demo}
-
-                          exportPackageDefault: ${project.groupId}.flow.component.*${packageName}.*
+                          exportPackageDefault: ${project.groupId}.flow.component.${packageName}.*
                           isExportPackageDefault: ${is;${osgi.export.package};default}
                           exportPackage: ${if;${isExportPackageDefault};${exportPackageDefault};${osgi.export.package}}
                           symbolicNameDefault: ${project.groupId}.flow.component.${packageName}
@@ -336,16 +331,13 @@
                           Bundle-SymbolicName: ${symbolicName}
 
                           Import-Package: *
-                          Export-Package: ${exportPackage};-noimport:=true
+                          Export-Package: ${join;${exportPackage};${osgi.export.package.additional}}
                           Bundle-License: ${osgi.bundle.license}
 
                           CvdlName: ${cvdlName}
                           Implementation-Title: ${project.name}
                           Vaadin-Package-Version: 1
                   includeresource.resources: -src/main/resources
-
-                          //if profile war is used in demos
-                  fixupmessages: "Classes found in the wrong directory";is:=warning
 
                           ]]></bnd>
                     </configuration>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -11,6 +11,7 @@
     <name>Vaadin Grid</name>
     <description>Vaadin Grid</description>
     <properties>
+        <osgi.export.package.additional>com.vaadin.flow.component.treegrid.*</osgi.export.package.additional>
         <surefire.argLine>-javaagent:${org.mockito:mockito-core:jar}</surefire.argLine>
     </properties>
     <dependencies>


### PR DESCRIPTION
## Description

Fixes the `vaadin-board` OSGI manifest to not export `com.vaadin.flow.component.clipboard` from `flow-server`:
- Change the exported package pattern to not use a wildcard before the component name
- Introduce a `osgi.export.package.additional` variable, so that `vaadin-grid` can still export `com.vaadin.flow.component.treegrid`, which is otherwise not exported anymore with the new pattern
- Remove the `-noimport:=true` directive to simplify the implementation, which doesn't seem to make any difference as the same manifests are generated without it
- Remove some demo related instructions, which should not be relevant since demo modules have been removed

Fixes https://github.com/vaadin/flow-components/issues/9392

## Type of change

- Bugfix
