### PR TITLE
feat: add Mode.ROUTER guard on Breadcrumbs child management methods

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -16,7 +16,11 @@
 package com.vaadin.flow.component.breadcrumbs;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.experimental.FeatureFlags;
@@ -31,7 +35,9 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * Breadcrumbs is a component for displaying a navigation trail that shows the
@@ -65,6 +71,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
     }
 
     private Mode mode;
+
+    private boolean routerUpdateInProgress;
 
     private BreadcrumbsI18n i18n;
 
@@ -114,7 +122,98 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         this.mode = newMode;
         // Listener register/unregister and the initial router rebuild are
         // deferred to a later task; for now just clear the existing children.
-        removeAll();
+        updateChildrenInternal(List.of());
+    }
+
+    @Override
+    public void add(BreadcrumbsItem... components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.add(components);
+    }
+
+    @Override
+    public void add(Collection<BreadcrumbsItem> components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.add(components);
+    }
+
+    @Override
+    public void remove(BreadcrumbsItem... components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.remove(components);
+    }
+
+    @Override
+    public void remove(Collection<BreadcrumbsItem> components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.remove(components);
+    }
+
+    @Override
+    public void removeAll() {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.removeAll();
+    }
+
+    @Override
+    public void addComponentAsFirst(BreadcrumbsItem component) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.addComponentAsFirst(component);
+    }
+
+    @Override
+    public void addComponentAtIndex(int index, BreadcrumbsItem component) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.addComponentAtIndex(index, component);
+    }
+
+    @Override
+    public void replace(BreadcrumbsItem oldComponent,
+            BreadcrumbsItem newComponent) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.replace(oldComponent, newComponent);
+    }
+
+    @Override
+    public <V extends @Nullable Object, S extends Signal<V>> void bindChildren(
+            Signal<List<S>> list,
+            SerializableFunction<S, BreadcrumbsItem> childFactory) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.bindChildren(list, childFactory);
+    }
+
+    /**
+     * Throws if manual child mutation is not allowed in the current mode.
+     * <p>
+     * Mutating children is rejected while in {@link Mode#ROUTER}, unless the
+     * internal {@link #routerUpdateInProgress} flag is set (i.e. the change
+     * originates from the router-driven rebuild via
+     * {@link #updateChildrenInternal(List)}).
+     */
+    private void checkManualMutationAllowed() {
+        if (mode == Mode.ROUTER && !routerUpdateInProgress) {
+            throw new IllegalStateException(
+                    "Cannot modify breadcrumb items manually in Mode.ROUTER. "
+                            + "Switch to Mode.MANUAL to manage items directly.");
+        }
+    }
+
+    /**
+     * Replaces the current children with the given router-derived trail,
+     * bypassing the {@link Mode#ROUTER} mutation guard for the duration of the
+     * update.
+     *
+     * @param trail
+     *            the breadcrumb items to set as the new children
+     */
+    void updateChildrenInternal(List<BreadcrumbsItem> trail) {
+        routerUpdateInProgress = true;
+        try {
+            removeAll();
+            add(trail.toArray(BreadcrumbsItem[]::new));
+        } finally {
+            routerUpdateInProgress = false;
+        }
     }
 
     @Override

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -72,7 +73,7 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
 
     private Mode mode;
 
-    private boolean routerUpdateInProgress;
+    private boolean internalChildUpdate;
 
     private BreadcrumbsI18n i18n;
 
@@ -114,10 +115,19 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
      * @param newMode
      *            the mode that determines how the trail is populated, not
      *            {@code null}
