### PR TITLE
fix: update method call in ComboBox to __focusIndex

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -170,7 +170,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         getElement().addPropertyChangeListener("opened", event -> {
             var isOpened = (boolean) event.getValue();
             if (isOpened && focusSelectedItem) {
-                scrollToSelectedItem();
+                focusSelectedItem();
             }
         });
     }
@@ -412,7 +412,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         return focusSelectedItem;
     }
 
-    private void scrollToSelectedItem() {
+    private void focusSelectedItem() {
         if (getValue() == null) {
             return;
         }
@@ -429,7 +429,7 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         if (index == null || index < 0) {
             return;
         }
-        getElement().callJsFunction("scrollToIndex", index);
+        getElement().callJsFunction("__focusIndex", index);
     }
 
     /**


### PR DESCRIPTION
## Description

After vaadin/web-components#11862, the feature moved from the public method `scrollToIndex` to the private `__focusIndex`. Also renamed the private method name to align with the web-component's method.

Same as https://github.com/vaadin/flow-components/pull/9385 but for 25.2