### PR TITLE
test: declare MockUIExtension directly in BreadcrumbsModeTest

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -19,14 +19,18 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
 import com.vaadin.flow.signals.local.ValueSignal;
-import com.vaadin.tests.AbstractSignalsTest;
+import com.vaadin.tests.MockUIExtension;
 
-class BreadcrumbsModeTest extends AbstractSignalsTest {
+class BreadcrumbsModeTest {
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     @Test
     void defaultConstructor_modeIsRouter() {


### PR DESCRIPTION
## Description

Refactored test as suggested in https://github.com/vaadin/flow-components/pull/9510#discussion_r3414424159

## Type of change

- Test