### PR TITLE
chore: fix npmPackage update failure in CI [skip ci]

### DIFF
--- a/scripts/updateNpmVer.js
+++ b/scripts/updateNpmVer.js
@@ -11,7 +11,6 @@
 const fs = require('fs');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
-const replace = require('replace-in-file');
 const {getAnnotations, computeVersionToUpdate} = require('./lib/versions.js');
 
 let exclude=[];
@@ -26,7 +25,8 @@ async function updateFiles(moduleData){
         to: updatedNpm,
       };
       try {
-        const results = await replace(options)
+        const { replaceInFile } = await import('replace-in-file');
+        const results = await replaceInFile(options)
         console.log('\x1b[33m', "Updated "+ moduleData.package + " from version " +
                     moduleData.version + " to " + moduleData.updatedVersion);
       }


### PR DESCRIPTION
after bumping `replace-in-file` from 6.x to 8.x in previous commit (f87a9d9d)
the NpmPackage update build  has failed with following error
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /opt/agent/work/1fcf94d1da2f425a/vaadin-flow-components/node_modules/replace-in-file/index.js from /opt/agent/work/1fcf94d1da2f425a/vaadin-flow-components/scripts/updateNpmVer.js not supported.
[18:30:42 ](https://bender.vaadin.com/buildConfiguration/VaadinFlowComponents_FlowComponentsUpdateNpmPackagesWebjarsVersions/889722?buildTab=log&focusLine=835&logView=flowAware&linesState=835)  Instead change the require of index.js in /opt/agent/work/1fcf94d1da2f425a/vaadin-flow-components/scripts/updateNpmVer.js to a dynamic import() which is available in all CommonJS modules.
[18:30:42 ](https://bender.vaadin.com/buildConfiguration/VaadinFlowComponents_FlowComponentsUpdateNpmPackagesWebjarsVersions/889722?buildTab=log&focusLine=836&logView=flowAware&linesState=836)      at Object.<anonymous> (/opt/agent/work/1fcf94d1da2f425a/vaadin-flow-components/scripts/updateNpmVer.js:14:17) {
[18:30:42 ](https://bender.vaadin.com/buildConfiguration/VaadinFlowComponents_FlowComponentsUpdateNpmPackagesWebjarsVersions/889722?buildTab=log&focusLine=837&logView=flowAware&linesState=837)    code: 'ERR_REQUIRE_ESM'
```

root cause:

- `replace-in-file` became ESM-only starting with v7.
- But scripts/updateNpmVer.js:14 still loads it with CommonJS require:
  const replace = require('replace-in-file');
- Under Node 18 in CI, require() of an ESM package throws ERR_REQUIRE_ESM, so the script crashes immediately and the PR step exits with code 1.
