### PR TITLE
fix: defer Spreadsheet.selectCellRange until sheet widget layout is ready (#9381) (CP: 25.2)

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -1838,6 +1838,16 @@ public class SheetWidget extends Panel {
         return selectingCells;
     }
 
+    /**
+     * Whether the deferred init scheduled in {@link #resetFromModel} has
+     * finished and the sheet's layout state (row heights, scroll metrics) is
+     * populated. Callers that dereference layout state must wait for this to be
+     * {@code true} or risk an NPE in {@link #getRowHeight} et al.
+     */
+    boolean isLoaded() {
+        return loaded;
+    }
+
     private void startRowResizeDrag(final int rowIndex, final int clientX,
             final int clientY) {
         resized = false;

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -2045,10 +2045,30 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
                 initialSelection);
     }
 
+    /**
+     * Selects the given cell range, optionally scrolling it into view.
+     * <p>
+     * The call may be deferred until the sheet layout is ready. Sheet layout
+     * state is populated by a {@code scheduleDeferred} command in
+     * {@link SheetWidget#resetFromModel}, so this method can be called before
+     * {@link SheetWidget#isLoaded()} flips {@code true} — for instance when
+     * property writes and RPCs are flushed within the same task. In that
+     * window, {@code scrollAreaIntoView} would dereference an uninitialized
+     * {@code definedRowHeights}, so when the widget has not loaded yet the call
+     * is deferred via the same scheduler to run after the layout init command.
+     * Only this RPC touches row/column metrics, so only it needs deferring.
+     */
     public void selectCellRange(String name, int selectedCellColumn,
             int selectedCellRow, int firstColumn, int lastColumn, int firstRow,
             int lastRow, boolean scroll) {
-
+        if (!sheetWidget.isLoaded()) {
+            Scheduler.get()
+                    .scheduleDeferred(() -> selectionHandler.selectCellRange(
+                            name, selectedCellColumn, selectedCellRow,
+                            firstColumn, lastColumn, firstRow, lastRow,
+                            scroll));
+            return;
+        }
         selectionHandler.selectCellRange(name, selectedCellColumn,
                 selectedCellRow, firstColumn, lastColumn, firstRow, lastRow,
                 scroll);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/vaadin-spreadsheet.js
@@ -366,37 +366,6 @@ export class VaadinSpreadsheet extends LitElement {
 
   setSelectedCellAndRange(name, col, row, c1, c2, r1, r2, scroll) {
     this._flush();
-    // The sheet widget's initial relayout is deferred via GWT's scheduler,
-    // so `definedRowHeights` may not yet exist when this RPC arrives in the
-    // same task as the initial property batch (e.g. opening a Dialog that
-    // contains the Spreadsheet). Calling `setSelectedCellAndRange` before
-    // it's populated would throw inside `$scrollAreaIntoView`. Re-queue the
-    // call until the layout state is ready; only the latest pending call is
-    // kept so rapid successive calls collapse to the final selection.
-    if (!this.api.spreadsheetWidget.sheetWidget.definedRowHeights) {
-      this._pendingSelection = [name, col, row, c1, c2, r1, r2, scroll];
-      if (!this._pendingSelectionScheduled) {
-        this._pendingSelectionScheduled = true;
-        const applyPending = () => {
-          if (!this.isConnected || !this._pendingSelection) {
-            this._pendingSelectionScheduled = false;
-            this._pendingSelection = null;
-            return;
-          }
-          if (this.api.spreadsheetWidget.sheetWidget.definedRowHeights) {
-            const args = this._pendingSelection;
-            this._pendingSelection = null;
-            this._pendingSelectionScheduled = false;
-            this.api.setSelectedCellAndRange(...args);
-            return;
-          }
-          setTimeout(applyPending, 10);
-        };
-        setTimeout(applyPending, 10);
-      }
-      return;
-    }
-    this._pendingSelection = null;
     this.api.setSelectedCellAndRange(name, col, row, c1, c2, r1, r2, scroll);
   }
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9381 to branch 25.2.

---

> <!-- Why -->
> Follow-up to #9333. When a Spreadsheet inside a closed Dialog is opened, Flow
> flushes the property writes and the `setSelectedCellAndRange` RPC in the same
> task. The api receives the call before the deferred init scheduled in
> `SheetWidget.resetFromModel` has run — so `SheetWidget.getRowHeight` reads an
> uninitialized `definedRowHeights` and throws
>
> ```
> Uncaught TypeError: Cannot read properties of undefined (reading 'length')
> ```
>
> That throw drops the selection and trips the `*_noErrors`/`*_noConsoleErrors`
> console-log assertions.
>
> #9333's connector-side guard masked this by probing `definedRowHeights`
> through the api's private GWT fields — names that only survive
> `-Dgwt.style=pretty` (local/dev). CI compiles the GWT client with
> `-Dgwt.style=OBF`, where those private names are renamed and `api.spreadsheetWidget`
> is `undefined`. The guard itself then threw, producing the same SEVERE log and
> the same ~20 spreadsheet IT failures on the cherry-pick PRs.
>
> <!-- Changes -->
> Move the layout-readiness handling into the widget that owns the operation:
>
> - `SheetWidget.isLoaded()` (package-private) — exposes the already-existing
>   `loaded` flag that flips at the end of `resetFromModel`'s deferred command.
> - `SpreadsheetWidget.selectCellRange` — if `!sheetWidget.isLoaded()`, store the
>   latest args and `Scheduler.scheduleDeferred(this::applyPendingSelectCellRange)`.
>   The deferred re-checks, applies, or re-schedules. Latest-wins (rapid successive
>   calls collapse to the final selection). Bounded at 100 hops as a safety net;
>   in the typical case the layout init has already been scheduled before us, so
>   GWT's FIFO scheduler resolves us in 0–1 hops.
> - `vaadin-spreadsheet.js` — `setSelectedCellAndRange` goes back to a one-liner
>   (`this._flush(); this.api.setSelectedCellAndRange(...args)`). No try/catch,
>   no pending state, no constants.
>
> Only `selectCellRange` is deferred — it's the only RPC that touches row/column
> metrics. Other RPCs (`cellsUpdated`, popup ops, etc.) don't need this and
> didn't fail in the original CI runs.
>
> <!-- Reproduction / validation -->
> Reproduce locally by compiling the client with `-Dgwt.style=OBF` (matching CI)
> and running the merged ITs in production mode:
>
> ```
> mvn clean install -DskipTests -Dgwt.style=OBF \
>   -pl vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client,vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow
> node scripts/mergeITs.js spreadsheet
> mvn verify -Drun-it -pl integration-tests -Dvaadin.productionMode=true \
>   -Dit.test='NavigationIT,SpreadsheetDialogIT' -DskipUnitTests
> ```
>
> - With this PR → NavigationIT 26/0, SpreadsheetDialogIT 1/0.
> - Reverting only the GWT-side change → SpreadsheetDialogIT fails with the
>   underlying `Cannot read properties of undefined (reading 'length')` in
>   `FlowClient-…js` — the actual `definedRowHeights` NPE.
>
> Follow-up to #9333.
>
> ---
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