+     * @throws IllegalStateException
+     *             if a children binding set via {@code bindChildren} is active;
+     *             such a binding takes over the trail and cannot be handed back
+     *             to component-controlled population, so it must be removed
+     *             before switching modes
      */
     public void setMode(Mode newMode) {
         if (newMode == mode) {
             return;
+        }
+        if (hasChildrenBinding()) {
+            throw new IllegalStateException(
+                    "Cannot change the mode while a children binding is active.");
         }
         this.mode = newMode;
         // Listener register/unregister and the initial router rebuild are
@@ -186,12 +196,12 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
      * Throws if manual child mutation is not allowed in the current mode.
      * <p>
      * Mutating children is rejected while in {@link Mode#ROUTER}, unless the
-     * internal {@link #routerUpdateInProgress} flag is set (i.e. the change
-     * originates from the router-driven rebuild via
-     * {@link #updateChildrenInternal(List)}).
+     * internal {@link #internalChildUpdate} flag is set (i.e. the change
+     * originates from an internal child update such as a mode switch or a
+     * router-driven rebuild via {@link #updateChildrenInternal(List)}).
      */
     private void checkManualMutationAllowed() {
-        if (mode == Mode.ROUTER && !routerUpdateInProgress) {
+        if (mode == Mode.ROUTER && !internalChildUpdate) {
             throw new IllegalStateException(
                     "Cannot modify breadcrumb items manually in Mode.ROUTER. "
                             + "Switch to Mode.MANUAL to manage items directly.");
@@ -199,21 +209,38 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
     }
 
     /**
-     * Replaces the current children with the given router-derived trail,
-     * bypassing the {@link Mode#ROUTER} mutation guard for the duration of the
-     * update.
+     * Replaces the current children with the given trail, bypassing the
+     * {@link Mode#ROUTER} mutation guard for the duration of the update. Used
+     * both for the router-driven rebuild and for clearing children on a mode
+     * switch.
      *
      * @param trail
      *            the breadcrumb items to set as the new children
      */
     void updateChildrenInternal(List<BreadcrumbsItem> trail) {
-        routerUpdateInProgress = true;
+        internalChildUpdate = true;
         try {
             removeAll();
             add(trail.toArray(BreadcrumbsItem[]::new));
         } finally {
-            routerUpdateInProgress = false;
+            internalChildUpdate = false;
         }
+    }
+
+    /**
+     * Checks whether a children binding (set via {@code bindChildren}) is
+     * currently active on this component's element. Mirrors the internal check
+     * Flow core performs, reading the binding state from the element node
+     * rather than tracking a separate field.
+     *
+     * @return {@code true} if a children binding is active
+     */
+    private boolean hasChildrenBinding() {
+        return getElement().getNode()
+                .getFeatureIfInitialized(SignalBindingFeature.class)
+                .map(feature -> feature
+                        .hasBinding(SignalBindingFeature.CHILDREN))
+                .orElse(false);
     }
 
     @Override

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -118,8 +118,7 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
      * @throws IllegalStateException
      *             if a children binding set via {@code bindChildren} is active;
      *             such a binding takes over the trail and cannot be handed back
-     *             to component-controlled population, so it must be removed
-     *             before switching modes
+     *             to component-controlled population
      */
     public void setMode(Mode newMode) {
         if (newMode == mode) {
@@ -230,8 +229,7 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
     /**
      * Checks whether a children binding (set via {@code bindChildren}) is
      * currently active on this component's element. Mirrors the internal check
-     * Flow core performs, reading the binding state from the element node
-     * rather than tracking a separate field.
+     * Flow core performs, reading the binding state from the element node.
      *
      * @return {@code true} if a children binding is active
      */

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -123,8 +123,8 @@ class BreadcrumbsModeTest extends AbstractSignalsTest {
         breadcrumbs.bindChildren(listSignal,
                 signal -> new BreadcrumbsItem(signal.peek()));
 
-        // A children binding takes over the trail; switching modes must fail
-        // rather than silently dropping the binding.
+        // A binding controls the children and cannot be removed; switching
+        // modes would clear them, so setMode must fail.
         Assertions.assertThrows(IllegalStateException.class,
                 () -> breadcrumbs.setMode(Mode.ROUTER));
     }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -15,14 +15,18 @@
  */
 package com.vaadin.flow.component.breadcrumbs.tests;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsTest;
 
-class BreadcrumbsModeTest {
+class BreadcrumbsModeTest extends AbstractSignalsTest {
 
     @Test
     void defaultConstructor_modeIsRouter() {
@@ -36,12 +40,68 @@ class BreadcrumbsModeTest {
     }
 
     @Test
-    void manualModeWithChildren_setModeRouter_clearsChildren() {
+    void manualMode_mutatingMethods_doNotThrow() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var home = new BreadcrumbsItem("Home");
+        var page = new BreadcrumbsItem("Page");
+
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.remove(home));
+        Assertions.assertDoesNotThrow(breadcrumbs::removeAll);
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.replace(home, page));
+        Assertions.assertDoesNotThrow(
+                () -> breadcrumbs.addComponentAsFirst(home));
+        Assertions.assertDoesNotThrow(
+                () -> breadcrumbs.addComponentAtIndex(0, page));
+    }
+
+    @Test
+    void routerMode_mutatingMethods_throw() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        var home = new BreadcrumbsItem("Home");
+        var page = new BreadcrumbsItem("Page");
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.add(home));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.remove(home));
+        Assertions.assertThrows(IllegalStateException.class,
+                breadcrumbs::removeAll);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.replace(home, page));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.addComponentAsFirst(home));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.addComponentAtIndex(0, page));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.bindChildren(null, null));
+    }
+
+    @Test
+    void getChildren_worksInBothModes() {
+        var manual = new Breadcrumbs(Mode.MANUAL);
+        manual.add(new BreadcrumbsItem("Home"));
+        Assertions.assertEquals(1, manual.getChildren().count());
+
+        var router = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertEquals(0, router.getChildren().count());
+    }
+
+    @Test
+    void manualModeWithChildren_setModeRouter_clearsChildrenAndReappliesGuard() {
         var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
         breadcrumbs.add(new BreadcrumbsItem("Home"),
                 new BreadcrumbsItem("Page"));
+
+        // MANUAL -> ROUTER clears manually-added children without throwing,
+        // exercising the updateChildrenInternal(List.of()) bypass.
         breadcrumbs.setMode(Mode.ROUTER);
         Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+
+        // The bypass flag is reset afterwards, so a guarded add throws again.
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.add(new BreadcrumbsItem("Other")));
     }
 
     @Test
@@ -53,5 +113,19 @@ class BreadcrumbsModeTest {
         Assertions.assertEquals(1, breadcrumbs.getChildren().count());
         Assertions.assertEquals(item,
                 breadcrumbs.getChildren().findFirst().orElse(null));
+    }
+
+    @Test
+    void setMode_withActiveChildrenBinding_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var itemSignal = new ValueSignal<>("Home");
+        var listSignal = new ValueSignal<>(List.of(itemSignal));
+        breadcrumbs.bindChildren(listSignal,
+                signal -> new BreadcrumbsItem(signal.peek()));
+
+        // A children binding takes over the trail; switching modes must fail
+        // rather than silently dropping the binding.
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.setMode(Mode.ROUTER));
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 
@@ -45,5 +46,97 @@ class BreadcrumbsTest {
     void implementsHasThemeVariant() {
         Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(Breadcrumbs.class));
+    }
+
+    @Test
+    void manualMode_mutatingMethods_doNotThrow() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var home = new BreadcrumbsItem("Home");
+        var page = new BreadcrumbsItem("Page");
+
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.remove(home));
+        Assertions.assertDoesNotThrow(breadcrumbs::removeAll);
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.replace(home, page));
+        Assertions.assertDoesNotThrow(
+                () -> breadcrumbs.addComponentAsFirst(home));
+        Assertions.assertDoesNotThrow(
+                () -> breadcrumbs.addComponentAtIndex(0, page));
+    }
+
+    @Test
+    void routerMode_add_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.add(new BreadcrumbsItem("Home")));
+    }
+
+    @Test
+    void routerMode_remove_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.remove(new BreadcrumbsItem("Home")));
+    }
+
+    @Test
+    void routerMode_removeAll_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class,
+                breadcrumbs::removeAll);
+    }
+
+    @Test
+    void routerMode_replace_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.replace(new BreadcrumbsItem("Home"),
+                        new BreadcrumbsItem("Page")));
+    }
+
+    @Test
+    void routerMode_addComponentAsFirst_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class, () -> breadcrumbs
+                .addComponentAsFirst(new BreadcrumbsItem("Home")));
+    }
+
+    @Test
+    void routerMode_addComponentAtIndex_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class, () -> breadcrumbs
+                .addComponentAtIndex(0, new BreadcrumbsItem("Home")));
+    }
+
+    @Test
+    void routerMode_bindChildren_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.bindChildren(null, null));
+    }
+
+    @Test
+    void getChildren_worksInBothModes() {
+        var manual = new Breadcrumbs(Mode.MANUAL);
+        manual.add(new BreadcrumbsItem("Home"));
+        Assertions.assertEquals(1, manual.getChildren().count());
+
+        var router = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertEquals(0, router.getChildren().count());
+    }
+
+    @Test
+    void routerMode_setModeManualThenAdd_clearsAndAllowsAdd() {
+        var manual = new Breadcrumbs(Mode.MANUAL);
+        manual.add(new BreadcrumbsItem("Home"), new BreadcrumbsItem("Page"));
+
+        // MANUAL -> ROUTER clears manually-added children without throwing,
+        // exercising the updateChildrenInternal(List.of()) bypass.
+        Assertions.assertDoesNotThrow(() -> manual.setMode(Mode.ROUTER));
+        Assertions.assertEquals(0, manual.getChildren().count());
+
+        // The bypass flag is reset afterwards, so a guarded add still throws.
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> manual.add(new BreadcrumbsItem("Other")));
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
-import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 
@@ -46,97 +45,5 @@ class BreadcrumbsTest {
     void implementsHasThemeVariant() {
         Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(Breadcrumbs.class));
-    }
-
-    @Test
-    void manualMode_mutatingMethods_doNotThrow() {
-        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
-        var home = new BreadcrumbsItem("Home");
-        var page = new BreadcrumbsItem("Page");
-
-        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
-        Assertions.assertDoesNotThrow(() -> breadcrumbs.remove(home));
-        Assertions.assertDoesNotThrow(breadcrumbs::removeAll);
-        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
-        Assertions.assertDoesNotThrow(() -> breadcrumbs.replace(home, page));
-        Assertions.assertDoesNotThrow(
-                () -> breadcrumbs.addComponentAsFirst(home));
-        Assertions.assertDoesNotThrow(
-                () -> breadcrumbs.addComponentAtIndex(0, page));
-    }
-
-    @Test
-    void routerMode_add_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> breadcrumbs.add(new BreadcrumbsItem("Home")));
-    }
-
-    @Test
-    void routerMode_remove_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> breadcrumbs.remove(new BreadcrumbsItem("Home")));
-    }
-
-    @Test
-    void routerMode_removeAll_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class,
-                breadcrumbs::removeAll);
-    }
-
-    @Test
-    void routerMode_replace_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> breadcrumbs.replace(new BreadcrumbsItem("Home"),
-                        new BreadcrumbsItem("Page")));
-    }
-
-    @Test
-    void routerMode_addComponentAsFirst_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class, () -> breadcrumbs
-                .addComponentAsFirst(new BreadcrumbsItem("Home")));
-    }
-
-    @Test
-    void routerMode_addComponentAtIndex_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class, () -> breadcrumbs
-                .addComponentAtIndex(0, new BreadcrumbsItem("Home")));
-    }
-
-    @Test
-    void routerMode_bindChildren_throws() {
-        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> breadcrumbs.bindChildren(null, null));
-    }
-
-    @Test
-    void getChildren_worksInBothModes() {
-        var manual = new Breadcrumbs(Mode.MANUAL);
-        manual.add(new BreadcrumbsItem("Home"));
-        Assertions.assertEquals(1, manual.getChildren().count());
-
-        var router = new Breadcrumbs(Mode.ROUTER);
-        Assertions.assertEquals(0, router.getChildren().count());
-    }
-
-    @Test
-    void routerMode_setModeManualThenAdd_clearsAndAllowsAdd() {
-        var manual = new Breadcrumbs(Mode.MANUAL);
-        manual.add(new BreadcrumbsItem("Home"), new BreadcrumbsItem("Page"));
-
-        // MANUAL -> ROUTER clears manually-added children without throwing,
-        // exercising the updateChildrenInternal(List.of()) bypass.
-        Assertions.assertDoesNotThrow(() -> manual.setMode(Mode.ROUTER));
-        Assertions.assertEquals(0, manual.getChildren().count());
-
-        // The bypass flag is reset afterwards, so a guarded add still throws.
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> manual.add(new BreadcrumbsItem("Other")));
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/9482

Depends on https://github.com/vaadin/flow-components/pull/9483

Task 6 of the Breadcrumbs SDD - based on tasks reorder in https://github.com/vaadin/web-components/pull/11912.

Added overrides to disallow manual children modifications when using `Mode.ROUTER`.

## Type of change

- Feature