### PR TITLE
chore: add prefix to fast tests workflows

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -150,7 +150,7 @@ jobs:
           echo "elements=$elements" >> "$GITHUB_OUTPUT"
 
   fast-tests:
-    name: ${{ matrix.name }}
+    name: Fast tests (${{ matrix.name }})
     needs: build
     if: needs.build.outputs.skip != 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use `Fast tests (${{ matrix.name }})` as name for the fast tests jobs. While this adds an (unnecessary) extra prefix for the individual jobs started from the matrix job, it provides a better name in cases when fast tests are skipped, which currently just shows as `matrix.name`.