### PR TITLE
chore: make grid WTR tests pass type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pom.xml.bak
 .vscode
 types.d.ts
 tsconfig.json
+!**/test/tsconfig.json
 webpack.*
 vite.generated.ts
 /vite.config.ts

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-cell-focus.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-cell-focus.test.ts
@@ -3,7 +3,7 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { init, setRootItems, getBodyCell } from './shared.js';
 import type { FlowGrid } from './shared.js';
-import { GridColumn } from '@vaadin/grid';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import sinon from 'sinon';
 
 describe('grid connector - cell focus', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-change-selection-mode.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-change-selection-mode.test.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { init, getBodyCellContent, setRootItems, initSelectionColumn } from './shared.js';
-import type { FlowGrid } from './shared.js';
+import type { FlowGrid, FlowGridSelectionColumn } from './shared.js';
 
 describe('grid connector - change selection mode', () => {
   let grid: FlowGrid;
 
   function clickSelectCheckbox(row: number) {
-    getBodyCellContent(grid, row, 0)!.querySelector('vaadin-checkbox')!.click();
+    getBodyCellContent(grid, row, 0)!.querySelector<HTMLElement>('vaadin-checkbox')!.click();
   }
 
   beforeEach(async () => {
@@ -20,7 +20,7 @@ describe('grid connector - change selection mode', () => {
 
     init(grid);
 
-    const selectionColumn = grid.querySelector('vaadin-grid-flow-selection-column')!;
+    const selectionColumn = grid.querySelector<FlowGridSelectionColumn>('vaadin-grid-flow-selection-column')!;
     initSelectionColumn(grid, selectionColumn);
 
     setRootItems(grid.$connector, [

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-generators.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-generators.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { init, setRootItems, getBodyCell } from './shared.js';
 import type { FlowGrid } from './shared.js';
-import { GridColumn } from '@vaadin/grid';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 
 describe('grid connector - generators', () => {
   let grid: FlowGrid;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-item-click.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-item-click.test.ts
@@ -3,7 +3,7 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { init, setRootItems, getBodyCell, getBodyCellContent, getHeaderCellContent } from './shared.js';
 import type { FlowGrid } from './shared.js';
 import sinon from 'sinon';
-import { GridColumn } from '@vaadin/grid';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 
 describe('grid connector - item click', () => {
   let grid: FlowGrid;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-multi-mode.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-multi-mode.test.ts
@@ -30,7 +30,7 @@ describe('grid connector - selection – multi mode', () => {
 
     grid.$connector.setSelectionMode('MULTI');
 
-    [selectAllCheckbox, ...selectRowCheckboxes] = [...grid.querySelectorAll('vaadin-checkbox')];
+    [selectAllCheckbox, ...selectRowCheckboxes] = [...grid.querySelectorAll<HTMLElement>('vaadin-checkbox')];
   });
 
   async function mouseClick(element: HTMLElement) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { init, getBodyCellContent, setRootItems } from './shared.js';
-import type { FlowGrid } from './shared.js';
+import type { FlowGrid, Item } from './shared.js';
 import sinon from 'sinon';
 
 describe('grid connector - selection', () => {
@@ -144,7 +144,7 @@ describe('grid connector - selection', () => {
     });
 
     describe('conditional selection', () => {
-      let items;
+      let items: Item[];
 
       beforeEach(async () => {
         items = Array.from({ length: 4 }, (_, i) => ({
@@ -192,7 +192,7 @@ describe('grid connector - selection', () => {
         setRootItems(grid.$connector, updatedItems);
 
         // active item still references the original item with selectable: true
-        expect(grid.activeItem.selectable).to.be.true;
+        expect(grid.activeItem!.selectable).to.be.true;
 
         // however clicking the row should not deselect the item
         getBodyCellContent(grid, 2, 0)!.click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-sorting.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { getHeaderCellContent, init, setRootItems } from './shared.js';
 import type { FlowGrid, FlowGridSorter, Item } from './shared.js';
-import { GridColumn } from '@vaadin/grid';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
 
 describe('grid connector - sorting', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -6,8 +6,9 @@ import '../frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js
 import sinon from 'sinon';
 import type { Grid } from '@vaadin/grid';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
+import type { GridSorter } from '@vaadin/grid/vaadin-grid-sorter.js';
 import type {} from '@web/test-runner-mocha';
-import { GridSorter } from '@vaadin/grid/src/all-imports.js';
+import type {} from 'sinon-chai';
 
 export type GridConnector = {
   updateFlatData: (updatedItems: Item[]) => void;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -4,7 +4,8 @@ import '../frontend/generated/jar-resources/gridConnector.ts';
 import '../frontend/generated/jar-resources/treeGridConnector.ts';
 import '../frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
 import sinon from 'sinon';
-import type { Grid, GridColumn } from '@vaadin/grid';
+import type { Grid } from '@vaadin/grid';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import type {} from '@web/test-runner-mocha';
 import { GridSorter } from '@vaadin/grid/src/all-imports.js';
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/tsconfig.json
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
## Summary
- The grid WTR test files are excluded from the module's root tsconfig and never go through tsc (the test runner only strips types), so type errors in them go unnoticed and only show up as IDE warnings. This makes the test folder pass type checking and adds a `test/tsconfig.json` so IDEs and `npx tsc -p test` check it with the right settings.
- The biggest sources of errors were `import { GridColumn } from '@vaadin/grid'` (the package root stopped re-exporting columns in vaadin/web-components#7090, released in 24.4) and the missing `sinon-chai` type augmentation for chai assertions. The rest were small: untyped locals, `Element` vs `HTMLElement` narrowing, and importing `GridSorter` from the untyped `all-imports.js`.
- The root `.gitignore` ignores all `tsconfig.json` files because the module-root ones are generated by Flow; an exception for `test/tsconfig.json` is added so the hand-written config can be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)