### PR TITLE
docs: fix Javadoc and comment typos

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/src/main/java/com/vaadin/flow/component/accordion/testbench/AccordionElement.java
@@ -59,7 +59,7 @@ public class AccordionElement extends TestBenchElement {
     }
 
     /**
-     * Gets the the opened panel or null if the accordion is closed.
+     * Gets the opened panel or null if the accordion is closed.
      *
      * @return the opened panel or null if closed.
      */

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -748,7 +748,7 @@ public class AvatarGroup extends Component
     }
 
     /**
-     * Sets the the maximum number of avatars to display.
+     * Sets the maximum number of avatars to display.
      * <p>
      * By default, all the avatars are displayed. When max is set, the
      * overflowing avatars are grouped into one avatar.

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/main/java/com/vaadin/flow/component/board/Row.java
@@ -50,7 +50,7 @@ public class Row extends Component
     }
 
     /**
-     * Creates an new row with the given components.
+     * Creates a new row with the given components.
      *
      * @param components
      *            initial content of the row

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Background.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Background.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * backgroundColor (which can be solid or gradient), innerWidth, outerWidth,
  * borderWidth, borderColor.
  * <p>
- * <b>These configuration options apply only to polar and angular gauges trough
+ * <b>These configuration options apply only to polar and angular gauges through
  * the Pane-configuration object.</b>
  */
 public class Background extends AbstractConfigurationObject {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * <p>
  * In
  * <a href="http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
- * >styled mode</a>, the data labels can be styled wtih the
+ * >styled mode</a>, the data labels can be styled with the
  * <code>.highcharts-data-label-box</code> and
  * <code>.highcharts-data-label</code> class names (<a href=
  * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Drilldown.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Drilldown.java
@@ -97,7 +97,7 @@ public class Drilldown extends AbstractConfigurationObject {
     }
 
     /**
-     * @return true if animation is enabled false otherwse.
+     * @return true if animation is enabled, false otherwise.
      */
     public Boolean getAnimation() {
         return animation;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Options3d.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Options3d.java
@@ -106,7 +106,7 @@ public class Options3d extends AbstractConfigurationObject {
     }
 
     /**
-     * Wether to render the chart using the 3D functionality.
+     * Whether to render the chart using the 3D functionality.
      * <p>
      * Defaults to: false
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -378,7 +378,7 @@ public class PlotOptionsArea extends AreaOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
@@ -381,7 +381,7 @@ public class PlotOptionsAreaspline extends AreaOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
@@ -342,7 +342,7 @@ public class PlotOptionsBubble extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBullet.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBullet.java
@@ -412,7 +412,7 @@ public class PlotOptionsBullet extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
@@ -451,7 +451,7 @@ public class PlotOptionsColumn extends ColumnOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGantt.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGantt.java
@@ -352,7 +352,7 @@ public class PlotOptionsGantt extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsHeatmap.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsHeatmap.java
@@ -440,7 +440,7 @@ public class PlotOptionsHeatmap extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
@@ -377,7 +377,7 @@ public class PlotOptionsLine extends PointOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
@@ -341,7 +341,7 @@ public class PlotOptionsScatter extends PointOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
@@ -379,7 +379,7 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
@@ -453,7 +453,7 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
     }
 
     /**
-     * Wether to draw rounded edges on the gauge.
+     * Whether to draw rounded edges on the gauge.
      * <p>
      * Defaults to: false
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
@@ -376,7 +376,7 @@ public class PlotOptionsSpline extends PointOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTimeline.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTimeline.java
@@ -245,7 +245,7 @@ public class PlotOptionsTimeline extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsWaterfall.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsWaterfall.java
@@ -462,7 +462,7 @@ public class PlotOptionsWaterfall extends ColumnOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsXrange.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsXrange.java
@@ -350,7 +350,7 @@ public class PlotOptionsXrange extends AbstractPlotOptions {
      * <p>
      * In <a href=
      * "http://www.highcharts.com/docs/chart-design-and-style/style-by-css"
-     * >styled mode</a>, the data labels can be styled wtih the
+     * >styled mode</a>, the data labels can be styled with the
      * <code>.highcharts-data-label-box</code> and
      * <code>.highcharts-data-label</code> class names (<a href=
      * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-datalabels"

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
@@ -1657,7 +1657,7 @@ public class XAxis extends Axis {
      * interval is calculated as a fifth of the tickInterval. On a logarithmic
      * axis, minor ticks are laid out based on a best guess, attempting to enter
      * approximately 5 minor ticks between each major tick. Prior to v6.0.0,
-     * ticks were unabled in auto layout by setting minorTickInterval to "auto".
+     * ticks were enabled in auto layout by setting minorTickInterval to "auto".
      * Defaults to false.
      *
      * @param minorTicks

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
@@ -1777,7 +1777,7 @@ public class YAxis extends Axis {
      * interval is calculated as a fifth of the tickInterval. On a logarithmic
      * axis, minor ticks are laid out based on a best guess, attempting to enter
      * approximately 5 minor ticks between each major tick. Prior to v6.0.0,
-     * ticks were unabled in auto layout by setting minorTickInterval to "auto".
+     * ticks were enabled in auto layout by setting minorTickInterval to "auto".
      * Defaults to false.
      *
      * @param minorTicks

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/util/Util.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/util/Util.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 public class Util {
 
     /**
-     * Gets the number of miliseconds from the Java epoch of
+     * Gets the number of milliseconds from the Java epoch of
      * 1970-01-01T00:00:00Z.
      *
      * @param date

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -847,12 +847,12 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      *
      * @param fetchCallback
      *            function that returns a stream of items from the backend based
-     *            on the offset, limit and a object filter
+     *            on the offset, limit and an object filter
      * @param filterConverter
      *            a function which converts a combo box's filter-string typed by
-     *            the user into a callback's object filter
+     *            the user into the callback's object filter
      * @param <C>
-     *            filter type used by a callback
+     *            filter type used by the callback
      * @return ComboBoxLazyDataView instance for further configuration
      */
     public <C> ComboBoxLazyDataView<TItem> setItemsWithFilterConverter(
@@ -887,15 +887,15 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      *
      * @param fetchCallback
      *            function that returns a stream of items from the backend based
-     *            on the offset, limit and a object filter
+     *            on the offset, limit and an object filter
      * @param countCallback
-     *            function that return the number of items in the back end for a
+     *            function that returns the number of items in the back end for a
      *            query
      * @param filterConverter
      *            a function which converts a combo box's filter-string typed by
-     *            the user into a callback's object filter
+     *            the user into the object filter used by the callbacks
      * @param <C>
-     *            filter type used by a callbacks
+     *            filter type used by the callbacks
      * @return ComboBoxLazyDataView instance for further configuration
      */
     public <C> ComboBoxLazyDataView<TItem> setItemsWithFilterConverter(
@@ -978,7 +978,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      *            function that returns a stream of items from the back end for
      *            a query
      * @param countCallback
-     *            function that return the number of items in the back end for a
+     *            function that returns the number of items in the back end for a
      *            query
      * @return ComboBoxLazyDataView instance for further configuration
      */

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -240,7 +240,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
     }
 
     /**
-     * Removes components to the (sub)menu.
+     * Removes components from the (sub)menu.
      *
      * @param components
      *            components to remove

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -534,7 +534,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
     }
 
     /**
-     * Controls visiblity of toolbar
+     * Controls the visibility of the toolbar.
      *
      * @param value
      */
@@ -548,10 +548,10 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
     }
 
     /**
-     * Gets visiblity state of toolbar
+     * Gets the visibility state of the toolbar.
      *
      * @param
-     * @return true if toolbar is visible false otherwise
+     * @return true if toolbar is visible, false otherwise
      */
     public boolean getToolbarVisible() {
         return toolbarVisible;

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -820,7 +820,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * Sets whether dialog can be resized by user or not.
      *
      * @param resizable
-     *            {@code true} to enabled resizing of the dialog, {@code false}
+     *            {@code true} to enable resizing of the dialog, {@code false}
      *            otherwise.
      */
     public void setResizable(boolean resizable) {
@@ -830,7 +830,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     /**
      * Gets whether dialog is enabled to be resized or not.
      *
-     * @return {@code true} if resizing is enabled, {@code falsoe} otherwiser
+     * @return {@code true} if resizing is enabled, {@code false} otherwise
      *         (default).
      */
     public boolean isResizable() {
@@ -876,7 +876,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * dialog footer area. The footer is displayed only if there's at least one
      * component added with {@link DialogHeaderFooter#add(Component...)}.
      *
-     * @return the header object
+     * @return the footer object
      */
     public DialogFooter getFooter() {
         if (this.dialogFooter == null) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/ValidationUtil.java
@@ -28,7 +28,7 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks if the value satistifies the required constraint and returns a
+     * Checks if the value satisfies the required constraint and returns a
      * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with an
      * empty error message depending on the result.
      *
@@ -53,7 +53,7 @@ public class ValidationUtil {
     }
 
     /**
-     * Checks if the value satistifies the required constraint and returns a
+     * Checks if the value satisfies the required constraint and returns a
      * {@code ValidationResult.ok()} or {@code ValidationResult.error()} with
      * the given error message depending on the result.
      *

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1757,7 +1757,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * client by using {@link String#valueOf(Object)}.
      * <p>
      * <em>NOTE:</em> For displaying components, see
-     * {@link #addComponentColumn(ValueProvider)}. For using build-in renderers,
+     * {@link #addComponentColumn(ValueProvider)}. For using built-in renderers,
      * see {@link #addColumn(Renderer)}.
      * </p>
      * <p>
@@ -1790,7 +1790,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * the client by using {@link String#valueOf(Object)}.
      * <p>
      * <em>NOTE:</em> For displaying components, see
-     * {@link #addComponentColumn(ValueProvider)}. For using build-in renderers,
+     * {@link #addComponentColumn(ValueProvider)}. For using built-in renderers,
      * see {@link #addColumn(Renderer)}.
      * </p>
      * <p>
@@ -2432,7 +2432,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * <p>
      * If there are no existing footer rows, this will create the first row.
      *
-     * @return the created header row
+     * @return the created footer row
      */
     public FooterRow appendFooterRow() {
         if (getFooterRows().size() == 0) {
@@ -3925,7 +3925,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * in-memory and backend sorting accordingly.
      * <p>
      * Notifies sort listeners with updated sort orders and whether the sorting
-     * updated originated from user.
+     * update originated from user.
      *
      * @param order
      *            sort order to be set to Grid.
@@ -4014,11 +4014,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
-     * Updates an in-memory and backend sortings in Grid's data communicator
+     * Updates in-memory and backend sorting in Grid's data communicator
      * taking into account Grid's sort orders and in-memory comparator.
      * <p>
      * Notifies sort listeners with updated sort orders and whether the sorting
-     * updated originated from user.
+     * update originated from user.
      *
      * @param userOriginated
      *            <code>true</code> if the sorting changes as a result of user

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
@@ -121,7 +121,7 @@ public interface GridMultiSelectionModel<T>
      * visible.
      *
      * @param selectAllCheckBoxVisibility
-     *            the visiblity mode to use
+     *            the visibility mode to use
      * @see SelectAllCheckboxVisibility
      */
     void setSelectAllCheckboxVisibility(
@@ -164,7 +164,7 @@ public interface GridMultiSelectionModel<T>
     void setSelectionColumnFrozen(boolean frozen);
 
     /**
-     * Gets the the selection column's frozen state.
+     * Gets the selection column's frozen state.
      *
      * @return whether the selection column is frozen
      */

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -464,7 +464,7 @@ public class BasicIT extends AbstractComponentIT {
         Assert.assertFalse(cell.innerHTMLContains(editorTag));
 
         // Entering edit mode with double click
-        // Workaround(yuriy-fix): doubleClick is not working on IE11
+        // Workaround(yuriy-fix): double-click is not working on IE11
         executeScript(
                 "arguments[0].dispatchEvent(new CustomEvent('dblclick', {composed: true, bubbles: true}));",
                 cell);

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -420,7 +420,7 @@ public class GridPro<E> extends Grid<E> {
      *
      * @param propertyName
      *            the property name of the new column, not <code>null</code>
-     * @return and edit column configurer for configuring the column editor
+     * @return an edit column configurer for configuring the column editor
      *
      * @see Grid#addColumn(String)
      * @see EditColumnConfigurator#text(ItemUpdater)
@@ -438,7 +438,7 @@ public class GridPro<E> extends Grid<E> {
 
     /**
      * Sets the value of the webcomponent's property enterNextRow. Default
-     * values is false. When true, pressing Enter while in cell edit mode will
+     * value is false. When true, pressing Enter while in cell edit mode will
      * move focus to the editable cell in the next row (Shift + Enter - same,
      * but for previous row).
      *
@@ -453,7 +453,7 @@ public class GridPro<E> extends Grid<E> {
 
     /**
      * Gets the value of the webcomponent's property enterNextRow. Default
-     * values is false. When true, pressing Enter while in cell edit mode will
+     * value is false. When true, pressing Enter while in cell edit mode will
      * move focus to the editable cell in the next row (Shift + Enter - same,
      * but for previous row).
      *
@@ -465,7 +465,7 @@ public class GridPro<E> extends Grid<E> {
 
     /**
      * Sets the value of the webcomponent's property singleCellEdit. Default
-     * values is false. When true, after moving to next or previous editable
+     * value is false. When true, after moving to next or previous editable
      * cell using Tab / Shift+Tab, it will be focused without edit mode.
      *
      * @param singleCellEdit
@@ -479,7 +479,7 @@ public class GridPro<E> extends Grid<E> {
 
     /**
      * Gets the value of the webcomponent's property singleCellEdit. Default
-     * values is false. When true, after moving to next or previous editable
+     * value is false. When true, after moving to next or previous editable
      * cell using Tab / Shift+Tab, it will be focused without edit mode.
      *
      * @return singleCellEdit value

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
@@ -452,10 +452,10 @@ public class HorizontalLayout extends Component implements ThemableLayout,
     }
 
     /**
-     * Adds the components to the <em>middle</em> slot of this layout.
+     * Adds the components to the <em>end</em> slot of this layout.
      *
      * @param components
-     *            Components to add to the middle slot.
+     *            Components to add to the end slot.
      * @throws NullPointerException
      *             if any of the components is null or if the components array
      *             is null.
@@ -470,7 +470,7 @@ public class HorizontalLayout extends Component implements ThemableLayout,
      * Adds the components to the <em>end</em> slot of this layout.
      *
      * @param components
-     *            Components to add to the middle slot.
+     *            Components to add to the end slot.
      * @throws NullPointerException
      *             if any of the components is null or if the components array
      *             is null.

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/ThemableLayout.java
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/ThemableLayout.java
@@ -34,7 +34,7 @@ import com.vaadin.flow.dom.ThemeList;
 public interface ThemableLayout extends HasElement {
     /**
      * Toggles {@code margin} theme setting for the element. If a theme supports
-     * this attribute, it will apply or remove margin to the element.
+     * this attribute, it will apply margin to or remove margin from the element.
      *
      * @param margin
      *            adds {@code margin} theme setting if {@code true} or removes
@@ -55,7 +55,8 @@ public interface ThemableLayout extends HasElement {
 
     /**
      * Toggles {@code padding} theme setting for the element. If a theme
-     * supports this attribute, it will apply or remove padding to the element.
+     * supports this attribute, it will apply padding to or remove padding from
+     * the element.
      *
      * @param padding
      *            adds {@code padding} theme setting if {@code true} or removes
@@ -76,7 +77,8 @@ public interface ThemableLayout extends HasElement {
 
     /**
      * Toggles {@code spacing} theme setting for the element. If a theme
-     * supports this attribute, it will apply or remove spacing to the element.
+     * supports this attribute, it will apply spacing to or remove spacing from
+     * the element.
      * <p>
      * This method adds medium spacing to the component theme, to set other
      * options, use {@link ThemableLayout#getThemeList()}. List of options

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/FormulaBarWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/FormulaBarWidget.java
@@ -683,7 +683,7 @@ public class FormulaBarWidget extends Composite {
         }
 
         // Find next not-matching char before and after caret, and try to match
-        // section inbetween.
+        // section in between.
 
         int start = -1, end = -1;
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -203,7 +203,7 @@ public class SheetWidget extends Panel {
      * Stylesheet element for holding the edited cell style (for convenience
      * reasons, not actually visible). The selector is updated to the edited
      * cell. Also holds the style for the last freeze panel column, if any. This
-     * is for preventing text oveflow over freeze panel.
+     * is for preventing text overflow over freeze panel.
      */
     private StyleElement editedCellFreezeColumnStyle = Document.get()
             .createStyleElement();
@@ -6236,7 +6236,7 @@ public class SheetWidget extends Panel {
                 int distanceFromWindowLeft = left - windowLeft;
 
                 // If there is not enough space for the overflow of the popup's
-                // width to the right of hte text box, and there IS enough space
+                // width to the right of the text box, and there IS enough space
                 // for the
                 // overflow to the left of the text box, then right-align the
                 // popup.

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -48,7 +48,7 @@ import com.vaadin.shared.ui.ui.UIConstants;
 public class ApplicationConfiguration implements EntryPoint {
 
     /**
-     * Helper class for reading configuration options from the bootstap
+     * Helper class for reading configuration options from the bootstrap
      * javascript
      *
      * @since 7.0

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -1030,7 +1030,7 @@ public class ApplicationConnection implements HasHandlers {
         if (connector == null) {
             /*
              * No connector will exist in cases where Vaadin widgets have been
-             * re-used without implementing server<->client communication.
+             * reused without implementing server<->client communication.
              */
             return false;
         }
@@ -1056,7 +1056,7 @@ public class ApplicationConnection implements HasHandlers {
     }
 
     /**
-     * Sets the delegate that is called whenever a communication error occurrs.
+     * Sets the delegate that is called whenever a communication error occurs.
      *
      * @param delegate
      *            the delegate.
@@ -1146,7 +1146,7 @@ public class ApplicationConnection implements HasHandlers {
     }
 
     /**
-     * Returns the hearbeat instance.
+     * Returns the heartbeat instance.
      */
     public Heartbeat getHeartbeat() {
         return null;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionShifter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionShifter.java
@@ -396,7 +396,7 @@ public class CellSelectionShifter implements Serializable {
                 if (newPaintedCellRange != null) {
                     CellReference selectedCellReference = spreadsheet
                             .getSelectedCellReference();
-                    // if the decrease caused the seleced cell to be out of
+            // if the decrease caused the selected cell to be out of
                     // painted range, move selected cell to first in range
                     if (!SpreadsheetUtil.isCellInRange(selectedCellReference,
                             newPaintedCellRange)) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/GroupingUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/GroupingUtil.java
@@ -383,7 +383,7 @@ class GroupingUtil implements Serializable {
                 sheet, idx);
 
         // expand:
-        // colapsed bit must be unset
+        // collapsed bit must be unset
         // hidden bit gets unset _if_ surrounding groups are expanded you can
         // determine
         // this by looking at the hidden bit of the enclosing group. You will

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -3459,7 +3459,7 @@ public class Spreadsheet extends Component
      *
      * @param fileName
      *            The full name of the file. If the name doesn't end with '.xls'
-     *            or '.xlsx', the approriate one will be appended.
+     *            or '.xlsx', the appropriate one will be appended.
      * @return A File with the content of the current {@link Workbook}, In the
      *         file format of the original {@link Workbook}.
      * @throws FileNotFoundException
@@ -6110,17 +6110,17 @@ public class Spreadsheet extends Component
     }
 
     /**
-     * Get the minimum row heigth in points for the rows that contain custom
+     * Get the minimum row height in points for the rows that contain custom
      * components
      *
-     * @return the minimum row heigths in points
+     * @return the minimum row heights in points
      */
     public int getMinimumRowHeightForComponents() {
         return minimumRowHeightForComponents;
     }
 
     /***
-     * Set the minimum row heigth in points for the rows that contain custom
+     * Set the minimum row height in points for the rows that contain custom
      * components. If set to a small value, it might cause some components like
      * checkboxes to be cut off
      *

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -730,7 +730,7 @@ public class SpreadsheetFactory implements Serializable {
          *
          * Each row that is part of a group has a set outline level. Unlike
          * cols, the 'collapse' property is actually used for rows, in
-         * conjuction with the 'hidden' prop. If a group is collapsed, each row
+         * conjunction with the 'hidden' prop. If a group is collapsed, each row
          * in the group has its 'hidden' prop set to true. Also, the column
          * after the group (or before, if inverted) has its 'collapsed' property
          * set to true.
@@ -874,10 +874,10 @@ public class SpreadsheetFactory implements Serializable {
                     } else {
                         LOGGER.debug("IMAGE WITHOUT ANCHOR: " + overlayWrapper);
 
-                        // FIXME seems like there is a POI bug, images that have
-                        // in Excel (XLSX) been se as a certain type (type==3)
-                        // will get a null anchor.
-                        // Achor types:
+            // FIXME seems like there is a POI bug, images that have
+            // in Excel (XLSX) been set as a certain type (type==3)
+            // will get a null anchor.
+            // Anchor types:
                         // 0 = Move and size with Cells,
                         // 2 = Move but don't size with cells,
                         // 3 = Don't move or size with cells.

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetStyleFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetStyleFactory.java
@@ -658,7 +658,7 @@ public class SpreadsheetStyleFactory implements Serializable {
         }
 
         // merged regions have their borders in edge cells that are "invisible"
-        // inside the region -> right and bottom cells need to be transfered to
+        // inside the region -> right and bottom cells need to be transferred to
         // the actual merged cell
         final int columnIndex = cell.getColumnIndex();
         final int rowIndex = cell.getRowIndex();
@@ -705,7 +705,7 @@ public class SpreadsheetStyleFactory implements Serializable {
 
         }
 
-        // only take transfered borders into account on the (possible) merged
+        // only take transferred borders into account on the (possible) merged
         // regions edges
         if (region == null || region.col1 == (columnIndex + 1)
                 || region.col2 == (columnIndex + 1)

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetUtil.java
@@ -150,7 +150,7 @@ public class SpreadsheetUtil implements Serializable {
 
     /**
      * Returns the POI index of the first visible sheet (not hidden or very
-     * hidden). If no sheets are visible, returns 0. This is not be possible at
+     * hidden). If no sheets are visible, returns 0. This should not be possible at
      * least in Excel, but unfortunately POI allows it.
      *
      * @param workbook

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/Utils.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/Utils.java
@@ -98,7 +98,7 @@ public class Utils {
      * @param version
      *            to infer max # of rows for column-only formula references
      * @param formula
-     *            containing possibly non-contiguous area refrences
+     *            containing possibly non-contiguous area references
      * @return array of references
      */
     public static AreaReference[] getAreaReferences(SpreadsheetVersion version,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/xssfreader/ColorUtils.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/xssfreader/ColorUtils.java
@@ -192,7 +192,7 @@ class ColorUtils {
     }
 
     /**
-     * Apply lum modifications according to the forumula from here:
+     * Apply lum modifications according to the formula from here:
      * https://msdn.microsoft.com/
      * en-us/library/office/dd560821(v=office.12).aspx
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/TestHelper.java
@@ -44,7 +44,7 @@ public class TestHelper {
     }
 
     /**
-     * Ceates a Spreadsheet component with the given Excel file as the data
+     * Creates a Spreadsheet component with the given Excel file as the data
      * source.
      *
      * @param fileName

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabSheetElement.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabSheetElement.java
@@ -43,7 +43,7 @@ public class TabSheetElement extends TestBenchElement {
     /**
      * Gets the index of the currently selected tab.
      *
-     * @return the index of the currenly selected tab
+     * @return the index of the currently selected tab
      */
     public int getSelectedTabIndex() {
         return getPropertyInteger("selected");
@@ -84,7 +84,7 @@ public class TabSheetElement extends TestBenchElement {
     }
 
     /**
-     * Gets the the content related to the currently selected tab.
+     * Gets the content related to the currently selected tab.
      *
      * @return the content of the currently selected tab.
      * @throws NoSuchElementException

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabsElement.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabsElement.java
@@ -41,7 +41,7 @@ public class TabsElement extends TestBenchElement {
     /**
      * Gets the index of the currently selected tab.
      *
-     * @return the index of the currenly selected tab
+     * @return the index of the currently selected tab
      */
     public int getSelectedTabIndex() {
         return getPropertyInteger("selected");


### PR DESCRIPTION
## Description

Some Javadocs and implementation comments contain copy-paste mistakes or spelling errors. A few docs describe the wrong target because text was likely copied from a related API and not fully adjusted, such as slot, header/footer, or row-type descriptions.

These docs should match the actual API behavior and use consistent wording across related methods.

Structural Javadoc tag cleanup has been split into follow-up PRs #9421 and #9422.

Fixes # (issue): no dedicated issue; docs-only cleanup.

## Type of change

- [x] Bugfix
- [ ] Feature

## Changes

Copy/paste mismatches:
- `HorizontalLayout`: describe `addToEnd` as adding to the end slot.
- `Dialog`: describe footer APIs as footer-related, not header-related.
- `Grid`: describe footer row APIs as footer rows, not header rows.

Typo and grammar cleanup in Javadocs/comments:
- Layout and shared component docs: `ThemableLayout`, `ValidationUtil`, `AvatarGroup`, `Row`.
- Component and selection docs: `ComboBoxBase`, `Crud`, `Grid`, `GridMultiSelectionModel`, `GridPro`, `MenuManager`.
- Charts docs: generated/model Javadocs under `vaadin-charts-flow`.
- Spreadsheet docs/comments: client, factory, grouping, style, formula bar, converter, utility, and test helper comments.
- TestBench docs/comments: accordion, grid pro, and tabs comments.

## Testing

- `git diff --check`
- Full Java comment scan with `codespell` after filtering known false positives
- Comment-only diff check

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

---

🤖 Generated with Codex (GPT-5.5)
