### PR TITLE
test: use fixed times in TimePicker validation tests

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BasicValidationTest.java
@@ -63,7 +63,7 @@ class BasicValidationTest
     @Test
     void required_validate_emptyErrorMessageDisplayed() {
         testField.setRequiredIndicatorVisible(true);
-        testField.setValue(LocalTime.now());
+        testField.setValue(LocalTime.of(12, 0));
         testField.setValue(null);
         Assertions.assertEquals("", testField.getErrorMessage());
     }
@@ -73,7 +73,7 @@ class BasicValidationTest
         testField.setRequiredIndicatorVisible(true);
         testField.setI18n(new TimePicker.TimePickerI18n()
                 .setRequiredErrorMessage("Field is required"));
-        testField.setValue(LocalTime.now());
+        testField.setValue(LocalTime.of(12, 0));
         testField.setValue(null);
         Assertions.assertEquals("Field is required",
                 testField.getErrorMessage());
@@ -81,34 +81,34 @@ class BasicValidationTest
 
     @Test
     void min_validate_emptyErrorMessageDisplayed() {
-        testField.setMin(LocalTime.now());
-        testField.setValue(LocalTime.now().minusHours(1));
+        testField.setMin(LocalTime.of(12, 0));
+        testField.setValue(LocalTime.of(11, 0));
         Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
     void min_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
-        testField.setMin(LocalTime.now());
+        testField.setMin(LocalTime.of(12, 0));
         testField.setI18n(new TimePicker.TimePickerI18n()
                 .setMinErrorMessage("Time is too small"));
-        testField.setValue(LocalTime.now().minusHours(1));
+        testField.setValue(LocalTime.of(11, 0));
         Assertions.assertEquals("Time is too small",
                 testField.getErrorMessage());
     }
 
     @Test
     void max_validate_emptyErrorMessageDisplayed() {
-        testField.setMax(LocalTime.now());
-        testField.setValue(LocalTime.now().plusHours(1));
+        testField.setMax(LocalTime.of(12, 0));
+        testField.setValue(LocalTime.of(13, 0));
         Assertions.assertEquals("", testField.getErrorMessage());
     }
 
     @Test
     void max_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
-        testField.setMax(LocalTime.now());
+        testField.setMax(LocalTime.of(12, 0));
         testField.setI18n(new TimePicker.TimePickerI18n()
                 .setMaxErrorMessage("Time is too big"));
-        testField.setValue(LocalTime.now().plusHours(1));
+        testField.setValue(LocalTime.of(13, 0));
         Assertions.assertEquals("Time is too big", testField.getErrorMessage());
     }
 
@@ -118,7 +118,7 @@ class BasicValidationTest
         testField.setI18n(new TimePicker.TimePickerI18n()
                 .setRequiredErrorMessage("Field is required"));
         testField.setErrorMessage("Custom error message");
-        testField.setValue(LocalTime.now());
+        testField.setValue(LocalTime.of(12, 0));
         testField.setValue(null);
         Assertions.assertEquals("Custom error message",
                 testField.getErrorMessage());
@@ -130,10 +130,10 @@ class BasicValidationTest
         testField.setI18n(new TimePicker.TimePickerI18n()
                 .setRequiredErrorMessage("Field is required"));
         testField.setErrorMessage("Custom error message");
-        testField.setValue(LocalTime.now());
+        testField.setValue(LocalTime.of(12, 0));
         testField.setValue(null);
         testField.setErrorMessage("");
-        testField.setValue(LocalTime.now());
+        testField.setValue(LocalTime.of(12, 0));
         testField.setValue(null);
         Assertions.assertEquals("Field is required",
                 testField.getErrorMessage());

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/validation/BinderValidationTest.java
@@ -59,14 +59,14 @@ class BinderValidationTest {
     void init() {
         MockitoAnnotations.openMocks(this);
         field = new TimePicker();
-        field.setMax(LocalTime.now().plusHours(1));
+        field.setMax(LocalTime.of(13, 0));
     }
 
     @Test
     void elementWithConstraints_componentValidationNotMet_elementValidationFails() {
         attachBinderToField();
 
-        field.setValue(LocalTime.now().plusHours(2));
+        field.setValue(LocalTime.of(14, 0));
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
         Assertions.assertTrue(statusCaptor.getValue().isError(),
@@ -76,7 +76,7 @@ class BinderValidationTest {
     @Test
     void elementWithConstraints_binderValidationNotMet_binderValidationFails() {
         attachBinderToField();
-        field.setValue(LocalTime.now().minusHours(2));
+        field.setValue(LocalTime.of(10, 0));
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
         Assertions.assertTrue(statusCaptor.getValue().isError(),
@@ -111,7 +111,7 @@ class BinderValidationTest {
     void elementWithConstraints_validValue_validationPasses() {
         attachBinderToField();
 
-        field.setValue(LocalTime.now());
+        field.setValue(LocalTime.of(12, 0));
 
         Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
         Assertions.assertFalse(statusCaptor.getValue().isError());
@@ -126,7 +126,7 @@ class BinderValidationTest {
         Binder.BindingBuilder<Bean, LocalTime> binding = binder.forField(field)
                 .withValidator(
                         value -> value == null
-                                || value.isAfter(LocalTime.now().minusHours(1)),
+                                || value.isAfter(LocalTime.of(11, 0)),
                         BINDER_FAIL_MESSAGE)
                 .withValidationStatusHandler(statusHandlerMock);
 


### PR DESCRIPTION
Tests used LocalTime.now() with plusHours/minusHours, which wraps around midnight and breaks the assumed min/max relationships. The nightly build runs at 23:30 UTC, so its unit tests could land in the wrap window and fail intermittently.

This replaces LocalTime.now() usages with constant times.