### PR TITLE
docs: add missing charts Javadoc descriptions

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/AbstractChartExample.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/AbstractChartExample.java
@@ -72,8 +72,11 @@ public abstract class AbstractChartExample extends Div {
      * Runs given task repeatedly until the reference component is attached
      *
      * @param component
+     *            the component
      * @param task
+     *            the task
      * @param interval
+     *            the interval
      * @param initialPause
      *            a timeout after tas is started
      */

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
@@ -120,6 +120,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * Creates a new chart with the given type
      *
      * @param type
+     *            the chart type
      * @see #Chart()
      */
     public Chart(ChartType type) {
@@ -243,6 +244,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * behavior.
      *
      * @param disabled
+     *            whether visibility toggling should be disabled
      */
     public void setVisibilityTogglingDisabled(boolean disabled) {
         getElement().setProperty("_visibilityTogglingDisabled", disabled);
@@ -296,6 +298,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * series is added to the chart
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartAddSeriesListener(
             ComponentEventListener<ChartAddSeriesEvent> listener) {
@@ -307,6 +310,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * is printed using the print menu
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartAfterPrintListener(
             ComponentEventListener<ChartAfterPrintEvent> listener) {
@@ -318,6 +322,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * chart is printed using the print menu
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartBeforePrintListener(
             ComponentEventListener<ChartBeforePrintEvent> listener) {
@@ -329,6 +334,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * area
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartClickListener(
             ComponentEventListener<ChartClickEvent> listener) {
@@ -340,6 +346,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * 'Back to previous series' button.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartDrillupListener(
             ComponentEventListener<ChartDrillupEvent> listener) {
@@ -351,6 +358,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * series have been drilled up in a chart with multiple drilldown series.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartDrillupAllListener(
             ComponentEventListener<ChartDrillupAllEvent> listener) {
@@ -362,6 +370,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * loaded
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartLoadListener(
             ComponentEventListener<ChartLoadEvent> listener) {
@@ -373,6 +382,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * redrawn
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartRedrawListener(
             ComponentEventListener<ChartRedrawEvent> listener) {
@@ -384,6 +394,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * clicked a checkbox in the legend
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addCheckBoxClickListener(
             ComponentEventListener<SeriesCheckboxClickEvent> listener) {
@@ -395,6 +406,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * drilldown series for each drilldown callback when doing async drilldown
      *
      * @param listener
+     *            the listener to add
      * @see DataSeries#addItemWithDrilldown(DataSeriesItem) addItemWithDrilldown
      *      to find out how to enable async drilldown
      */
@@ -413,6 +425,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * listener implementation.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addChartSelectionListener(
             ComponentEventListener<ChartSelectionEvent> listener) {
@@ -428,6 +441,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * setVisibilityTogglingDisabled(<code>true</code>)
      *
      * @param listener
+     *            the listener to add
      * @see #setVisibilityTogglingDisabled(boolean)
      */
     public Registration addSeriesLegendItemClickListener(
@@ -444,6 +458,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * setVisibilityTogglingDisabled(<code>true</code>)
      *
      * @param listener
+     *            the listener to add
      * @see #setVisibilityTogglingDisabled(boolean)
      */
     public Registration addPointLegendItemClickListener(
@@ -456,6 +471,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * series is animated
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addSeriesAfterAnimateListener(
             ComponentEventListener<SeriesAfterAnimateEvent> listener) {
@@ -467,6 +483,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * series in the chart
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addSeriesClickListener(
             ComponentEventListener<SeriesClickEvent> listener) {
@@ -478,6 +495,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * hidden
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addSeriesHideListener(
             ComponentEventListener<SeriesHideEvent> listener) {
@@ -489,6 +507,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * exits the neighborhood of a series
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addSeriesMouseOutListener(
             ComponentEventListener<SeriesMouseOutEvent> listener) {
@@ -500,6 +519,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * enters the neighborhood of a series
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addSeriesMouseOverListener(
             ComponentEventListener<SeriesMouseOverEvent> listener) {
@@ -511,6 +531,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * shown
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addSeriesShowListener(
             ComponentEventListener<SeriesShowEvent> listener) {
@@ -522,6 +543,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * points, bars or columns in the chart
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointClickListener(
             ComponentEventListener<PointClickEvent> listener) {
@@ -533,6 +555,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * exits the neighborhood of a data point
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointMouseOutListener(
             ComponentEventListener<PointMouseOutEvent> listener) {
@@ -544,6 +567,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * enters the neighborhood of a data point
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointMouseOverListener(
             ComponentEventListener<PointMouseOverEvent> listener) {
@@ -555,6 +579,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * removed.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointRemoveListener(
             ComponentEventListener<PointRemoveEvent> listener) {
@@ -566,6 +591,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * selected.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointSelectListener(
             ComponentEventListener<PointSelectEvent> listener) {
@@ -577,6 +603,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * is unselected.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointUnselectListener(
             ComponentEventListener<PointUnselectEvent> listener) {
@@ -588,6 +615,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * updated.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointUpdateListener(
             ComponentEventListener<PointUpdateEvent> listener) {
@@ -599,6 +627,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * drag a point.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointDragStartListener(
             ComponentEventListener<PointDragStartEvent> listener) {
@@ -609,6 +638,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * Adds a point drop listener, which will be notified point is dropped.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointDropListener(
             ComponentEventListener<PointDropEvent> listener) {
@@ -620,6 +650,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * dragged.
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addPointDragListener(
             ComponentEventListener<PointDragEvent> listener) {
@@ -631,6 +662,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * axis extremes are set
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addXAxesExtremesSetListener(
             ComponentEventListener<XAxesExtremesSetEvent> listener) {
@@ -642,6 +674,7 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * axis extremes are set
      *
      * @param listener
+     *            the listener to add
      */
     public Registration addYAxesExtremesSetListener(
             ComponentEventListener<YAxesExtremesSetEvent> listener) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ChartOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/ChartOptions.java
@@ -55,6 +55,7 @@ public class ChartOptions extends AbstractConfigurationObject {
      * Changes the language of all charts.
      *
      * @param lang
+     *            the language options
      */
     public void setLang(Lang lang) {
         this.lang = lang;
@@ -88,6 +89,7 @@ public class ChartOptions extends AbstractConfigurationObject {
      * be redrawn.
      *
      * @param theme
+     *            the chart theme
      */
     public void setTheme(Theme theme) {
         this.theme = theme;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartAddSeriesEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartAddSeriesEvent.java
@@ -29,9 +29,13 @@ public class ChartAddSeriesEvent extends ComponentEvent<Chart> {
      * Constructs a ChartAddSeriesEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      * @param name
+     *            the name
      * @param data
+     *            the data
      */
     public ChartAddSeriesEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.options.name") String name,
@@ -47,7 +51,7 @@ public class ChartAddSeriesEvent extends ComponentEvent<Chart> {
     /**
      * Gets the series name
      *
-     * @return
+     * @return the name
      */
     public String getName() {
         return name;
@@ -56,7 +60,7 @@ public class ChartAddSeriesEvent extends ComponentEvent<Chart> {
     /**
      * Gets the series data
      *
-     * @return
+     * @return the data
      */
     public Number[] getData() {
         return data;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartAfterPrintEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartAfterPrintEvent.java
@@ -22,7 +22,9 @@ public class ChartAfterPrintEvent extends ComponentEvent<Chart> {
      * Constructs a ChartAfterPrintEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public ChartAfterPrintEvent(Chart source, boolean fromClient) {
         super(source, fromClient);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartBeforePrintEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartBeforePrintEvent.java
@@ -22,7 +22,9 @@ public class ChartBeforePrintEvent extends ComponentEvent<Chart> {
      * Constructs a ChartBeforePrintEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public ChartBeforePrintEvent(Chart source, boolean fromClient) {
         super(source, fromClient);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartClickEvent.java
@@ -27,14 +27,23 @@ public class ChartClickEvent extends ComponentEvent<Chart>
      * Constructs a ChartClickEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      * @param pageX
+     *            the absolute X coordinate
      * @param pageY
+     *            the absolute Y coordinate
      * @param altKey
+     *            whether the Alt key was pressed
      * @param ctrlKey
+     *            whether the Ctrl key was pressed
      * @param metaKey
+     *            whether the Meta key was pressed
      * @param shiftKey
+     *            whether the Shift key was pressed
      * @param button
+     *            the mouse button
      */
     public ChartClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.xValue") Double x,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartDrillupAllEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartDrillupAllEvent.java
@@ -23,7 +23,9 @@ public class ChartDrillupAllEvent extends ComponentEvent<Chart> {
      * Constructs a ChartDrillupAllEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public ChartDrillupAllEvent(Chart source, boolean fromClient) {
         super(source, fromClient);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartDrillupEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartDrillupEvent.java
@@ -23,7 +23,9 @@ public class ChartDrillupEvent extends ComponentEvent<Chart> {
      * Constructs a ChartDrillupEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public ChartDrillupEvent(Chart source, boolean fromClient) {
         super(source, fromClient);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartLoadEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartLoadEvent.java
@@ -22,7 +22,9 @@ public class ChartLoadEvent extends ComponentEvent<Chart> {
      * Constructs a ChartLoadEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public ChartLoadEvent(Chart source, boolean fromClient) {
         super(source, fromClient);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartSelectionEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ChartSelectionEvent.java
@@ -31,10 +31,15 @@ public class ChartSelectionEvent extends ComponentEvent<Chart> {
      * Construct a ChartSelectionEvent
      *
      * @param source
+     *            the event source
      * @param selectionStart
+     *            the selection start
      * @param selectionEnd
+     *            the selection end
      * @param valueStart
+     *            the value start
      * @param valueEnd
+     *            the value end
      */
     public ChartSelectionEvent(Chart source, boolean fromClient,
             @EventData("event.detail.xAxisMin") Double selectionStart,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/ClickEvent.java
@@ -17,7 +17,7 @@ public interface ClickEvent extends Serializable {
     /**
      * Gets the mouse click details
      *
-     * @return
+     * @return the mouse details
      */
     MouseEventDetails getMouseDetails();
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/DrilldownEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/DrilldownEvent.java
@@ -32,6 +32,7 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
      * Construct a ChartDrilldownEvent
      *
      * @param source
+     *            the event source
      */
     public DrilldownEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.point.drilldown") String drilldown,
@@ -55,7 +56,7 @@ public class DrilldownEvent extends ComponentEvent<Chart> implements HasItem {
     /**
      * Gets the name of the drilldown
      *
-     * @return
+     * @return the drilldown
      */
     public String getDrilldown() {
         return drilldown;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/HasSeries.java
@@ -23,14 +23,14 @@ public interface HasSeries extends Serializable {
     /**
      * Returns the index of the series
      *
-     * @return
+     * @return the index of the series
      */
     int getSeriesItemIndex();
 
     /**
      * Returns the series
      *
-     * @return
+     * @return the series
      */
     default Series getSeries() {
         return getSource().getConfiguration().getSeries()

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointClickEvent.java
@@ -31,18 +31,31 @@ public class PointClickEvent extends ComponentEvent<Chart>
      * Constructs a PointClickEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      * @param pageX
+     *            the absolute X coordinate
      * @param pageY
+     *            the absolute Y coordinate
      * @param altKey
+     *            whether the Alt key was pressed
      * @param ctrlKey
+     *            whether the Ctrl key was pressed
      * @param metaKey
+     *            whether the Meta key was pressed
      * @param shiftKey
+     *            whether the Shift key was pressed
      * @param button
+     *            the mouse button
      * @param seriesIndex
+     *            the series index
      * @param category
+     *            the category
      * @param pointIndex
+     *            the point index
      * @param pointId
+     *            the point id
      */
     public PointClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.pageX") int pageX,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/PointLegendItemClickEvent.java
@@ -31,7 +31,9 @@ public class PointLegendItemClickEvent extends ComponentEvent<Chart>
      * Constructs a SeriesLegendItemClickEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public PointLegendItemClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.browserEvent.pageX") int pageX,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/SeriesCheckboxClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/SeriesCheckboxClickEvent.java
@@ -27,9 +27,13 @@ public class SeriesCheckboxClickEvent extends ComponentEvent<Chart>
      * Constructs a SeriesCheckboxClickEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      * @param isChecked
+     *            whether the checkbox is checked
      * @param seriesIndex
+     *            the series index
      */
     public SeriesCheckboxClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.checked") boolean isChecked,
@@ -42,7 +46,7 @@ public class SeriesCheckboxClickEvent extends ComponentEvent<Chart>
     /**
      * Checks if the checkbox is checked
      *
-     * @return
+     * @return whether the checkbox is checked
      */
     public boolean isChecked() {
         return checked;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/SeriesLegendItemClickEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/SeriesLegendItemClickEvent.java
@@ -28,7 +28,9 @@ public class SeriesLegendItemClickEvent extends ComponentEvent<Chart>
      * Constructs a SeriesLegendItemClickEvent
      *
      * @param source
+     *            the event source
      * @param fromClient
+     *            whether the event originated from the client
      */
     public SeriesLegendItemClickEvent(Chart source, boolean fromClient,
             @EventData("event.detail.originalEvent.browserEvent.pageX") int pageX,

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ConfigurationChangeListener.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ConfigurationChangeListener.java
@@ -62,6 +62,7 @@ public interface ConfigurationChangeListener extends Serializable {
      * A new series has been added
      *
      * @param event
+     *            the configuration change event
      */
     void seriesAdded(SeriesAddedEvent event);
 
@@ -85,7 +86,9 @@ public interface ConfigurationChangeListener extends Serializable {
      * Reset zoom level by setting axis extremes to null
      *
      * @param redraw
+     *            whether to redraw the chart
      * @param animate
+     *            whether to animate the redraw
      */
     void resetZoom(boolean redraw, boolean animate);
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ItemSlicedEvent.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/events/internal/ItemSlicedEvent.java
@@ -26,9 +26,13 @@ public class ItemSlicedEvent extends AbstractSeriesEvent {
      * Constructs the event.
      *
      * @param index
+     *            the item index
      * @param sliced
+     *            whether the item is sliced
      * @param redraw
+     *            whether to redraw the chart
      * @param animation
+     *            whether to animate the operation
      */
     public ItemSlicedEvent(Series series, int index, boolean sliced,
             boolean redraw, boolean animation) {
@@ -43,8 +47,11 @@ public class ItemSlicedEvent extends AbstractSeriesEvent {
      * Constructs the event with animated transition
      *
      * @param index
+     *            the item index
      * @param sliced
+     *            whether the item is sliced
      * @param redraw
+     *            whether to redraw the chart
      */
     public ItemSlicedEvent(Series series, int index, boolean sliced,
             boolean redraw) {
@@ -55,7 +62,9 @@ public class ItemSlicedEvent extends AbstractSeriesEvent {
      * Constructs the event with animated transition, redraws the chart
      *
      * @param index
+     *            the item index
      * @param sliced
+     *            whether the item is sliced
      */
     public ItemSlicedEvent(Series series, int index, boolean sliced) {
         this(series, index, sliced, true, true);
@@ -64,7 +73,7 @@ public class ItemSlicedEvent extends AbstractSeriesEvent {
     /**
      * Returns the index of the point to be sliced
      *
-     * @return
+     * @return the index of the point to be sliced
      */
     public int getIndex() {
         return index;
@@ -74,7 +83,7 @@ public class ItemSlicedEvent extends AbstractSeriesEvent {
      * When true, the point is sliced out. When false, the point is set in. When
      * null or undefined, the sliced state is toggled.
      *
-     * @return
+     * @return whether the item is sliced
      */
     public boolean isSliced() {
         return sliced;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AbstractSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AbstractSeries.java
@@ -84,6 +84,7 @@ public abstract class AbstractSeries extends AbstractConfigurationObject
      * series' stack options match each other. Defaults to null.
      *
      * @param stack
+     *            the stack
      */
     public void setStack(String stack) {
         this.stack = stack;
@@ -243,6 +244,7 @@ public abstract class AbstractSeries extends AbstractConfigurationObject
      * @see #setyAxis(Integer)
      *
      * @param secondaryAxis
+     *            whether to use the secondary axis
      */
     public void setyAxis(YAxis secondaryAxis) {
         if (configuration == null) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AnnotationItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AnnotationItem.java
@@ -33,6 +33,7 @@ public class AnnotationItem extends AbstractConfigurationObject {
      * Sets labels that can be positioned anywhere in the chart area.
      *
      * @param labels
+     *            the labels
      */
     public void setLabels(AnnotationItemLabel... labels) {
         clearLabels();
@@ -44,6 +45,7 @@ public class AnnotationItem extends AbstractConfigurationObject {
      *
      * @see #setLabels(AnnotationItemLabel...)
      * @param labels
+     *            the labels
      */
     public void addLabels(AnnotationItemLabel... labels) {
         for (AnnotationItemLabel label : labels) {
@@ -56,6 +58,7 @@ public class AnnotationItem extends AbstractConfigurationObject {
      *
      * @see #setLabels(AnnotationItemLabel...)
      * @param label
+     *            the label
      */
     public void addLabel(AnnotationItemLabel label) {
         getLabels().add(label);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Attributes.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Attributes.java
@@ -23,7 +23,7 @@ public class Attributes extends AbstractConfigurationObject {
 
     /**
      * @see #setFill(Color)
-     * @return
+     * @return the fill
      */
     public Color getFill() {
         return fill;
@@ -33,6 +33,7 @@ public class Attributes extends AbstractConfigurationObject {
      * SVG fill attribute
      *
      * @param fill
+     *            the fill
      */
     public void setFill(Color fill) {
         this.fill = fill;
@@ -40,7 +41,7 @@ public class Attributes extends AbstractConfigurationObject {
 
     /**
      * @see #setStroke(Color)
-     * @return
+     * @return the stroke
      */
     public Color getStroke() {
         return stroke;
@@ -50,6 +51,7 @@ public class Attributes extends AbstractConfigurationObject {
      * SVG stroke attribute
      *
      * @param stroke
+     *            the stroke
      */
     public void setStroke(Color stroke) {
         this.stroke = stroke;
@@ -57,7 +59,7 @@ public class Attributes extends AbstractConfigurationObject {
 
     /**
      * @see #setStrokeWidth(Number)
-     * @return
+     * @return the stroke width
      */
     public Number getStrokeWidth() {
         return strokeWidth;
@@ -67,6 +69,7 @@ public class Attributes extends AbstractConfigurationObject {
      * SVG stroke-width attribute
      *
      * @param strokeWidth
+     *            the stroke width
      */
     public void setStrokeWidth(Number strokeWidth) {
         this.strokeWidth = strokeWidth;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Axis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Axis.java
@@ -51,6 +51,7 @@ public abstract class Axis extends AbstractConfigurationObject {
      * rounded down.
      *
      * @param min
+     *            the minimum value
      */
     public void setMin(Number min) {
         this.min = min;
@@ -60,6 +61,7 @@ public abstract class Axis extends AbstractConfigurationObject {
      * The minimum value of the axis as Instant.
      *
      * @param min
+     *            the minimum value
      * @see #setMin(Number)
      */
     public void setMin(Instant min) {
@@ -81,6 +83,7 @@ public abstract class Axis extends AbstractConfigurationObject {
      * chart.alignTicks.
      *
      * @param max
+     *            the maximum value
      */
     public void setMax(Number max) {
         this.max = max;
@@ -90,6 +93,7 @@ public abstract class Axis extends AbstractConfigurationObject {
      * The maximum value of the axis as Instant.
      *
      * @param max
+     *            the maximum value
      * @see #setMax(Number)
      */
     public void setMax(Instant max) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Background.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Background.java
@@ -39,6 +39,7 @@ public class Background extends AbstractConfigurationObject {
      * Sets the background color
      *
      * @param backgroundColor
+     *            the background color
      */
     public void setBackgroundColor(Color backgroundColor) {
         this.backgroundColor = backgroundColor;
@@ -55,6 +56,7 @@ public class Background extends AbstractConfigurationObject {
      * Sets the border color
      *
      * @param borderColor
+     *            the border color
      */
     public void setBorderColor(Color borderColor) {
         this.borderColor = borderColor;
@@ -76,6 +78,7 @@ public class Background extends AbstractConfigurationObject {
      * string.
      *
      * @param borderRadius
+     *            the border radius
      */
     public void setBorderRadius(String borderRadius) {
         this.borderRadius = borderRadius;
@@ -92,6 +95,7 @@ public class Background extends AbstractConfigurationObject {
      * Sets the width of the border
      *
      * @param borderWidth
+     *            the border width
      */
     public void setBorderWidth(Number borderWidth) {
         this.borderWidth = borderWidth;
@@ -126,6 +130,7 @@ public class Background extends AbstractConfigurationObject {
      * charts.</em>
      *
      * @param outerRadius
+     *            the outer radius
      */
     public void setOuterRadius(String outerRadius) {
         this.outerRadius = outerRadius;
@@ -147,6 +152,7 @@ public class Background extends AbstractConfigurationObject {
      * charts.</em>
      *
      * @param innerRadius
+     *            the inner radius
      */
     public void setInnerRadius(String innerRadius) {
         this.innerRadius = innerRadius;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/BoxPlotItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/BoxPlotItem.java
@@ -34,12 +34,15 @@ public class BoxPlotItem extends DataSeriesItem {
      * Constructs an item for box plot with given values.
      *
      * @param low
+     *            the low
      * @param q1
      *            lower quartile
      * @param median
+     *            the median
      * @param q3
      *            upper quartile
      * @param high
+     *            the high
      */
     public BoxPlotItem(Number low, Number q1, Number median, Number q3,
             Number high) {
@@ -53,7 +56,7 @@ public class BoxPlotItem extends DataSeriesItem {
 
     /**
      * @see #setLowerQuartile(Number)
-     * @return
+     * @return the lower quartile
      */
     public Number getLowerQuartile() {
         return q1;
@@ -97,6 +100,7 @@ public class BoxPlotItem extends DataSeriesItem {
      * Sets the median of the item. Often referred as q2 value.
      *
      * @param median
+     *            the median
      */
     public void setMedian(Number median) {
         this.median = median;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ChartModel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ChartModel.java
@@ -899,6 +899,7 @@ public class ChartModel extends AbstractConfigurationObject {
      * support.
      *
      * @param zooming
+     *            the zooming
      */
     public void setZooming(Zooming zooming) {
         this.zooming = zooming;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Completed.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Completed.java
@@ -43,6 +43,7 @@ public class Completed extends AbstractConfigurationObject {
      * (finished). Defaults to 0.
      *
      * @param amount
+     *            the amount
      */
     public void setAmount(Number amount) {
         this.amount = amount;
@@ -60,6 +61,7 @@ public class Completed extends AbstractConfigurationObject {
      * main color. The value will be ignored if the chart is in Styled mode.
      *
      * @param fill
+     *            the fill
      */
     public void setFill(Color fill) {
         this.fill = fill;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Configuration.java
@@ -80,6 +80,7 @@ public class Configuration extends AbstractConfigurationObject
      * Sets options for configuring accessibility for the chart.
      *
      * @param accessibility
+     *            the accessibility
      */
     public void setAccessibility(Accessibility accessibility) {
         this.accessibility = accessibility;
@@ -118,6 +119,7 @@ public class Configuration extends AbstractConfigurationObject
      * Adds a single series to the list of series in this configuration.
      *
      * @param series
+     *            the series
      */
     public void addSeries(Series series) {
         this.series.add(series);
@@ -149,6 +151,7 @@ public class Configuration extends AbstractConfigurationObject
      * the client.
      *
      * @param series
+     *            the series
      */
     public void setSeries(List<Series> series) {
         this.series = new ArrayList<>(series);
@@ -161,6 +164,7 @@ public class Configuration extends AbstractConfigurationObject
     /**
      * @see #setSeries(List)
      * @param series
+     *            the series
      */
     public void setSeries(Series... series) {
         setSeries(Arrays.asList(series));
@@ -172,6 +176,7 @@ public class Configuration extends AbstractConfigurationObject
      * at this point
      *
      * @param series
+     *            the series
      */
     private void addSeriesToDrilldownConfiguration(Series series) {
         if (series instanceof DataSeries) {
@@ -215,6 +220,7 @@ public class Configuration extends AbstractConfigurationObject
      * The main title of the chart.
      *
      * @param title
+     *            the title
      */
     public void setTitle(Title title) {
         this.title = title;
@@ -254,6 +260,7 @@ public class Configuration extends AbstractConfigurationObject
      * Sets the chart's subtitle
      *
      * @param subTitle
+     *            the subtitle
      */
     public void setSubTitle(Subtitle subTitle) {
         subtitle = subTitle;
@@ -505,6 +512,7 @@ public class Configuration extends AbstractConfigurationObject
      * series or point.
      *
      * @param tooltip
+     *            the tooltip
      */
     public void setTooltip(Tooltip tooltip) {
         this.tooltip = tooltip;
@@ -525,6 +533,7 @@ public class Configuration extends AbstractConfigurationObject
      * the chart.
      *
      * @param credits
+     *            the credits
      */
     public void setCredits(Credits credits) {
         this.credits = credits;
@@ -555,6 +564,7 @@ public class Configuration extends AbstractConfigurationObject
      * each series item or point item in the chart.
      *
      * @param legend
+     *            the legend
      */
     public void setLegend(Legend legend) {
         this.legend = legend;
@@ -579,6 +589,7 @@ public class Configuration extends AbstractConfigurationObject
      * @see #setPlotOptions(AbstractPlotOptions...)
      *
      * @param type
+     *            the chart type
      */
     public AbstractPlotOptions getPlotOptions(ChartType type) {
         return plotOptions.get(type.toString());
@@ -598,6 +609,7 @@ public class Configuration extends AbstractConfigurationObject
      * @see AbstractPlotOptions
      *
      * @param plotOptions
+     *            the plot options
      */
     public void setPlotOptions(AbstractPlotOptions... plotOptions) {
         this.plotOptions.clear();
@@ -612,6 +624,7 @@ public class Configuration extends AbstractConfigurationObject
      * @see #setPlotOptions(AbstractPlotOptions...)
      *
      * @param plotOptions
+     *            the plot options
      */
     public void addPlotOptions(AbstractPlotOptions plotOptions) {
         if (plotOptions instanceof PlotOptionsSeries) {
@@ -626,6 +639,7 @@ public class Configuration extends AbstractConfigurationObject
      * Sets whether to enable exporting
      *
      * @param exporting
+     *            the exporting
      * @see Exporting
      * @see #setExporting(Exporting)
      */
@@ -637,6 +651,7 @@ public class Configuration extends AbstractConfigurationObject
      * Sets the exporting module settings.
      *
      * @param exporting
+     *            the exporting
      * @see Exporting
      */
     public void setExporting(Exporting exporting) {
@@ -677,6 +692,7 @@ public class Configuration extends AbstractConfigurationObject
      * set. Each XAxis or YAxis can reference the pane by index.
      *
      * @param pane
+     *            the pane
      */
     public void addPane(Pane pane) {
         if (this.pane == null) {
@@ -691,6 +707,7 @@ public class Configuration extends AbstractConfigurationObject
      * This is only valid if the chart is configured to use timeline mode. See
      *
      * @param rangeSelector
+     *            the range selector
      * @see RangeSelector
      */
     public void setRangeSelector(RangeSelector rangeSelector) {
@@ -723,6 +740,7 @@ public class Configuration extends AbstractConfigurationObject
      * Allows panning over the X axis of the chart
      *
      * @param scrollbar
+     *            the scrollbar
      */
     public void setScrollbar(Scrollbar scrollbar) {
         this.scrollbar = scrollbar;
@@ -744,6 +762,7 @@ public class Configuration extends AbstractConfigurationObject
      * The actual text to display is set in the {@link Lang#setNoData(String)}
      *
      * @param noData
+     *            the no-data options
      */
     public void setNoData(NoData noData) {
         this.noData = noData;
@@ -763,6 +782,7 @@ public class Configuration extends AbstractConfigurationObject
      * Set options for buttons and menus appearing in the exporting module.
      *
      * @param navigation
+     *            the navigation
      */
     public void setNavigation(Navigation navigation) {
         this.navigation = navigation;
@@ -783,6 +803,7 @@ public class Configuration extends AbstractConfigurationObject
      * covers the plot area on chart operations.
      *
      * @param loading
+     *            the loading
      */
     public void setLoading(Loading loading) {
         this.loading = loading;
@@ -802,6 +823,7 @@ public class Configuration extends AbstractConfigurationObject
      * Set configuration for the navigator
      *
      * @param navigator
+     *            the navigator
      */
     public void setNavigator(Navigator navigator) {
         this.navigator = navigator;
@@ -821,6 +843,7 @@ public class Configuration extends AbstractConfigurationObject
      * Set configuration for time options
      *
      * @param time
+     *            the time
      */
     public void setTime(Time time) {
         this.time = time;
@@ -858,7 +881,9 @@ public class Configuration extends AbstractConfigurationObject
      * Notifies listeners that a data point has been added
      *
      * @param series
+     *            the series
      * @param value
+     *            the value
      */
     void fireDataAdded(Series series, Number value) {
         DataAddedEvent dataAddedEvent = new DataAddedEvent(series, value);
@@ -871,6 +896,7 @@ public class Configuration extends AbstractConfigurationObject
      * Notifies listeners that a data point has been added
      *
      * @param shift
+     *            the shift
      */
     void fireDataAdded(Series series, DataSeriesItem item, boolean shift) {
         DataAddedEvent dataAddedEvent = new DataAddedEvent(series, item, shift);
@@ -1039,10 +1065,15 @@ public class Configuration extends AbstractConfigurationObject
      * Fires point sliced event
      *
      * @param series
+     *            the series
      * @param index
+     *            the item index
      * @param sliced
+     *            whether the item is sliced
      * @param redraw
+     *            whether to redraw the chart
      * @param animation
+     *            whether to animate the operation
      */
     void fireItemSliced(Series series, int index, boolean sliced,
             boolean redraw, boolean animation) {
@@ -1203,6 +1234,7 @@ public class Configuration extends AbstractConfigurationObject
      * dependency (see {@link GanttSeriesItemDependency}).
      *
      * @param connectors
+     *            the connectors
      */
     public void setConnectors(ChartConnectors connectors) {
         this.connectors = connectors;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
@@ -612,6 +612,7 @@ public class DataLabels extends AbstractDataLabels {
      * possible, it defaults to right. Defaults to "center".
      *
      * @param position
+     *            the position
      */
     public void setPosition(HorizontalAlign position) {
         this.position = position;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataProviderSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataProviderSeries.java
@@ -221,7 +221,7 @@ public class DataProviderSeries<T> extends AbstractSeries {
      * Returns a list mappings between chart attributes(keys) and values. For
      * example: x->1, x->2, y->2, y->3 for linear chart
      *
-     * @return
+     * @return a list mappings between chart attributes(keys) and values
      */
 
     public List<Map<String, Optional<Object>>> getValues() {
@@ -238,7 +238,7 @@ public class DataProviderSeries<T> extends AbstractSeries {
     /**
      * Returns a set of chart attributes(keys).
      *
-     * @return
+     * @return a set of chart attributes(keys)
      */
     public Set<String> getChartAttributes() {
         return chartAttributeToCallback.keySet();
@@ -248,7 +248,8 @@ public class DataProviderSeries<T> extends AbstractSeries {
      * Returns true if the chart is updated automatically when a DataChangeEvent
      * is emitted by the data provider. Default is true.
      *
-     * @return
+     * @return true if the chart is updated automatically when a DataChangeEvent
+     *         is emitted by the data provider
      */
     public boolean isAutomaticChartUpdateEnabled() {
         return automaticChartUpdateEnabled;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeries.java
@@ -47,7 +47,9 @@ public class DataSeries extends AbstractSeries {
      * value pairs.
      *
      * @param categories
+     *            the categories
      * @param ys
+     *            the ys
      */
     public DataSeries(String[] categories, Number[] ys) {
         for (int i = 0; i < categories.length; i++) {
@@ -153,6 +155,7 @@ public class DataSeries extends AbstractSeries {
      * value for names (value.toString) and Y-values.
      *
      * @param values
+     *            the values
      */
     public void setData(Number... values) {
         data.clear();
@@ -165,6 +168,7 @@ public class DataSeries extends AbstractSeries {
      * Sets the data to the provided list of data items.
      *
      * @param data
+     *            the data
      */
     public void setData(List<DataSeriesItem> data) {
         this.data = data;
@@ -206,7 +210,9 @@ public class DataSeries extends AbstractSeries {
      * {@link Configuration#getDrilldown()}
      *
      * @param item
+     *            the item
      * @param series
+     *            the series
      */
     public void addItemWithDrilldown(DataSeriesItem item, Series series) {
         add(item);
@@ -227,6 +233,7 @@ public class DataSeries extends AbstractSeries {
      * {@link Configuration#getDrilldown()}
      *
      * @param item
+     *            the item
      */
     public void addItemWithDrilldown(DataSeriesItem item) {
         add(item);
@@ -317,6 +324,7 @@ public class DataSeries extends AbstractSeries {
      * Returns {@link DataSeriesItem} at given index
      *
      * @param index
+     *            the item index
      * @return the Item
      * @throws IndexOutOfBoundsException
      *             if data series don't have item at given index

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItem.java
@@ -314,6 +314,7 @@ public class DataSeriesItem extends AbstractSeriesItem {
      * {@link DrilldownCallback} will be triggered when user clicks in a point.
      *
      * @param drilldown
+     *            the drilldown
      */
     void setDrilldown(String drilldown) {
         this.drilldown = drilldown;
@@ -324,6 +325,7 @@ public class DataSeriesItem extends AbstractSeriesItem {
      * triggered when user clicks in a point.
      *
      * @param drilldown
+     *            the drilldown
      */
     void setDrilldown(Boolean drilldown) {
         this.drilldown = drilldown;
@@ -341,6 +343,7 @@ public class DataSeriesItem extends AbstractSeriesItem {
      * Set the label configuration for this item
      *
      * @param dataLabels
+     *            the data labels
      */
     public void setDataLabels(DataLabels dataLabels) {
         this.dataLabels = dataLabels;
@@ -368,6 +371,7 @@ public class DataSeriesItem extends AbstractSeriesItem {
      * Note that not all browsers have support for all values.
      *
      * @param cursor
+     *            the cursor
      */
     public void setCursor(String cursor) {
         this.cursor = cursor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItem3d.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItem3d.java
@@ -23,8 +23,11 @@ public class DataSeriesItem3d extends DataSeriesItem {
      * Constructs an item with X, Y and Z values
      *
      * @param x
+     *            the X value
      * @param y
+     *            the Y value
      * @param z
+     *            the z
      */
     public DataSeriesItem3d(Number x, Number y, Number z) {
         super(x, y);
@@ -35,6 +38,7 @@ public class DataSeriesItem3d extends DataSeriesItem {
      * Sets the z value of the point.
      *
      * @param z
+     *            the z
      */
     public void setZ(Number z) {
         this.z = z;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemBullet.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemBullet.java
@@ -30,7 +30,9 @@ public class DataSeriesItemBullet extends DataSeriesItem {
      * Constructs an item with Y and Target
      *
      * @param y
+     *            the Y value
      * @param target
+     *            the target
      */
     public DataSeriesItemBullet(Number y, Number target) {
         super();
@@ -42,8 +44,11 @@ public class DataSeriesItemBullet extends DataSeriesItem {
      * Constructs an item with X, Y and Target
      *
      * @param x
+     *            the X value
      * @param y
+     *            the Y value
      * @param target
+     *            the target
      */
     public DataSeriesItemBullet(Number x, Number y, Number target) {
         super(x, y);
@@ -54,8 +59,11 @@ public class DataSeriesItemBullet extends DataSeriesItem {
      * Constructs an item with X, Y and Target
      *
      * @param x
+     *            the X value
      * @param y
+     *            the Y value
      * @param target
+     *            the target
      */
     public DataSeriesItemBullet(Instant x, Number y, Number target) {
         super(x, y);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemSankey.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemSankey.java
@@ -27,8 +27,11 @@ public class DataSeriesItemSankey extends DataSeriesItem {
      * Constructs an item with from, to and weight values
      *
      * @param from
+     *            the from
      * @param to
+     *            the to
      * @param weight
+     *            the weight
      */
     public DataSeriesItemSankey(String from, String to, Number weight) {
         this();

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemTimeline.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemTimeline.java
@@ -26,8 +26,11 @@ public class DataSeriesItemTimeline extends DataSeriesItem {
      * Constructs an item with Name, Label and Description values
      *
      * @param name
+     *            the name
      * @param label
+     *            the label
      * @param description
+     *            the description
      */
     public DataSeriesItemTimeline(String name, String label,
             String description) {
@@ -41,9 +44,13 @@ public class DataSeriesItemTimeline extends DataSeriesItem {
      * Constructs an item with X, Name, Label and Description values
      *
      * @param x
+     *            the X value
      * @param name
+     *            the name
      * @param label
+     *            the label
      * @param description
+     *            the description
      */
     public DataSeriesItemTimeline(Number x, String name, String label,
             String description) {
@@ -55,9 +62,13 @@ public class DataSeriesItemTimeline extends DataSeriesItem {
      * Constructs an item with X, Name, Label and Description values
      *
      * @param x
+     *            the X value
      * @param name
+     *            the name
      * @param label
+     *            the label
      * @param description
+     *            the description
      */
     public DataSeriesItemTimeline(Instant x, String name, String label,
             String description) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemXrange.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataSeriesItemXrange.java
@@ -36,8 +36,11 @@ public class DataSeriesItemXrange extends DataSeriesItem {
      * Constructs an item with X, X2 and Y
      *
      * @param x
+     *            the X value
      * @param x2
+     *            the x2
      * @param y
+     *            the Y value
      */
     public DataSeriesItemXrange(Number x, Number x2, Number y) {
         super(x, y);
@@ -48,8 +51,11 @@ public class DataSeriesItemXrange extends DataSeriesItem {
      * Constructs an item with X, X2 and Y
      *
      * @param x
+     *            the X value
      * @param x2
+     *            the x2
      * @param y
+     *            the Y value
      */
     public DataSeriesItemXrange(Instant x, Instant x2, Number y) {
         super(x, y);
@@ -60,9 +66,13 @@ public class DataSeriesItemXrange extends DataSeriesItem {
      * Constructs an item with X, X2, Y and partialFillAmount.
      *
      * @param x
+     *            the X value
      * @param x2
+     *            the x2
      * @param y
+     *            the Y value
      * @param partialFillAmount
+     *            the partial fill amount
      */
     public DataSeriesItemXrange(Number x, Number x2, Number y,
             Number partialFillAmount) {
@@ -74,9 +84,13 @@ public class DataSeriesItemXrange extends DataSeriesItem {
      * Constructs an item with X, X2, Y and partialFillAmount.
      *
      * @param x
+     *            the X value
      * @param x2
+     *            the x2
      * @param y
+     *            the Y value
      * @param partialFillAmount
+     *            the partial fill amount
      */
     public DataSeriesItemXrange(Instant x, Instant x2, Number y,
             Number partialFillAmount) {
@@ -88,10 +102,15 @@ public class DataSeriesItemXrange extends DataSeriesItem {
      * Constructs an item with X, X2, Y, partialFillAmount and partialFillColor.
      *
      * @param x
+     *            the X value
      * @param x2
+     *            the x2
      * @param y
+     *            the Y value
      * @param partialFillAmount
+     *            the partial fill amount
      * @param partialFillColor
+     *            the partial fill color
      */
     public DataSeriesItemXrange(Number x, Number x2, Number y,
             Number partialFillAmount, Color partialFillColor) {
@@ -104,10 +123,15 @@ public class DataSeriesItemXrange extends DataSeriesItem {
      * Constructs an item with X, X2, Y, partialFillAmount and partialFillColor.
      *
      * @param x
+     *            the X value
      * @param x2
+     *            the x2
      * @param y
+     *            the Y value
      * @param partialFillAmount
+     *            the partial fill amount
      * @param partialFillColor
+     *            the partial fill color
      */
     public DataSeriesItemXrange(Instant x, Instant x2, Number y,
             Number partialFillAmount, Color partialFillColor) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DateTimeLabelFormats.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DateTimeLabelFormats.java
@@ -45,7 +45,9 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * and year
      *
      * @param month
+     *            the month
      * @param year
+     *            the year
      */
     public DateTimeLabelFormats(String month, String year) {
         this.month = month;
@@ -64,6 +66,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for second resolution.
      *
      * @param second
+     *            the second
      */
     public void setSecond(String second) {
         this.second = second;
@@ -81,6 +84,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for minute resolution.
      *
      * @param minute
+     *            the minute
      */
     public void setMinute(String minute) {
         this.minute = minute;
@@ -98,6 +102,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for hour resolution
      *
      * @param hour
+     *            the hour
      */
     public void setHour(String hour) {
         this.hour = hour;
@@ -115,6 +120,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for day resolution.
      *
      * @param day
+     *            the day
      */
     public void setDay(String day) {
         this.day = day;
@@ -132,6 +138,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for week resolution.
      *
      * @param week
+     *            the week
      */
     public void setWeek(String week) {
         this.week = week;
@@ -149,6 +156,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for month resolution.
      *
      * @param month
+     *            the month
      */
     public void setMonth(String month) {
         this.month = month;
@@ -166,6 +174,7 @@ public class DateTimeLabelFormats extends AbstractConfigurationObject {
      * Sets the format String for year resolution.
      *
      * @param year
+     *            the year
      */
     public void setYear(String year) {
         this.year = year;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragDrop.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragDrop.java
@@ -41,6 +41,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * individually. Defaults to true.
      *
      * @param draggableEnd
+     *            the draggable end
      */
     public void setDraggableEnd(Boolean draggableEnd) {
         this.draggableEnd = draggableEnd;
@@ -58,6 +59,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * individually. Defaults to true.
      *
      * @param draggableStart
+     *            the draggable start
      */
     public void setDraggableStart(Boolean draggableStart) {
         this.draggableStart = draggableStart;
@@ -74,6 +76,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Enable dragging in the X dimension.
      *
      * @param draggableX
+     *            the draggable x
      */
     public void setDraggableX(Boolean draggableX) {
         this.draggableX = draggableX;
@@ -90,6 +93,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Allow X1 value to be dragged individually. Defaults to true.
      *
      * @param draggableX1
+     *            the draggable x1
      */
     public void setDraggableX1(Boolean draggableX1) {
         this.draggableX1 = draggableX1;
@@ -106,6 +110,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Allow X2 value to be dragged individually. Defaults to true.
      *
      * @param draggableX2
+     *            the draggable x2
      */
     public void setDraggableX2(Boolean draggableX2) {
         this.draggableX2 = draggableX2;
@@ -123,6 +128,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * TreeGrid axes (the default axis type in Gantt charts).
      *
      * @param draggableY
+     *            the draggable y
      */
     public void setDraggableY(Boolean draggableY) {
         this.draggableY = draggableY;
@@ -142,6 +148,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Options for the drag handles.
      *
      * @param dragHandle
+     *            the drag handle
      */
     public void setDragHandle(DragHandle dragHandle) {
         this.dragHandle = dragHandle;
@@ -158,6 +165,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Set the maximum X value the points can be moved to.
      *
      * @param dragMaxX
+     *            the drag max x
      */
     public void setDragMaxX(Number dragMaxX) {
         this.dragMaxX = dragMaxX;
@@ -174,6 +182,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Set the maximum Y value the points can be moved to.
      *
      * @param dragMaxY
+     *            the drag max y
      */
     public void setDragMaxY(Number dragMaxY) {
         this.dragMaxY = dragMaxY;
@@ -190,6 +199,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Set the minimum X value the points can be moved to.
      *
      * @param dragMinX
+     *            the drag min x
      */
     public void setDragMinX(Number dragMinX) {
         this.dragMinX = dragMinX;
@@ -206,6 +216,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * Set the minimum Y value the points can be moved to.
      *
      * @param dragMinY
+     *            the drag min y
      */
     public void setDragMinY(Number dragMinY) {
         this.dragMinY = dragMinY;
@@ -224,6 +235,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * 1. Defaults to 0.
      *
      * @param dragPrecisionX
+     *            the drag precision x
      */
     public void setDragPrecisionX(Number dragPrecisionX) {
         this.dragPrecisionX = dragPrecisionX;
@@ -242,6 +254,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * 1. Defaults to 0.
      *
      * @param dragPrecisionY
+     *            the drag precision y
      */
     public void setDragPrecisionY(Number dragPrecisionY) {
         this.dragPrecisionY = dragPrecisionY;
@@ -260,6 +273,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * selecting points. Defaults to 2.
      *
      * @param dragSensitivity
+     *            the drag sensitivity
      */
     public void setDragSensitivity(Number dragSensitivity) {
         this.dragSensitivity = dragSensitivity;
@@ -277,6 +291,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * be grouped together when moving. Defaults to undefined.
      *
      * @param groupBy
+     *            the group by
      */
     public void setGroupBy(String groupBy) {
         this.groupBy = groupBy;
@@ -299,6 +314,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * @see #setLiveRedraw(Boolean)
      *
      * @param guideBox
+     *            the guide box
      */
     public void setGuideBox(GuideBox guideBox) {
         this.guideBox = guideBox;
@@ -316,6 +332,7 @@ public class DragDrop extends AbstractConfigurationObject {
      * illustrate the new point size. Defaults to true.
      *
      * @param liveRedraw
+     *            whether live redraw is enabled
      */
     public void setLiveRedraw(Boolean liveRedraw) {
         this.liveRedraw = liveRedraw;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragHandle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DragHandle.java
@@ -33,6 +33,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * Defaults to highcharts-drag-handle.
      *
      * @param className
+     *            the class name
      */
     public void setClassName(String className) {
         this.className = className;
@@ -49,6 +50,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * The fill color of the drag handles. Defaults to #fff.
      *
      * @param color
+     *            the color
      */
     public void setColor(Color color) {
         this.color = color;
@@ -67,6 +69,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * direction the point is being dragged.
      *
      * @param cursor
+     *            the cursor
      */
     public void setCursor(String cursor) {
         this.cursor = cursor;
@@ -83,6 +86,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * The line color of the drag handles. Defaults to rgba(0, 0, 0, 0.6).
      *
      * @param lineColor
+     *            the line color
      */
     public void setLineColor(Color lineColor) {
         this.lineColor = lineColor;
@@ -99,6 +103,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * The line width for the drag handles. Defaults to 1.
      *
      * @param lineWidth
+     *            the line width
      */
     public void setLineWidth(Number lineWidth) {
         this.lineWidth = lineWidth;
@@ -115,6 +120,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * The z index for the drag handles. Defaults to 901.
      *
      * @param zIndex
+     *            the z index
      */
     public void setzIndex(Number zIndex) {
         this.zIndex = zIndex;
@@ -133,6 +139,7 @@ public class DragHandle extends AbstractConfigurationObject {
      * path is automatically positioned on the point.
      *
      * @param _fn_pathFormatter
+     *            the path formatter
      */
     public void setPathFormatter(String _fn_pathFormatter) {
         this._fn_pathFormatter = _fn_pathFormatter;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Drilldown.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Drilldown.java
@@ -37,6 +37,7 @@ public class Drilldown extends AbstractConfigurationObject {
      * series' point by its {@link Series#getId()}
      *
      * @param series
+     *            the series
      */
     void addSeries(Series series) {
         this.series.add(series);
@@ -46,6 +47,7 @@ public class Drilldown extends AbstractConfigurationObject {
      * Sets the configuration linked to the drilldown series.
      *
      * @param configuration
+     *            the chart configuration
      */
     public void setConfiguration(Configuration configuration) {
         this.configuration = configuration;
@@ -62,7 +64,7 @@ public class Drilldown extends AbstractConfigurationObject {
 
     /**
      * @see #setActiveAxisLabelStyle(Style)
-     * @return
+     * @return the active axis label style
      */
     public Style getActiveAxisLabelStyle() {
         return activeAxisLabelStyle;
@@ -73,6 +75,7 @@ public class Drilldown extends AbstractConfigurationObject {
      * drilldown data.
      *
      * @param activeAxisLabelStyle
+     *            the active axis label style
      */
     public void setActiveAxisLabelStyle(Style activeAxisLabelStyle) {
         this.activeAxisLabelStyle = activeAxisLabelStyle;
@@ -80,7 +83,7 @@ public class Drilldown extends AbstractConfigurationObject {
 
     /**
      * @see #setActiveDataLabelStyle(Style)
-     * @return
+     * @return the active data label style
      */
     public Style getActiveDataLabelStyle() {
         return activeDataLabelStyle;
@@ -91,6 +94,7 @@ public class Drilldown extends AbstractConfigurationObject {
      * drilldown data.
      *
      * @param activeDataLabelStyle
+     *            the active data label style
      */
     public void setActiveDataLabelStyle(Style activeDataLabelStyle) {
         this.activeDataLabelStyle = activeDataLabelStyle;
@@ -110,6 +114,7 @@ public class Drilldown extends AbstractConfigurationObject {
      * and points of different types, but animation will not occur.
      *
      * @param animation
+     *            whether to animate the operation
      */
     public void setAnimation(Boolean animation) {
         this.animation = animation;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DrilldownCallback.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DrilldownCallback.java
@@ -29,6 +29,7 @@ public interface DrilldownCallback extends Serializable {
      * return the Series to be used as drilldown for the point.
      *
      * @param event
+     *            the configuration change event
      * @return a {@link Series} instance to be used as drilldown for the point
      *         or <code>null</code> if nothing should be done
      */
@@ -59,7 +60,7 @@ public interface DrilldownCallback extends Serializable {
         /**
          * Returns the {@link #getItem()} series.
          *
-         * @return
+         * @return the {@link #getItem()} series
          */
         public Series getSeries() {
             return series;
@@ -68,7 +69,7 @@ public interface DrilldownCallback extends Serializable {
         /**
          * Returns the item that was clicked
          *
-         * @return
+         * @return the item that was clicked
          */
         public DataSeriesItem getItem() {
             return item;
@@ -77,7 +78,7 @@ public interface DrilldownCallback extends Serializable {
         /**
          * Returns the index of {@link #getItem()} in {@link #getSeries()}.
          *
-         * @return
+         * @return the index of {@link #getItem()} in {@link #getSeries()}
          */
         public int getItemIndex() {
             return itemIndex;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/FlagItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/FlagItem.java
@@ -23,7 +23,9 @@ public class FlagItem extends DataSeriesItem {
      * Constructs an item with X and Title values
      *
      * @param x
+     *            the X value
      * @param title
+     *            the title
      */
     public FlagItem(Number x, String title) {
         setX(x);
@@ -34,7 +36,9 @@ public class FlagItem extends DataSeriesItem {
      * Constructs an item with X and Title values
      *
      * @param instant
+     *            the instant
      * @param title
+     *            the title
      */
     public FlagItem(Instant instant, String title) {
         setX(instant);
@@ -45,7 +49,9 @@ public class FlagItem extends DataSeriesItem {
      * Constructs an item with X, Title and Text values
      *
      * @param x
+     *            the X value
      * @param title
+     *            the title
      */
     public FlagItem(Number x, String title, String text) {
         setX(x);
@@ -57,8 +63,11 @@ public class FlagItem extends DataSeriesItem {
      * Constructs an item with X, Title and Text values
      *
      * @param instant
+     *            the instant
      * @param title
+     *            the title
      * @param text
+     *            the text
      */
     public FlagItem(Instant instant, String title, String text) {
         setX(instant);
@@ -70,6 +79,7 @@ public class FlagItem extends DataSeriesItem {
      * Sets the title of the flag
      *
      * @param title
+     *            the title
      */
     public void setTitle(String title) {
         this.title = title;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GanttSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GanttSeries.java
@@ -53,7 +53,7 @@ public class GanttSeries extends AbstractSeries {
     /**
      * Return an unmodifiable copy of the items in this series.
      *
-     * @return
+     * @return an unmodifiable copy of the items in this series
      * @see #setData(Collection)
      */
     public Collection<GanttSeriesItem> getData() {
@@ -64,6 +64,7 @@ public class GanttSeries extends AbstractSeries {
      * Set the list of {@link GanttSeriesItem} in this series.
      *
      * @param data
+     *            the data
      */
     public void setData(Collection<GanttSeriesItem> data) {
         this.data = new LinkedList<>(data);
@@ -80,6 +81,7 @@ public class GanttSeries extends AbstractSeries {
      * Add given item to the series
      *
      * @param item
+     *            the item
      */
     public void add(GanttSeriesItem item) {
         data.add(item);
@@ -89,6 +91,7 @@ public class GanttSeries extends AbstractSeries {
      * Add all the given items to the series
      *
      * @param items
+     *            the items
      */
     public void addAll(GanttSeriesItem... items) {
         data.addAll(Arrays.asList(items));
@@ -98,6 +101,7 @@ public class GanttSeries extends AbstractSeries {
      * Returns {@link GanttSeriesItem} at given index
      *
      * @param index
+     *            the item index
      * @return the Item
      * @throws IndexOutOfBoundsException
      *             if data series don't have item at given index

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GanttSeriesItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GanttSeriesItem.java
@@ -85,6 +85,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * Used in axes of type treegrid. Defaults to false.
      *
      * @param collapsed
+     *            the collapsed
      */
     public void setCollapsed(Boolean collapsed) {
         this.collapsed = collapsed;
@@ -120,6 +121,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * Progress indicator of how much of the task is completed.
      *
      * @param completed
+     *            the completed
      */
     public void setCompleted(Completed completed) {
         this.completed = completed;
@@ -129,6 +131,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * Progress indicator of how much of the task is completed.
      *
      * @param completed
+     *            the completed
      */
     public void setCompleted(Number completed) {
         if (this.completed == null) {
@@ -191,6 +194,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * The end time of a task.
      *
      * @param end
+     *            the end
      */
     public void setEnd(Instant end) {
         this.end = Util.toHighchartsTS(end);
@@ -208,6 +212,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * handled, while end is ignored. Defaults to false.
      *
      * @param milestone
+     *            the milestone
      */
     public void setMilestone(Boolean milestone) {
         this.milestone = milestone;
@@ -225,6 +230,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * to null
      *
      * @param parent
+     *            the parent
      */
     public void setParent(String parent) {
         this.parent = parent;
@@ -241,6 +247,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * The start time of a task.
      *
      * @param start
+     *            the start
      */
     public void setStart(Instant start) {
         this.start = Util.toHighchartsTS(start);
@@ -257,6 +264,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * The Y value of a task.
      *
      * @param y
+     *            the Y value
      */
     public void setY(Number y) {
         this.y = y;
@@ -340,6 +348,7 @@ public class GanttSeriesItem extends AbstractConfigurationObject {
      * callbacks and formatter callbacks.
      *
      * @param custom
+     *            the custom
      */
     public void setCustom(AbstractConfigurationObject custom) {
         this.custom = custom;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBox.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBox.java
@@ -34,6 +34,7 @@ public class GuideBox extends AbstractConfigurationObject {
      * Style options for the guide box default state.
      *
      * @param defaultState
+     *            the default state
      */
     public void setDefaultState(GuideBoxDefaultState defaultState) {
         this.defaultState = defaultState;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBoxDefaultState.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/GuideBoxDefaultState.java
@@ -31,6 +31,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
      * highcharts-drag-box-default. Defaults to highcharts-drag-box-default.
      *
      * @param className
+     *            the class name
      */
     public void setClassName(String className) {
         this.className = className;
@@ -47,6 +48,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
      * Guide box fill color. Defaults to rgba(0, 0, 0, 0.1).
      *
      * @param color
+     *            the color
      */
     public void setColor(Color color) {
         this.color = color;
@@ -63,6 +65,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
      * Guide box cursor. Defaults to "move".
      *
      * @param cursor
+     *            the cursor
      */
     public void setCursor(String cursor) {
         this.cursor = cursor;
@@ -79,6 +82,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
      * Color of the border around the guide box. Defaults to #888.
      *
      * @param lineColor
+     *            the line color
      */
     public void setLineColor(Color lineColor) {
         this.lineColor = lineColor;
@@ -95,6 +99,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
      * Width of the line around the guide box. Defaults to 1.
      *
      * @param lineWidth
+     *            the line width
      */
     public void setLineWidth(Number lineWidth) {
         this.lineWidth = lineWidth;
@@ -111,6 +116,7 @@ public class GuideBoxDefaultState extends AbstractConfigurationObject {
      * Guide box zIndex. Defaults to 900.
      *
      * @param zIndex
+     *            the z index
      */
     public void setzIndex(Number zIndex) {
         this.zIndex = zIndex;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ItemPartialFill.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ItemPartialFill.java
@@ -83,6 +83,7 @@ public class ItemPartialFill extends AbstractConfigurationObject {
      * converted to percentages in the default data label formatter.
      *
      * @param amount
+     *            the amount
      */
     public void setAmount(Number amount) {
         this.amount = amount;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ListSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ListSeries.java
@@ -32,6 +32,7 @@ public class ListSeries extends AbstractSeries {
      * Constructs a ListSeries with the given series name.
      *
      * @param name
+     *            the name
      */
     public ListSeries(String name) {
         super(name);
@@ -41,6 +42,7 @@ public class ListSeries extends AbstractSeries {
      * Constructs a ListSeries with the given array of values.
      *
      * @param values
+     *            the values
      */
     public ListSeries(Number... values) {
         Collections.addAll(data, values);
@@ -60,7 +62,9 @@ public class ListSeries extends AbstractSeries {
      * Constructs a ListSeries with the given series name and array of values.
      *
      * @param name
+     *            the name
      * @param values
+     *            the values
      */
     public ListSeries(String name, Number... values) {
         this(name);
@@ -92,6 +96,7 @@ public class ListSeries extends AbstractSeries {
      * Sets the values in the list series to the ones provided.
      *
      * @param values
+     *            the values
      */
     public void setData(Number... values) {
         data.clear();
@@ -102,6 +107,7 @@ public class ListSeries extends AbstractSeries {
      * Sets the given list of numeric values as the values in this list series.
      *
      * @param data
+     *            the data
      */
     public void setData(List<Number> data) {
         this.data = data;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/MarkerSymbolUrl.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/MarkerSymbolUrl.java
@@ -21,6 +21,7 @@ public class MarkerSymbolUrl extends AbstractConfigurationObject
      * Constructs a MarkerSymbol with the given URL
      *
      * @param url
+     *            the URL
      */
     public MarkerSymbolUrl(String url) {
         this.setUrl(url);
@@ -30,6 +31,7 @@ public class MarkerSymbolUrl extends AbstractConfigurationObject
      * Sets the URL of the marker symbol
      *
      * @param url
+     *            the URL
      */
     public void setUrl(String url) {
         this.url = "url(" + url + ")";

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/OhlcItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/OhlcItem.java
@@ -35,10 +35,15 @@ public class OhlcItem extends DataSeriesItem {
      * Constructs an ohlc data item for give open, high, low and close values
      *
      * @param x
+     *            the X value
      * @param open
+     *            the open
      * @param high
+     *            the high
      * @param low
+     *            the low
      * @param close
+     *            the close
      */
     public OhlcItem(Number x, Number open, Number high, Number low,
             Number close) {
@@ -54,10 +59,15 @@ public class OhlcItem extends DataSeriesItem {
      * Constructs an ohlc data item for give open, high, low and close values
      *
      * @param instant
+     *            the instant
      * @param open
+     *            the open
      * @param high
+     *            the high
      * @param low
+     *            the low
      * @param close
+     *            the close
      */
     public OhlcItem(Instant instant, Number open, Number high, Number low,
             Number close) {
@@ -80,6 +90,7 @@ public class OhlcItem extends DataSeriesItem {
      * Sets the open value of the OHLC item
      *
      * @param open
+     *            the open
      */
     public void setOpen(Number open) {
         this.open = open;
@@ -96,6 +107,7 @@ public class OhlcItem extends DataSeriesItem {
      * Sets the close value of the OHLC item
      *
      * @param close
+     *            the close
      */
     public void setClose(Number close) {
         this.close = close;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/OhlcOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/OhlcOptions.java
@@ -203,6 +203,7 @@ public abstract class OhlcOptions extends AbstractPlotOptions {
      * groupPixelWidth option.
      *
      * @param dataGrouping
+     *            the data grouping
      */
     public abstract void setDataGrouping(DataGrouping dataGrouping);
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
@@ -322,6 +322,7 @@ public class PlotOptionsColumn extends ColumnOptions {
      * Defaults to <code>y</code>.
      *
      * @param colorKey
+     *            the color key
      */
     public void setColorKey(String colorKey) {
         this.colorKey = colorKey;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
@@ -131,7 +131,7 @@ public class PlotOptionsErrorbar extends AbstractPlotOptions {
 
     /**
      * @see #setClip(Boolean)
-     * @return
+     * @return the clip
      */
     public Boolean getClip() {
         return clip;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGantt.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGantt.java
@@ -905,6 +905,7 @@ public class PlotOptionsGantt extends AbstractPlotOptions {
      * form of data export.
      *
      * @param includeInDataExport
+     *            the include in data export
      */
     public void setIncludeInDataExport(Boolean includeInDataExport) {
         this.includeInDataExport = includeInDataExport;
@@ -930,6 +931,7 @@ public class PlotOptionsGantt extends AbstractPlotOptions {
      * @see Chart#addPointDragListener(ComponentEventListener)
      * @see Chart#addPointDropListener(ComponentEventListener)
      * @param dragDrop
+     *            the drag drop
      */
     public void setDragDrop(DragDrop dragDrop) {
         this.dragDrop = dragDrop;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPie.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPie.java
@@ -223,6 +223,7 @@ public class PlotOptionsPie extends AbstractPlotOptions {
      * Defaults to <code>false</code>.
      *
      * @param clip
+     *            whether clipping is enabled
      */
     public void setClip(Boolean clip) {
         this.clip = clip;
@@ -262,6 +263,7 @@ public class PlotOptionsPie extends AbstractPlotOptions {
      * Defaults to <code>y</code>.
      *
      * @param colorKey
+     *            the color key
      */
     public void setColorKey(String colorKey) {
         this.colorKey = colorKey;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
@@ -226,6 +226,7 @@ public class PlotOptionsScatter extends PointOptions {
      * Defaults to <code>y</code>.
      *
      * @param colorKey
+     *            the color key
      */
     public void setColorKey(String colorKey) {
         this.colorKey = colorKey;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
@@ -231,6 +231,7 @@ public class PlotOptionsSeries extends AbstractPlotOptions {
      * Defaults to <code>y</code>.
      *
      * @param colorKey
+     *            the color key
      */
     public void setColorKey(String colorKey) {
         this.colorKey = colorKey;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
@@ -107,6 +107,7 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
      * relative size.
      *
      * @param borderRadius
+     *            the border radius
      */
     public void setBorderRadius(String borderRadius) {
         this.borderRadius = borderRadius;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTreemap.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTreemap.java
@@ -118,7 +118,7 @@ public class PlotOptionsTreemap extends AbstractPlotOptions {
     }
 
     /**
-     * {@see #setAllowTraversingTree(Boolean)}
+     * @see #setAllowTraversingTree(Boolean)
      */
     public Boolean getAllowTraversingTree() {
 
@@ -231,7 +231,7 @@ public class PlotOptionsTreemap extends AbstractPlotOptions {
     }
 
     /**
-     * {@see #setBreadcrumbs(Breadcrumbs)}
+     * @see #setBreadcrumbs(Breadcrumbs)
      */
     public Breadcrumbs getBreadcrumbs() {
         if (breadcrumbs == null) {
@@ -245,6 +245,7 @@ public class PlotOptionsTreemap extends AbstractPlotOptions {
      * through the traversed levels.
      *
      * @param breadcrumbs
+     *            the breadcrumbs
      */
     public void setBreadcrumbs(Breadcrumbs breadcrumbs) {
         this.breadcrumbs = breadcrumbs;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PointOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PointOptions.java
@@ -205,6 +205,7 @@ public abstract class PointOptions extends AbstractPlotOptions {
      * Specific data labels configuration for a series type
      *
      * @param dataLabels
+     *            the data labels
      */
     public abstract void setDataLabels(DataLabels dataLabels);
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PyramidOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PyramidOptions.java
@@ -157,6 +157,7 @@ public abstract class PyramidOptions extends AbstractPlotOptions {
      * Specific data labels configuration for a series type
      *
      * @param dataLabels
+     *            the data labels
      */
     public abstract void setDataLabels(DataLabelsFunnel dataLabels);
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/RangeSelectorButton.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/RangeSelectorButton.java
@@ -44,6 +44,7 @@ public class RangeSelectorButton extends AbstractConfigurationObject {
      * Defines the timespan for the button
      *
      * @param type
+     *            the chart type
      */
     public void setType(RangeSelectorTimespan type) {
         this.type = type;
@@ -60,6 +61,7 @@ public class RangeSelectorButton extends AbstractConfigurationObject {
      * Defines how many units of the defined type to use.
      *
      * @param count
+     *            the count
      */
     public void setCount(Number count) {
         this.count = count;
@@ -76,6 +78,7 @@ public class RangeSelectorButton extends AbstractConfigurationObject {
      * Defines the text for the button
      *
      * @param text
+     *            the text
      */
     public void setText(String text) {
         this.text = text;
@@ -92,6 +95,7 @@ public class RangeSelectorButton extends AbstractConfigurationObject {
      * Defines a custom data grouping definition for the button
      *
      * @param dataGrouping
+     *            the data grouping
      */
     public void setDataGrouping(DataGrouping dataGrouping) {
         this.dataGrouping = dataGrouping;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/RangeSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/RangeSeries.java
@@ -20,6 +20,7 @@ public class RangeSeries extends DataSeries {
      * Constructs a RangeSeries with the given name
      *
      * @param name
+     *            the name
      */
     public RangeSeries(String name) {
         setName(name);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Series.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Series.java
@@ -26,6 +26,7 @@ public interface Series extends Serializable {
      * to "".
      *
      * @param name
+     *            the name
      */
     void setName(String name);
 
@@ -33,6 +34,7 @@ public interface Series extends Serializable {
      * Sets the configuration to which this series is linked.
      *
      * @param configuration
+     *            the chart configuration
      */
     void setConfiguration(Configuration configuration);
 
@@ -40,7 +42,7 @@ public interface Series extends Serializable {
      * Gets the plot options related to this specific series. This is needed
      * e.g. in combined charts.
      *
-     * @return
+     * @return the plot options
      */
     AbstractPlotOptions getPlotOptions();
 
@@ -54,6 +56,7 @@ public interface Series extends Serializable {
      * chart and theme levels.
      *
      * @param plotOptions
+     *            the plot options
      */
     void setPlotOptions(AbstractPlotOptions plotOptions);
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/SeriesConnectorAnimation.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/SeriesConnectorAnimation.java
@@ -27,6 +27,7 @@ public class SeriesConnectorAnimation extends AbstractConfigurationObject {
      * Defaults to true.
      *
      * @param reversed
+     *            whether the animation direction is reversed
      */
     public void setReversed(Boolean reversed) {
         this.reversed = reversed;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Time.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Time.java
@@ -45,6 +45,7 @@ public class Time extends AbstractConfigurationObject {
      * {@link #setUseUTC(Boolean) useUTC} to true.
      *
      * @param timezone
+     *            the timezone
      */
     public void setTimezone(String timezone) {
         this.timezone = timezone;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/TreeSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/TreeSeries.java
@@ -52,7 +52,7 @@ public class TreeSeries extends AbstractSeries {
     /**
      * Return an unmodifiable copy of the items in this series.
      *
-     * @return
+     * @return an unmodifiable copy of the items in this series
      * @see #setData(Collection)
      */
     public Collection<TreeSeriesItem> getData() {
@@ -64,6 +64,7 @@ public class TreeSeries extends AbstractSeries {
      * whole tree, and the list is not ordered.
      *
      * @param data
+     *            the data
      */
     public void setData(Collection<TreeSeriesItem> data) {
         this.data = new LinkedList<>(data);
@@ -80,6 +81,7 @@ public class TreeSeries extends AbstractSeries {
      * Add given item to the series
      *
      * @param item
+     *            the item
      */
     public void add(TreeSeriesItem item) {
         data.add(item);
@@ -89,6 +91,7 @@ public class TreeSeries extends AbstractSeries {
      * Add all the given items to the series
      *
      * @param items
+     *            the items
      */
     public void addAll(TreeSeriesItem... items) {
         data.addAll(Arrays.asList(items));

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/TreeSeriesItem.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/TreeSeriesItem.java
@@ -38,7 +38,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
 
     /**
      * @see #setParent(String)
-     * @return
+     * @return the parent
      */
     public String getParent() {
         return parent;
@@ -50,6 +50,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
      * the root. Defaults to null.
      *
      * @param parent
+     *            the parent
      */
     public void setParent(String parent) {
         this.parent = parent;
@@ -59,6 +60,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
      * Set the parent of this node.
      *
      * @param parent
+     *            the parent
      */
     public void setParent(TreeSeriesItem parent) {
         String parentString = (parent != null ? parent.getId() : null);
@@ -67,7 +69,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
 
     /**
      * @see #setValue(Number)
-     * @return
+     * @return the value
      */
     public Number getValue() {
         return value;
@@ -77,6 +79,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
      * Set the numeric value of this node
      *
      * @param value
+     *            the value
      */
     public void setValue(Number value) {
         this.value = value;
@@ -84,7 +87,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
 
     /**
      * @see #setColorValue(Number)
-     * @return
+     * @return the color value
      */
     public Number getColorValue() {
         return colorValue;
@@ -95,6 +98,7 @@ public class TreeSeriesItem extends AbstractSeriesItem {
      * colorAxis.
      *
      * @param colorValue
+     *            the color value
      */
     public void setColorValue(Number colorValue) {
         this.colorValue = colorValue;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
@@ -1537,6 +1537,7 @@ public class XAxis extends Axis {
      * current date and time.
      *
      * @param currentDateIndicator
+     *            the current date indicator
      */
     public void setCurrentDateIndicator(Boolean currentDateIndicator) {
         if (currentDateIndicator) {
@@ -1551,6 +1552,7 @@ public class XAxis extends Axis {
      * current date and time.
      *
      * @param currentDateIndicator
+     *            the current date indicator
      */
     public void setCurrentDateIndicator(PlotLine currentDateIndicator) {
         this.currentDateIndicator = currentDateIndicator;
@@ -1588,6 +1590,7 @@ public class XAxis extends Axis {
      * Defaults to true.
      *
      * @param alignTicks
+     *            the align ticks
      */
     public void setAlignTicks(Boolean alignTicks) {
         this.alignTicks = alignTicks;
@@ -1606,6 +1609,7 @@ public class XAxis extends Axis {
      * axes.
      *
      * @param margin
+     *            the margin
      */
     public void setMargin(Number margin) {
         this.margin = margin;
@@ -1623,6 +1627,7 @@ public class XAxis extends Axis {
      * {@link #setMinRange(Number)}
      *
      * @param maxRange
+     *            the max range
      */
     public void setMaxRange(Number maxRange) {
         this.maxRange = maxRange;
@@ -1640,6 +1645,7 @@ public class XAxis extends Axis {
      * disable panning on an individual axis. Defaults to true.
      *
      * @param panningEnabled
+     *            the panning enabled
      */
     public void setPanningEnabled(Boolean panningEnabled) {
         this.panningEnabled = panningEnabled;
@@ -1661,6 +1667,7 @@ public class XAxis extends Axis {
      * Defaults to false.
      *
      * @param minorTicks
+     *            the minor ticks
      */
     public void setMinorTicks(Boolean minorTicks) {
         this.minorTicks = minorTicks;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
@@ -1725,6 +1725,7 @@ public class YAxis extends Axis {
      * Defaults to true.
      *
      * @param alignTicks
+     *            the align ticks
      */
     public void setAlignTicks(Boolean alignTicks) {
         this.alignTicks = alignTicks;
@@ -1743,6 +1744,7 @@ public class YAxis extends Axis {
      * axes.
      *
      * @param margin
+     *            the margin
      */
     public void setMargin(Number margin) {
         this.margin = margin;
@@ -1760,6 +1762,7 @@ public class YAxis extends Axis {
      * {@link #setMinRange(Number)}
      *
      * @param maxRange
+     *            the max range
      */
     public void setMaxRange(Number maxRange) {
         this.maxRange = maxRange;
@@ -1781,6 +1784,7 @@ public class YAxis extends Axis {
      * Defaults to false.
      *
      * @param minorTicks
+     *            the minor ticks
      */
     public void setMinorTicks(Boolean minorTicks) {
         this.minorTicks = minorTicks;
@@ -1801,6 +1805,7 @@ public class YAxis extends Axis {
      * Adding or removing items will make the chart resize. Defaults to 50.
      *
      * @param staticScale
+     *            the static scale
      */
     public void setStaticScale(Number staticScale) {
         this.staticScale = staticScale;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Zooming.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Zooming.java
@@ -37,6 +37,7 @@ public class Zooming extends AbstractConfigurationObject {
      * {@link ChartModel#getPanKey()}.
      *
      * @param key
+     *            the key
      */
     public void setKey(PanKey key) {
         this.key = key;
@@ -56,6 +57,7 @@ public class Zooming extends AbstractConfigurationObject {
      * Configuration for mouse wheel zoom.
      *
      * @param mouseWheel
+     *            the mouse wheel
      */
     public void setMouseWheel(ZoomingMouseWheel mouseWheel) {
         this.mouseWheel = mouseWheel;
@@ -73,6 +75,7 @@ public class Zooming extends AbstractConfigurationObject {
      * the same as the {@link #getType()} setting.
      *
      * @param pinchType
+     *            the pinch type
      */
     public void setPinchType(Dimension pinchType) {
         this.pinchType = pinchType;
@@ -93,6 +96,7 @@ public class Zooming extends AbstractConfigurationObject {
      * reset zoom.
      *
      * @param resetButton
+     *            the reset button
      */
     public void setResetButton(ZoomingResetButton resetButton) {
         this.resetButton = resetButton;
@@ -114,6 +118,7 @@ public class Zooming extends AbstractConfigurationObject {
      * the page.
      *
      * @param singleTouch
+     *            the single touch
      */
     public void setSingleTouch(Boolean singleTouch) {
         this.singleTouch = singleTouch;
@@ -134,6 +139,7 @@ public class Zooming extends AbstractConfigurationObject {
      * due to the radial nature of the coordinate system.
      *
      * @param type
+     *            the chart type
      */
     public void setType(Dimension type) {
         this.type = type;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingMouseWheel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingMouseWheel.java
@@ -38,6 +38,7 @@ public class ZoomingMouseWheel extends AbstractConfigurationObject {
      * Enable zooming with mouse wheel.
      *
      * @param enabled
+     *            whether mouse-wheel zooming is enabled
      */
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
@@ -59,6 +60,7 @@ public class ZoomingMouseWheel extends AbstractConfigurationObject {
      * while with 2, one mouse wheel delta will zoom in 50%.
      *
      * @param sensitivity
+     *            the sensitivity
      */
     public void setSensitivity(Number sensitivity) {
         this.sensitivity = sensitivity;
@@ -86,6 +88,7 @@ public class ZoomingMouseWheel extends AbstractConfigurationObject {
      * and {@link YAxis#setEndOnTick(Boolean)} to false.
      *
      * @param type
+     *            the chart type
      */
     public void setType(Dimension type) {
         this.type = type;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingResetButton.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZoomingResetButton.java
@@ -39,6 +39,7 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
      * automatically if zooming is enabled and hidden if zooming is disabled.
      *
      * @param enabled
+     *            whether the reset button is visible
      */
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
@@ -63,6 +64,7 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
      * </p>
      *
      * @param position
+     *            the position
      */
     public void setPosition(Position position) {
         this.position = position;
@@ -79,6 +81,7 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
      * What frame the button placement should be related to.
      *
      * @param relativeTo
+     *            the relative to
      */
     public void setRelativeTo(ButtonRelativeTo relativeTo) {
         this.relativeTo = relativeTo;
@@ -98,6 +101,7 @@ public class ZoomingResetButton extends AbstractConfigurationObject {
      * A collection of attributes for the button theme.
      *
      * @param theme
+     *            the chart theme
      */
     public void setTheme(ButtonTheme theme) {
         this.theme = theme;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/BeanSerializationDelegate.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/BeanSerializationDelegate.java
@@ -18,6 +18,7 @@ import tools.jackson.databind.ser.bean.BeanSerializerBase;
  * implementing {@link BeanSerializerBase}.
  *
  * @param <T>
+ *            the serialized value type
  */
 public abstract class BeanSerializationDelegate<T> {
     public abstract Class<T> getBeanClass();

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/BeanSerializerDelegator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/serializers/BeanSerializerDelegator.java
@@ -26,6 +26,7 @@ import tools.jackson.databind.util.NameTransformer;
  * implementing {@link BeanSerializerBase}.
  *
  * @param <T>
+ *            the serialized value type
  */
 public class BeanSerializerDelegator<T> extends BeanSerializerBase {
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/AxisStyle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/AxisStyle.java
@@ -51,6 +51,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * Defaults to null.
      *
      * @param minorTickInterval
+     *            the minor tick interval
      */
     public void setMinorTickInterval(TickIntervalStyle minorTickInterval) {
         this.minorTickInterval = minorTickInterval;
@@ -68,6 +69,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * "#C0D0E0".
      *
      * @param lineColor
+     *            the line color
      */
     public void setLineColor(Color lineColor) {
         this.lineColor = lineColor;
@@ -84,6 +86,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * Sets the width of the line marking the axis itself. Defaults to 1.
      *
      * @param lineWidth
+     *            the line width
      */
     public void setLineWidth(Number lineWidth) {
         this.lineWidth = lineWidth;
@@ -100,6 +103,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * Sets the pixel width of the major tick marks. Defaults to 1.
      *
      * @param tickWidth
+     *            the tick width
      */
     public void setTickWidth(Number tickWidth) {
         this.tickWidth = tickWidth;
@@ -116,6 +120,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * Sets the color for the main tick marks. Defaults to #C0D0E0.
      *
      * @param tickColor
+     *            the tick color
      */
     public void setTickColor(Color tickColor) {
         this.tickColor = tickColor;
@@ -132,6 +137,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * Sets the title style
      *
      * @param style
+     *            the style
      */
     public void setTitle(Style style) {
         title.setStyle(style);
@@ -185,6 +191,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * area. Defaults to 0.
      *
      * @param gridLineWidth
+     *            the grid line width
      */
     public void setGridLineWidth(Number gridLineWidth) {
         this.gridLineWidth = gridLineWidth;
@@ -205,6 +212,7 @@ public class AxisStyle extends AbstractConfigurationObject {
      * to null.
      *
      * @param alternateGridColor
+     *            the alternate grid color
      */
     public void setAlternateGridColor(Color alternateGridColor) {
         this.alternateGridColor = alternateGridColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/ChartStyle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/ChartStyle.java
@@ -44,6 +44,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * @see #setPlotBackgroundColor(Color)
      *
      * @param backgroundColor
+     *            the background color
      */
     public void setBackgroundColor(Color backgroundColor) {
         this.backgroundColor = backgroundColor;
@@ -66,6 +67,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * @see #setBackgroundColor(Color)
      *
      * @param plotBackgroundColor
+     *            the plot background color
      */
     public void setPlotBackgroundColor(Color plotBackgroundColor) {
         this.plotBackgroundColor = plotBackgroundColor;
@@ -105,6 +107,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * plotBackgroundColor be set.
      *
      * @param plotShadow
+     *            the plot shadow
      */
     public void setPlotShadow(Boolean plotShadow) {
         this.plotShadow = plotShadow;
@@ -141,6 +144,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * allowing unique CSS styling for each chart. Defaults to "".
      *
      * @param className
+     *            the class name
      */
     public void setClassName(String className) {
         this.className = className;
@@ -199,6 +203,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * "#4572A7".
      *
      * @param plotBorderColor
+     *            the plot border color
      */
     public void setPlotBorderColor(Color plotBorderColor) {
         this.plotBorderColor = plotBorderColor;
@@ -228,6 +233,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * </p>
      *
      * @param style
+     *            the style
      */
     public void setStyle(Style style) {
         this.style = style;
@@ -245,6 +251,7 @@ public class ChartStyle extends AbstractConfigurationObject {
      * Sets the color of the outer chart border. Defaults to #4572A7.
      *
      * @param borderColor
+     *            the border color
      */
     public void setBorderColor(Color borderColor) {
         this.borderColor = borderColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/MarkerStyle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/MarkerStyle.java
@@ -28,6 +28,7 @@ public class MarkerStyle extends AbstractConfigurationObject {
      * point's color is used. Defaults to "#FFFFFF".
      *
      * @param lineColor
+     *            the line color
      */
     public void setLineColor(Color lineColor) {
         this.lineColor = lineColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/PlotOptionsStyle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/PlotOptionsStyle.java
@@ -90,6 +90,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#BAR} charts
      *
      * @param bar
+     *            the bar
      */
     public void setBar(PlotOptionsBar bar) {
         this.bar = bar;
@@ -106,6 +107,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#AREA} charts
      *
      * @param area
+     *            the area
      */
     public void setArea(PlotOptionsArea area) {
         this.area = area;
@@ -122,6 +124,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#PIE} charts
      *
      * @param pie
+     *            the pie
      */
     public void setPie(PlotOptionsPie pie) {
         this.pie = pie;
@@ -138,6 +141,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#LINE} charts
      *
      * @param line
+     *            the line
      */
     public void setLine(PlotOptionsLine line) {
         this.line = line;
@@ -154,6 +158,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#COLUMN} charts
      *
      * @param column
+     *            the column
      */
     public void setColumn(PlotOptionsColumn column) {
         this.column = column;
@@ -170,6 +175,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#SPLINE} charts
      *
      * @param spline
+     *            the spline
      */
     public void setSpline(PlotOptionsSpline spline) {
         this.spline = spline;
@@ -186,6 +192,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for all type of charts
      *
      * @param series
+     *            the series
      */
     public void setSeries(PlotOptionsSeries series) {
         this.series = series;
@@ -202,6 +209,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#AREARANGE} charts
      *
      * @param arearange
+     *            the arearange
      */
     public void setArearange(PlotOptionsArearange arearange) {
         this.arearange = arearange;
@@ -218,6 +226,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#AREASPLINERANGE} charts
      *
      * @param areasplinerange
+     *            the areasplinerange
      */
     public void setAreasplinerange(PlotOptionsAreasplinerange areasplinerange) {
         this.areasplinerange = areasplinerange;
@@ -234,6 +243,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#AREASPLINE} charts
      *
      * @param areaspline
+     *            the areaspline
      */
     public void setAreaspline(PlotOptionsAreaspline areaspline) {
         this.areaspline = areaspline;
@@ -250,6 +260,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#PYRAMID} charts
      *
      * @param pyramid
+     *            the pyramid
      */
     public void setPyramid(PlotOptionsPyramid pyramid) {
         this.pyramid = pyramid;
@@ -266,6 +277,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#WATERFALL} charts
      *
      * @param waterfall
+     *            the waterfall
      */
     public void setWaterfall(PlotOptionsWaterfall waterfall) {
         this.waterfall = waterfall;
@@ -279,6 +291,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#TREEMAP} charts
      *
      * @param treemap
+     *            the treemap
      */
     public void setTreemap(PlotOptionsTreemap treemap) {
         this.treemap = treemap;
@@ -295,6 +308,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#POLYGON} charts
      *
      * @param polygon
+     *            the polygon
      */
     public void setPolygon(PlotOptionsPolygon polygon) {
         this.polygon = polygon;
@@ -311,6 +325,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#BOXPLOT} charts
      *
      * @param boxplot
+     *            the boxplot
      */
     public void setBoxplot(PlotOptionsBoxplot boxplot) {
         this.boxplot = boxplot;
@@ -327,6 +342,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#BUBBLE} charts
      *
      * @param bubble
+     *            the bubble
      */
     public void setBubble(PlotOptionsBubble bubble) {
         this.bubble = bubble;
@@ -340,6 +356,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#COLUMNRANGE} charts
      *
      * @param columnrange
+     *            the columnrange
      */
     public void setColumnrange(PlotOptionsColumnrange columnrange) {
         this.columnrange = columnrange;
@@ -353,6 +370,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#ERRORBAR} charts
      *
      * @param errorbar
+     *            the errorbar
      */
     public void setErrorbar(PlotOptionsErrorbar errorbar) {
         this.errorbar = errorbar;
@@ -369,6 +387,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#FUNNEL} charts
      *
      * @param funnel
+     *            the funnel
      */
     public void setFunnel(PlotOptionsFunnel funnel) {
         this.funnel = funnel;
@@ -385,6 +404,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#GAUGE} charts
      *
      * @param gauge
+     *            the gauge
      */
     public void setGauge(PlotOptionsGauge gauge) {
         this.gauge = gauge;
@@ -398,6 +418,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#HEATMAP} charts
      *
      * @param heatmap
+     *            the heatmap
      */
     public void setHeatmap(PlotOptionsHeatmap heatmap) {
         this.heatmap = heatmap;
@@ -411,6 +432,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#SCATTER} charts
      *
      * @param scatter
+     *            the scatter
      */
     public void setScatter(PlotOptionsScatter scatter) {
         this.scatter = scatter;
@@ -424,6 +446,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#SOLIDGAUGE} charts
      *
      * @param solidgauge
+     *            the solidgauge
      */
     public void setSolidgauge(PlotOptionsSolidgauge solidgauge) {
         this.solidgauge = solidgauge;
@@ -444,6 +467,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#CANDLESTICK} charts
      *
      * @param candlestick
+     *            the candlestick
      */
     public void setCandlestick(PlotOptionsCandlestick candlestick) {
         this.candlestick = candlestick;
@@ -460,6 +484,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#FLAGS} charts
      *
      * @param flags
+     *            the flags
      */
     public void setFlags(PlotOptionsFlags flags) {
         this.flags = flags;
@@ -476,6 +501,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#OHLC} charts
      *
      * @param ohlc
+     *            the ohlc
      */
     public void setOhlc(PlotOptionsOhlc ohlc) {
         this.ohlc = ohlc;
@@ -492,6 +518,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#BULLET} charts
      *
      * @param bullet
+     *            the bullet
      */
     public void setBullet(PlotOptionsBullet bullet) {
         this.bullet = bullet;
@@ -508,6 +535,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#ORGANIZATION} charts
      *
      * @param organization
+     *            the organization
      */
     public void setOrganization(PlotOptionsOrganization organization) {
         this.organization = organization;
@@ -524,6 +552,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#TIMELINE} charts
      *
      * @param timeline
+     *            the timeline
      */
     public void setTimeline(PlotOptionsTimeline timeline) {
         this.timeline = timeline;
@@ -540,6 +569,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#XRANGE} charts
      *
      * @param xrange
+     *            the xrange
      */
     public void setXrange(PlotOptionsXrange xrange) {
         this.xrange = xrange;
@@ -556,6 +586,7 @@ public class PlotOptionsStyle extends AbstractConfigurationObject {
      * Sets the style options for {@link ChartType#GANTT} charts
      *
      * @param gantt
+     *            the gantt
      */
     public void setGantt(PlotOptionsGantt gantt) {
         this.gantt = gantt;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/SolidColor.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/SolidColor.java
@@ -174,6 +174,7 @@ public class SolidColor extends AbstractConfigurationObject implements Color {
      * Constructs a new color from a hex value like "#ff0000" for red.
      *
      * @param color
+     *            the color
      */
     public SolidColor(String color) {
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Style.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Style.java
@@ -36,6 +36,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>color</code> CSS attribute.
      *
      * @param color
+     *            the color
      */
     public void setColor(Color color) {
         this.color = color;
@@ -52,6 +53,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>font-weight</code> CSS attribute.
      *
      * @param fontWeight
+     *            the font weight
      */
     public void setFontWeight(FontWeight fontWeight) {
         this.fontWeight = fontWeight;
@@ -68,6 +70,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>font-family</code> CSS attribute.
      *
      * @param fontFamily
+     *            the font family
      */
     public void setFontFamily(String fontFamily) {
         this.fontFamily = fontFamily;
@@ -84,6 +87,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>font-size</code> CSS attribute.
      *
      * @param fontSize
+     *            the font size
      */
     public void setFontSize(String fontSize) {
         this.fontSize = fontSize;
@@ -100,6 +104,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>left</code> CSS attribute
      *
      * @param left
+     *            the left
      */
     public void setLeft(String left) {
         this.left = left;
@@ -116,6 +121,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>top</code> CSS attribute
      *
      * @param top
+     *            the top
      */
     public void setTop(String top) {
         this.top = top;
@@ -125,6 +131,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>position</code> CSS attribute
      *
      * @param position
+     *            the position
      */
     public void setPosition(StylePosition position) {
         this.position = position;
@@ -162,6 +169,7 @@ public class Style extends AbstractConfigurationObject {
      * Sets the <code>textShadow</code> CSS attribute
      *
      * @param textShadow
+     *            the text shadow
      */
     public void setTextShadow(String textShadow) {
         this.textShadow = textShadow;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/StyleWrapper.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/StyleWrapper.java
@@ -19,7 +19,7 @@ public class StyleWrapper extends AbstractConfigurationObject {
     /**
      * Return the style object
      *
-     * @return
+     * @return the style object
      */
     public Style getStyle() {
         return style;
@@ -29,6 +29,7 @@ public class StyleWrapper extends AbstractConfigurationObject {
      * Set the style object
      *
      * @param style
+     *            the style
      */
     public void setStyle(Style style) {
         this.style = style;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/TooltipStyle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/TooltipStyle.java
@@ -33,6 +33,7 @@ public class TooltipStyle extends AbstractConfigurationObject {
      * Sets the background color of tooltips
      *
      * @param backgroundColor
+     *            the background color
      */
     public void setBackgroundColor(Color backgroundColor) {
         this.backgroundColor = backgroundColor;
@@ -49,6 +50,7 @@ public class TooltipStyle extends AbstractConfigurationObject {
      * Sets the width of the border of tooltips
      *
      * @param borderWidth
+     *            the border width
      */
     public void setBorderWidth(Number borderWidth) {
         this.borderWidth = borderWidth;
@@ -116,6 +118,7 @@ public class TooltipStyle extends AbstractConfigurationObject {
      * color of the corresponding series or point. Defaults to null.
      *
      * @param borderColor
+     *            the border color
      */
     public void setBorderColor(Color borderColor) {
         this.borderColor = borderColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/util/ChartSerialization.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/util/ChartSerialization.java
@@ -87,6 +87,7 @@ public class ChartSerialization implements Serializable {
      * for it, adding custom serializers might be needed.
      *
      * @param newObjectWriter
+     *            the new object writer
      * @see #createObjectMapper()
      */
     public static void setObjectMapperInstance(ObjectWriter newObjectWriter) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/util/Util.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/util/Util.java
@@ -13,11 +13,12 @@ import java.time.Instant;
 public class Util {
 
     /**
-     * Gets the number of miliseconds from the Java epoch of
+     * Gets the number of milliseconds from the Java epoch of
      * 1970-01-01T00:00:00Z.
      *
      * @param date
-     * @return
+     *            the date
+     * @return the number of milliseconds from the Java epoch
      */
     public static long toHighchartsTS(Instant date) {
         return date.getEpochSecond() * 1000;


### PR DESCRIPTION
## Description

Follow-up to #9420.

Charts Javadocs contain empty block tags in events, utility classes, and historically generated model classes. This fills the existing empty `@param` and `@return` tags and fixes invalid inline `{@see}` usage so the generated API docs are complete and doclint-friendly.

Fixes # (issue): no dedicated issue; docs-only follow-up.

## Type of change

- [x] Bugfix
- [ ] Feature

## Changes

- Add missing descriptions for empty `@param` and `@return` tags under `vaadin-charts-flow-parent`.
- Replace invalid inline `{@see}` usages with block `@see` tags.
- Keep non-Charts Javadoc cleanup in #9421.

## Testing

- `git diff --check`
- Structural Javadoc scan for empty `@param`, `@return`, `@throws`, `@exception`, and invalid inline `{@see}` tags under Charts
- Comment-only diff check

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

---

🤖 Generated with Codex (GPT-5.5)
