### PR TITLE
fix: preserve custom editors and scope the display callback

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
@@ -23,17 +23,19 @@ import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
 import com.vaadin.flow.router.Route;
 
 /**
- * View for verifying that reloading the visible cell contents does not re-fire
- * {@code onCustomEditorDisplayed} or wipe/duplicate custom editors
+ * View for verifying custom editor handling on scroll versus explicit refresh
  * (vaadin/flow-components#9180).
  * <p>
  * The factory returns a new {@link ComboBox} on every
- * {@code getCustomEditorForCell} call (a common usage pattern), so without the
- * fix a reload would re-create empty editors. The callback counter is rendered
- * on the page (id {@code callbackCount}) rather than inside a cell, so it stays
- * visible regardless of scrolling. The {@code reloadBtn} triggers
- * {@link Spreadsheet#reloadVisibleCellContents()} without changing the
- * selection.
+ * {@code getCustomEditorForCell} call (a common usage pattern). Scrolling must
+ * reuse the editor already shown for a cell, so its value survives and
+ * {@code onCustomEditorDisplayed} is not re-fired for an unchanged selection.
+ * An explicit refresh via {@link Spreadsheet#reloadVisibleCellContents()}
+ * ({@code reloadBtn}) keeps the long-standing behavior of recreating editors
+ * from the factory.
+ * <p>
+ * The callback counter is rendered on the page (id {@code callbackCount})
+ * rather than inside a cell, so it stays visible regardless of scrolling.
  */
 @Route("vaadin-spreadsheet/custom-editor-reload")
 public class CustomEditorReloadPage extends VerticalLayout {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
@@ -22,21 +22,6 @@ import com.vaadin.flow.component.spreadsheet.Spreadsheet;
 import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
 import com.vaadin.flow.router.Route;
 
-/**
- * View for verifying custom editor handling on scroll versus explicit refresh
- * (vaadin/flow-components#9180).
- * <p>
- * The factory returns a new {@link ComboBox} on every
- * {@code getCustomEditorForCell} call (a common usage pattern). Scrolling must
- * reuse the editor already shown for a cell, so its value survives and
- * {@code onCustomEditorDisplayed} is not re-fired for an unchanged selection.
- * An explicit refresh via {@link Spreadsheet#reloadVisibleCellContents()}
- * ({@code reloadBtn}) keeps the long-standing behavior of recreating editors
- * from the factory.
- * <p>
- * The callback counter is rendered on the page (id {@code callbackCount})
- * rather than inside a cell, so it stays visible regardless of scrolling.
- */
 @Route("vaadin-spreadsheet/custom-editor-reload")
 public class CustomEditorReloadPage extends VerticalLayout {
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
@@ -77,9 +77,9 @@ public class CustomEditorReloadPage extends VerticalLayout {
         @Override
         public Component getCustomEditorForCell(Cell cell, int rowIndex,
                 int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
-            // Editors in B2:E2. A new instance is returned on every call to
+            // Editor in B2. A new instance is returned on every call to
             // exercise the editor-preservation logic.
-            if (rowIndex == 1 && columnIndex >= 1 && columnIndex <= 4) {
+            if (rowIndex == 1 && columnIndex == 1) {
                 ComboBox<String> comboBox = new ComboBox<>();
                 comboBox.setItems(FRUITS);
                 comboBox.setWidthFull();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
+import com.vaadin.flow.router.Route;
+
+/**
+ * View for verifying that reloading the visible cell contents does not re-fire
+ * {@code onCustomEditorDisplayed} or wipe/duplicate custom editors
+ * (vaadin/flow-components#9180).
+ * <p>
+ * The factory returns a new {@link ComboBox} on every
+ * {@code getCustomEditorForCell} call (a common usage pattern), so without the
+ * fix a reload would re-create empty editors. The callback counter is rendered
+ * on the page (id {@code callbackCount}) rather than inside a cell, so it stays
+ * visible regardless of scrolling. The {@code reloadBtn} triggers
+ * {@link Spreadsheet#reloadVisibleCellContents()} without changing the
+ * selection.
+ */
+@Route("vaadin-spreadsheet/custom-editor-reload")
+public class CustomEditorReloadPage extends VerticalLayout {
+
+    static final String[] FRUITS = { "Apple", "Banana", "Cherry" };
+
+    private int callbackCount;
+    private final Span callbackCounter = new Span("0");
+    private final Spreadsheet spreadsheet = new Spreadsheet();
+
+    public CustomEditorReloadPage() {
+        setSizeFull();
+
+        callbackCounter.setId("callbackCount");
+
+        Button reload = new Button("Reload visible cell contents",
+                e -> spreadsheet.reloadVisibleCellContents());
+        reload.setId("reloadBtn");
+
+        spreadsheet.setSpreadsheetComponentFactory(new ComboBoxEditorFactory());
+        spreadsheet.setSizeFull();
+
+        Div spreadsheetContainer = new Div(spreadsheet);
+        spreadsheetContainer.setSizeFull();
+
+        add(new HorizontalLayout(callbackCounter, reload),
+                spreadsheetContainer);
+        setFlexGrow(1, spreadsheetContainer);
+    }
+
+    private class ComboBoxEditorFactory implements SpreadsheetComponentFactory {
+
+        @Override
+        public Component getCustomComponentForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            return null;
+        }
+
+        @Override
+        public Component getCustomEditorForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            // Editors in B2:E2. A new instance is returned on every call to
+            // exercise the editor-preservation logic.
+            if (rowIndex == 1 && columnIndex >= 1 && columnIndex <= 4) {
+                ComboBox<String> comboBox = new ComboBox<>();
+                comboBox.setItems(FRUITS);
+                comboBox.setWidthFull();
+                return comboBox;
+            }
+            return null;
+        }
+
+        @Override
+        public void onCustomEditorDisplayed(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet,
+                Component customEditor) {
+            callbackCount++;
+            callbackCounter.setText(String.valueOf(callbackCount));
+            if (customEditor instanceof ComboBox<?> comboBox) {
+                @SuppressWarnings("unchecked")
+                ComboBox<String> typed = (ComboBox<String>) comboBox;
+                typed.setValue(FRUITS[columnIndex % FRUITS.length]);
+            }
+        }
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
@@ -20,11 +20,12 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
 /**
- * Tests that reloading the visible cell contents does not re-fire
- * {@code onCustomEditorDisplayed} or wipe/duplicate custom editors
+ * Tests custom editor handling on scroll versus explicit refresh
  * (vaadin/flow-components#9180). The factory returns a new editor instance on
- * every call, so the framework must preserve the editor already shown for a
- * cell instead of re-creating it.
+ * every call. Scrolling must reuse the editor already shown for a cell, so its
+ * value survives and {@code onCustomEditorDisplayed} is not re-fired for an
+ * unchanged selection. An explicit refresh keeps the long-standing behavior of
+ * recreating editors from the factory.
  */
 @TestPath("vaadin-spreadsheet/custom-editor-reload")
 public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
@@ -40,13 +41,8 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
     }
 
     @Test
-    public void editorSelected_visibleContentsReloaded_callbackNotRefiredAndValuePreserved() {
-        // Select the editor cell B2 via keyboard (select a plain cell, then
-        // Tab) rather than clicking the combobox, which is an unreliable way
-        // to change the selection.
-        selectCell("A2");
-        getSpreadsheet().sendKeys(Keys.TAB);
-        getCommandExecutor().waitForVaadin();
+    public void editorSelected_scrolledAwayAndBack_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
 
         // B2 is column index 1, so the factory sets the editor value to
         // FRUITS[1] = "Banana".
@@ -54,16 +50,42 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
         int comboBoxes = countComboBoxes();
 
-        // Reloading keeps the selection on B2, so the callback must not fire
-        // again, the editor value must be preserved, and no orphan editors
-        // should accumulate across repeated reloads.
-        for (int i = 0; i < 3; i++) {
-            clickReload();
-            getCommandExecutor().waitForVaadin();
-            Assert.assertEquals("1", getCallbackCount());
-            Assert.assertEquals("Banana", getComboBoxValue("B2"));
-            Assert.assertEquals(comboBoxes, countComboBoxes());
-        }
+        // Scroll the editor row out of view and back. The selection stays on
+        // B2, so its editor must be reused: the callback must not fire again,
+        // the editor value must be preserved, and no orphan editors should
+        // accumulate.
+        getSpreadsheet().scroll(5000);
+        getCommandExecutor().waitForVaadin();
+        getSpreadsheet().scroll(0);
+        getCommandExecutor().waitForVaadin();
+        waitUntil(driver -> countComboBoxes() == comboBoxes);
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        Assert.assertEquals(comboBoxes, countComboBoxes());
+    }
+
+    @Test
+    public void editorSelected_visibleContentsReloaded_editorRecreated() {
+        selectEditorCellB2();
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        // An explicit refresh recreates editors from the factory (preserving
+        // the long-standing behavior of reloadVisibleCellContents). The factory
+        // returns a blank editor and a refresh does not invoke the callback, so
+        // the previously shown value is gone.
+        clickReload();
+        getCommandExecutor().waitForVaadin();
+        Assert.assertEquals("", getComboBoxValue("B2"));
+    }
+
+    private void selectEditorCellB2() {
+        // Select the editor cell B2 via keyboard (select a plain cell, then
+        // Tab) rather than clicking the combobox, which is an unreliable way to
+        // change the selection.
+        selectCell("A2");
+        getSpreadsheet().sendKeys(Keys.TAB);
+        getCommandExecutor().waitForVaadin();
     }
 
     private String getCallbackCount() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
+
+import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Tests that reloading the visible cell contents does not re-fire
+ * {@code onCustomEditorDisplayed} or wipe/duplicate custom editors
+ * (vaadin/flow-components#9180). The factory returns a new editor instance on
+ * every call, so the framework must preserve the editor already shown for a
+ * cell instead of re-creating it.
+ */
+@TestPath("vaadin-spreadsheet/custom-editor-reload")
+public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
+
+    @Before
+    public void init() {
+        open();
+        setSpreadsheet($(SpreadsheetElement.class).first());
+        // Wait until the always-visible editors (B2:E2) have rendered, so the
+        // first selection reliably lands on the editor instead of an
+        // not-yet-loaded cell.
+        waitUntil(driver -> countComboBoxes() == 4);
+    }
+
+    @Test
+    public void editorSelected_visibleContentsReloaded_callbackNotRefiredAndValuePreserved() {
+        // Select the editor cell B2 via keyboard (select a plain cell, then
+        // Tab) rather than clicking the combobox, which is an unreliable way
+        // to change the selection.
+        selectCell("A2");
+        getSpreadsheet().sendKeys(Keys.TAB);
+        getCommandExecutor().waitForVaadin();
+
+        // B2 is column index 1, so the factory sets the editor value to
+        // FRUITS[1] = "Banana".
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        int comboBoxes = countComboBoxes();
+
+        // Reloading keeps the selection on B2, so the callback must not fire
+        // again, the editor value must be preserved, and no orphan editors
+        // should accumulate across repeated reloads.
+        for (int i = 0; i < 3; i++) {
+            clickReload();
+            getCommandExecutor().waitForVaadin();
+            Assert.assertEquals("1", getCallbackCount());
+            Assert.assertEquals("Banana", getComboBoxValue("B2"));
+            Assert.assertEquals(comboBoxes, countComboBoxes());
+        }
+    }
+
+    private String getCallbackCount() {
+        return $(TestBenchElement.class).id("callbackCount").getText();
+    }
+
+    private void clickReload() {
+        $("vaadin-button").id("reloadBtn").click();
+    }
+
+    private String getComboBoxValue(String cellAddress) {
+        var cell = getSpreadsheet().getCellAt(cellAddress);
+        try {
+            var slotName = cell.findElement(By.tagName("slot"))
+                    .getDomAttribute("name");
+            return getSpreadsheet()
+                    .findElement(By.cssSelector("[slot='" + slotName + "']"))
+                    .findElement(By.cssSelector("input"))
+                    .getDomProperty("value");
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
+
+    private int countComboBoxes() {
+        return getSpreadsheet().findElements(By.tagName("vaadin-combo-box"))
+                .size();
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
@@ -20,42 +20,22 @@ import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
-/**
- * Tests custom editor handling on the paths that re-render the visible cells
- * (vaadin/flow-components#9180). The factory returns a new editor instance on
- * every call. Scrolling, changing the selection (column, row, or range) and
- * resizing rows or columns all keep the same cells visible, so the editor
- * already shown for a cell must be reused: its value survives and
- * {@code onCustomEditorDisplayed} is not re-fired for an unchanged selection.
- * An explicit refresh keeps the long-standing behavior of recreating editors
- * from the factory.
- */
 @TestPath("vaadin-spreadsheet/custom-editor-reload")
 public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
 
     @Before
     public void init() {
         open();
-        setSpreadsheet($(SpreadsheetElement.class).first());
-        // Wait until the always-visible editor (B2) has rendered, so the first
-        // selection reliably lands on the editor instead of a not-yet-loaded
-        // cell.
-        waitUntil(driver -> !getSpreadsheet()
-                .findElements(By.tagName("vaadin-combo-box")).isEmpty());
+        setSpreadsheet($(SpreadsheetElement.class).single());
+        $("vaadin-combo-box").waitForFirst();
     }
 
     @Test
     public void editorSelected_scrolledAwayAndBack_callbackNotRefiredAndValuePreserved() {
         selectEditorCellB2();
-
-        // B2 is column index 1, so the factory sets the editor value to
-        // FRUITS[1] = "Banana".
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
 
-        // Scroll the editor row out of view and back. The selection stays on
-        // B2, so its editor must be reused: the callback must not fire again
-        // and the editor value must be preserved.
         getSpreadsheet().scroll(5000);
         getCommandExecutor().waitForVaadin();
         getSpreadsheet().scroll(0);
@@ -73,10 +53,6 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
 
-        // Selecting a column re-renders the visible cells. B2's editor stays
-        // visible, so it must be reused and its value preserved. The new
-        // selected cell (B1) has no editor, so the callback does not fire
-        // again.
         selectColumn("B");
         getCommandExecutor().waitForVaadin();
 
@@ -90,10 +66,6 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
 
-        // Extending the selection to a range (B2:B5) keeps B2 as the selected
-        // cell and re-renders the visible cells. The editor must be reused: the
-        // callback must not fire again for the unchanged selection and the
-        // editor value must be preserved.
         selectCell("B5", false, true);
         getCommandExecutor().waitForVaadin();
 
@@ -107,9 +79,6 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
 
-        // Resizing the editor row re-renders the visible cells while the
-        // selection stays on B2, so the editor must be reused: the callback
-        // must not fire again and the editor value must be preserved.
         resizeRow(2);
 
         Assert.assertEquals("1", getCallbackCount());
@@ -122,9 +91,6 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
 
-        // Resizing the editor column re-renders the visible cells while the
-        // selection stays on B2, so the editor must be reused: the callback
-        // must not fire again and the editor value must be preserved.
         resizeColumn("B");
 
         Assert.assertEquals("1", getCallbackCount());
@@ -136,10 +102,6 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         selectEditorCellB2();
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
 
-        // An explicit refresh recreates editors from the factory (preserving
-        // the long-standing behavior of reloadVisibleCellContents). The factory
-        // returns a blank editor and a refresh does not invoke the callback, so
-        // the previously shown value is gone.
         clickReload();
         getCommandExecutor().waitForVaadin();
         Assert.assertEquals("", getComboBoxValue("B2"));

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
@@ -14,18 +14,21 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
 /**
- * Tests custom editor handling on scroll versus explicit refresh
+ * Tests custom editor handling on the paths that re-render the visible cells
  * (vaadin/flow-components#9180). The factory returns a new editor instance on
- * every call. Scrolling must reuse the editor already shown for a cell, so its
- * value survives and {@code onCustomEditorDisplayed} is not re-fired for an
- * unchanged selection. An explicit refresh keeps the long-standing behavior of
- * recreating editors from the factory.
+ * every call. Scrolling, changing the selection (column, row, or range) and
+ * resizing rows or columns all keep the same cells visible, so the editor
+ * already shown for a cell must be reused: its value survives and
+ * {@code onCustomEditorDisplayed} is not re-fired for an unchanged selection.
+ * An explicit refresh keeps the long-standing behavior of recreating editors
+ * from the factory.
  */
 @TestPath("vaadin-spreadsheet/custom-editor-reload")
 public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
@@ -34,10 +37,11 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
     public void init() {
         open();
         setSpreadsheet($(SpreadsheetElement.class).first());
-        // Wait until the always-visible editors (B2:E2) have rendered, so the
-        // first selection reliably lands on the editor instead of an
-        // not-yet-loaded cell.
-        waitUntil(driver -> countComboBoxes() == 4);
+        // Wait until the always-visible editor (B2) has rendered, so the first
+        // selection reliably lands on the editor instead of a not-yet-loaded
+        // cell.
+        waitUntil(driver -> !getSpreadsheet()
+                .findElements(By.tagName("vaadin-combo-box")).isEmpty());
     }
 
     @Test
@@ -48,21 +52,83 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         // FRUITS[1] = "Banana".
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
-        int comboBoxes = countComboBoxes();
 
         // Scroll the editor row out of view and back. The selection stays on
-        // B2, so its editor must be reused: the callback must not fire again,
-        // the editor value must be preserved, and no orphan editors should
-        // accumulate.
+        // B2, so its editor must be reused: the callback must not fire again
+        // and the editor value must be preserved.
         getSpreadsheet().scroll(5000);
         getCommandExecutor().waitForVaadin();
         getSpreadsheet().scroll(0);
         getCommandExecutor().waitForVaadin();
-        waitUntil(driver -> countComboBoxes() == comboBoxes);
+        waitUntil(driver -> !getSpreadsheet()
+                .findElements(By.tagName("vaadin-combo-box")).isEmpty());
 
         Assert.assertEquals("1", getCallbackCount());
         Assert.assertEquals("Banana", getComboBoxValue("B2"));
-        Assert.assertEquals(comboBoxes, countComboBoxes());
+    }
+
+    @Test
+    public void editorSelected_columnSelected_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        // Selecting a column re-renders the visible cells. B2's editor stays
+        // visible, so it must be reused and its value preserved. The new
+        // selected cell (B1) has no editor, so the callback does not fire
+        // again.
+        selectColumn("B");
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_rangeSelected_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        // Extending the selection to a range (B2:B5) keeps B2 as the selected
+        // cell and re-renders the visible cells. The editor must be reused: the
+        // callback must not fire again for the unchanged selection and the
+        // editor value must be preserved.
+        selectCell("B5", false, true);
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_rowResized_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        // Resizing the editor row re-renders the visible cells while the
+        // selection stays on B2, so the editor must be reused: the callback
+        // must not fire again and the editor value must be preserved.
+        resizeRow(2);
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_columnResized_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        // Resizing the editor column re-renders the visible cells while the
+        // selection stays on B2, so the editor must be reused: the callback
+        // must not fire again and the editor value must be preserved.
+        resizeColumn("B");
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
     }
 
     @Test
@@ -88,6 +154,21 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         getCommandExecutor().waitForVaadin();
     }
 
+    private void resizeColumn(String column) {
+        int index = column.charAt(0) - 'A' + 1;
+        var handle = getSpreadsheet().getColumnHeader(index).getResizeHandle();
+        var target = getSpreadsheet().getColumnHeader(index + 1);
+        new Actions(getDriver()).dragAndDrop(handle, target).perform();
+        getCommandExecutor().waitForVaadin();
+    }
+
+    private void resizeRow(int row) {
+        var handle = getSpreadsheet().getRowHeader(row).getResizeHandle();
+        var target = getSpreadsheet().getRowHeader(row + 1);
+        new Actions(getDriver()).dragAndDrop(handle, target).perform();
+        getCommandExecutor().waitForVaadin();
+    }
+
     private String getCallbackCount() {
         return $(TestBenchElement.class).id("callbackCount").getText();
     }
@@ -108,10 +189,5 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         } catch (NoSuchElementException e) {
             return null;
         }
-    }
-
-    private int countComboBoxes() {
-        return getSpreadsheet().findElements(By.tagName("vaadin-combo-box"))
-                .size();
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1066,17 +1066,19 @@ public class Spreadsheet extends Component
 
     /**
      * Editor instance currently shown for each cell key. Used to reuse the same
-     * editor across re-renders (scroll, refresh) instead of re-creating it from
-     * the factory, which would discard editor state such as an uncommitted
-     * ComboBox value. Editor-only; cleared on sheet switch and factory
-     * replacement.
+     * editor across re-renders that keep the same cells visible (scroll,
+     * selection, resize) instead of re-creating it from the factory, which
+     * would discard editor state such as an uncommitted ComboBox value.
+     * Editor-only; cleared whenever editors are recreated from the factory (see
+     * {@link #clearCustomEditorCache()}).
      */
     private Map<String, Component> cellKeyToEditor = new HashMap<>();
 
     /**
      * Cell key and editor instance that {@code onCustomEditorDisplayed} was
      * last invoked for, so the callback fires only on a real selection change
-     * and not on scroll/refresh re-renders of the same selection.
+     * and not on re-renders that keep the same selection (scroll, resize,
+     * extending a range).
      */
     private String lastEditorCallbackKey;
 
@@ -1614,11 +1616,7 @@ public class Spreadsheet extends Component
             this.lastRow = lastRow;
             this.firstColumn = firstColumn;
             this.lastColumn = lastColumn;
-            // Scrolling keeps the current selection, so reuse the editors
-            // already shown for cells instead of recreating them. This keeps
-            // editor state (e.g. an uncommitted ComboBox value) and avoids
-            // re-firing onCustomEditorDisplayed for the unchanged selection.
-            loadCells(firstRow, firstColumn, lastRow, lastColumn, false);
+            loadCells(firstRow, firstColumn, lastRow, lastColumn);
         }
         if (initialSheetSelection != null) {
             selectionManager.onSheetAddressChanged(initialSheetSelection, true);
@@ -3809,10 +3807,10 @@ public class Spreadsheet extends Component
             final String key = SpreadsheetUtil.toKey(col + 1, row + 1);
             Component editor = cellKeyToEditor.get(key);
             if (editor != null) {
-                // Fire only on a real selection change. Scroll and refresh
-                // re-run this method for the same selection; re-firing would
-                // re-run the user's setValue and clobber in-progress editor
-                // input.
+                // Fire only on a real selection change. Re-renders that keep
+                // the same selection (scroll, resize, extending a range) re-run
+                // this method; re-firing would re-run the user's setValue and
+                // clobber in-progress editor input.
                 if (key.equals(lastEditorCallbackKey)
                         && editor == lastEditorCallbackComponent) {
                     return;
@@ -3842,8 +3840,9 @@ public class Spreadsheet extends Component
 
     /**
      * Drops the reuse cache and the callback tracker so custom editors are
-     * recreated from the factory. Called on sheet switch and factory
-     * replacement.
+     * recreated from the factory on the next load. Called on the paths that
+     * recreate editors instead of reusing them (see
+     * {@link #loadCustomComponents(boolean)}).
      */
     private void clearCustomEditorCache() {
         cellKeyToEditor.clear();
@@ -4082,12 +4081,10 @@ public class Spreadsheet extends Component
      */
     protected void loadCells(int firstRow, int firstColumn, int lastRow,
             int lastColumn) {
-        loadCells(firstRow, firstColumn, lastRow, lastColumn, true);
-    }
-
-    private void loadCells(int firstRow, int firstColumn, int lastRow,
-            int lastColumn, boolean recreateEditors) {
-        loadCustomComponents(recreateEditors);
+        // Reuse the editors already shown for cells instead of recreating them.
+        // For all existing callers of this method (scrolling, selection,
+        // row/column resize) it makes sense to preserve editor state.
+        loadCustomComponents(false);
         loadHyperLinks();
         loadCellComments();
         loadOrUpdateOverlays();
@@ -4676,10 +4673,12 @@ public class Spreadsheet extends Component
      * previous components that are not currently visible.
      *
      * @param recreateEditors
-     *            {@code true} to recreate custom editors from the factory (the
-     *            default for explicit refreshes), {@code false} to reuse the
-     *            editor already shown for a cell so its state survives the
-     *            re-render. Only the scroll handler reuses editors.
+     *            {@code true} to recreate custom editors from the factory, used
+     *            when the application forces a refresh, changes the factory, or
+     *            the sheet changes; {@code false} to reuse the editor already
+     *            shown for a cell so its state survives the re-render, used
+     *            when the same cells stay visible (scrolling, selection,
+     *            resize).
      */
     private void loadCustomComponents(boolean recreateEditors) {
         if (recreateEditors) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1614,7 +1614,11 @@ public class Spreadsheet extends Component
             this.lastRow = lastRow;
             this.firstColumn = firstColumn;
             this.lastColumn = lastColumn;
-            loadCells(firstRow, firstColumn, lastRow, lastColumn);
+            // Scrolling keeps the current selection, so reuse the editors
+            // already shown for cells instead of recreating them. This keeps
+            // editor state (e.g. an uncommitted ComboBox value) and avoids
+            // re-firing onCustomEditorDisplayed for the unchanged selection.
+            loadCells(firstRow, firstColumn, lastRow, lastColumn, false);
         }
         if (initialSheetSelection != null) {
             selectionManager.onSheetAddressChanged(initialSheetSelection, true);
@@ -1783,7 +1787,7 @@ public class Spreadsheet extends Component
             // The node id's of custom components may no longer be valid after a
             // detach/attach. Remove all custom components and reload them (with
             // updated node id's).
-            loadCustomComponents();
+            loadCustomComponents(true);
         }
     }
 
@@ -1942,7 +1946,7 @@ public class Spreadsheet extends Component
         // if the currently active sheet was protected, the protection for the
         // currently selected cell might have changed
         if (sheetPOIIndex == workbook.getActiveSheetIndex()) {
-            loadCustomComponents();
+            loadCustomComponents(true);
             selectionManager.reSelectSelectedCell();
         }
     }
@@ -3618,7 +3622,7 @@ public class Spreadsheet extends Component
      * comments and cells' contents. Also updates styles for the visible area.
      */
     public void reloadVisibleCellContents() {
-        loadCustomComponents();
+        loadCustomComponents(true);
         updateRowAndColumnRangeCellData(firstRow, firstColumn, lastRow,
                 lastColumn);
     }
@@ -4078,7 +4082,12 @@ public class Spreadsheet extends Component
      */
     protected void loadCells(int firstRow, int firstColumn, int lastRow,
             int lastColumn) {
-        loadCustomComponents();
+        loadCells(firstRow, firstColumn, lastRow, lastColumn, true);
+    }
+
+    private void loadCells(int firstRow, int firstColumn, int lastRow,
+            int lastColumn, boolean recreateEditors) {
+        loadCustomComponents(recreateEditors);
         loadHyperLinks();
         loadCellComments();
         loadOrUpdateOverlays();
@@ -4665,8 +4674,20 @@ public class Spreadsheet extends Component
     /**
      * Loads the custom components for the currently viewed cells and clears
      * previous components that are not currently visible.
+     *
+     * @param recreateEditors
+     *            {@code true} to recreate custom editors from the factory (the
+     *            default for explicit refreshes), {@code false} to reuse the
+     *            editor already shown for a cell so its state survives the
+     *            re-render. Only the scroll handler reuses editors.
      */
-    private void loadCustomComponents() {
+    private void loadCustomComponents(boolean recreateEditors) {
+        if (recreateEditors) {
+            // Drop the cached editors (and the callback tracker) so the loop
+            // below asks the factory for fresh instances and the callback fires
+            // again for the selected cell.
+            clearCustomEditorCache();
+        }
         if (customComponentFactory != null) {
             HashMap<String, String> _componentIDtoCellKeysMap = new HashMap<>();
             HashSet<Component> newCustomComponents = new HashSet<Component>();
@@ -4932,7 +4953,7 @@ public class Spreadsheet extends Component
         // previous factory's editors by cell-key.
         clearCustomEditorCache();
         if (firstRow != -1) {
-            loadCustomComponents();
+            loadCustomComponents(true);
             loadCustomEditorOnSelectedCell();
         } else {
             clearClientEditorMap();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -224,6 +224,26 @@ public class Spreadsheet extends Component
 
     private boolean sheetProtected;
 
+    /**
+     * Editor instance currently shown for each cell key. Used to reuse the same
+     * editor across re-renders that keep the same cells visible (scroll,
+     * selection, resize) instead of re-creating it from the factory, which
+     * would discard editor state such as an uncommitted ComboBox value.
+     * Editor-only; cleared whenever editors are recreated from the factory (see
+     * {@link #setCellKeyToEditorMap(Map)}).
+     */
+    private Map<String, Component> cellKeyToEditor = new HashMap<>();
+
+    /**
+     * Cell key and editor instance that {@code onCustomEditorDisplayed} was
+     * last invoked for, so the callback fires only on a real selection change
+     * and not on re-renders that keep the same selection (scroll, resize,
+     * extending a range).
+     */
+    private String lastEditorCallbackKey;
+
+    private Component lastEditorCallbackComponent;
+
     private HashMap<String, String> componentIDtoCellKeysMap = new HashMap<>();
 
     // Cell CSS key to link tooltip (usually same as address)
@@ -1063,26 +1083,6 @@ public class Spreadsheet extends Component
     protected String initialSheetSelection = null;
 
     private Set<Component> customComponents = new HashSet<Component>();
-
-    /**
-     * Editor instance currently shown for each cell key. Used to reuse the same
-     * editor across re-renders that keep the same cells visible (scroll,
-     * selection, resize) instead of re-creating it from the factory, which
-     * would discard editor state such as an uncommitted ComboBox value.
-     * Editor-only; cleared whenever editors are recreated from the factory (see
-     * {@link #setCellKeyToEditorMap(Map)}).
-     */
-    private Map<String, Component> cellKeyToEditor = new HashMap<>();
-
-    /**
-     * Cell key and editor instance that {@code onCustomEditorDisplayed} was
-     * last invoked for, so the callback fires only on a real selection change
-     * and not on re-renders that keep the same selection (scroll, resize,
-     * extending a range).
-     */
-    private String lastEditorCallbackKey;
-
-    private Component lastEditorCallbackComponent;
 
     private Map<CellReference, PopupButton> sheetPopupButtons = new HashMap<CellReference, PopupButton>();
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -553,30 +553,30 @@ public class Spreadsheet extends Component
     }
 
     /**
-     * Pushes the editor map to the client, derived from
-     * {@link #cellKeyToEditor} (the single source of truth). The client
-     * property maps each cell key to its editor's node id, so it is recomputed
-     * from the live editor instances on every push and cannot drift from the
-     * server-side cache.
+     * Sets the cell-key-to-editor map and pushes it to the client. The client
+     * property maps each cell key to its editor's node id, derived from the
+     * live editor instances so it cannot drift from the server-side map.
+     * <p>
+     * Passing {@code null} clears the server map and the callback tracker and
+     * sends a {@code null} property. A {@code null} property has different
+     * client semantics than an empty map (see
+     * {@code SpreadsheetConnector.setupCustomEditors}), so the reset paths
+     * (sheet switch, factory removal/replacement, forced refresh) rely on it.
      */
-    private void updateClientEditorMap() {
-        HashMap<String, String> editorIds = new HashMap<>();
-        cellKeyToEditor.forEach((key, editor) -> editorIds.put(key,
-                getComponentNodeId(editor)));
-        getElement().setProperty("cellKeysToEditorIdMap",
-                Serializer.serialize(editorIds));
-    }
-
-    /**
-     * Tells the client to drop all custom editors along with the editor factory
-     * and slot cache. A {@code null} property has different client semantics
-     * than an empty map (see {@code SpreadsheetConnector.setupCustomEditors}),
-     * so the reset paths (sheet switch, factory removal) must send
-     * {@code null}.
-     */
-    private void clearClientEditorMap() {
-        getElement().setProperty("cellKeysToEditorIdMap",
-                Serializer.serialize((HashMap<String, String>) null));
+    private void setCellKeyToEditorMap(Map<String, Component> cellKeyToEditor) {
+        if (cellKeyToEditor == null) {
+            this.cellKeyToEditor.clear();
+            resetEditorCallbackTracker();
+            getElement().setProperty("cellKeysToEditorIdMap",
+                    Serializer.serialize((HashMap<String, String>) null));
+        } else {
+            this.cellKeyToEditor = cellKeyToEditor;
+            HashMap<String, String> editorIds = new HashMap<>();
+            cellKeyToEditor.forEach((key, editor) -> editorIds.put(key,
+                    getComponentNodeId(editor)));
+            getElement().setProperty("cellKeysToEditorIdMap",
+                    Serializer.serialize(editorIds));
+        }
     }
 
     private void setComponentIDtoCellKeysMap(
@@ -1070,7 +1070,7 @@ public class Spreadsheet extends Component
      * selection, resize) instead of re-creating it from the factory, which
      * would discard editor state such as an uncommitted ComboBox value.
      * Editor-only; cleared whenever editors are recreated from the factory (see
-     * {@link #clearCustomEditorCache()}).
+     * {@link #setCellKeyToEditorMap(Map)}).
      */
     private Map<String, Component> cellKeyToEditor = new HashMap<>();
 
@@ -3744,7 +3744,7 @@ public class Spreadsheet extends Component
         setSheetIndex(
                 getSpreadsheetSheetIndex(workbook.getActiveSheetIndex()) + 1);
         setSheetProtected(getActiveSheet().getProtect());
-        clearClientEditorMap();
+        setCellKeyToEditorMap(null);
         setHyperlinksTooltips(null);
         setComponentIDtoCellKeysMap(null);
         setOverlays(null);
@@ -3758,8 +3758,6 @@ public class Spreadsheet extends Component
             unRegisterCustomComponent(c);
         }
         customComponents.clear();
-        // Editors belong to a sheet; recreate them for the new sheet.
-        clearCustomEditorCache();
 
         if (attachedPopupButtons != null && !attachedPopupButtons.isEmpty()) {
             for (PopupButton sf : new ArrayList<PopupButton>(
@@ -3834,19 +3832,7 @@ public class Spreadsheet extends Component
             // Selected cell has no custom editor: forget the last-fired editor
             // so a later return to an editor cell fires the callback again.
             resetEditorCallbackTracker();
-            updateClientEditorMap();
         }
-    }
-
-    /**
-     * Drops the reuse cache and the callback tracker so custom editors are
-     * recreated from the factory on the next load. Called on the paths that
-     * recreate editors instead of reusing them (see
-     * {@link #loadCustomComponents(boolean)}).
-     */
-    private void clearCustomEditorCache() {
-        cellKeyToEditor.clear();
-        resetEditorCallbackTracker();
     }
 
     private void resetEditorCallbackTracker() {
@@ -4685,7 +4671,7 @@ public class Spreadsheet extends Component
             // Drop the cached editors (and the callback tracker) so the loop
             // below asks the factory for fresh instances and the callback fires
             // again for the selected cell.
-            clearCustomEditorCache();
+            setCellKeyToEditorMap(null);
         }
         if (customComponentFactory != null) {
             HashMap<String, String> _componentIDtoCellKeysMap = new HashMap<>();
@@ -4740,9 +4726,8 @@ public class Spreadsheet extends Component
             // cell that lost its editor); keep those still in use, including
             // out-of-view cells whose editors remain registered.
             _cellKeyToEditor.values().retainAll(customComponents);
-            cellKeyToEditor = _cellKeyToEditor;
 
-            updateClientEditorMap();
+            setCellKeyToEditorMap(_cellKeyToEditor);
             setComponentIDtoCellKeysMap(_componentIDtoCellKeysMap);
 
             if (!rowsWithComponents.isEmpty()) {
@@ -4750,9 +4735,8 @@ public class Spreadsheet extends Component
             }
 
         } else {
-            clearClientEditorMap();
+            setCellKeyToEditorMap(null);
             setComponentIDtoCellKeysMap(null);
-            clearCustomEditorCache();
             if (!customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);
@@ -4948,14 +4932,13 @@ public class Spreadsheet extends Component
     public void setSpreadsheetComponentFactory(
             SpreadsheetComponentFactory customComponentFactory) {
         this.customComponentFactory = customComponentFactory;
-        // A new factory produces its own editors, so don't preserve the
-        // previous factory's editors by cell-key.
-        clearCustomEditorCache();
         if (firstRow != -1) {
+            // A new factory produces its own editors, so recreate them instead
+            // of reusing the previous factory's by cell-key.
             loadCustomComponents(true);
             loadCustomEditorOnSelectedCell();
         } else {
-            clearClientEditorMap();
+            setCellKeyToEditorMap(null);
             if (!customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -224,8 +224,6 @@ public class Spreadsheet extends Component
 
     private boolean sheetProtected;
 
-    private HashMap<String, String> cellKeysToEditorIdMap = new HashMap<>();
-
     private HashMap<String, String> componentIDtoCellKeysMap = new HashMap<>();
 
     // Cell CSS key to link tooltip (usually same as address)
@@ -349,10 +347,6 @@ public class Spreadsheet extends Component
 
     private boolean isSheetProtected() {
         return sheetProtected;
-    }
-
-    private HashMap<String, String> getCellKeysToEditorIdMap() {
-        return cellKeysToEditorIdMap;
     }
 
     HashMap<String, String> getComponentIDtoCellKeysMap() {
@@ -558,15 +552,31 @@ public class Spreadsheet extends Component
         getElement().setProperty("workbookProtected", workbookProtected);
     }
 
-    private void setCellKeysToEditorIdMap(
-            HashMap<String, String> cellKeysToEditorIdMap) {
-        if (cellKeysToEditorIdMap == null) {
-            this.cellKeysToEditorIdMap.clear();
-        } else {
-            this.cellKeysToEditorIdMap = cellKeysToEditorIdMap;
-        }
+    /**
+     * Pushes the editor map to the client, derived from
+     * {@link #cellKeyToEditor} (the single source of truth). The client
+     * property maps each cell key to its editor's node id, so it is recomputed
+     * from the live editor instances on every push and cannot drift from the
+     * server-side cache.
+     */
+    private void updateClientEditorMap() {
+        HashMap<String, String> editorIds = new HashMap<>();
+        cellKeyToEditor.forEach((key, editor) -> editorIds.put(key,
+                getComponentNodeId(editor)));
         getElement().setProperty("cellKeysToEditorIdMap",
-                Serializer.serialize(cellKeysToEditorIdMap));
+                Serializer.serialize(editorIds));
+    }
+
+    /**
+     * Tells the client to drop all custom editors along with the editor factory
+     * and slot cache. A {@code null} property has different client semantics
+     * than an empty map (see {@code SpreadsheetConnector.setupCustomEditors}),
+     * so the reset paths (sheet switch, factory removal) must send
+     * {@code null}.
+     */
+    private void clearClientEditorMap() {
+        getElement().setProperty("cellKeysToEditorIdMap",
+                Serializer.serialize((HashMap<String, String>) null));
     }
 
     private void setComponentIDtoCellKeysMap(
@@ -1053,6 +1063,24 @@ public class Spreadsheet extends Component
     protected String initialSheetSelection = null;
 
     private Set<Component> customComponents = new HashSet<Component>();
+
+    /**
+     * Editor instance currently shown for each cell key. Used to reuse the same
+     * editor across re-renders (scroll, refresh) instead of re-creating it from
+     * the factory, which would discard editor state such as an uncommitted
+     * ComboBox value. Editor-only; cleared on sheet switch and factory
+     * replacement.
+     */
+    private Map<String, Component> cellKeyToEditor = new HashMap<>();
+
+    /**
+     * Cell key and editor instance that {@code onCustomEditorDisplayed} was
+     * last invoked for, so the callback fires only on a real selection change
+     * and not on scroll/refresh re-renders of the same selection.
+     */
+    private String lastEditorCallbackKey;
+
+    private Component lastEditorCallbackComponent;
 
     private Map<CellReference, PopupButton> sheetPopupButtons = new HashMap<CellReference, PopupButton>();
 
@@ -1751,8 +1779,7 @@ public class Spreadsheet extends Component
             loadOrUpdateOverlays();
         }
 
-        if (!componentIDtoCellKeysMap.isEmpty()
-                || !cellKeysToEditorIdMap.isEmpty()) {
+        if (!componentIDtoCellKeysMap.isEmpty() || !cellKeyToEditor.isEmpty()) {
             // The node id's of custom components may no longer be valid after a
             // detach/attach. Remove all custom components and reload them (with
             // updated node id's).
@@ -3715,7 +3742,7 @@ public class Spreadsheet extends Component
         setSheetIndex(
                 getSpreadsheetSheetIndex(workbook.getActiveSheetIndex()) + 1);
         setSheetProtected(getActiveSheet().getProtect());
-        setCellKeysToEditorIdMap(null);
+        clearClientEditorMap();
         setHyperlinksTooltips(null);
         setComponentIDtoCellKeysMap(null);
         setOverlays(null);
@@ -3729,6 +3756,8 @@ public class Spreadsheet extends Component
             unRegisterCustomComponent(c);
         }
         customComponents.clear();
+        // Editors belong to a sheet; recreate them for the new sheet.
+        clearCustomEditorCache();
 
         if (attachedPopupButtons != null && !attachedPopupButtons.isEmpty()) {
             for (PopupButton sf : new ArrayList<PopupButton>(
@@ -3774,30 +3803,52 @@ public class Spreadsheet extends Component
             final short col = selectedCellReference.getCol();
             final int row = selectedCellReference.getRow();
             final String key = SpreadsheetUtil.toKey(col + 1, row + 1);
-            var currentCellKeysToEditorIdMap = getCellKeysToEditorIdMap();
-            if (currentCellKeysToEditorIdMap.containsKey(key)) {
-                String componentId = currentCellKeysToEditorIdMap.get(key);
-                for (Component c : customComponents) {
-                    if (getComponentNodeId(c).equals(componentId)) {
-                        insideCustomEditorCallback = true;
-                        try {
-                            customComponentFactory.onCustomEditorDisplayed(
-                                    getCell(row, col), row, col, this,
-                                    getActiveSheet(), c);
-                        } catch (Exception e) {
-                            LOGGER.warn(
-                                    "Error in onCustomEditorDisplayed for cell ({}, {})",
-                                    col + 1, row + 1, e);
-                        } finally {
-                            insideCustomEditorCallback = false;
-                        }
-                        return;
-                    }
+            Component editor = cellKeyToEditor.get(key);
+            if (editor != null) {
+                // Fire only on a real selection change. Scroll and refresh
+                // re-run this method for the same selection; re-firing would
+                // re-run the user's setValue and clobber in-progress editor
+                // input.
+                if (key.equals(lastEditorCallbackKey)
+                        && editor == lastEditorCallbackComponent) {
+                    return;
                 }
+                lastEditorCallbackKey = key;
+                lastEditorCallbackComponent = editor;
+                insideCustomEditorCallback = true;
+                try {
+                    customComponentFactory.onCustomEditorDisplayed(
+                            getCell(row, col), row, col, this, getActiveSheet(),
+                            editor);
+                } catch (Exception e) {
+                    LOGGER.warn(
+                            "Error in onCustomEditorDisplayed for cell ({}, {})",
+                            col + 1, row + 1, e);
+                } finally {
+                    insideCustomEditorCallback = false;
+                }
+                return;
             }
-            setCellKeysToEditorIdMap(
-                    new HashMap<>(currentCellKeysToEditorIdMap));
+            // Selected cell has no custom editor: forget the last-fired editor
+            // so a later return to an editor cell fires the callback again.
+            resetEditorCallbackTracker();
+            updateClientEditorMap();
         }
+    }
+
+    /**
+     * Drops the reuse cache and the callback tracker so custom editors are
+     * recreated from the factory. Called on sheet switch and factory
+     * replacement.
+     */
+    private void clearCustomEditorCache() {
+        cellKeyToEditor.clear();
+        resetEditorCallbackTracker();
+    }
+
+    private void resetEditorCallbackTracker() {
+        lastEditorCallbackKey = null;
+        lastEditorCallbackComponent = null;
     }
 
     private void reloadSheetNames() {
@@ -4617,11 +4668,12 @@ public class Spreadsheet extends Component
      */
     private void loadCustomComponents() {
         if (customComponentFactory != null) {
-            // Preserve custom editor mappings to maintain StateNode connections
-            HashMap<String, String> _cellKeysToEditorIdMap = new HashMap<>(
-                    getCellKeysToEditorIdMap());
             HashMap<String, String> _componentIDtoCellKeysMap = new HashMap<>();
             HashSet<Component> newCustomComponents = new HashSet<Component>();
+            // Carry over the editor-instance cache so editors are reused
+            // (state preserved) instead of re-created from the factory.
+            HashMap<String, Component> _cellKeyToEditor = new HashMap<>(
+                    cellKeyToEditor);
             Set<Integer> rowsWithComponents = new HashSet<Integer>();
             // iteration indexes 0-based
             int verticalSplitPosition = getLastFrozenRow();
@@ -4629,23 +4681,23 @@ public class Spreadsheet extends Component
             if (verticalSplitPosition > 0 && horizontalSplitPosition > 0) {
                 // top left pane
                 loadRangeComponents(newCustomComponents, rowsWithComponents,
-                        _cellKeysToEditorIdMap, _componentIDtoCellKeysMap, 1, 1,
+                        _componentIDtoCellKeysMap, _cellKeyToEditor, 1, 1,
                         verticalSplitPosition, horizontalSplitPosition);
             }
             if (verticalSplitPosition > 0) {
                 // top right pane
                 loadRangeComponents(newCustomComponents, rowsWithComponents,
-                        _cellKeysToEditorIdMap, _componentIDtoCellKeysMap, 1,
+                        _componentIDtoCellKeysMap, _cellKeyToEditor, 1,
                         firstColumn, verticalSplitPosition, lastColumn);
             }
             if (horizontalSplitPosition > 0) {
                 // bottom left pane
                 loadRangeComponents(newCustomComponents, rowsWithComponents,
-                        _cellKeysToEditorIdMap, _componentIDtoCellKeysMap,
-                        firstRow, 1, lastRow, horizontalSplitPosition);
+                        _componentIDtoCellKeysMap, _cellKeyToEditor, firstRow,
+                        1, lastRow, horizontalSplitPosition);
             }
             loadRangeComponents(newCustomComponents, rowsWithComponents,
-                    _cellKeysToEditorIdMap, _componentIDtoCellKeysMap, firstRow,
+                    _componentIDtoCellKeysMap, _cellKeyToEditor, firstRow,
                     firstColumn, lastRow, lastColumn);
 
             // Keep custom editors registered to preserve StateNode connections
@@ -4653,19 +4705,24 @@ public class Spreadsheet extends Component
                     .hasNext();) {
                 Component c = i.next();
                 if (!newCustomComponents.contains(c)) {
-                    String nodeId = getComponentNodeId(c);
-                    if (_cellKeysToEditorIdMap.containsValue(nodeId)) {
+                    if (_cellKeyToEditor.containsValue(c)) {
                         newCustomComponents.add(c);
                     } else {
                         unRegisterCustomComponent(c);
-                        _componentIDtoCellKeysMap.remove(nodeId);
+                        _componentIDtoCellKeysMap.remove(getComponentNodeId(c));
                         i.remove();
                     }
                 }
             }
             customComponents = newCustomComponents;
 
-            setCellKeysToEditorIdMap(_cellKeysToEditorIdMap);
+            // Drop cache entries whose editor is no longer registered (e.g. a
+            // cell that lost its editor); keep those still in use, including
+            // out-of-view cells whose editors remain registered.
+            _cellKeyToEditor.values().retainAll(customComponents);
+            cellKeyToEditor = _cellKeyToEditor;
+
+            updateClientEditorMap();
             setComponentIDtoCellKeysMap(_componentIDtoCellKeysMap);
 
             if (!rowsWithComponents.isEmpty()) {
@@ -4673,8 +4730,9 @@ public class Spreadsheet extends Component
             }
 
         } else {
-            setCellKeysToEditorIdMap(null);
+            clearClientEditorMap();
             setComponentIDtoCellKeysMap(null);
+            clearCustomEditorCache();
             if (!customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);
@@ -4687,9 +4745,9 @@ public class Spreadsheet extends Component
 
     void loadRangeComponents(HashSet<Component> newCustomComponents,
             Set<Integer> rowsWithComponents,
-            HashMap<String, String> cellKeysToEditorIdMap,
-            HashMap<String, String> componentIDtoCellKeysMap, int row1,
-            int col1, int row2, int col2) {
+            HashMap<String, String> componentIDtoCellKeysMap,
+            Map<String, Component> cellKeyToEditor, int row1, int col1,
+            int row2, int col2) {
         for (int r = row1 - 1; r < row2; r++) {
             final Row row = getActiveSheet().getRow(r);
             for (int c = col1 - 1; c < col2; c++) {
@@ -4720,19 +4778,25 @@ public class Spreadsheet extends Component
                         } else if (!isCellLocked(new CellAddress(r, c))) {
                             // no custom component and not locked, check if
                             // the cell has a custom editor
-                            Component customEditor = customComponentFactory
-                                    .getCustomEditorForCell(cell, r, c, this,
-                                            getActiveSheet());
+                            final String key = SpreadsheetUtil.toKey(c + 1,
+                                    r + 1);
+                            // Reuse the editor already shown for this cell so
+                            // its state (e.g. an uncommitted ComboBox value)
+                            // survives the re-render. Only ask the factory when
+                            // the cell does not have an editor yet.
+                            Component customEditor = cellKeyToEditor.get(key);
+                            if (customEditor == null) {
+                                customEditor = customComponentFactory
+                                        .getCustomEditorForCell(cell, r, c,
+                                                this, getActiveSheet());
+                            }
                             if (customEditor != null) {
-                                final String key = SpreadsheetUtil.toKey(c + 1,
-                                        r + 1);
                                 if (!newCustomComponents.contains(customEditor)
                                         && !customComponents
                                                 .contains(customEditor)) {
                                     registerCustomComponent(customEditor);
                                 }
-                                cellKeysToEditorIdMap.put(key,
-                                        getComponentNodeId(customEditor));
+                                cellKeyToEditor.put(key, customEditor);
                                 newCustomComponents.add(customEditor);
                                 rowsWithComponents.add(r);
                             }
@@ -4864,11 +4928,14 @@ public class Spreadsheet extends Component
     public void setSpreadsheetComponentFactory(
             SpreadsheetComponentFactory customComponentFactory) {
         this.customComponentFactory = customComponentFactory;
+        // A new factory produces its own editors, so don't preserve the
+        // previous factory's editors by cell-key.
+        clearCustomEditorCache();
         if (firstRow != -1) {
             loadCustomComponents();
             loadCustomEditorOnSelectedCell();
         } else {
-            setCellKeysToEditorIdMap(null);
+            clearClientEditorMap();
             if (!customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
@@ -108,6 +108,16 @@ public interface SpreadsheetComponentFactory extends Serializable {
      * <p>
      * For merged regions, this method is only called for the first cell of the
      * merged region.
+     * <p>
+     * The Spreadsheet keeps the editor instance shown for a cell and reuses it
+     * across re-renders such as scrolling or refreshing. This method is called
+     * to create the editor when a cell first needs one; while that editor is
+     * kept, the method is not called again for the cell. A new editor is
+     * created when the active sheet changes or a new component factory is set.
+     * Do not rely on this method to update an editor for the current cell; do
+     * per-cell updates in
+     * {@link #onCustomEditorDisplayed(Cell, int, int, Spreadsheet, Sheet, Component)}
+     * instead.
      *
      * @param cell
      *            Cell that should display the custom editor or
@@ -128,13 +138,26 @@ public interface SpreadsheetComponentFactory extends Serializable {
             Spreadsheet spreadsheet, Sheet sheet);
 
     /**
-     * This method is called when a cell with a custom editor is displayed (the
-     * cell is selected). The purpose of this method is to make it possible to
-     * share the same editor component instance between multiple cells; you can
-     * update the component with the appropriate value depending on the cell.
+     * This method is called when the selection changes to a cell with a custom
+     * editor. The purpose of this method is to make it possible to share the
+     * same editor component instance between multiple cells; you can update the
+     * component with the appropriate value depending on the cell. It is called
+     * once per selection change to such a cell, not on scrolling or refreshing
+     * the same selection.
+     * <p>
+     * When {@link Spreadsheet#setShowCustomEditorOnFocus(boolean)} is disabled
+     * (the default), an editor is shown for every applicable cell, but this
+     * method is still called only for the currently selected cell, not for
+     * every displayed editor. To give an editor a value before its cell is
+     * first selected, set it on the instance returned from
+     * {@link #getCustomEditorForCell(Cell, int, int, Spreadsheet, Sheet)}.
      * <p>
      * Note that the Spreadsheet component doesn't automatically update the Cell
-     * value if it has a custom editor.
+     * value if it has a custom editor. The editor's value is transient UI
+     * state: it is preserved while the editor stays displayed, but it is not
+     * written to the cell. To keep a value across a workbook reload or when the
+     * editor is recreated (sheet change, factory change), persist it to the
+     * cell (for example from a value-change listener) and restore it here.
      *
      * @param cell
      *            The cell that has the editor, might be <code>null</code> if

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
@@ -108,16 +108,6 @@ public interface SpreadsheetComponentFactory extends Serializable {
      * <p>
      * For merged regions, this method is only called for the first cell of the
      * merged region.
-     * <p>
-     * The Spreadsheet keeps the editor instance shown for a cell and reuses it
-     * across re-renders such as scrolling or refreshing. This method is called
-     * to create the editor when a cell first needs one; while that editor is
-     * kept, the method is not called again for the cell. A new editor is
-     * created when the active sheet changes or a new component factory is set.
-     * Do not rely on this method to update an editor for the current cell; do
-     * per-cell updates in
-     * {@link #onCustomEditorDisplayed(Cell, int, int, Spreadsheet, Sheet, Component)}
-     * instead.
      *
      * @param cell
      *            Cell that should display the custom editor or
@@ -138,26 +128,13 @@ public interface SpreadsheetComponentFactory extends Serializable {
             Spreadsheet spreadsheet, Sheet sheet);
 
     /**
-     * This method is called when the selection changes to a cell with a custom
-     * editor. The purpose of this method is to make it possible to share the
-     * same editor component instance between multiple cells; you can update the
-     * component with the appropriate value depending on the cell. It is called
-     * once per selection change to such a cell, not on scrolling or refreshing
-     * the same selection.
-     * <p>
-     * When {@link Spreadsheet#setShowCustomEditorOnFocus(boolean)} is disabled
-     * (the default), an editor is shown for every applicable cell, but this
-     * method is still called only for the currently selected cell, not for
-     * every displayed editor. To give an editor a value before its cell is
-     * first selected, set it on the instance returned from
-     * {@link #getCustomEditorForCell(Cell, int, int, Spreadsheet, Sheet)}.
+     * This method is called when a cell with a custom editor is displayed (the
+     * cell is selected). The purpose of this method is to make it possible to
+     * share the same editor component instance between multiple cells; you can
+     * update the component with the appropriate value depending on the cell.
      * <p>
      * Note that the Spreadsheet component doesn't automatically update the Cell
-     * value if it has a custom editor. The editor's value is transient UI
-     * state: it is preserved while the editor stays displayed, but it is not
-     * written to the cell. To keep a value across a workbook reload or when the
-     * editor is recreated (sheet change, factory change), persist it to the
-     * cell (for example from a value-change listener) and restore it here.
+     * value if it has a custom editor.
      *
      * @param cell
      *            The cell that has the editor, might be <code>null</code> if


### PR DESCRIPTION
When a `SpreadsheetComponentFactory` returns a new editor instance from `getCustomEditorForCell` (the common pattern, e.g. `return new ComboBox<>()`), that editor was re-created on every re-render that kept the same cells visible — scrolling, changing the selection, or resizing a row or column. This wiped any value the user had typed but not yet written into the cell, left orphaned editor instances registered on the client, and re-fired `onCustomEditorDisplayed` even when the selected cell never changed.

To reproduce: a factory whose `getCustomEditorForCell` returns a new `ComboBox` for a cell. Select the cell, pick or type a value, then scroll, select another cell or range, or resize a row or column. The value is cleared, and `onCustomEditorDisplayed` runs again for the same selection.

## Changes

- Keep one server-side map from cell key to the editor instance already shown there. When `loadCells` re-renders the same visible cells (scroll, selection, row/column resize), reuse that instance instead of asking the factory for a new one, so editor state (such as an uncommitted value) survives. The factory is only called the first time a cell needs an editor.
- Recreate editors from the factory only when the application forces it: `reloadVisibleCellContents()`, a factory change, a sheet change, or a detach/attach reload. These paths drop the cache so the factory is asked for fresh instances, keeping the existing public-API behavior unchanged.
- Fire `onCustomEditorDisplayed` only when the selected cell or its editor actually changes, not on every re-render of the same selection.
- Derive the client `cellKeysToEditorIdMap` property (cell key to editor node id) from the single editor map each time it is sent, instead of storing a second map, so the two can no longer drift apart.
- Manage the editor map through one `setCellKeyToEditorMap` setter: a non-null map replaces the server map and pushes the derived node ids to the client; a `null` clears the server map, resets the callback tracker, and sends a `null` property (which has different client semantics than an empty map).

Part of #9180

---

🤖 Generated with Claude Code
