### PR TITLE
refactor: trigger range fetching before items reach viewport

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -144,6 +144,21 @@ describe('grid connector - data range', () => {
     expect(grid.loading).to.be.false;
   });
 
+  it('should request uncached buffer pages while scrolling over cached rows', async () => {
+    // Simulate the state the grid maintains while a scroll is in progress
+    grid.shadowRoot!.querySelector('#scroller')!.setAttribute('scrolling', '');
+
+    // Scroll so that all rendered rows stay within the cached page 0,
+    // while the fetch range buffer extends into the uncached page 1
+    const renderedCount = grid.$connector.getRenderedRange()[1] + 1;
+    grid.scrollToIndex(PAGE_SIZE - renderedCount);
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+    // Every rendered row already has data, so without eager fetch range
+    // loading during scrolling, no request would be made at all
+    expectRangeRequest([0, PAGE_SIZE * 2]);
+  });
+
   it('should skip duplicate range request while a request is in flight', async () => {
     // Trigger a request for the end of the grid and leave it in flight
     // (do not resolve it).

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -187,51 +187,5 @@ describe('grid connector', () => {
         expect(grid.$server.setViewportRange).to.be.not.called;
       });
     });
-
-    describe('last requested range is not in viewport', () => {
-      beforeEach(async () => {
-        // Request a range of items further down
-        clear(grid.$connector, 50, 50);
-        grid.scrollToIndex(50);
-        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setViewportRange).to.have.been.calledOnceWith(30, 50);
-        setRootItems(grid.$connector, items, 30, 50);
-        grid.$server.setViewportRange.resetHistory();
-      });
-
-      it('should request for items if part of the last range was cleared', async () => {
-        // Simulate preloading of items when scrolling to top programmatically on server-side, which may also partially clear the last requested range:
-        // - Scroll to top
-        // - Clear last requested range partially
-        // - Preload first two pages so that grid doesn't need to request a new range yet
-        grid.scrollToIndex(0);
-        clear(grid.$connector, 40, grid.pageSize);
-        setRootItems(grid.$connector, items, 0, 30);
-        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setViewportRange).to.not.have.been.called;
-
-        // Scroll down again, should reload the range because part of it was cleared
-        grid.scrollToIndex(50);
-        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setViewportRange).to.have.been.calledOnceWith(30, 50);
-      });
-
-      it('should not request for items if data outside of the last range was cleared', async () => {
-        // Simulate preloading of items when scrolling to top programmatically on server-side, which may also partially clear the last requested range:
-        // - Scroll to top
-        // - Clear data outside the requested range
-        // - Preload first two pages so that grid doesn't need to request a new range yet
-        grid.scrollToIndex(0);
-        clear(grid.$connector, 70, grid.pageSize);
-        grid.$connector.confirm(-1);
-        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setViewportRange).to.not.have.been.called;
-
-        // Scroll down again, should not reload the range because nothing from it was cleared
-        grid.scrollToIndex(50);
-        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-        expect(grid.$server.setViewportRange).to.not.have.been.called;
-      });
-    });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -7,8 +7,8 @@ import sinon from 'sinon';
 import type { Grid } from '@vaadin/grid';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import type { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
-import type { } from '@web/test-runner-mocha';
-import type { } from 'sinon-chai';
+import type {} from '@web/test-runner-mocha';
+import type {} from 'sinon-chai';
 
 export type GridConnector = {
   updateFlatData: (updatedItems: Item[]) => void;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -22,6 +22,7 @@ export type GridConnector = {
   doDeselection: (items: Item[], userOriginated: boolean) => void;
   clear: (index: number, length: number) => void;
   setSorterDirections: (sorters: { column: string, direction: string }[]) => void;
+  getRenderedRange: () => [number, number];
   setHeaderRenderer: (column: GridColumn, options: { content: Node | string, showSorter: boolean, sorterPath?: string }) => void;
 };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -210,11 +210,10 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
   };
 
-  grid._updateScrollerItem = function (row, index) {
-    Object.getPrototypeOf(this)._updateScrollerItem.call(this, row, index);
+  grid.__updateVirtualizerElement = function (...args) {
+    Object.getPrototypeOf(this).__updateVirtualizerElement.call(this, ...args);
 
-    const isScrolling = grid.style.overscrollBehavior === 'auto';
-    if (isScrolling) {
+    if (grid.$.scroller.hasAttribute('scrolling')) {
       const fetchRange = grid.$connector.getFetchRange();
       dataProviderController.ensureFlatIndexLoaded(fetchRange[0]);
       dataProviderController.ensureFlatIndexLoaded(fetchRange[1]);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -150,12 +150,14 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     // Get the range of currently rendered rows
     let range = grid.$connector.getRenderedRange();
 
-    // Expand the range in both directions to add a buffer
+    // Expand the range in both directions to add a buffer, e.g. a rendered
+    // range of [100, 120] becomes [80, 140]
     const buffer = range[1] - range[0];
     range[0] = Math.max(range[0] - buffer, 0);
     range[1] = Math.min(range[1] + buffer, grid.size - 1);
 
-    // Align the range to page boundaries (inclusive)
+    // Align the range to page boundaries (inclusive), e.g. with pageSize 50,
+    // a range of [60, 110] becomes [50, 149]
     range[0] = Math.floor(range[0] / grid.pageSize) * grid.pageSize;
     range[1] = (Math.floor(range[1] / grid.pageSize) + 1) * grid.pageSize - 1;
 
@@ -172,6 +174,8 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
     requestedRange = range;
 
+    // The range is inclusive while the server expects a length, hence + 1,
+    // e.g. a range of [50, 149] results in a length of 100
     await grid.$server.setViewportRange(range[0], range[1] - range[0] + 1);
 
     // Resolve any pending callbacks in case the server responded with no new
@@ -209,6 +213,10 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
   };
 
+  // The grid requests a page only when a row from that page gets rendered,
+  // which is too late to keep up while scrolling and leads to blank rows.
+  // To load data ahead of rendering, request the fetch range (rendered
+  // rows + buffer) on every virtualizer update while scrolling.
   grid.__updateVirtualizerElement = function (...args) {
     Object.getPrototypeOf(this).__updateVirtualizerElement.call(this, ...args);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -150,13 +150,12 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     // Get the range of currently rendered rows
     let range = grid.$connector.getRenderedRange();
 
-    // Add a buffer to the range in both directions
+    // Expand the range in both directions to add a buffer
     const buffer = range[1] - range[0];
     range[0] = Math.max(range[0] - buffer, 0);
     range[1] = Math.min(range[1] + buffer, grid.size - 1);
 
-    // Align the range to page boundaries. range[1] is inclusive of the last
-    // rendered row, so round it up to the last row of that row's page.
+    // Align the range to page boundaries (inclusive)
     range[0] = Math.floor(range[0] / grid.pageSize) * grid.pageSize;
     range[1] = (Math.floor(range[1] / grid.pageSize) + 1) * grid.pageSize - 1;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -150,15 +150,15 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     // Get the range of currently rendered rows
     let range = grid.$connector.getRenderedRange();
 
-    // Expand the range in both directions to add a buffer
+    // Add a buffer to the range in both directions
     const buffer = range[1] - range[0];
     range[0] = Math.max(range[0] - buffer, 0);
     range[1] = Math.min(range[1] + buffer, grid.size - 1);
 
     // Align the range to page boundaries. range[1] is inclusive of the last
-    // rendered row, so round it up to the end of that row's page.
+    // rendered row, so round it up to the last row of that row's page.
     range[0] = Math.floor(range[0] / grid.pageSize) * grid.pageSize;
-    range[1] = (Math.floor(range[1] / grid.pageSize) + 1) * grid.pageSize;
+    range[1] = (Math.floor(range[1] / grid.pageSize) + 1) * grid.pageSize - 1;
 
     return range;
   };
@@ -173,7 +173,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
     requestedRange = range;
 
-    await grid.$server.setViewportRange(range[0], range[1] - range[0]);
+    await grid.$server.setViewportRange(range[0], range[1] - range[0] + 1);
 
     // Resolve any pending callbacks in case the server responded with no new
     // data and $connector.confirm wasn't called because the server assumes all
@@ -207,6 +207,16 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     if (Object.values(rootCache.pendingRequests).length === 0) {
       requestDebouncer?.cancel();
       requestedRange = null;
+    }
+  };
+
+  grid._updateScrollerItem = function (row, index) {
+    Object.getPrototypeOf(this)._updateScrollerItem.call(this, row, index);
+
+    if (grid._columnTree) {
+      const fetchRange = grid.$connector.getFetchRange();
+      dataProviderController.ensureFlatIndexLoaded(fetchRange[0]);
+      dataProviderController.ensureFlatIndexLoaded(fetchRange[1]);
     }
   };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -213,7 +213,8 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   grid._updateScrollerItem = function (row, index) {
     Object.getPrototypeOf(this)._updateScrollerItem.call(this, row, index);
 
-    if (grid._columnTree) {
+    const isScrolling = grid.style.overscrollBehavior === 'auto';
+    if (isScrolling) {
       const fetchRange = grid.$connector.getFetchRange();
       dataProviderController.ensureFlatIndexLoaded(fetchRange[0]);
       dataProviderController.ensureFlatIndexLoaded(fetchRange[1]);


### PR DESCRIPTION
The grid web component fires a page request to the data provider only when a row from that page gets rendered in the DOM. Combined with the limited size of the viewport buffer, this often leads to the grid showing blank rows even when scrolling at a relatively slow speed, since pages can't load fast enough to keep up. Then, when the response arrives, many rendered rows get updated at once, triggering a heavy synchronous DOM update that blocks the event loop and has a negative impact on FPS. This effect has become even more noticeable after https://github.com/vaadin/web-components/pull/11196, which reduced the number of rendered rows outside the viewport. So while render time metrics improved after that fix, scroll frame time metrics regressed.

This PR makes the connector request data ahead of rendering while the user scrolls. On every virtualizer row update during scrolling, the connector computes the fetch range (the rendered range expanded by one viewport of buffer in both directions and aligned to page boundaries) and ensures its first and last indexes are requested from the data provider. If a boundary page is missing from the cache, this in turn triggers a server request that fetches the whole computed range. As a result, buffer pages start loading before their rows get rendered, so rows entering the viewport are much more likely to already have data, and row updates arrive in smaller batches. When the fetch range is already cached, the calls do nothing.

The prefetch only runs while the scroller has the `scrolling` attribute. During other row updates (initial render, server-side data changes), requests driven by rendered rows are enough, and prefetching there would only produce redundant requests for pages the server chose not to send.

#### Before:

https://github.com/user-attachments/assets/9f11832d-d28e-438f-b979-3e4c132743a7

#### After:

https://github.com/user-attachments/assets/07cf7888-77dd-4b9d-bc63-65fe064ab9a6


Depends on 
- https://github.com/vaadin/flow-components/pull/9490
- https://github.com/vaadin/web-components/pull/11914
