### PR TITLE
fix: apply aria-multiselectable on grid attach

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-aria.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-aria.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init } from './shared.js';
+import type { FlowGrid } from './shared.js';
+
+describe('grid connector - aria attributes', () => {
+  describe('aria-multiselectable', () => {
+    it('should apply aria-multiselectable on attach for a selection mode set while detached', async () => {
+      const container = fixtureSync('<div></div>');
+      const detachedGrid = document.createElement('vaadin-grid') as FlowGrid;
+      init(detachedGrid);
+
+      // Setting the selection mode before the grid is rendered should not throw
+      detachedGrid.$connector.setSelectionMode('SINGLE');
+
+      container.appendChild(detachedGrid);
+      await nextFrame();
+
+      const table = detachedGrid.shadowRoot!.querySelector('#table')!;
+      expect(table.getAttribute('aria-multiselectable')).to.equal('false');
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -435,7 +435,8 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   };
 
   // Have the multi-selectable state updated on attach
-  grid._createPropertyObserver('isAttached', () => grid.$connector.updateMultiSelectable());
+  grid.__updateMultiSelectable = () => grid.$connector.updateMultiSelectable();
+  grid._createPropertyObserver('isAttached', '__updateMultiSelectable');
 
   const singleTimeRenderer = (renderer) => {
     return (root) => {


### PR DESCRIPTION
## Summary
- The `isAttached` observer that updates `aria-multiselectable` on attach has not fired since the grid's Polymer to Lit migration: the Lit `_createPropertyObserver` shim only accepts a method name, while the connector passed a function, so the observer was silently never registered.
- As a result, a grid whose selection mode was set before the first render kept the template default `aria-multiselectable="true"` regardless of the actual selection mode.
- The added WTR test initializes the connector on a detached grid like Flow does and checks the attribute after attach; it fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)