### PR TITLE
test: cover gridConnector logic with WTR unit tests

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-aria.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-aria.test.ts
@@ -1,10 +1,46 @@
 import { expect } from 'chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { init } from './shared.js';
+import { init, setRootItems, getBodyCell } from './shared.js';
 import type { FlowGrid } from './shared.js';
 
 describe('grid connector - aria attributes', () => {
+  let grid: FlowGrid;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+    await nextFrame();
+  });
+
+  function getTable(grid: FlowGrid): HTMLElement {
+    return grid.shadowRoot!.querySelector('#table')!;
+  }
+
   describe('aria-multiselectable', () => {
+    it('should set aria-multiselectable false in single selection mode', () => {
+      grid.$connector.setSelectionMode('SINGLE');
+      expect(getTable(grid).getAttribute('aria-multiselectable')).to.equal('false');
+    });
+
+    it('should set aria-multiselectable true in multi selection mode', () => {
+      grid.$connector.setSelectionMode('SINGLE');
+      grid.$connector.setSelectionMode('MULTI');
+      expect(getTable(grid).getAttribute('aria-multiselectable')).to.equal('true');
+    });
+
+    it('should remove aria-multiselectable in none selection mode', () => {
+      grid.$connector.setSelectionMode('MULTI');
+      grid.$connector.setSelectionMode('NONE');
+      expect(getTable(grid).getAttribute('aria-multiselectable')).to.be.null;
+    });
+
     it('should apply aria-multiselectable on attach for a selection mode set while detached', async () => {
       const container = fixtureSync('<div></div>');
       const detachedGrid = document.createElement('vaadin-grid') as FlowGrid;
@@ -18,6 +54,30 @@ describe('grid connector - aria attributes', () => {
 
       const table = detachedGrid.shadowRoot!.querySelector('#table')!;
       expect(table.getAttribute('aria-multiselectable')).to.equal('false');
+    });
+  });
+
+  describe('aria-selected', () => {
+    it('should remove aria-selected from rows and cells in none selection mode', async () => {
+      grid.$connector.setSelectionMode('NONE');
+      grid.requestContentUpdate();
+      await nextFrame();
+
+      const cell = getBodyCell(grid, 0, 0)!;
+      const row = cell.parentElement!;
+      expect(row.getAttribute('aria-selected')).to.be.null;
+      expect(cell.getAttribute('aria-selected')).to.be.null;
+    });
+
+    it('should keep aria-selected on rows and cells in single selection mode', async () => {
+      grid.$connector.setSelectionMode('SINGLE');
+      grid.requestContentUpdate();
+      await nextFrame();
+
+      const cell = getBodyCell(grid, 0, 0)!;
+      const row = cell.parentElement!;
+      expect(row.getAttribute('aria-selected')).to.equal('false');
+      expect(cell.getAttribute('aria-selected')).to.equal('false');
     });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-aria.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-aria.test.ts
@@ -59,8 +59,9 @@ describe('grid connector - aria attributes', () => {
 
   describe('aria-selected', () => {
     it('should remove aria-selected from rows and cells in none selection mode', async () => {
+      // Select an item first so switching to NONE re-renders the affected rows
+      grid.$connector.doSelection([{ key: '0' }], false);
       grid.$connector.setSelectionMode('NONE');
-      grid.requestContentUpdate();
       await nextFrame();
 
       const cell = getBodyCell(grid, 0, 0)!;
@@ -71,7 +72,6 @@ describe('grid connector - aria attributes', () => {
 
     it('should keep aria-selected on rows and cells in single selection mode', async () => {
       grid.$connector.setSelectionMode('SINGLE');
-      grid.requestContentUpdate();
       await nextFrame();
 
       const cell = getBodyCell(grid, 0, 0)!;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-change-selection-mode.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-change-selection-mode.test.ts
@@ -72,5 +72,16 @@ describe('grid connector - change selection mode', () => {
 
       expect(grid.selectedItems).to.be.empty;
     });
+
+    it('should not restore items selected before mode change on subsequent selections', () => {
+      grid.$connector.setSelectionMode('MULTI');
+      grid.$connector.doSelection([{ key: '0' }], false);
+
+      grid.$connector.setSelectionMode('MULTI');
+
+      grid.$connector.doSelection([{ key: '1' }], false);
+      expect(grid.selectedItems).to.have.lengthOf(1);
+      expect(grid.selectedItems[0].key).to.equal('1');
+    });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-column-events.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-column-events.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, setRootItems } from './shared.js';
+import type { FlowGrid } from './shared.js';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
+import sinon from 'sinon';
+
+type FlowColumn = GridColumn & { _flowId: string };
+
+describe('grid connector - column events', () => {
+  let grid: FlowGrid;
+  let columns: FlowColumn[];
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="key"></vaadin-grid-column>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    columns = [...grid.querySelectorAll<FlowColumn>('vaadin-grid-column')];
+    columns[0]._flowId = 'col0';
+    columns[1]._flowId = 'col1';
+
+    setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+    await nextFrame();
+  });
+
+  describe('column-resize', () => {
+    it('should dispatch column-drag-resize on visible columns', () => {
+      const spies = columns.map((column) => {
+        const spy = sinon.spy();
+        column.addEventListener('column-drag-resize', spy);
+        return spy;
+      });
+
+      grid.dispatchEvent(new CustomEvent('column-resize', { detail: { resizedColumn: columns[0] } }));
+
+      spies.forEach((spy) => expect(spy.calledOnce).to.be.true);
+    });
+
+    it('should dispatch column-drag-resize on the grid with the resized column key', () => {
+      const spy = sinon.spy();
+      grid.addEventListener('column-drag-resize' as any, spy);
+
+      grid.dispatchEvent(new CustomEvent('column-resize', { detail: { resizedColumn: columns[0] } }));
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0].detail.resizedColumnKey).to.equal('col0');
+    });
+  });
+
+  describe('column-reorder', () => {
+    it('should dispatch column-reorder-all-columns with ordered column ids', () => {
+      const spy = sinon.spy();
+      grid.addEventListener('column-reorder-all-columns' as any, spy);
+
+      grid.dispatchEvent(new CustomEvent('column-reorder'));
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0].detail.columns).to.deep.equal(['col0', 'col1']);
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-context-menu.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-context-menu.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, setRootItems, getBodyCellContent, initSelectionColumn } from './shared.js';
+import type { FlowGrid, FlowGridSelectionColumn } from './shared.js';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
+
+describe('grid connector - context menu', () => {
+  let grid: FlowGrid;
+  let column: GridColumn;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-flow-selection-column></vaadin-grid-flow-selection-column>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    const selectionColumn = grid.querySelector<FlowGridSelectionColumn>('vaadin-grid-flow-selection-column')!;
+    initSelectionColumn(grid, selectionColumn);
+
+    column = grid.querySelector('vaadin-grid-column')!;
+    column.id = 'name-column';
+
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo' },
+      { key: '1', name: 'bar' }
+    ]);
+    await nextFrame();
+  });
+
+  it('should update context menu target item on before-open event', () => {
+    grid.dispatchEvent(
+      new CustomEvent('vaadin-context-menu-before-open', {
+        detail: { key: '0', columnId: 'name-column' }
+      })
+    );
+    expect(grid.$server.updateContextMenuTargetItem.calledWith('0', 'name-column')).to.be.true;
+  });
+
+  it('should return item key and column id in before-open detail', () => {
+    let detail: { key: string, columnId: string };
+    // The detail is resolved while the source event is still being dispatched
+    grid.addEventListener('contextmenu', (e) => {
+      detail = grid.getContextMenuBeforeOpenDetail({ detail: { sourceEvent: e } });
+    });
+    getBodyCellContent(grid, 0, 1)!.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, composed: true }));
+
+    expect(detail!).to.deep.equal({ key: '0', columnId: 'name-column' });
+  });
+
+  it('should prevent context menu on selection column left click', () => {
+    let prevented: boolean;
+    grid.addEventListener('click', (e) => (prevented = grid.preventContextMenu(e)));
+
+    getBodyCellContent(grid, 0, 0)!.click();
+    expect(prevented!).to.be.true;
+  });
+
+  it('should not prevent context menu on regular column left click', () => {
+    let prevented: boolean;
+    grid.addEventListener('click', (e) => (prevented = grid.preventContextMenu(e)));
+
+    getBodyCellContent(grid, 0, 1)!.click();
+    expect(prevented!).to.be.false;
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-context-menu.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-context-menu.test.ts
@@ -53,7 +53,9 @@ describe('grid connector - context menu', () => {
 
   it('should prevent context menu on selection column left click', () => {
     let prevented: boolean;
-    grid.addEventListener('click', (e) => (prevented = grid.preventContextMenu(e)));
+    grid.addEventListener('click', (e) => {
+      prevented = grid.preventContextMenu(e);
+    });
 
     getBodyCellContent(grid, 0, 0)!.click();
     expect(prevented!).to.be.true;
@@ -61,7 +63,9 @@ describe('grid connector - context menu', () => {
 
   it('should not prevent context menu on regular column left click', () => {
     let prevented: boolean;
-    grid.addEventListener('click', (e) => (prevented = grid.preventContextMenu(e)));
+    grid.addEventListener('click', (e) => {
+      prevented = grid.preventContextMenu(e);
+    });
 
     getBodyCellContent(grid, 0, 1)!.click();
     expect(prevented!).to.be.false;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-drag-drop.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-drag-drop.test.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, setRootItems, getBodyCell } from './shared.js';
+import type { FlowGrid, Item } from './shared.js';
+import sinon from 'sinon';
+
+describe('grid connector - drag and drop', () => {
+  let grid: FlowGrid;
+  let items: Item[];
+
+  function dispatchDragStart(draggedItems: Item[]) {
+    const setDragData = sinon.spy();
+    const setDraggedItemsCount = sinon.spy();
+    grid.dispatchEvent(
+      new CustomEvent('grid-dragstart', {
+        detail: { draggedItems, setDragData, setDraggedItemsCount }
+      })
+    );
+    return { setDragData, setDraggedItemsCount };
+  }
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    items = [
+      { key: '0', name: 'foo', dragData: { text: 'foo drag data' } },
+      { key: '1', name: 'bar', dragData: { text: 'bar drag data' } }
+    ];
+    setRootItems(grid.$connector, items);
+    await nextFrame();
+  });
+
+  describe('row drag and drop filters', () => {
+    beforeEach(async () => {
+      setRootItems(grid.$connector, [
+        { key: '0', name: 'foo', dragDisabled: true, dropDisabled: true },
+        { key: '1', name: 'bar' }
+      ]);
+      grid.rowsDraggable = true;
+      grid.dropMode = 'on-top';
+      await nextFrame();
+    });
+
+    it('should disable dragging rows based on item drag data', () => {
+      expect(getBodyCell(grid, 0, 0)!.parentElement!.getAttribute('part')).to.contain('drag-disabled-row');
+      expect(getBodyCell(grid, 1, 0)!.parentElement!.getAttribute('part')).to.not.contain('drag-disabled-row');
+    });
+
+    it('should disable dropping on rows based on item drop data', () => {
+      expect(getBodyCell(grid, 0, 0)!.parentElement!.getAttribute('part')).to.contain('drop-disabled-row');
+      expect(getBodyCell(grid, 1, 0)!.parentElement!.getAttribute('part')).to.not.contain('drop-disabled-row');
+    });
+  });
+
+  describe('drag data', () => {
+    beforeEach(() => {
+      grid.__dragDataTypes = ['text'];
+    });
+
+    it('should set drag data for a dragged non-selected item', () => {
+      const { setDragData } = dispatchDragStart([items[0]]);
+      expect(setDragData.calledWith('text', 'foo drag data')).to.be.true;
+    });
+
+    it('should set combined drag data for dragged selected items', () => {
+      grid.$connector.setSelectionMode('MULTI');
+      grid.$connector.doSelection(items, false);
+
+      const { setDragData } = dispatchDragStart(items);
+      expect(setDragData.calledWith('text', 'foo drag data\nbar drag data')).to.be.true;
+    });
+
+    it('should set selection drag data for dragged selected items when defined', () => {
+      grid.$connector.setSelectionMode('MULTI');
+      grid.$connector.doSelection(items, false);
+      grid.__selectionDragData = { text: 'selection drag data' };
+
+      const { setDragData } = dispatchDragStart(items);
+      expect(setDragData.calledWith('text', 'selection drag data')).to.be.true;
+    });
+
+    it('should set dragged items count for dragged selected items', () => {
+      grid.$connector.setSelectionMode('MULTI');
+      grid.$connector.doSelection(items, false);
+      grid.__selectionDraggedItemsCount = 5;
+
+      const { setDraggedItemsCount } = dispatchDragStart(items);
+      expect(setDraggedItemsCount.calledWith(5)).to.be.true;
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, setRootItems, getHeaderCellContent, getFooterCellContent } from './shared.js';
+import type { FlowGrid } from './shared.js';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
+
+describe('grid connector - header and footer renderers', () => {
+  let grid: FlowGrid;
+  let column: GridColumn;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    init(grid);
+
+    column = grid.querySelector('vaadin-grid-column')!;
+
+    setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+    await nextFrame();
+  });
+
+  describe('header', () => {
+    it('should render text content', async () => {
+      grid.$connector.setHeaderRenderer(column, { content: 'Header text' });
+      await nextFrame();
+      expect(getHeaderCellContent(column).textContent).to.equal('Header text');
+    });
+
+    it('should render node content', async () => {
+      const span = document.createElement('span');
+      span.textContent = 'Header node';
+      grid.$connector.setHeaderRenderer(column, { content: span });
+      await nextFrame();
+      expect(getHeaderCellContent(column).contains(span)).to.be.true;
+    });
+
+    it('should clear previous content when re-rendering', async () => {
+      const first = document.createElement('span');
+      first.textContent = 'first';
+      grid.$connector.setHeaderRenderer(column, { content: first });
+      await nextFrame();
+
+      const second = document.createElement('span');
+      second.textContent = 'second';
+      grid.$connector.setHeaderRenderer(column, { content: second });
+      await nextFrame();
+
+      expect(getHeaderCellContent(column).textContent).to.equal('second');
+    });
+
+    it('should restore the default header when content is null', async () => {
+      grid.$connector.setHeaderRenderer(column, { content: 'Custom' });
+      await nextFrame();
+
+      grid.$connector.setHeaderRenderer(column, { content: null });
+      await nextFrame();
+
+      // With no header renderer, the column falls back to the default
+      // path-based header
+      expect(getHeaderCellContent(column).textContent).to.equal('Name');
+      expect(column.headerRenderer === null).to.be.true;
+    });
+
+    describe('sorter', () => {
+      it('should render content inside the sorter', async () => {
+        grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
+        await nextFrame();
+
+        const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+        expect(sorter).to.exist;
+        expect(sorter.textContent).to.equal('Name');
+      });
+
+      it('should set aria-label on the sorter', async () => {
+        grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
+        await nextFrame();
+
+        const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+        expect(sorter.getAttribute('aria-label')).to.equal('Sort by Name');
+      });
+    });
+  });
+
+  describe('footer', () => {
+    it('should render text content', async () => {
+      grid.$connector.setFooterRenderer(column, { content: 'Footer text' });
+      await nextFrame();
+      expect(getFooterCellContent(column).textContent).to.equal('Footer text');
+    });
+
+    it('should render node content', async () => {
+      const span = document.createElement('span');
+      span.textContent = 'Footer node';
+      grid.$connector.setFooterRenderer(column, { content: span });
+      await nextFrame();
+      expect(getFooterCellContent(column).contains(span)).to.be.true;
+    });
+
+    it('should clear previous content when re-rendering', async () => {
+      const first = document.createElement('span');
+      first.textContent = 'first';
+      grid.$connector.setFooterRenderer(column, { content: first });
+      await nextFrame();
+
+      const second = document.createElement('span');
+      second.textContent = 'second';
+      grid.$connector.setFooterRenderer(column, { content: second });
+      await nextFrame();
+
+      expect(getFooterCellContent(column).textContent).to.equal('second');
+    });
+
+    it('should remove the footer renderer when content is null', async () => {
+      grid.$connector.setFooterRenderer(column, { content: 'Custom' });
+      await nextFrame();
+
+      grid.$connector.setFooterRenderer(column, { content: null });
+      await nextFrame();
+
+      expect(getFooterCellContent(column).textContent).to.equal('');
+      expect(column.footerRenderer === null).to.be.true;
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
@@ -62,7 +62,7 @@ describe('grid connector - header and footer renderers', () => {
       // With no header renderer, the column falls back to the default
       // path-based header
       expect(getHeaderCellContent(column).textContent).to.equal('Name');
-      expect(column.headerRenderer === null).to.be.true;
+      expect(column.headerRenderer).to.be.null;
     });
 
     describe('sorter', () => {
@@ -122,7 +122,7 @@ describe('grid connector - header and footer renderers', () => {
       await nextFrame();
 
       expect(getFooterCellContent(column).textContent).to.equal('');
-      expect(column.footerRenderer === null).to.be.true;
+      expect(column.footerRenderer).to.be.null;
     });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-item-click.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-item-click.test.ts
@@ -59,11 +59,9 @@ describe('grid connector - item click', () => {
     };
 
     const spy = sinon.spy();
-    const content = getBodyCellContent(grid, 0, 0);
-    const overlayContent = content?.querySelector('span');
-
     grid.addEventListener('item-click' as any, spy);
-    overlayContent?.click();
+
+    getBodyCellContent(grid, 0, 0)?.querySelector('span')?.click();
     expect(spy.called).to.be.false;
   });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-item-click.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-item-click.test.ts
@@ -53,6 +53,20 @@ describe('grid connector - item click', () => {
     expect(spy.called).to.be.false;
   });
 
+  it('should not dispatch an item-click event on overlay content click', async () => {
+    column.renderer = (root: HTMLElement) => {
+      root.innerHTML = '<foo-overlay><span>overlay content</span></foo-overlay>';
+    };
+
+    const spy = sinon.spy();
+    const content = getBodyCellContent(grid, 0, 0);
+    const overlayContent = content?.querySelector('span');
+
+    grid.addEventListener('item-click' as any, spy);
+    overlayContent?.click();
+    expect(spy.called).to.be.false;
+  });
+
   it('should not dispatch an item-click event on focusable click', async () => {
     column.renderer = (root: HTMLElement) => {
       root.innerHTML = '<input>';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -23,9 +23,65 @@ describe('grid connector - row details', () => {
     await nextFrame();
   });
 
+  it('should not inform server about details visibility on attach', async () => {
+    // Initialize the connector for a detached grid and attach it afterwards,
+    // like Flow does
+    const detachedGrid = document.createElement('vaadin-grid') as FlowGrid;
+    init(detachedGrid);
+
+    grid.parentElement!.appendChild(detachedGrid);
+    await nextFrame();
+
+    expect(detachedGrid.$server.setDetailsVisible.called).to.be.false;
+    detachedGrid.remove();
+  });
+
   it('should set details visible on click', () => {
     getBodyCellContent(grid, 0, 0)!.click();
     expect(grid.$server.setDetailsVisible).to.be.calledWith('0');
+  });
+
+  it('should open details for items opened from data', async () => {
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo', detailsOpened: true },
+      { key: '1', name: 'bar' }
+    ]);
+    expect(grid.detailsOpenedItems).to.have.lengthOf(1);
+    expect(grid.detailsOpenedItems[0].key).to.equal('0');
+  });
+
+  it('should close details for items closed from data', async () => {
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo', detailsOpened: true },
+      { key: '1', name: 'bar' }
+    ]);
+
+    grid.$connector.set(0, [{ key: '0', name: 'foo' }]);
+    expect(grid.detailsOpenedItems).to.be.empty;
+  });
+
+  it('should close details for cleared items', async () => {
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo', detailsOpened: true },
+      { key: '1', name: 'bar' }
+    ]);
+
+    grid.$connector.clear(0, 2);
+    expect(grid.detailsOpenedItems).to.be.empty;
+  });
+
+  describe('updateFlatData', () => {
+    it('should open details for updated items', () => {
+      grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
+      expect(grid.detailsOpenedItems).to.have.lengthOf(1);
+      expect(grid.detailsOpenedItems[0].key).to.equal('0');
+    });
+
+    it('should close details for updated items', () => {
+      grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
+      grid.$connector.updateFlatData([{ key: '0', name: 'foo' }]);
+      expect(grid.detailsOpenedItems).to.be.empty;
+    });
   });
 
   it('should set details hidden on another item click', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-scroll-to-item.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-scroll-to-item.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, setRootItems, getBodyCell } from './shared.js';
+import type { FlowGrid } from './shared.js';
+
+describe('grid connector - scroll to item', () => {
+  let grid: FlowGrid;
+  let table: HTMLElement;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid style="height: 400px">
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+      <style>
+        vaadin-grid::part(cell) {
+          min-height: 36px;
+        }
+      </style>
+    `);
+
+    init(grid);
+
+    const items = Array.from({ length: 200 }, (_, i) => ({ key: `${i}`, name: `name-${i}` }));
+    setRootItems(grid.$connector, items);
+    await nextFrame();
+
+    table = grid.shadowRoot!.querySelector('#table')!;
+  });
+
+  it('should scroll to an item outside the viewport', async () => {
+    grid.$connector.scrollToItem('100', 100);
+    await nextFrame();
+    expect(getBodyCell(grid, 100, 0)).to.exist;
+  });
+
+  it('should not scroll when the item is already fully in viewport', async () => {
+    grid.scrollToIndex(20);
+    await nextFrame();
+    const scrollTopBefore = table.scrollTop;
+
+    // An item a couple of rows below the first visible one is fully visible
+    grid.$connector.scrollToItem('22', 22);
+    await nextFrame();
+    expect(table.scrollTop).to.equal(scrollTopBefore);
+  });
+
+  it('should scroll to an item that is rendered but not fully in viewport', async () => {
+    grid.scrollToIndex(20);
+    await nextFrame();
+    const scrollTopBefore = table.scrollTop;
+
+    // Find the last rendered row index. The row is rendered in the scroll
+    // buffer below the visible viewport.
+    let lastRenderedIndex = 20;
+    while (getBodyCell(grid, lastRenderedIndex + 1, 0)) {
+      lastRenderedIndex += 1;
+    }
+
+    grid.$connector.scrollToItem(`${lastRenderedIndex}`, lastRenderedIndex);
+    await nextFrame();
+    expect(table.scrollTop).to.be.greaterThan(scrollTopBefore);
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-multi-mode.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-multi-mode.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import { fixtureSync, middleOfNode, nextFrame } from '@vaadin/testing-helpers';
-import { init, setRootItems, FlowGridSelectionColumn, initSelectionColumn } from './shared.js';
+import { init, setRootItems, getBodyCellContent, FlowGridSelectionColumn, initSelectionColumn } from './shared.js';
 import type { FlowGrid } from './shared.js';
 
 describe('grid connector - selection – multi mode', () => {
@@ -152,5 +152,19 @@ describe('grid connector - selection – multi mode', () => {
       grid.$connector.doDeselection([{ key: '0' }], false);
       expect(grid.$server.deselect).not.to.be.called;
     });
+
+    it('should not reapply deselected items on subsequent selections', () => {
+      grid.$connector.doSelection([{ key: '0' }], false);
+      grid.$connector.doDeselection([{ key: '0' }], false);
+      grid.$connector.doSelection([{ key: '1' }], false);
+      expect(grid.selectedItems).to.have.lengthOf(1);
+      expect(grid.selectedItems[0].key).to.equal('1');
+    });
+  });
+
+  it('should not select item on row click', () => {
+    getBodyCellContent(grid, 0, 1)!.click();
+    expect(grid.selectedItems).to.be.empty;
+    expect(grid.$server.select.called).to.be.false;
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -73,6 +73,41 @@ describe('grid connector - selection', () => {
       expect(grid.selectedItems).to.be.empty;
     });
 
+    it('should apply selection from server when grid is disabled', async () => {
+      grid.disabled = true;
+      await nextFrame();
+      grid.$connector.doSelection([{ key: '0' }], false);
+      expect(grid.selectedItems).to.have.lengthOf(1);
+      expect(grid.selectedItems[0].key).to.equal('0');
+    });
+
+    it('should not deselect items on user interaction when grid is disabled', async () => {
+      grid.$connector.doSelection([{ key: '0' }], false);
+      grid.disabled = true;
+      await nextFrame();
+      grid.$connector.doDeselection([{ key: '0' }], true);
+      expect(grid.selectedItems).to.have.lengthOf(1);
+      expect(grid.$server.deselect.called).to.be.false;
+    });
+
+    it('should not request deselect for an active item that is not selected', () => {
+      // Select an item by clicking it
+      getBodyCellContent(grid, 0, 0)!.click();
+
+      // Deselect the item from the server
+      grid.$connector.doDeselection([{ key: '0' }], false);
+
+      // Click the item again to clear the active item
+      getBodyCellContent(grid, 0, 0)!.click();
+      expect(grid.$server.deselect.called).to.be.false;
+    });
+
+    it('should deselect cleared items', () => {
+      grid.$connector.doSelection([{ key: '0' }], false);
+      grid.$connector.clear(0, 2);
+      expect(grid.selectedItems).to.be.empty;
+    });
+
     it('should select on server', () => {
       getBodyCellContent(grid, 0, 0)!.click();
       expect(grid.$server.select).to.be.calledWith('0');

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -71,21 +71,13 @@ describe('grid connector - selection', () => {
       grid.disabled = true;
       getBodyCellContent(grid, 0, 0)!.click();
       expect(grid.selectedItems).to.be.empty;
+      expect(grid.$server.select.called).to.be.false;
     });
 
-    it('should apply selection from server when grid is disabled', async () => {
-      grid.disabled = true;
-      await nextFrame();
-      grid.$connector.doSelection([{ key: '0' }], false);
-      expect(grid.selectedItems).to.have.lengthOf(1);
-      expect(grid.selectedItems[0].key).to.equal('0');
-    });
-
-    it('should not deselect items on user interaction when grid is disabled', async () => {
+    it('should not deselect item on click when grid is disabled', async () => {
       grid.$connector.doSelection([{ key: '0' }], false);
       grid.disabled = true;
-      await nextFrame();
-      grid.$connector.doDeselection([{ key: '0' }], true);
+      getBodyCellContent(grid, 0, 0)!.click();
       expect(grid.selectedItems).to.have.lengthOf(1);
       expect(grid.$server.deselect.called).to.be.false;
     });
@@ -100,12 +92,6 @@ describe('grid connector - selection', () => {
       // Click the item again to clear the active item
       getBodyCellContent(grid, 0, 0)!.click();
       expect(grid.$server.deselect.called).to.be.false;
-    });
-
-    it('should deselect cleared items', () => {
-      grid.$connector.doSelection([{ key: '0' }], false);
-      grid.$connector.clear(0, 2);
-      expect(grid.selectedItems).to.be.empty;
     });
 
     it('should select on server', () => {
@@ -147,6 +133,20 @@ describe('grid connector - selection', () => {
         grid.$connector.doSelection([{ key: '0' }], false);
         expect(grid.selectedItems).to.have.lengthOf(1);
         expect(grid.selectedItems[0].key).to.equal('0');
+      });
+
+      it('should apply selection from server when grid is disabled', async () => {
+        grid.disabled = true;
+        await nextFrame();
+        grid.$connector.doSelection([{ key: '0' }], false);
+        expect(grid.selectedItems).to.have.lengthOf(1);
+        expect(grid.selectedItems[0].key).to.equal('0');
+      });
+
+      it('should deselect cleared items', () => {
+        grid.$connector.doSelection([{ key: '0' }], false);
+        grid.$connector.clear(0, 2);
+        expect(grid.selectedItems).to.be.empty;
       });
 
       it('should update activeItem when selecting an item', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { getHeaderCellContent, init, setRootItems } from './shared.js';
+import { getHeaderCellContent, init, setRootItems, GRID_CONNECTOR_ROOT_REQUEST_DELAY } from './shared.js';
 import type { FlowGrid, FlowGridSorter, Item } from './shared.js';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
@@ -36,6 +36,13 @@ describe('grid connector - sorting', () => {
 
   it('should not make sort requests by default', () => {
     expect(grid.$server.sortersChanged).to.not.be.called;
+  });
+
+  it('should not clear the cache and request data again when sorting', async () => {
+    grid.$server.setViewportRange.resetHistory();
+    sorters[0].click();
+    await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+    expect(grid.$server.setViewportRange.called).to.be.false;
   });
 
   describe('single column sorting', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector.test.ts
@@ -44,6 +44,43 @@ describe('grid connector', () => {
     expect(getBodyCellText(grid, 0, 0)).to.equal('foo');
   });
 
+  it('should update item id path', () => {
+    grid.$connector.updateUniqueItemIdPath('name');
+    expect(grid.itemIdPath).to.equal('name');
+  });
+
+  it('should confirm updates to the server', () => {
+    grid.$connector.confirm(42);
+    expect(grid.$server.confirmUpdate.calledWith(42)).to.be.true;
+  });
+
+  describe('updateFlatData', () => {
+    beforeEach(async () => {
+      setRootItems(grid.$connector, [
+        { key: '0', name: 'foo' },
+        { key: '1', name: 'bar' }
+      ]);
+      await nextFrame();
+    });
+
+    it('should update item data', async () => {
+      grid.$connector.updateFlatData([{ key: '1', name: 'bar updated' }]);
+      await nextFrame();
+      expect(getBodyCellText(grid, 1, 0)).to.equal('bar updated');
+    });
+
+    it('should ignore unknown items', async () => {
+      expect(() => {
+        grid.$connector.updateFlatData([
+          { key: '999', name: 'unknown' },
+          { key: '0', name: 'foo updated' }
+        ]);
+      }).to.not.throw();
+      await nextFrame();
+      expect(getBodyCellText(grid, 0, 0)).to.equal('foo updated');
+    });
+  });
+
   describe('multiple set calls', () => {
     beforeEach(async () => {
       setRootItems(grid.$connector, [
@@ -109,6 +146,17 @@ describe('grid connector', () => {
 
       expect(grid.$server.setViewportRange.called).to.be.false;
     });
+
+    it('should not schedule debounced requests when refreshing grid', async () => {
+      setRootItems(grid.$connector, []);
+      await nextFrame();
+
+      // Force grid to refresh data
+      grid.clearCache();
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+      expect(grid.$server.setViewportRange.called).to.be.false;
+    });
   });
 
   describe('clear', () => {
@@ -153,6 +201,29 @@ describe('grid connector', () => {
       await nextFrame();
     });
 
+    it('should report a root request queue while requesting data', async () => {
+      expect(grid.$connector.hasRootRequestQueue()).to.be.false;
+
+      // Clearing visible items makes the grid request data again (debounced)
+      clear(grid.$connector, 0, 30);
+      expect(grid.$connector.hasRootRequestQueue()).to.be.true;
+
+      // The debounced request has been sent but not yet confirmed
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$connector.hasRootRequestQueue()).to.be.true;
+
+      // Receiving the items resolves the queue
+      setRootItems(grid.$connector, items, 0, 30);
+      expect(grid.$connector.hasRootRequestQueue()).to.be.false;
+    });
+
+    it('should request data again after reset', async () => {
+      grid.$server.setViewportRange.resetHistory();
+      grid.$connector.reset();
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setViewportRange.called).to.be.true;
+    });
+
     describe('last requested range is in viewport', () => {
       beforeEach(async () => {
         // Request a range of items at the top
@@ -185,6 +256,32 @@ describe('grid connector', () => {
 
         // Grid should not have request for items
         expect(grid.$server.setViewportRange).to.be.not.called;
+      });
+
+      it('should request the same range again after reset', async () => {
+        // Make the grid request a range again, but leave the request unconfirmed
+        clear(grid.$connector, 0, 30);
+        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+        expect(grid.$server.setViewportRange.calledOnceWith(0, 30)).to.be.true;
+        grid.$server.setViewportRange.resetHistory();
+
+        // Resetting while the request is pending should allow requesting
+        // the same range again
+        grid.$connector.reset();
+        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+        expect(grid.$server.setViewportRange.calledOnceWith(0, 30)).to.be.true;
+      });
+
+      it('should cancel pending debounced requests on reset', async () => {
+        // Clearing visible items makes the grid request data again (debounced)
+        clear(grid.$connector, 0, 30);
+
+        // The grid becomes empty before the debounced request is sent
+        grid.$connector.updateSize(0);
+        grid.$connector.reset();
+        await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+
+        expect(grid.$server.setViewportRange.called).to.be.false;
       });
     });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -7,13 +7,15 @@ import sinon from 'sinon';
 import type { Grid } from '@vaadin/grid';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import type { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
-import type {} from '@web/test-runner-mocha';
-import type {} from 'sinon-chai';
+import type { } from '@web/test-runner-mocha';
+import type { } from 'sinon-chai';
 
 export type GridConnector = {
   updateFlatData: (updatedItems: Item[]) => void;
   initLazy: (grid: Grid) => void;
   updateSize: (size: number) => void;
+  updateUniqueItemIdPath: (path: string) => void;
+  hasRootRequestQueue: () => boolean;
   set: (index: number, items: any[]) => void;
   confirm: (index: number) => void;
   setSelectionMode: (mode: 'SINGLE' | 'NONE' | 'MULTI') => void;
@@ -22,7 +24,9 @@ export type GridConnector = {
   doDeselection: (items: Item[], userOriginated: boolean) => void;
   clear: (index: number, length: number) => void;
   setSorterDirections: (sorters: { column: string, direction: string }[]) => void;
-  setHeaderRenderer: (column: GridColumn, options: { content: Node | string, showSorter: boolean, sorterPath?: string }) => void;
+  setHeaderRenderer: (column: GridColumn, options: { content: Node | string | null, showSorter?: boolean, sorterPath?: string }) => void;
+  setFooterRenderer: (column: GridColumn, options: { content: Node | string | null }) => void;
+  scrollToItem: (itemKey: string, index: number) => void;
 };
 
 export type GridServer = {
@@ -36,6 +40,7 @@ export type GridServer = {
   setViewportRange: ((firstIndex: number, size: number) => Promise<void>) & sinon.SinonSpy & { promise?: sinon.SinonPromise<void> };
   sortersChanged: ((sorters: { path: string, direction: string }[]) => void) & sinon.SinonSpy;
   setShiftKeyDown: ((shiftKeyDown: boolean) => void) & sinon.SinonSpy;
+  updateContextMenuTargetItem: ((key: string, columnId: string) => void) & sinon.SinonSpy;
 };
 
 export type Item = {
@@ -49,6 +54,9 @@ export type Item = {
   detailsOpened?: boolean;
   style?: Record<string, string>;
   part?: Record<string, string>;
+  dragData?: Record<string, string>;
+  dragDisabled?: boolean;
+  dropDisabled?: boolean;
 };
 
 export type FlowGrid = Grid<Item> & {
@@ -56,9 +64,14 @@ export type FlowGrid = Grid<Item> & {
   $server: GridServer;
   __deselectDisallowed: boolean;
   __disallowDetailsOnClick: boolean;
+  __dragDataTypes?: string[];
+  __selectionDragData?: Record<string, string>;
+  __selectionDraggedItemsCount?: number;
   _flatSize: number;
   __updateVisibleRows: () => void;
   _updateItem: (index: number, item: Item) => void;
+  preventContextMenu: (event: Event) => boolean;
+  getContextMenuBeforeOpenDetail: (event: { detail: { sourceEvent?: Event } }) => { key: string, columnId: string };
 };
 
 export type FlowGridSorter = GridSorter & {
@@ -102,6 +115,7 @@ export function init(grid: FlowGrid, gridConnector = Vaadin.Flow.gridConnector):
     }),
     sortersChanged: sinon.spy(),
     setShiftKeyDown: sinon.spy(),
+    updateContextMenuTargetItem: sinon.spy(),
   };
 
   gridConnector.initLazy(grid);
@@ -128,6 +142,13 @@ export function getBodyRowCount(grid: FlowGrid): number {
  */
 export function getHeaderCellContent(column: GridColumn): HTMLElement {
   return (column as any)._headerCell._content as HTMLElement;
+}
+
+/**
+ * Returns the content of a footer cell.
+ */
+export function getFooterCellContent(column: GridColumn): HTMLElement {
+  return (column as any)._footerCell._content as HTMLElement;
 }
 
 /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -456,8 +456,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
 
     column.headerRenderer = singleTimeRenderer((root) => {
-      // Clear previous contents
-      root.innerHTML = '';
       // Render sorter
       let contentRoot = root;
       if (showSorter) {
@@ -524,8 +522,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
 
     column.footerRenderer = singleTimeRenderer((root) => {
-      // Clear previous contents
-      root.innerHTML = '';
       // Add content
       if (content instanceof Node) {
         root.appendChild(content);


### PR DESCRIPTION
## Summary
- Much of the gridConnector logic had no direct test coverage: a line could be removed without any unit test failing, and while integration tests likely cover some of the behavior, it is hard to tell which test covers which line. This adds fast WTR unit tests that target each behavior directly. Each new test was verified to fail when the line it covers is removed.
- Writing the tests revealed one cleanup, included here: the header/footer renderers cleared `root.innerHTML` even though the grid already clears cell content whenever the renderer changes, so the lines were removed as redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)