### PR TITLE
fix: avoid serializing full File instance for determining uploading state

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -182,6 +182,58 @@ public class UploadIT extends AbstractUploadIT {
     }
 
     @Test
+    public void multipleFiles_oneStillUploading_allFinishedNotFiredYet()
+            throws Exception {
+        UploadElement upload = getUpload();
+
+        // Disable auto upload so the files can be uploaded one at a time.
+        upload.setProperty("noAuto", true);
+
+        // Add two files. Mark them as uploading in order to be able to test
+        // that all-finished event is not fired until both files have succeeded
+        // uploading.
+        upload.upload(createTempFile("txt"), 0);
+        upload.upload(createTempFile("txt"), 0);
+        executeScript(
+                "arguments[0].files.forEach(file => { file.uploading = true });",
+                upload);
+
+        // Upload the first file by pressing its manual upload start button.
+        startUploadOfFile(upload, 0);
+
+        // Wait for the first file to finish uploading.
+        waitUntil(driver -> eventsOutput.getText().contains("-succeeded"));
+
+        // The second file is still uploading, so the all-finished event must
+        // not have fired yet.
+        Assert.assertEquals(
+                "All-finished event must not fire while another file is "
+                        + "still uploading",
+                "-succeeded", eventsOutput.getText());
+
+        // Upload the second file by pressing its manual upload start button.
+        startUploadOfFile(upload, 1);
+
+        // All files have finished now, so the all-finished event must fire.
+        waitUntil(driver -> "-succeeded-succeeded-finished"
+                .equals(eventsOutput.getText()));
+    }
+
+    private void startUploadOfFile(UploadElement upload, int index) {
+        // Clear the uploading flag on the file and re-render the file list so
+        // the start button becomes available
+        executeScript("""
+                const upload = arguments[0];
+                const fileIndex = arguments[1];
+                upload.files[fileIndex].uploading = false;
+                upload.files = [...upload.files];
+                """, upload, index);
+        WebElement startButton = upload.$("vaadin-upload-file").get(index)
+                .$("*").withAttribute("part", "start-button").single();
+        startButton.click();
+    }
+
+    @Test
     public void slowUpload_waitForUpload_pollsUntilUploadFinishes()
             throws Exception {
         Assume.assumeTrue("Current driver does not support Dev Tools",

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -22,7 +22,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
@@ -51,9 +50,6 @@ import com.vaadin.flow.server.StreamVariable;
 import com.vaadin.flow.server.streams.UploadEvent;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.flow.shared.Registration;
-
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.node.ArrayNode;
 
 /**
  * Upload is a component for uploading one or more files. It shows the upload
@@ -137,17 +133,10 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
 
         setUploadHandler(new FailFastUploadHandler());
 
-        final String elementFiles = "element.files";
+        final String filesUploading = "element.files.some(file => file.uploading)";
         DomEventListener allFinishedListener = e -> {
-            ArrayNode files = (ArrayNode) e.getEventData().get(elementFiles);
-
-            boolean isUploading = IntStream.range(0, files.size())
-                    .anyMatch(index -> {
-                        final String KEY = "uploading";
-                        JsonNode object = files.get(index);
-                        return object.has(KEY)
-                                && object.get(KEY).booleanValue();
-                    });
+            boolean isUploading = e.getEventData().get(filesUploading)
+                    .booleanValue();
 
             if (this.uploading && !isUploading) {
                 this.fireAllFinish();
@@ -159,11 +148,11 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
                 e -> this.uploading = true);
 
         getElement().addEventListener("upload-success", allFinishedListener)
-                .addEventData(elementFiles);
+                .addEventData(filesUploading);
         getElement().addEventListener("upload-error", allFinishedListener)
-                .addEventData(elementFiles);
+                .addEventData(filesUploading);
         getElement().addEventListener("upload-abort", allFinishedListener)
-                .addEventData(elementFiles);
+                .addEventData(filesUploading);
 
         defaultUploadButton = new Button();
         // Ensure the flag is set before the element is added to the slot


### PR DESCRIPTION
## Description

The Flow Upload component currently listens to several web component events to determine whether the component is still processing any upload or not. To facilitate that it sends fully serialized instances of all JS `File` objects to the server in order to access the `uploading` property of each. Serializing the full File object can lead to circular serialization issues as reported in https://github.com/vaadin/flow-components/issues/9434.

This changes the respective event listeners to determine the uploading state on the client via a JS expression and then only sends a single boolean with the event, rather than the full File object. This avoids serializing File objects completely and also reduces the payload of the event.

Fixes https://github.com/vaadin/flow-components/issues/9434

## Type of change

- Bugfix
