### PR TITLE
feat: add Tooltip AriaLinkMode enum for setting ARIA attribute

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -457,9 +457,13 @@ public class Tooltip implements Serializable {
      * tooltip content.
      *
      * @param ariaLinkMode
-     *            the ARIA link mode to set, not {@code null}
+     *            the ARIA link mode to set, or {@code null} to reset to the
+     *            default {@link AriaLinkMode#ARIA_DESCRIBED_BY}
      */
     public void setAriaLinkMode(AriaLinkMode ariaLinkMode) {
+        if (ariaLinkMode == null) {
+            ariaLinkMode = AriaLinkMode.ARIA_DESCRIBED_BY;
+        }
         tooltipElement.setProperty("ariaLinkMode", ariaLinkMode.getValue());
     }
 
@@ -479,7 +483,9 @@ public class Tooltip implements Serializable {
      * tooltip content.
      *
      * @param ariaLinkMode
-     *            the ARIA link mode to set, not {@code null}
+     *            the ARIA link mode to set, or {@code null} to reset to the
+     *            default {@link AriaLinkMode#ARIA_DESCRIBED_BY}
+     * @return the tooltip handle for chaining
      */
     public Tooltip withAriaLinkMode(AriaLinkMode ariaLinkMode) {
         setAriaLinkMode(ariaLinkMode);

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -89,6 +89,51 @@ public class Tooltip implements Serializable {
     }
 
     /**
+     * Controls which ARIA attribute links the target element(s) with the
+     * tooltip content.
+     */
+    public enum AriaLinkMode {
+        /**
+         * Links the tooltip as a description of the target using
+         * {@code aria-describedby}. This is the default.
+         */
+        ARIA_DESCRIBED_BY("aria-describedby"),
+        /**
+         * Links the tooltip as the accessible name of the target using
+         * {@code aria-labelledby}.
+         */
+        ARIA_LABELLED_BY("aria-labelledby"),
+        /**
+         * Does not add any ARIA linking attribute to the target.
+         */
+        NONE("none");
+
+        private final String value;
+
+        AriaLinkMode(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Gets the {@link AriaLinkMode} for the given value string. Returns
+         * {@link AriaLinkMode#ARIA_DESCRIBED_BY} if no match is found.
+         *
+         * @param value
+         *            the value string
+         * @return the {@link AriaLinkMode}
+         */
+        public static AriaLinkMode fromValue(String value) {
+            return Arrays.stream(AriaLinkMode.values())
+                    .filter(m -> m.getValue().equals(value)).findFirst()
+                    .orElse(ARIA_DESCRIBED_BY);
+        }
+    }
+
+    /**
      * Creates a tooltip for the given element.
      *
      * @param element
@@ -405,5 +450,39 @@ public class Tooltip implements Serializable {
      */
     public boolean isOpened() {
         return tooltipElement.getProperty("opened", false);
+    }
+
+    /**
+     * Controls which ARIA attribute links the target element(s) with the
+     * tooltip content.
+     *
+     * @param ariaLinkMode
+     *            the ARIA link mode to set, not {@code null}
+     */
+    public void setAriaLinkMode(AriaLinkMode ariaLinkMode) {
+        tooltipElement.setProperty("ariaLinkMode", ariaLinkMode.getValue());
+    }
+
+    /**
+     * Controls which ARIA attribute links the target element(s) with the
+     * tooltip content. Defaults to {@link AriaLinkMode#ARIA_DESCRIBED_BY}.
+     *
+     * @return the ARIA link mode
+     */
+    public AriaLinkMode getAriaLinkMode() {
+        return AriaLinkMode
+                .fromValue(tooltipElement.getProperty("ariaLinkMode"));
+    }
+
+    /**
+     * Controls which ARIA attribute links the target element(s) with the
+     * tooltip content.
+     *
+     * @param ariaLinkMode
+     *            the ARIA link mode to set, not {@code null}
+     */
+    public Tooltip withAriaLinkMode(AriaLinkMode ariaLinkMode) {
+        setAriaLinkMode(ariaLinkMode);
+        return this;
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.shared.Tooltip.AriaLinkMode;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.tests.MockUIExtension;
@@ -191,6 +192,24 @@ class TooltipTest {
     }
 
     @Test
+    void createTooltip_setAriaLinkMode() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setAriaLinkMode(AriaLinkMode.ARIA_LABELLED_BY);
+        ui.add(component);
+        Assertions.assertEquals("aria-labelledby",
+                getTooltipElement().get().getProperty("ariaLinkMode"));
+        Assertions.assertEquals(AriaLinkMode.ARIA_LABELLED_BY,
+                tooltip.getAriaLinkMode());
+    }
+
+    @Test
+    void createTooltip_defaultAriaLinkMode() {
+        var tooltip = Tooltip.forComponent(component);
+        Assertions.assertEquals(AriaLinkMode.ARIA_DESCRIBED_BY,
+                tooltip.getAriaLinkMode());
+    }
+
+    @Test
     void tooltipForCompopnentTwice_sameReference() {
         var tooltip = Tooltip.forComponent(component);
         var tooltip2 = Tooltip.forComponent(component);
@@ -203,7 +222,8 @@ class TooltipTest {
 
         var tooltip = Tooltip.forComponent(component).withText("foo")
                 .withFocusDelay(200).withHideDelay(1000).withHoverDelay(500)
-                .withPosition(TooltipPosition.BOTTOM_END).withManual(true);
+                .withPosition(TooltipPosition.BOTTOM_END).withManual(true)
+                .withAriaLinkMode(AriaLinkMode.ARIA_LABELLED_BY);
 
         tooltip.setOpened(true);
 
@@ -221,6 +241,8 @@ class TooltipTest {
                 getTooltipElement().get().getProperty("position"));
         Assertions.assertEquals(true,
                 getTooltipElement().get().getProperty("manual", false));
+        Assertions.assertEquals("aria-labelledby",
+                getTooltipElement().get().getProperty("ariaLinkMode"));
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -210,6 +210,18 @@ class TooltipTest {
     }
 
     @Test
+    void createTooltip_setAriaLinkModeNull_resetsToDefault() {
+        var tooltip = Tooltip.forComponent(component);
+        tooltip.setAriaLinkMode(AriaLinkMode.ARIA_LABELLED_BY);
+        tooltip.setAriaLinkMode(null);
+        ui.add(component);
+        Assertions.assertEquals("aria-describedby",
+                getTooltipElement().get().getProperty("ariaLinkMode"));
+        Assertions.assertEquals(AriaLinkMode.ARIA_DESCRIBED_BY,
+                tooltip.getAriaLinkMode());
+    }
+
+    @Test
     void tooltipForCompopnentTwice_sameReference() {
         var tooltip = Tooltip.forComponent(component);
         var tooltip2 = Tooltip.forComponent(component);


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/8905

Based on https://github.com/vaadin/web-components/pull/11845

Added `AriaLinkMode` enum and methods to set `ariaLinkMode` property on the tooltip.

## Type of change

- Feature