### PR TITLE
chore: configure Failsafe to reuse forks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
                     <configuration>
                         <forkCount>${failsafe.forkCount}</forkCount>
                         <argLine>-Xmx2048m</argLine>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>true</reuseForks>
                         <trimStackTrace>false</trimStackTrace>
                         <systemPropertyVariables>
                             <com.vaadin.tests.SharedBrowser.reuseBrowser>${com.vaadin.tests.SharedBrowser.reuseBrowser}</com.vaadin.tests.SharedBrowser.reuseBrowser>

--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,6 @@
                     <configuration>
                         <forkCount>${failsafe.forkCount}</forkCount>
                         <argLine>-Xmx2048m</argLine>
-                        <reuseForks>true</reuseForks>
                         <trimStackTrace>false</trimStackTrace>
                         <systemPropertyVariables>
                             <com.vaadin.tests.SharedBrowser.reuseBrowser>${com.vaadin.tests.SharedBrowser.reuseBrowser}</com.vaadin.tests.SharedBrowser.reuseBrowser>


### PR DESCRIPTION
Currently Failsafe is configured to fork a new JVM for each test file, which in general provides better test isolation but with the downside that it adds several seconds to the runtime of each test.

This changes the config to reuse forks. I can't think of any static state in test classes that could be problematic, and from several test runs this seems to be stable.