### PR TITLE
feat: add BreadcrumbsI18n and setI18n API to Breadcrumbs

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.component.breadcrumbs;
 
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
@@ -27,6 +31,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.internal.JacksonUtils;
 
 /**
  * Breadcrumbs is a component for displaying a navigation trail that shows the
@@ -44,6 +49,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>,
         HasThemeVariant<BreadcrumbsVariant> {
 
+    private BreadcrumbsI18n i18n;
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
@@ -56,6 +63,62 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         if (!featureFlags.isEnabled(
                 BreadcrumbsFeatureFlagProvider.BREADCRUMBS_COMPONENT)) {
             throw new ExperimentalFeatureException();
+        }
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(BreadcrumbsI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public BreadcrumbsI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization properties for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(BreadcrumbsI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+        getElement().setPropertyJson("i18n", JacksonUtils.beanToJson(i18n));
+    }
+
+    /**
+     * The internationalization properties for {@link Breadcrumbs}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class BreadcrumbsI18n implements Serializable {
+        private String moreItems;
+
+        /**
+         * Gets the accessible label announced by screen readers for the
+         * overflow button that reveals the hidden breadcrumb items.
+         *
+         * @return the translated label for the overflow button
+         */
+        public String getMoreItems() {
+            return moreItems;
+        }
+
+        /**
+         * Sets the accessible label announced by screen readers for the
+         * overflow button that reveals the hidden breadcrumb items.
+         *
+         * @param moreItems
+         *            the translated label for the overflow button
+         * @return this instance for method chaining
+         */
+        public BreadcrumbsI18n setMoreItems(String moreItems) {
+            this.moreItems = moreItems;
+            return this;
         }
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsI18nTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsI18nTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.BreadcrumbsI18n;
+
+import tools.jackson.databind.node.ObjectNode;
+
+class BreadcrumbsI18nTest {
+
+    private Breadcrumbs breadcrumbs;
+
+    @BeforeEach
+    void setup() {
+        breadcrumbs = new Breadcrumbs();
+    }
+
+    @Test
+    void setMoreItems_returnsValue() {
+        Assertions.assertEquals("Show hidden items", new BreadcrumbsI18n()
+                .setMoreItems("Show hidden items").getMoreItems());
+    }
+
+    @Test
+    void setI18n() {
+        BreadcrumbsI18n i18n = new BreadcrumbsI18n()
+                .setMoreItems("Show hidden items");
+        breadcrumbs.setI18n(i18n);
+
+        Assertions.assertSame(i18n, breadcrumbs.getI18n());
+        Assertions.assertEquals("Show hidden items",
+                getI18nPropertyAsJson(breadcrumbs).get("moreItems").asString());
+    }
+
+    @Test
+    void setI18nToNull_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> breadcrumbs.setI18n(null));
+    }
+
+    private ObjectNode getI18nPropertyAsJson(Breadcrumbs breadcrumbs) {
+        return (ObjectNode) breadcrumbs.getElement().getPropertyRaw("i18n");
+    }
+}


### PR DESCRIPTION
## Description

Task 4 of the Breadcrumbs SDD - based on tasks reorder in https://github.com/vaadin/web-components/pull/11912.

Added `BreadcrumbsI18n` and `setI18n()` API for setting it reflecting the web component `i18n` property.

## Type of change

- Feature