### PR TITLE
chore: make result job fail when any previous job fails

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -498,9 +498,9 @@ jobs:
           if-no-files-found: ignore
 
   results:
-    name: Collect tests
+    name: Validation result
     needs: [build, fast-tests, its]
-    if: always() && needs.build.result == 'success'
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -668,10 +668,16 @@ jobs:
               gh api -X DELETE "repos/$GH_REPO/actions/artifacts/$id" || true
             done
 
-      - name: Fail if any test failed
+      - name: Fail if any job or test failed
         if: always()
         run: |
           failed=false
+          # Job-level failures (build/setup/compile/packaging/infra).
+          # Skipped is OK: skip-ci skips fast-tests/its, empty builds skip its.
+          for r in "${{ needs.build.result }}" "${{ needs.fast-tests.result }}" "${{ needs.its.result }}"; do
+            [[ "$r" == "failure" || "$r" == "cancelled" ]] && failed=true
+          done
+          # Actual test failures captured in the published reports.
           [[ "${{ steps.unit-dorny.outputs.conclusion }}" == "failure" ]] && failed=true
           [[ "${{ steps.wtr-dorny.outputs.conclusion }}"  == "failure" ]] && failed=true
           [[ "${{ steps.it-dorny.outputs.conclusion }}"   == "failure" ]] && failed=true


### PR DESCRIPTION
The results job only failed on test failures captured in report XMLs. It did not fail when any previous job failed, for example the build, or when a test job runs into an error that didn't produce failed tests.

This changes the result step to run unconditionally and fail on any job's failure/canceled result, so it can serve as the single required check. Renamed the job to "Validation result" to reflect the broader responsibility.

This change was triggered by the discussion in this PR: https://github.com/vaadin/flow-components/pull/9448. There the required checks on "Unit tests", "Package WAR", etc. prevented the PR from merging, as with `[skip ci]` those jobs are never actually run due to `fast-tests` being skipped and never spawning them. As such it seems useful to have a single result job as required check that reports success for all previous jobs and test results.