### PR TITLE
chore: run unit tests in CI only for changed modules

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -136,31 +136,24 @@ jobs:
         if: steps.skip-ci.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_COMPONENTS: ${{ github.event.inputs.components || '' }}
         run: |
-          elements="${{ github.event.inputs.components || '' }}"
-          changed_files=""
-          if [ -n "$elements" ]; then
-            echo "elements=$elements" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pr_number="${{ github.event.pull_request.number }}"
-            changed_files=$(gh api "repos/${{ github.repository }}/pulls/$pr_number/files" --jq '.[].filename')
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            changed_files=$(git diff --name-only "${{ github.event.merge_group.base_sha }}" "${{ github.event.merge_group.head_sha }}")
-          fi
-          if [ -n "$changed_files" ]; then
-            modified=$(echo "$changed_files" \
-              | grep 'vaadin.*flow-parent' \
-              | sed 's,^vaadin-\(.*\)-flow-parent.*,\1,' \
-              | sort -u)
-            nmods=$(echo "$modified" | wc -w | tr -d ' ')
-            all_files=$(echo "$changed_files" | sort -u | tr -d '[:space:]')
-            component_files=$(echo "$changed_files" | grep 'vaadin.*flow-parent' | sort -u | tr -d '[:space:]')
-            if [ "$nmods" -lt 5 ] && [ ${#all_files} -eq ${#component_files} ]; then
-              elements=$(echo $modified | tr '\n' ' ')
-              echo "Running partial build for: $elements"
+          if [ -n "$INPUT_COMPONENTS" ]; then
+            # Explicitly specified components are used as-is, without adding
+            # dependent components
+            elements="$INPUT_COMPONENTS"
+          else
+            changed_files=""
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              pr_number="${{ github.event.pull_request.number }}"
+              changed_files=$(gh api --paginate "repos/${{ github.repository }}/pulls/$pr_number/files" --jq '.[].filename')
+            elif [ "${{ github.event_name }}" = "merge_group" ]; then
+              changed_files=$(git diff --name-only "${{ github.event.merge_group.base_sha }}" "${{ github.event.merge_group.head_sha }}")
             fi
+            elements=$(echo "$changed_files" | node scripts/computeModules.js --changed-files)
+          fi
+          if [ -n "$elements" ]; then
+            echo "Running partial validation for: $elements"
           fi
           echo "elements=$elements" >> "$GITHUB_OUTPUT"
 
@@ -336,7 +329,26 @@ jobs:
 
       - name: Run unit tests
         if: matrix.type == 'unit'
-        run: mvn test -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 -DskipSvgChartsBuild $MAVEN_ARGS
+        env:
+          COMPONENTS: ${{ needs.build.outputs.components }}
+        run: |
+          shopt -s nullglob
+          pl=""
+          for component in $COMPONENTS; do
+            for pom in vaadin-$component-flow-parent/*/pom.xml; do
+              dir=${pom%/pom.xml}
+              case "$dir" in
+                *-integration-tests|*-testbench) continue ;;
+              esac
+              pl+="${pl:+,}$dir"
+            done
+          done
+          pl_arg=""
+          if [ -n "$pl" ]; then
+            echo "Running unit tests for: $pl"
+            pl_arg="-pl $pl"
+          fi
+          mvn test $pl_arg -Drelease -T $FORK_COUNT -Dsurefire.parallel=classes -Dsurefire.threadCount=2 -DskipSvgChartsBuild $MAVEN_ARGS
 
       - name: Upload unit test reports
         if: always() && matrix.type == 'unit'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -150,7 +150,8 @@ jobs:
             elif [ "${{ github.event_name }}" = "merge_group" ]; then
               changed_files=$(git diff --name-only "${{ github.event.merge_group.base_sha }}" "${{ github.event.merge_group.head_sha }}")
             fi
-            elements=$(echo "$changed_files" | node scripts/computeModules.js --changed-files)
+            mapfile -t files <<< "$changed_files"
+            elements=$(node scripts/computeModules.js --changed-files -- "${files[@]}")
           fi
           if [ -n "$elements" ]; then
             echo "Running partial validation for: $elements"

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -154,6 +154,8 @@ jobs:
           fi
           if [ -n "$elements" ]; then
             echo "Running partial validation for: $elements"
+          else
+            echo "Running full validation for all components"
           fi
           echo "elements=$elements" >> "$GITHUB_OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ NOTE: By default it merges all modules, but it's also possible to merge certain 
 
 - `./scripts/mergeITs.js button text-field crud`
 
+To also include components that depend on the given ones, expand the list first with `./scripts/computeModules.js`:
+
+- `./scripts/mergeITs.js $(./scripts/computeModules.js button)`
+
 ## Running ITs of all components in the merged module
 
 It should take around 15-20 minutes depending on the computer capabilities.

--- a/scripts/computeModules.js
+++ b/scripts/computeModules.js
@@ -9,9 +9,9 @@
  *     Expands an explicit list of components with components that depend
  *     on them.
  *
- *   echo "$changed_files" | node scripts/computeModules.js --changed-files
- *     Reads changed file paths from stdin, maps them to components, and
- *     expands the result with dependent components.
+ *   node scripts/computeModules.js --changed-files -- [file...]
+ *     Maps changed file paths to components and expands the result with
+ *     dependent components.
  *
  * Prints the resulting component names (e.g. "grid crud grid-pro") to
  * stdout. Prints nothing when everything should be validated: when the
@@ -95,11 +95,7 @@ function main() {
   });
   let components;
   if (values['changed-files']) {
-    const changedFiles = fs
-      .readFileSync(0, 'utf8')
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
+    const changedFiles = positionals.filter(Boolean);
     if (changedFiles.length === 0) {
       return;
     }

--- a/scripts/computeModules.js
+++ b/scripts/computeModules.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Compute the set of components affected by a change. This is the single
+ * place that decides which component modules CI should validate; unit tests,
+ * WTR tests and merged ITs all consume its output.
+ *
+ * Usage:
+ *   node scripts/computeModules.js grid combo-box
+ *     Expands an explicit list of components with components that depend
+ *     on them.
+ *
+ *   echo "$changed_files" | node scripts/computeModules.js --changed-files
+ *     Reads changed file paths from stdin, maps them to components, and
+ *     expands the result with dependent components.
+ *
+ * Prints the resulting component names (e.g. "grid crud grid-pro") to
+ * stdout. Prints nothing when everything should be validated: when the
+ * change touches files outside component modules, when it touches too many
+ * components, or when there is no input.
+ */
+
+const fs = require('fs');
+
+// Changes touching this many components or more trigger a full validation
+const MAX_COMPONENTS = 5;
+
+// Read component parent modules from the root pom.xml
+function readParentModules() {
+  const rootPom = fs.readFileSync('pom.xml', 'utf8');
+  return [...rootPom.matchAll(/<module>([^<]+)<\/module>/g)]
+    .map((match) => match[1])
+    .filter((module) => /^vaadin-.*-flow-parent$/.test(module));
+}
+
+// Check whether a pom declares a dependency on com.vaadin:<artifactId>
+function dependsOn(pomXml, artifactId) {
+  return [...pomXml.matchAll(/<dependency>([\s\S]*?)<\/dependency>/g)].some(
+    ([, dependency]) =>
+      dependency.includes('<groupId>com.vaadin</groupId>') &&
+      dependency.includes(`<artifactId>${artifactId}</artifactId>`)
+  );
+}
+
+// Map changed file paths to component names. Returns null (= full
+// validation) if any file is outside a component parent module or if too
+// many components are affected.
+function componentsFromChangedFiles(changedFiles) {
+  const components = new Set();
+  for (const file of changedFiles) {
+    const match = file.match(/^vaadin-(.+)-flow-parent\//);
+    if (!match) {
+      return null;
+    }
+    components.add(match[1]);
+  }
+  if (components.size === 0 || components.size >= MAX_COMPONENTS) {
+    return null;
+  }
+  return [...components];
+}
+
+// Recursively add components whose main module depends on one of the
+// given components
+function addDependentComponents(components) {
+  const parentModules = readParentModules();
+  const result = [...components];
+  const queue = [...components];
+  while (queue.length > 0) {
+    const artifactId = `vaadin-${queue.shift()}-flow`;
+    for (const parentModule of parentModules) {
+      const componentName = parentModule.replace(/^vaadin-(.+)-flow-parent$/, '$1');
+      if (result.includes(componentName)) {
+        continue;
+      }
+      const pomPath = `${parentModule}/vaadin-${componentName}-flow/pom.xml`;
+      if (!fs.existsSync(pomPath)) {
+        continue;
+      }
+      if (dependsOn(fs.readFileSync(pomPath, 'utf8'), artifactId)) {
+        result.push(componentName);
+        queue.push(componentName);
+      }
+    }
+  }
+  return result;
+}
+
+function main() {
+  let components;
+  if (process.argv[2] === '--changed-files') {
+    const changedFiles = fs
+      .readFileSync(0, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (changedFiles.length === 0) {
+      return;
+    }
+    components = componentsFromChangedFiles(changedFiles);
+    if (!components) {
+      return;
+    }
+  } else if (process.argv.length > 2) {
+    components = process.argv.slice(2);
+  } else {
+    return;
+  }
+  console.log(addDependentComponents(components).join(' '));
+}
+
+main();

--- a/scripts/computeModules.js
+++ b/scripts/computeModules.js
@@ -15,15 +15,12 @@
  *
  * Prints the resulting component names (e.g. "grid crud grid-pro") to
  * stdout. Prints nothing when everything should be validated: when the
- * change touches files outside component modules, when it touches too many
- * components, or when there is no input.
+ * change touches files outside component modules, or when there is no
+ * input.
  */
 
 const fs = require('fs');
 const { parseArgs } = require('util');
-
-// Changes touching this many components or more trigger a full validation
-const MAX_COMPONENTS = 5;
 
 // Read component parent modules from the root pom.xml
 function readParentModules() {
@@ -43,8 +40,7 @@ function dependsOn(pomXml, artifactId) {
 }
 
 // Map changed file paths to component names. Returns null (= full
-// validation) if any file is outside a component parent module or if too
-// many components are affected.
+// validation) if any file is outside a component parent module.
 function componentsFromChangedFiles(changedFiles) {
   const components = new Set();
   for (const file of changedFiles) {
@@ -53,9 +49,6 @@ function componentsFromChangedFiles(changedFiles) {
       return null;
     }
     components.add(match[1]);
-  }
-  if (components.size === 0 || components.size >= MAX_COMPONENTS) {
-    return null;
   }
   return [...components];
 }

--- a/scripts/computeModules.js
+++ b/scripts/computeModules.js
@@ -20,6 +20,7 @@
  */
 
 const fs = require('fs');
+const { parseArgs } = require('util');
 
 // Changes touching this many components or more trigger a full validation
 const MAX_COMPONENTS = 5;
@@ -86,8 +87,14 @@ function addDependentComponents(components) {
 }
 
 function main() {
+  const { values, positionals } = parseArgs({
+    options: {
+      'changed-files': { type: 'boolean', default: false }
+    },
+    allowPositionals: true
+  });
   let components;
-  if (process.argv[2] === '--changed-files') {
+  if (values['changed-files']) {
     const changedFiles = fs
       .readFileSync(0, 'utf8')
       .split('\n')
@@ -100,8 +107,8 @@ function main() {
     if (!components) {
       return;
     }
-  } else if (process.argv.length > 2) {
-    components = process.argv.slice(2);
+  } else if (positionals.length > 0) {
+    components = positionals;
   } else {
     return;
   }

--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -23,48 +23,12 @@ exclude = [
 
 let modules = [];
 
-async function addDependentModules(dependencyParentModule) {
-  // Get all parent module from root POM
-  const rootPOM = await xml2js.parseStringPromise(fs.readFileSync(`pom.xml`, 'utf8'));
-  const allModules = rootPOM.project.modules[0].module.filter(m => !/shared-parent/.test(m)).filter(m => !/bom/.test(m));
-  // Determine artifact ID of the dependency: vaadin-grid-flow-parent -> vaadin-grid-flow
-  const dependencyArtifactId = dependencyParentModule.replace('-parent', '');
-
-  // Check all modules to see if they depend on the given dependency
-  for (const parentModule of allModules) {
-    // Check if there is a component module / pom.xml
-    const componentModule = parentModule.replace('-parent', '');
-    const pomPath = `${parentModule}/${componentModule}/pom.xml`;
-
-    if (fs.existsSync(pomPath)) {
-      try {
-        const componentPom = await xml2js.parseStringPromise(fs.readFileSync(pomPath, 'utf8'));
-        if (componentPom.project.dependencies && componentPom.project.dependencies[0].dependency) {
-          // Check if the component module depends on the given dependency
-          const hasDependency = componentPom.project.dependencies[0].dependency.some(dep =>
-            dep.groupId[0] === 'com.vaadin' && dep.artifactId[0] === dependencyArtifactId
-          );
-          if (hasDependency && !modules.includes(parentModule)) {
-            modules.push(parentModule);
-            await addDependentModules(parentModule);
-          }
-        }
-      } catch (e) {
-        // Skip modules that can't be parsed
-      }
-    }
-  }
-}
-
 async function computeModules() {
   if (process.argv.length > 2) {
-    // Modules are passed as arguments
+    // Modules are passed as arguments. Use scripts/computeModules.js to
+    // expand a list of changed components with their dependent components.
     for (let i = 2; i < process.argv.length; i++) {
       modules.push(`vaadin-${process.argv[i]}-flow-parent`);
-    }
-    // Detect and add modules that depend on the selected ones
-    for (let parentModule of [...modules]) {
-      await addDependentModules(parentModule);
     }
   } else {
     // Read modules from the parent pom.xml


### PR DESCRIPTION
Scopes running unit tests to only those modules that have changed and their dependents, similar to how it already works for ITs. The full set of unit tests is still run when no changed files are detected, so for example when running snapshot validation.

This moves changed-module detection and dependent expansion into a new `scripts/computeModules.js` as the single source, and scope unit tests, WTR tests and merged ITs to its output. Explicitly specified component lists (workflow_dispatch, manual script runs) are used as-is, without adding dependent modules.
