### PR TITLE
feat: add Breadcrumbs Mode enum, constructors and mode switching logic

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -49,7 +49,73 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>,
         HasThemeVariant<BreadcrumbsVariant> {
 
+    /**
+     * The mode that determines how the breadcrumb trail is populated.
+     */
+    public enum Mode {
+        /**
+         * The trail is populated automatically from the active route hierarchy.
+         */
+        ROUTER,
+        /**
+         * The trail is populated manually by the application through
+         * {@code add} / {@code remove} methods.
+         */
+        MANUAL
+    }
+
+    private Mode mode;
+
     private BreadcrumbsI18n i18n;
+
+    /**
+     * Creates a new breadcrumbs component in {@link Mode#ROUTER} mode.
+     */
+    public Breadcrumbs() {
+        this(Mode.ROUTER);
+    }
+
+    /**
+     * Creates a new breadcrumbs component in the given mode.
+     *
+     * @param mode
+     *            the mode that determines how the trail is populated, not
+     *            {@code null}
+     */
+    public Breadcrumbs(Mode mode) {
+        this.mode = mode;
+    }
+
+    /**
+     * Gets the mode that determines how the breadcrumb trail is populated.
+     *
+     * @return the current mode
+     */
+    public Mode getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets the mode that determines how the breadcrumb trail is populated.
+     * <p>
+     * Switching to a different mode discards the existing children: both the
+     * {@code ROUTER -> MANUAL} and {@code MANUAL -> ROUTER} transitions clear
+     * the current trail so the new mode can start fresh. Setting the mode to
+     * its current value is a no-op and leaves the children untouched.
+     *
+     * @param newMode
+     *            the mode that determines how the trail is populated, not
+     *            {@code null}
+     */
+    public void setMode(Mode newMode) {
+        if (newMode == mode) {
+            return;
+        }
+        this.mode = newMode;
+        // Listener register/unregister and the initial router rebuild are
+        // deferred to a later task; for now just clear the existing children.
+        removeAll();
+    }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+
+class BreadcrumbsModeTest {
+
+    @Test
+    void defaultConstructor_modeIsRouter() {
+        Assertions.assertEquals(Mode.ROUTER, new Breadcrumbs().getMode());
+    }
+
+    @Test
+    void modeConstructor_modeIsSet() {
+        Assertions.assertEquals(Mode.MANUAL,
+                new Breadcrumbs(Mode.MANUAL).getMode());
+    }
+
+    @Test
+    void routerMode_setModeManual_clearsChildren() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        breadcrumbs.setMode(Mode.MANUAL);
+        Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+    }
+
+    @Test
+    void manualModeWithChildren_setModeRouter_clearsChildren() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        breadcrumbs.add(new BreadcrumbsItem("Home"),
+                new BreadcrumbsItem("Page"));
+        breadcrumbs.setMode(Mode.ROUTER);
+        Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+    }
+
+    @Test
+    void setModeSameValue_isNoOp_childrenUnchanged() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var item = new BreadcrumbsItem("Home");
+        breadcrumbs.add(item);
+        breadcrumbs.setMode(Mode.MANUAL);
+        Assertions.assertEquals(1, breadcrumbs.getChildren().count());
+        Assertions.assertEquals(item,
+                breadcrumbs.getChildren().findFirst().orElse(null));
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -36,13 +36,6 @@ class BreadcrumbsModeTest {
     }
 
     @Test
-    void routerMode_setModeManual_clearsChildren() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        breadcrumbs.setMode(Mode.MANUAL);
-        Assertions.assertEquals(0, breadcrumbs.getChildren().count());
-    }
-
-    @Test
     void manualModeWithChildren_setModeRouter_clearsChildren() {
         var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
         breadcrumbs.add(new BreadcrumbsItem("Home"),


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/9481

Task 5 of the Breadcrumbs SDD - based on tasks reorder in https://github.com/vaadin/web-components/pull/11912.

Added `Mode` enum with `ROUTER` and `MANUAL` and logic related to mode switching.

## Type of change

- Feature