### PR TITLE
chore: update GridPro IT to use cell doubleClick

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/BasicIT.java
@@ -464,10 +464,7 @@ public class BasicIT extends AbstractComponentIT {
         Assert.assertFalse(cell.innerHTMLContains(editorTag));
 
         // Entering edit mode with double click
-        // Workaround(yuriy-fix): doubleClick is not working on IE11
-        executeScript(
-                "arguments[0].dispatchEvent(new CustomEvent('dblclick', {composed: true, bubbles: true}));",
-                cell);
+        cell.doubleClick();
         Assert.assertEquals(editingEnabled, cell.innerHTMLContains(editorTag));
     }
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/GridProDetachAttachIT.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/test/java/com/vaadin/flow/component/gridpro/tests/GridProDetachAttachIT.java
@@ -65,9 +65,7 @@ public class GridProDetachAttachIT extends AbstractComponentIT {
         Assert.assertFalse(cell.innerHTMLContains(editorTag));
 
         // Entering edit mode with double click
-        executeScript(
-                "arguments[0].dispatchEvent(new CustomEvent('dblclick', {composed: true, bubbles: true}));",
-                cell);
+        cell.doubleClick();
         Assert.assertTrue(cell.innerHTMLContains(editorTag));
         // Assert there are no null reference errors
         checkLogsForErrors();


### PR DESCRIPTION
## Description

We no longer support IE11 so this shouldn't be needed, let's try using `doubleClick()`.

## Type of change

- Test