### PR TITLE
fix: do not request page past end when scrolled to bottom

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-data-range.test.ts
@@ -75,9 +75,9 @@ describe('grid connector - data range', () => {
   it('should request correct ranges when scrolling (start -> end -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
 
-    await resolveRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    await resolveRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
 
     grid.scrollToIndex(0);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -89,7 +89,7 @@ describe('grid connector - data range', () => {
     rootSize /= 2;
     grid.$connector.updateSize(rootSize);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
   });
 
   it('should request correct ranges when scrolling (start -> middle -> end)', async () => {
@@ -101,15 +101,15 @@ describe('grid connector - data range', () => {
 
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
   });
 
   it('should request correct ranges when scrolling (end -> middle -> start)', async () => {
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
 
-    await resolveRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    await resolveRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
 
     grid.scrollToIndex(rootSize / 2);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
@@ -126,7 +126,7 @@ describe('grid connector - data range', () => {
     grid.scrollToIndex(rootSize / 2);
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
   });
 
   it('should request correct ranges when scrolling fast (start -> end -> start)', async () => {
@@ -149,7 +149,7 @@ describe('grid connector - data range', () => {
     // (do not resolve it).
     grid.scrollToIndex(rootSize - 1);
     await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
-    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE * 2]);
+    expectRangeRequest([rootSize - PAGE_SIZE, PAGE_SIZE]);
     grid.$server.setViewportRange.resetHistory();
 
     // While that request is still in flight, scroll to an uncached page so

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -153,7 +153,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     // Expand the range in both directions to add a buffer
     const buffer = range[1] - range[0];
     range[0] = Math.max(range[0] - buffer, 0);
-    range[1] = Math.min(range[1] + buffer, grid.size);
+    range[1] = Math.min(range[1] + buffer, grid.size - 1);
 
     // Align the range to page boundaries. range[1] is inclusive of the last
     // rendered row, so round it up to the end of that row's page.


### PR DESCRIPTION
When the grid is scrolled to the bottom, the connector may request one page more than the grid has. For example, with 200 rows and a page size of 50, it requests rows 150–249 even though the last row is 199.

The root cause is that the range end in `getFetchRange` is a row index, but it was clamped to `grid.size` instead of the last row index, `grid.size - 1`. That off-by-one could push the end of the request onto the next page, past the end of the data.

The item count estimate feature is unaffected: `DataCommunicator` grows the estimate whenever the requested range ends within one page of it, so requesting only the last existing page still triggers the increase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)