### PR TITLE
feat: add BreadcrumbsVariant enum and HasThemeVariant to Breadcrumbs

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 
 /**
  * Breadcrumbs is a component for displaying a navigation trail that shows the
@@ -40,7 +41,8 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/breadcrumbs", version = "25.2.0-beta1")
 @JsModule("@vaadin/breadcrumbs/src/vaadin-breadcrumbs.js")
 public class Breadcrumbs extends Component implements HasSize, HasStyle,
-        HasAriaLabel, HasComponentsOfType<BreadcrumbsItem> {
+        HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>,
+        HasThemeVariant<BreadcrumbsVariant> {
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs;
+
+import com.vaadin.flow.component.shared.ThemeVariant;
+
+/**
+ * Set of theme variants applicable for {@code vaadin-breadcrumbs} component.
+ */
+public enum BreadcrumbsVariant implements ThemeVariant {
+    SLASH("slash");
+
+    private final String variant;
+
+    BreadcrumbsVariant(String variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the variant name.
+     *
+     * @return variant name
+     */
+    @Override
+    public String getVariantName() {
+        return variant;
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 
 class BreadcrumbsTest {
 
@@ -38,5 +39,11 @@ class BreadcrumbsTest {
         Assertions.assertEquals("vaadin-breadcrumbs-item",
                 item.getElement().getTag());
         Assertions.assertEquals("Home", item.getText());
+    }
+
+    @Test
+    void implementsHasThemeVariant() {
+        Assertions.assertTrue(
+                HasThemeVariant.class.isAssignableFrom(Breadcrumbs.class));
     }
 }


### PR DESCRIPTION
## Description

Task 3 of the Breadcrumbs SDD - based on tasks reorder in https://github.com/vaadin/web-components/pull/11912.

Added `BreadcrumbsVariant` enum with `"slash"` variant and `HasThemeVariant<BreadcrumbsVariant>`.

## Type of change

- Feature