### PR TITLE
docs: add missing non-charts Javadoc descriptions

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -511,8 +511,8 @@ public class MultiSelectComboBox<TItem>
      * Expansion only works with undefined size in the desired direction (i.e.
      * setting `max-width` limits the component's width).
      *
-     * @param {AutoExpandMode}
-     *            autoExpandMode
+     * @param autoExpandMode
+     *            the auto-expand mode
      * @since 24.3
      */
     public void setAutoExpand(AutoExpandMode autoExpandMode) {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/SubMenuBase.java
@@ -159,7 +159,7 @@ public abstract class SubMenuBase<C extends ContextMenuBase<C, I, S>, I extends 
     /**
      * Gets a (sub) menu manager.
      *
-     * @return
+     * @return the menu manager
      */
     protected MenuManager<C, I, S> getMenuManager() {
         if (menuManager == null) {

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -537,6 +537,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
      * Controls visiblity of toolbar
      *
      * @param value
+     *            {@code true} to show the toolbar, {@code false} to hide it
      */
     public void setToolbarVisible(boolean value) {
         toolbarVisible = value;
@@ -550,7 +551,6 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
     /**
      * Gets visiblity state of toolbar
      *
-     * @param
      * @return true if toolbar is visible false otherwise
      */
     public boolean getToolbarVisible() {
@@ -570,6 +570,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
      * Sets the Crud new item button
      *
      * @param button
+     *            the new item button
      */
     public void setNewButton(Component button) {
         newButton = button;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -44,7 +44,7 @@ public class DatePickerElement extends TestBenchElement
          * Gets all visible month calendars that are currently rendered by the
          * infinite scroller in the overlay.
          *
-         * @return
+         * @return the visible month calendars
          */
         public List<MonthCalendarElement> getVisibleMonthCalendars() {
             return this.$("vaadin-month-calendar").all().stream()
@@ -55,7 +55,7 @@ public class DatePickerElement extends TestBenchElement
         /**
          * Gets the today button from the overlays toolbar
          *
-         * @return
+         * @return the today button
          */
         public ButtonElement getTodayButton() {
             return this.$(ButtonElement.class)
@@ -65,7 +65,7 @@ public class DatePickerElement extends TestBenchElement
         /**
          * Gets the cancel button from the overlays toolbar
          *
-         * @return
+         * @return the cancel button
          */
         public ButtonElement getCancelButton() {
             return this.$(ButtonElement.class)
@@ -77,7 +77,7 @@ public class DatePickerElement extends TestBenchElement
         /**
          * Gets the header text of the month calendar, e.g. `January 1999`
          *
-         * @return
+         * @return the header text
          */
         public String getHeaderText() {
             return this.$(TestBenchElement.class)
@@ -87,7 +87,7 @@ public class DatePickerElement extends TestBenchElement
         /**
          * Gets the weekday headers that are rendered by the month calendar
          *
-         * @return
+         * @return the weekdays
          */
         public List<WeekdayElement> getWeekdays() {
             return this.$(WeekdayElement.class).withAttribute("part", "weekday")
@@ -175,7 +175,7 @@ public class DatePickerElement extends TestBenchElement
      * Gets the visible presentation value from the inner input element as a
      * string. This value depends on the used Locale.
      *
-     * @return
+     * @return the input value
      */
     public String getInputValue() {
         TestBenchElement input = $("input").first();

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -1020,6 +1020,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
          * dialog is closed.
          *
          * @param rendererCreated
+         *            {@code true} if the renderer function has been created,
+         *            {@code false} otherwise
          */
         void setRendererCreated(boolean rendererCreated) {
             this.rendererCreated = rendererCreated;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/FooterRow.java
@@ -80,6 +80,7 @@ public class FooterRow extends AbstractRow<FooterCell> {
      * Creates a new footer row from the layer of column elements.
      *
      * @param layer
+     *            the column layer
      */
     FooterRow(ColumnLayer layer) {
         super(layer, FooterCell::new);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -44,6 +44,7 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
          * Creates a new HeaderCell which wraps the given column element.
          *
          * @param column
+         *            the column index
          */
         HeaderCell(AbstractColumn<?> column) {
             super(column);
@@ -89,6 +90,7 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
      * Creates a new header row from the layer of column elements.
      *
      * @param layer
+     *            the column layer
      */
     HeaderRow(ColumnLayer layer) {
         super(layer, HeaderCell::new);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -44,7 +44,7 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
          * Creates a new HeaderCell which wraps the given column element.
          *
          * @param column
-         *            the column index
+         *            the column element
          */
         HeaderCell(AbstractColumn<?> column) {
             super(column);

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/java/com/vaadin/flow/component/map/configuration/Coordinate.java
@@ -36,7 +36,9 @@ public class Coordinate implements Serializable {
      * in that projection instead.
      *
      * @param x
+     *            the x coordinate
      * @param y
+     *            the y coordinate
      */
     public Coordinate(double x, double y) {
         this.x = x;

--- a/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/src/main/java/com/vaadin/flow/component/map/testbench/MapElement.java
@@ -34,7 +34,9 @@ public class MapElement extends TestBenchElement {
      * at the calculated pixel offset.
      *
      * @param x
+     *            the x coordinate
      * @param y
+     *            the y coordinate
      */
     public void clickAtCoordinates(double x, double y) {
         PixelCoordinate pixelCoordinates = getPixelCoordinates(x, y, true);

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageListElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageListElement.java
@@ -33,7 +33,7 @@ public class MessageListElement extends TestBenchElement {
      * Gets the <code>&lt;vaadin-message&gt;</code> elements rendered in this
      * message list.
      *
-     * @return
+     * @return the message elements
      */
     public List<MessageElement> getMessageElements() {
         return $(MessageElement.class).all();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/FormulaBarWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/FormulaBarWidget.java
@@ -881,7 +881,8 @@ public class FormulaBarWidget extends Composite {
      * Parses single
      *
      * @param cellRef
-     * @return
+     *            the cell reference
+     * @return the parsed cell coordinate
      */
     private static CellCoord parseSingleCell(String cellRef) {
         String c = "", r = "";

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/MergedRegionUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/MergedRegionUtil.java
@@ -55,7 +55,7 @@ public class MergedRegionUtil {
      *            the left column index
      * @param rightColumn
      *            the right column index
-     * @return the merged region element
+     * @return the merged region
      */
     public static MergedRegion findIncreasingSelection(
             MergedRegionContainer container, int topRow, int bottomRow,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/MergedRegionUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/MergedRegionUtil.java
@@ -46,11 +46,16 @@ public class MergedRegionUtil {
      * Parameters 1-based.
      *
      * @param container
+     *            the container
      * @param topRow
+     *            the top row index
      * @param bottomRow
+     *            the bottom row index
      * @param leftColumn
+     *            the left column index
      * @param rightColumn
-     * @return
+     *            the right column index
+     * @return the merged region element
      */
     public static MergedRegion findIncreasingSelection(
             MergedRegionContainer container, int topRow, int bottomRow,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/PopupButtonWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/PopupButtonWidget.java
@@ -139,7 +139,9 @@ public class PopupButtonWidget extends FocusWidget
      * 1-based
      *
      * @param row
+     *            the row index
      * @param col
+     *            the column index
      */
     public void setRowCol(int row, int col) {
         Widget owner = popup.getOwner();
@@ -237,7 +239,7 @@ public class PopupButtonWidget extends FocusWidget
     /**
      * Returns the position callback method used for the button's popup.
      *
-     * @return
+     * @return the position callback
      */
     public PositionCallback getPositionCallback() {
         return callback;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionHandler.java
@@ -502,9 +502,13 @@ public class SelectionHandler {
      * Parameters 1-based.
      *
      * @param topRow
+     *            the top row index
      * @param bottomRow
+     *            the bottom row index
      * @param leftColumn
+     *            the left column index
      * @param rightColumn
+     *            the right column index
      * @return merged region
      */
     protected MergedRegion findDecreasingSelection(int topRow, int bottomRow,
@@ -1034,7 +1038,9 @@ public class SelectionHandler {
      * selection in favor of the given cell.
      *
      * @param col
+     *            the column index
      * @param row
+     *            the row index
      */
     protected void checkNewSelectionInMergedRegion(int col, int row) {
         MergedRegion region = spreadsheet.getMergedRegion(col, row);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionWidget.java
@@ -1032,11 +1032,12 @@ public class SelectionWidget extends Composite {
     /**
      *
      * @param sizes
+     *            the cell sizes
      * @param beginIndex
      *            1-based inclusive
      * @param endIndex
      *            1-based exclusive
-     * @return
+     * @return the sum of the sizes in the range
      */
     public int countSum(int[] sizes, int beginIndex, int endIndex) {
         if (sizes == null || sizes.length < endIndex - 1) {
@@ -1064,7 +1065,7 @@ public class SelectionWidget extends Composite {
      * @param forSelection
      *            true if the result is used for touch selection, false if it's
      *            used for painting cells
-     * @return
+     * @return the closest cell edge index
      */
     public int closestCellEdgeIndexToCursor(int cellSizes[], int startIndex,
             int cursorPosition, boolean forSelection) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetHandler.java
@@ -62,7 +62,7 @@ public interface SheetHandler extends GroupingHandler {
     /**
      * default row height in points (?)
      *
-     * @return
+     * @return the default row height
      */
     float getDefaultRowHeight();
 
@@ -105,14 +105,14 @@ public interface SheetHandler extends GroupingHandler {
     /**
      * The maximum amount of columns that are visible
      *
-     * @return
+     * @return the maximum column count
      */
     int getMaxColumns();
 
     /**
      * The maximum amount of rows that are visible
      *
-     * @return
+     * @return the maximum row count
      */
     int getMaxRows();
 
@@ -146,6 +146,7 @@ public interface SheetHandler extends GroupingHandler {
      * Called on right mouse button click on top of some cell.
      *
      * @param nativeEvent
+     *            the native event
      * @param column
      *            1-based
      * @param row
@@ -157,6 +158,7 @@ public interface SheetHandler extends GroupingHandler {
      * Called on right mouse button click on top of a row header
      *
      * @param nativeEvent
+     *            the native event
      * @param rowIndex
      *            1-based
      */
@@ -166,6 +168,7 @@ public interface SheetHandler extends GroupingHandler {
      * Called on right mouse button click on top of a column header
      *
      * @param nativeEvent
+     *            the native event
      * @param columnIndex
      *            1-based
      */
@@ -200,8 +203,10 @@ public interface SheetHandler extends GroupingHandler {
      * Returns the merged region that this cell belongs to.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return the merged region element
      */
     MergedRegion getMergedRegion(int col, int row);
 
@@ -212,7 +217,7 @@ public interface SheetHandler extends GroupingHandler {
      *            starting column of merged cell
      * @param row
      *            starting row of merged cell
-     * @return
+     * @return the merged region element
      */
     MergedRegion getMergedRegionStartingFrom(int col, int row);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
@@ -551,6 +551,7 @@ public class SheetTabSheet extends Widget {
      * Set the tab inner text and title to the given name value
      *
      * @param tab
+     *            the tab
      * @param name
      *            to use
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
@@ -553,7 +553,7 @@ public class SheetTabSheet extends Widget {
      * @param tab
      *            the tab
      * @param name
-     *            to use
+     *            the tab name
      */
     private void setTabName(Element tab, String name) {
         if (tab == null)

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -1040,6 +1040,7 @@ public class SheetWidget extends Panel {
      * stuff when it is unnecessary.
      *
      * @param event
+     *            the event
      */
     protected void onSheetMouseOverOrOut(Event event) {
         mouseOverOrOutEvent = event;
@@ -3399,7 +3400,10 @@ public class SheetWidget extends Panel {
      * Calculates viewed cells after a scroll to right. Runs the escalator for
      * column headers.
      *
-     * @param scrollLeft
+     * @param leftBound
+     *            the left scroll boundary
+     * @param rightBound
+     *            the right scroll boundary
      */
     private void handleHorizontalScrollRight(int leftBound, int rightBound) {
         final int maximumCols = actionHandler.getMaxColumns();
@@ -4216,6 +4220,7 @@ public class SheetWidget extends Panel {
      * the triangle) that has a cell comment.
      *
      * @param event
+     *            the event
      */
     private void updateCellCommentDisplay(Event event, Element target) {
         int eventTypeInt = event.getTypeInt();
@@ -4573,7 +4578,7 @@ public class SheetWidget extends Panel {
      *            1 based
      * @param row
      *            1 based
-     * @return
+     * @return the cell key
      */
     public final static String toKey(int col, int row) {
         return "col" + col + " row" + row;
@@ -4883,7 +4888,9 @@ public class SheetWidget extends Panel {
      * headers).
      *
      * @param column
+     *            the column index
      * @param row
+     *            the row index
      */
     public void swapCellSelection(int column, int row) {
         // highlight previously selected cell (background white->selected)
@@ -4981,7 +4988,9 @@ public class SheetWidget extends Panel {
      * selection. No need to modify highlighted headers.
      *
      * @param col
+     *            the column index
      * @param row
+     *            the row index
      */
     public void swapSelectedCellInsideSelection(int col, int row) {
         Cell newSelectionCell = getCell(col, row);
@@ -5030,9 +5039,13 @@ public class SheetWidget extends Panel {
      * old selected cells. Ignores the currently selected cell.
      *
      * @param col1
+     *            the first column index
      * @param col2
+     *            the second column index
      * @param row1
+     *            the first row index
      * @param row2
+     *            the second row index
      */
     public void replaceAsSelectedCells(int col1, int col2, int row1, int row2) {
         clearCellRangeStylesFromCells();
@@ -5066,9 +5079,13 @@ public class SheetWidget extends Panel {
      * given intervals.
      *
      * @param row1
+     *            the first row index
      * @param row2
+     *            the second row index
      * @param col1
+     *            the first column index
      * @param col2
+     *            the second column index
      */
     public void replaceHeadersAsSelected(int row1, int row2, int col1,
             int col2) {
@@ -5374,8 +5391,10 @@ public class SheetWidget extends Panel {
      * Returns the cell. Checks for it from a freeze pane.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return the cell
      */
     Cell getCell(int col, int row) {
         if (isCellRenderedInFrozenPane(col, row)) {
@@ -5641,8 +5660,10 @@ public class SheetWidget extends Panel {
      * Is the cell currently rendered in any of the frozen panes.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return {@code true} if frozen cell rendered, {@code false} otherwise
      */
     public boolean isFrozenCellRendered(int col, int row) {
         return isCellRenderedInTopLeftPane(col, row)
@@ -5654,8 +5675,11 @@ public class SheetWidget extends Panel {
      * Is the cell currently rendered in top left pane.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return {@code true} if cell rendered in top left pane, {@code false}
+     *         otherwise
      */
     public boolean isCellRenderedInTopLeftPane(int col, int row) {
         return col <= horizontalSplitPosition && row <= verticalSplitPosition;
@@ -5665,8 +5689,11 @@ public class SheetWidget extends Panel {
      * Is the cell currently rendered in top right pane.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return {@code true} if cell rendered in top right pane, {@code false}
+     *         otherwise
      */
     public boolean isCellRenderedInTopRightPane(int col, int row) {
         return col > horizontalSplitPosition && col <= lastColumnIndex
@@ -5677,8 +5704,11 @@ public class SheetWidget extends Panel {
      * Is the cell currently rendered in bottom left pane.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return {@code true} if cell rendered in bottom left pane, {@code false}
+     *         otherwise
      */
     public boolean isCellRenderedInBottomLeftPane(int col, int row) {
         return row > verticalSplitPosition && row <= lastRowIndex
@@ -5689,8 +5719,10 @@ public class SheetWidget extends Panel {
      * Is the given cell currently rendered. Checks freeze panes too.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return {@code true} if cell rendered, {@code false} otherwise
      */
     public boolean isCellRendered(int col, int row) {
         return isCellRenderedInScrollPane(col, row)
@@ -5701,8 +5733,10 @@ public class SheetWidget extends Panel {
      * Is the given cell currently visible completely. Checks freeze panes too.
      *
      * @param col
+     *            the column index
      * @param row
-     * @return
+     *            the row index
+     * @return {@code true} if cell completely visible, {@code false} otherwise
      */
     public boolean isCellCompletelyVisible(int col, int row) {
         return (col <= horizontalSplitPosition
@@ -6682,7 +6716,7 @@ public class SheetWidget extends Panel {
      *
      * @param index
      *            1 based column index
-     * @return
+     * @return the column width
      */
     private int getColumnWidth(int index) {
         return actionHandler.getColWidthActual(index);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -4221,6 +4221,8 @@ public class SheetWidget extends Panel {
      *
      * @param event
      *            the event
+     * @param target
+     *            the target element
      */
     private void updateCellCommentDisplay(Event event, Element target) {
         int eventTypeInt = event.getTypeInt();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetClientRpc.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetClientRpc.java
@@ -39,6 +39,7 @@ public interface SpreadsheetClientRpc extends ClientRpc {
      * The String arrays contain the caption and the icon resource key.
      *
      * @param actionDetails
+     *            the action details
      */
     void showActions(ArrayList<SpreadsheetActionDetails> actionDetails);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetContextMenuPolyfill.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetContextMenuPolyfill.java
@@ -47,6 +47,7 @@ final class SpreadsheetContextMenuPolyfill implements TouchStartHandler,
 
     /**
      * @param widget
+     *            the widget
      */
     public SpreadsheetContextMenuPolyfill(SheetWidget widget) {
         this.sheetWidget = widget;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetHandler.java
@@ -128,10 +128,10 @@ public interface SpreadsheetHandler extends GroupingHandler {
      *
      * @param sheetIndex
      *            0-based
-     * @param scrollTop
-     *            the vertical scroll position
      * @param scrollLeft
      *            the horizontal scroll position
+     * @param scrollTop
+     *            the vertical scroll position
      */
     public void sheetSelected(int sheetIndex, int scrollLeft, int scrollTop);
 
@@ -147,10 +147,10 @@ public interface SpreadsheetHandler extends GroupingHandler {
     /**
      * Sheet is created as the last sheet
      *
-     * @param scrollTop
-     *            the vertical scroll position
      * @param scrollLeft
      *            the horizontal scroll position
+     * @param scrollTop
+     *            the vertical scroll position
      */
     public void sheetCreated(int scrollLeft, int scrollTop);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetHandler.java
@@ -129,7 +129,9 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * @param sheetIndex
      *            0-based
      * @param scrollTop
+     *            the vertical scroll position
      * @param scrollLeft
+     *            the horizontal scroll position
      */
     public void sheetSelected(int sheetIndex, int scrollLeft, int scrollTop);
 
@@ -138,6 +140,7 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * @param sheetIndex
      *            0-based
      * @param newName
+     *            the new name
      */
     public void sheetRenamed(int sheetIndex, String newName);
 
@@ -145,7 +148,9 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Sheet is created as the last sheet
      *
      * @param scrollTop
+     *            the vertical scroll position
      * @param scrollLeft
+     *            the horizontal scroll position
      */
     public void sheetCreated(int scrollLeft, int scrollTop);
 
@@ -153,11 +158,17 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Cell range selected by painting
      *
      * @param selectedCellRow
+     *            the selected cell row
      * @param selectedCellColumn
+     *            the selected cell column
      * @param row1
+     *            the first row index
      * @param col1
+     *            the first column index
      * @param row2
+     *            the second row index
      * @param col2
+     *            the second column index
      */
     @Delayed(lastOnly = true)
     public void cellRangePainted(int selectedCellRow, int selectedCellColumn,
@@ -185,9 +196,13 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * @param newRowSizes
      *            row index and new size (converted pt)
      * @param row1
+     *            the first row index
      * @param col1
+     *            the first column index
      * @param row2
+     *            the second row index
      * @param col2
+     *            the second column index
      */
     public void rowsResized(Map<Integer, Float> newRowSizes, int row1, int col1,
             int row2, int col2);
@@ -196,9 +211,13 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Columns resized with drag and drop. Indexes 1-based.
      *
      * @param row1
+     *            the first row index
      * @param col1
+     *            the first column index
      * @param row2
+     *            the second row index
      * @param col2
+     *            the second column index
      * @param newColumnSizes
      *            column index and new size (px)
      */
@@ -243,6 +262,7 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Client pasted text at current selection.
      *
      * @param text
+     *            the text
      */
     public void onPaste(String text);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetServerRpc.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetServerRpc.java
@@ -39,6 +39,7 @@ public interface SpreadsheetServerRpc extends ServerRpc, SpreadsheetHandler {
      * The action was selected from context menu for the current selection.
      *
      * @param actionKey
+     *            the action key
      */
     void actionOnCurrentSelection(String actionKey);
 
@@ -54,6 +55,7 @@ public interface SpreadsheetServerRpc extends ServerRpc, SpreadsheetHandler {
      * The action was selected from context menu for the row header.
      *
      * @param actionKey
+     *            the action key
      */
     void actionOnRowHeader(String actionKey);
 
@@ -69,6 +71,7 @@ public interface SpreadsheetServerRpc extends ServerRpc, SpreadsheetHandler {
      * The action was selected from context menu for the column header.
      *
      * @param actionKey
+     *            the action key
      */
     void actionOnColumnHeader(String actionKey);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -1627,7 +1627,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
      * @param value
      *            the value
      * @param focusSheet
-     *            the focus sheet
+     *            whether to focus the sheet
      */
     private void doDeferredCellValueCommit(final String value,
             final boolean focusSheet) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -61,6 +61,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
          * Right click (event) on top of row header at the index
          *
          * @param nativeEvent
+         *            the native event
          * @param rowIndex
          *            1-based
          */
@@ -70,6 +71,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
          * Right click (event) on top of column header at the index
          *
          * @param nativeEvent
+         *            the native event
          * @param columnIndex
          *            1-based
          */
@@ -1598,8 +1600,10 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
      * update the sheet display after editing has finished
      *
      * @param focusSheet
+     *            the focus sheet
      *
      * @param focusSheet
+     *            the focus sheet
      */
     private void cellEditingDone(String value, boolean focusSheet) {
         inlineEditing = false;
@@ -1622,7 +1626,9 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
     /**
      *
      * @param value
+     *            the value
      * @param focusSheet
+     *            the focus sheet
      */
     private void doDeferredCellValueCommit(final String value,
             final boolean focusSheet) {
@@ -2006,6 +2012,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
      * the client side cache, but the cell is not actually visible.
      *
      * @param updatedCellData
+     *            the updated cell data
      */
     public void cellValuesUpdated(ArrayList<CellData> updatedCellData) {
         sheetWidget.cellValuesUpdated(updatedCellData);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -1599,11 +1599,10 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
     /**
      * update the sheet display after editing has finished
      *
+     * @param value
+     *            the cell value
      * @param focusSheet
-     *            the focus sheet
-     *
-     * @param focusSheet
-     *            the focus sheet
+     *            whether to focus the sheet after editing
      */
     private void cellEditingDone(String value, boolean focusSheet) {
         inlineEditing = false;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -367,7 +367,7 @@ public class ApplicationConfiguration implements EntryPoint {
      * Gets the initial UIDL from the DOM, if it was provided during the init
      * process.
      *
-     * @return
+     * @return the UIDL
      */
     public String getUIDL() {
         return getJsoConfiguration(id).getUIDL();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -363,6 +363,7 @@ public class ApplicationConnection implements HasHandlers {
      * source code.
      *
      * @param serverConnector
+     *            the server-side connector to highlight
      * @deprecated as of 7.1. Replaced by
      *             {@link UIConnector#showServerDebugInfo(ServerConnector)}
      */
@@ -404,7 +405,7 @@ public class ApplicationConnection implements HasHandlers {
      * Checks whether or not the CSS is loaded. By default checks the size of
      * the loading indicator element.
      *
-     * @return
+     * @return {@code true} if CSS is loaded, {@code false} otherwise
      */
     protected boolean isCSSLoaded() {
         return cssLoaded;
@@ -724,6 +725,7 @@ public class ApplicationConnection implements HasHandlers {
      * Does absolutely nothing. Replaced by {@link LayoutManager}.
      *
      * @param container
+     *            the container
      * @deprecated As of 7.0, serves no purpose
      */
     @Deprecated
@@ -744,6 +746,7 @@ public class ApplicationConnection implements HasHandlers {
      * Returns false
      *
      * @param paintable
+     *            the paintable widget
      * @return false, always
      * @deprecated As of 7.0, serves no purpose
      */
@@ -756,6 +759,7 @@ public class ApplicationConnection implements HasHandlers {
      * Returns false.
      *
      * @param widget
+     *            the widget
      * @return false, always
      * @deprecated As of 7.0, serves no purpose
      */
@@ -866,6 +870,7 @@ public class ApplicationConnection implements HasHandlers {
      *
      * @since 7.2
      * @param uri
+     *            the URI
      * @return Icon object
      */
     public Icon getIcon(String uri) {
@@ -998,10 +1003,14 @@ public class ApplicationConnection implements HasHandlers {
      * return true if the UIDL is a "cached" update.
      *
      * @param component
+     *            the component
      * @param uidl
+     *            the UIDL
      * @param manageCaption
+     *            whether to manage the caption
      * @deprecated As of 7.0, no longer serves any purpose
-     * @return
+     * @return {@code true} if the UIDL is a cached update, {@code false}
+     *         otherwise
      */
     @Deprecated
     public boolean updateComponent(Widget component, UIDL uidl,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -746,7 +746,7 @@ public class ApplicationConnection implements HasHandlers {
      * Returns false
      *
      * @param paintable
-     *            the paintable widget
+     *            the paintable connector
      * @return false, always
      * @deprecated As of 7.0, serves no purpose
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/UndoRedoIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/UndoRedoIT.java
@@ -346,7 +346,9 @@ public class UndoRedoIT extends AbstractSpreadsheetIT {
      * Does not work with PhantomJS or Firefox
      *
      * @param spreadsheet
+     *            the spreadsheet
      * @param row
+     *            the row index
      */
     private void deleteRow(SpreadsheetElement spreadsheet, int row) {
         spreadsheet.getRowHeader(row).contextClick();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/XSSFColorConverterIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/XSSFColorConverterIT.java
@@ -97,7 +97,9 @@ public class XSSFColorConverterIT extends AbstractSpreadsheetIT {
      * for testing only - POI should do the proper color lookups now
      *
      * @param workbook
+     *            the workbook
      * @param color
+     *            the color
      * @return ARGB Hex
      */
     private static String getIndexedARGB(XSSFWorkbook workbook,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionManager.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionManager.java
@@ -50,6 +50,7 @@ public class CellSelectionManager implements Serializable {
      * Creates a new CellSelectionManager and ties it to the given Spreadsheet
      *
      * @param spreadsheet
+     *            the spreadsheet
      */
     public CellSelectionManager(Spreadsheet spreadsheet) {
         this.spreadsheet = spreadsheet;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellValueManager.java
@@ -446,6 +446,7 @@ public class CellValueManager implements Serializable {
      * Calculate cell width, accounting for merged cells (see #655)
      *
      * @param cell
+     *            the cell
      * @return cell width, including widths of any merged columns
      */
     protected int getCellWidth(Cell cell) {
@@ -913,7 +914,9 @@ public class CellValueManager implements Serializable {
      * Checks whether the given cell belongs to any given range.
      *
      * @param cell
+     *            the cell
      * @param cellRangeAddresses
+     *            the cell range addresses
      * @return {@code true} if in range, {@code false} otherwise
      */
     private boolean selectedIsInRange(CellReference cell,
@@ -932,6 +935,7 @@ public class CellValueManager implements Serializable {
      * everything.
      *
      * @param selectedCellReference
+     *            the selected cell reference
      * @return {@code true} if the default handling should be performed,
      *         {@code false} otherwise
      */
@@ -963,6 +967,7 @@ public class CellValueManager implements Serializable {
      * care of everything.
      *
      * @param individualSelectedCells
+     *            the individually selected cells
      * @return {@code true} if the default handling should be performed,
      *         {@code false} otherwise
      */
@@ -985,6 +990,7 @@ public class CellValueManager implements Serializable {
      * cell range or whether a custom deletion handler takes care of everything.
      *
      * @param cellRangeAddresses
+     *            the cell range addresses
      * @return {@code true} if the default handling should be performed,
      *         {@code false} otherwise
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ChartCreator.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ChartCreator.java
@@ -23,7 +23,7 @@ public interface ChartCreator extends Serializable {
      *            metadata with the chart configuration
      * @param spreadsheet
      *            spreadsheet that chart uses as data source
-     * @return
+     * @return the created chart component
      */
     public Component createChart(XSSFChart chartXml, Spreadsheet spreadsheet);
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ColorConverter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ColorConverter.java
@@ -76,6 +76,7 @@ public interface ColorConverter extends Serializable {
      * Returns true if the given cell style has a background color.
      *
      * @param cs
+     *            the color space
      * @return Whether the given cell style has a defined background color or
      *         not.
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ColorConverter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ColorConverter.java
@@ -76,7 +76,7 @@ public interface ColorConverter extends Serializable {
      * Returns true if the given cell style has a background color.
      *
      * @param cs
-     *            the color space
+     *            the cell style
      * @return Whether the given cell style has a defined background color or
      *         not.
      */

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/DefaultHyperlinkCellClickHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/DefaultHyperlinkCellClickHandler.java
@@ -42,6 +42,7 @@ public class DefaultHyperlinkCellClickHandler
 
     /**
      * @param spreadsheet
+     *            the spreadsheet
      */
     public DefaultHyperlinkCellClickHandler(Spreadsheet spreadsheet) {
         this(spreadsheet, HyperlinkOpenStyle.NewTab);
@@ -49,6 +50,7 @@ public class DefaultHyperlinkCellClickHandler
 
     /**
      * @param spreadsheet
+     *            the spreadsheet
      * @param openStyle
      *            defaults to {@link HyperlinkOpenStyle#NewTab} if null
      */
@@ -88,6 +90,7 @@ public class DefaultHyperlinkCellClickHandler
      * Called when a hyperlink cell has been clicked.
      *
      * @param cell
+     *            the cell
      * @param hyperlink
      *            may be null, only for Excel link relations, not formula
      */
@@ -283,6 +286,7 @@ public class DefaultHyperlinkCellClickHandler
          * open external link
          *
          * @param address
+         *            the address
          */
         public abstract void openExternalLink(String address);
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetOverlayWrapper.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SheetOverlayWrapper.java
@@ -45,6 +45,7 @@ public abstract class SheetOverlayWrapper implements Serializable {
      * this method can inform the spreadsheet.
      *
      * @param listener
+     *            the listener
      */
     public void setOverlayChangeListener(OverlayChangeListener listener) {
         // NOP

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1217,6 +1217,7 @@ public class Spreadsheet extends Component
      * the default / previously set spreadsheet handler.
      *
      * @param spreadsheetHandler
+     *            the spreadsheet handler
      */
     public void setSpreadsheetHandler(
             SpreadsheetHandlerImpl spreadsheetHandler) {
@@ -1497,7 +1498,7 @@ public class Spreadsheet extends Component
      * Returns true if embedded charts are displayed
      *
      * @see #setChartsEnabled(boolean)
-     * @return
+     * @return {@code true} if charts are enabled, {@code false} otherwise
      */
     public boolean isChartsEnabled() {
         return chartsEnabled;
@@ -1508,6 +1509,7 @@ public class Spreadsheet extends Component
      * the spreadsheet or not.
      *
      * @param chartsEnabled
+     *            whether charts are enabled
      */
     public void setChartsEnabled(boolean chartsEnabled) {
         this.chartsEnabled = chartsEnabled;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetFactory.java
@@ -514,7 +514,9 @@ public class SpreadsheetFactory implements Serializable {
      * indexes.
      *
      * @param spreadsheet
+     *            the spreadsheet
      * @param sheet
+     *            the sheet
      */
     static void calculateSheetSizes(final Spreadsheet spreadsheet,
             final Sheet sheet) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetUtil.java
@@ -447,8 +447,11 @@ public class SpreadsheetUtil implements Serializable {
      * and find the bounding rectangle for the referenced cells.
      *
      * @param formula
+     *            the formula
      * @param spreadsheet
+     *            the spreadsheet
      * @param includeHiddenCells
+     *            whether hidden cells are included
      * @return CellRangeAddress bounding the evaluated result
      */
     public static CellRangeAddress getRangeForReference(String formula,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/Utils.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/Utils.java
@@ -80,6 +80,7 @@ public class Utils {
      * @param version
      *            for inferring ranges for column-only references
      * @param formula
+     *            the formula
      * @return all cells in the referenced areas
      */
     public static List<CellReference> getAllReferencedCells(

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/xssfreader/ChartStylesReader.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/charts/converter/xssfreader/ChartStylesReader.java
@@ -216,6 +216,7 @@ class ChartStylesReader {
      * properties like these can come from a common interface
      *
      * @param xAx
+     *            the x-axis
      * @return axis properties
      */
     protected AxisProperties getAxisProperties(CTCatAx xAx) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/MergedRegionUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/MergedRegionUtil.java
@@ -55,7 +55,7 @@ public class MergedRegionUtil {
      *            the left column index
      * @param rightColumn
      *            the right column index
-     * @return the merged region element
+     * @return the merged region
      */
     public static MergedRegion findIncreasingSelection(
             MergedRegionContainer container, int topRow, int bottomRow,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/MergedRegionUtil.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/MergedRegionUtil.java
@@ -46,11 +46,16 @@ public class MergedRegionUtil {
      * Parameters 1-based.
      *
      * @param container
+     *            the container
      * @param topRow
+     *            the top row index
      * @param bottomRow
+     *            the bottom row index
      * @param leftColumn
+     *            the left column index
      * @param rightColumn
-     * @return
+     *            the right column index
+     * @return the merged region element
      */
     public static MergedRegion findIncreasingSelection(
             MergedRegionContainer container, int topRow, int bottomRow,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/SpreadsheetHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/SpreadsheetHandler.java
@@ -125,10 +125,10 @@ public interface SpreadsheetHandler extends GroupingHandler {
      *
      * @param sheetIndex
      *            0-based
-     * @param scrollTop
-     *            the vertical scroll position
      * @param scrollLeft
      *            the horizontal scroll position
+     * @param scrollTop
+     *            the vertical scroll position
      */
     public void sheetSelected(int sheetIndex, int scrollLeft, int scrollTop);
 
@@ -144,10 +144,10 @@ public interface SpreadsheetHandler extends GroupingHandler {
     /**
      * Sheet is created as the last sheet
      *
-     * @param scrollTop
-     *            the vertical scroll position
      * @param scrollLeft
      *            the horizontal scroll position
+     * @param scrollTop
+     *            the vertical scroll position
      */
     public void sheetCreated(int scrollLeft, int scrollTop);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/SpreadsheetHandler.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/client/SpreadsheetHandler.java
@@ -126,7 +126,9 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * @param sheetIndex
      *            0-based
      * @param scrollTop
+     *            the vertical scroll position
      * @param scrollLeft
+     *            the horizontal scroll position
      */
     public void sheetSelected(int sheetIndex, int scrollLeft, int scrollTop);
 
@@ -135,6 +137,7 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * @param sheetIndex
      *            0-based
      * @param newName
+     *            the new name
      */
     public void sheetRenamed(int sheetIndex, String newName);
 
@@ -142,7 +145,9 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Sheet is created as the last sheet
      *
      * @param scrollTop
+     *            the vertical scroll position
      * @param scrollLeft
+     *            the horizontal scroll position
      */
     public void sheetCreated(int scrollLeft, int scrollTop);
 
@@ -150,11 +155,17 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Cell range selected by painting
      *
      * @param selectedCellRow
+     *            the selected cell row
      * @param selectedCellColumn
+     *            the selected cell column
      * @param row1
+     *            the first row index
      * @param col1
+     *            the first column index
      * @param row2
+     *            the second row index
      * @param col2
+     *            the second column index
      */
     // @Delayed(lastOnly = true)
     public void cellRangePainted(int selectedCellRow, int selectedCellColumn,
@@ -182,9 +193,13 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * @param newRowSizes
      *            row index and new size (converted pt)
      * @param row1
+     *            the first row index
      * @param col1
+     *            the first column index
      * @param row2
+     *            the second row index
      * @param col2
+     *            the second column index
      */
     public void rowsResized(Map<Integer, Float> newRowSizes, int row1, int col1,
             int row2, int col2);
@@ -193,9 +208,13 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Columns resized with drag and drop. Indexes 1-based.
      *
      * @param row1
+     *            the first row index
      * @param col1
+     *            the first column index
      * @param row2
+     *            the second row index
      * @param col2
+     *            the second column index
      * @param newColumnSizes
      *            column index and new size (px)
      */
@@ -240,6 +259,7 @@ public interface SpreadsheetHandler extends GroupingHandler {
      * Client pasted text at current selection.
      *
      * @param text
+     *            the text
      */
     public void onPaste(String text);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/CellShiftValuesCommand.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/command/CellShiftValuesCommand.java
@@ -32,6 +32,7 @@ public class CellShiftValuesCommand extends CellValueCommand {
      * @param spreadsheet
      *            Target spreadsheet
      * @param decrease
+     *            whether the selection decreases
      */
     public CellShiftValuesCommand(Spreadsheet spreadsheet, boolean decrease) {
         super(spreadsheet);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/rpc/SpreadsheetClientRpc.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/rpc/SpreadsheetClientRpc.java
@@ -40,6 +40,7 @@ public interface SpreadsheetClientRpc {
      * The String arrays contain the caption and the icon resource key.
      *
      * @param actionDetails
+     *            the action details
      */
     void showActions(ArrayList<SpreadsheetActionDetails> actionDetails);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/rpc/SpreadsheetServerRpc.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/rpc/SpreadsheetServerRpc.java
@@ -39,6 +39,7 @@ public interface SpreadsheetServerRpc extends SpreadsheetHandler {
      * The action was selected from context menu for the current selection.
      *
      * @param actionKey
+     *            the action key
      */
     void actionOnCurrentSelection(String actionKey);
 
@@ -54,6 +55,7 @@ public interface SpreadsheetServerRpc extends SpreadsheetHandler {
      * The action was selected from context menu for the row header.
      *
      * @param actionKey
+     *            the action key
      */
     void actionOnRowHeader(String actionKey);
 
@@ -69,6 +71,7 @@ public interface SpreadsheetServerRpc extends SpreadsheetHandler {
      * The action was selected from context menu for the column header.
      *
      * @param actionKey
+     *            the action key
      */
     void actionOnColumnHeader(String actionKey);
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/shared/URLReference.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/shared/URLReference.java
@@ -29,6 +29,7 @@ public class URLReference implements Serializable {
      * Sets the URL that this object refers to.
      *
      * @param url
+     *            the URL
      */
     public void setURL(String url) {
         this.url = url;

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
@@ -31,6 +31,7 @@ public abstract class AbstractUploadIT extends AbstractComponentIT {
      *            the temp file extension without leading dot
      * @return The generated temp file handle
      * @throws IOException
+     *             if the temp file cannot be created or written
      */
     File createTempFile(String extension) throws IOException {
         return createTempFile("TestFileUpload", extension);
@@ -46,6 +47,7 @@ public abstract class AbstractUploadIT extends AbstractComponentIT {
      *            the temp file extension without leading dot
      * @return The generated temp file handle
      * @throws IOException
+     *             if the temp file cannot be created or written
      */
     File createTempFile(String fileName, String extension) throws IOException {
         File tempFile = File.createTempFile(fileName, "." + extension);

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -381,7 +381,7 @@ public class UploadI18N implements Serializable {
             /**
              * @param serverUnavailable
              *            translation string
-             * @return
+             * @return this instance
              */
             public Error setServerUnavailable(String serverUnavailable) {
                 this.serverUnavailable = serverUnavailable;
@@ -398,7 +398,7 @@ public class UploadI18N implements Serializable {
             /**
              * @param unexpectedServerError
              *            translation string
-             * @return
+             * @return this instance
              */
             public Error setUnexpectedServerError(
                     String unexpectedServerError) {
@@ -416,7 +416,7 @@ public class UploadI18N implements Serializable {
             /**
              * @param forbidden
              *            translation string
-             * @return
+             * @return this instance
              */
             public Error setForbidden(String forbidden) {
                 this.forbidden = forbidden;
@@ -491,7 +491,7 @@ public class UploadI18N implements Serializable {
         /**
          * get units size list
          *
-         * @return
+         * @return the size
          */
         public List<String> getSize() {
             return size;
@@ -502,7 +502,8 @@ public class UploadI18N implements Serializable {
          * "YB"]
          *
          * @param size
-         * @return
+         *            the size
+         * @return this instance
          */
         public Units setSize(List<String> size) {
             this.size = size;

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadI18N.java
@@ -491,7 +491,7 @@ public class UploadI18N implements Serializable {
         /**
          * get units size list
          *
-         * @return the size
+         * @return the list of size unit labels
          */
         public List<String> getSize() {
             return size;
@@ -502,7 +502,7 @@ public class UploadI18N implements Serializable {
          * "YB"]
          *
          * @param size
-         *            the size
+         *            the list of size unit labels
          * @return this instance
          */
         public Units setSize(List<String> size) {


### PR DESCRIPTION
## Description

Follow-up to #9420.

Some non-Charts Javadocs have malformed block tags, mostly missing descriptions for `@param`, `@return`, and `@throws`. This fills those existing tags and fixes wrong `@param` descriptor names so generated API docs are complete and doclint-friendly.

Fixes # (issue): no dedicated issue; docs-only follow-up.

## Type of change

- [x] Bugfix
- [ ] Feature

## Changes

- Add missing descriptions for empty `@param`, `@return`, and `@throws` tags outside `vaadin-charts-flow-parent`.
- Remove an empty `@param` tag from a parameterless `Crud` getter.
- Fix non-Charts `@param` descriptor names that did not match their method parameters.
- Keep Charts-related Javadoc cleanup in #9422.

## Testing

- `git diff --check`
- Structural Javadoc scan for empty `@param`, `@return`, `@throws`, `@exception`, and invalid inline `{@see}` tags outside Charts
- Existing `@param` descriptor-name scan against method signatures outside Charts
- Comment-only diff check

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

---

🤖 Generated with Codex (GPT-5.5)
