### PR TITLE
chore: make @NpmPackage gate a standalone workflow

### DIFF
--- a/.github/workflows/npm-package-gate.yml
+++ b/.github/workflows/npm-package-gate.yml
@@ -1,49 +1,67 @@
 name: NpmPackage 24h gate
 
-# Posts the @NpmPackage version-bump block on a PR, then automatically dismisses
-# it and approves the PR 24 hours later. Triggered by validation.yml via a
-# repository_dispatch when it detects an added @NpmPackage version.
+# Self-contained @NpmPackage version-bump gate. On every PR it detects an added
+# @NpmPackage version and, if found, posts a CHANGES_REQUESTED block, then 24
+# hours later automatically dismisses it, approves the PR and enables auto-merge.
+#
+# It triggers on `pull_request` (same PR events as validation.yml), so it catches
+# PR creation and updates on its own. The `repository_dispatch` trigger is an
+# internal hop: the `block` job dispatches `npm-package-blocked` to launch the
+# `wait-and-unblock` job in a separate run. That run is immune to PR pushes, so
+# the 24h timer is anchored to the block message and never reset by new commits.
 #
 # The 24h wait is implemented with an Environment named "24h-gate" that has a
 # Wait timer of 1440 minutes (Settings -> Environments). A job waiting on a wait
 # timer does not consume runner minutes, so this costs nothing while it waits,
 # and it sidesteps the 6h single-job limit (the timer runs before the job does).
-#
-# This lives in its own workflow on purpose: validation.yml uses
-# `cancel-in-progress: true`, which would cancel the pending 24h job on the next
-# push to the PR.
 
 on:
+  pull_request:
   repository_dispatch:
     types: [npm-package-blocked]
-
-concurrency:
-  # One gate per PR; never cancel, or we'd kill a pending 24h waiter.
-  group: npm-package-gate-${{ github.event.client_payload.pr }}
-  cancel-in-progress: false
 
 env:
   MARKER: '<!-- vaadin-flow-components:npm-package-bump-review -->'
 
 jobs:
   block:
-    name: Request changes
+    name: Detect bump and request changes
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    concurrency:
+      # A newer push supersedes an in-flight detection; cheap to cancel.
+      group: npm-package-gate-block-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
-      - name: Request changes on PR
+      - name: Detect bump, block and schedule unblock
         env:
           GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT }}
-          PR_NUMBER: ${{ github.event.client_payload.pr }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Detect an added @NpmPackage version in the PR's .java files. Use the
+          # PR files API so we diff against the merge base, not against main's
+          # current tip — otherwise unrelated @NpmPackage commits already merged
+          # into main since the PR branched would trigger a false positive.
+          if ! gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+               --jq '.[] | select(.filename | endswith(".java")) | .patch // ""' \
+             | grep -qE '^\+.*@NpmPackage'; then
+            echo "No added @NpmPackage version, nothing to block."
+            exit 0
+          fi
+
+          # Only fire once per block: if the block review already exists, the
+          # gate is already running and re-dispatching would spawn a second
+          # waiter. This is what stops every later push from re-blocking.
           existing=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
             --jq "[.[] | select(.state == \"CHANGES_REQUESTED\") | select(.body | contains(\"$MARKER\"))] | length")
           if [ "$existing" -gt 0 ]; then
-            echo "Existing CHANGES_REQUESTED review found, skipping."
+            echo "Block review already present, gate already running."
             exit 0
           fi
+
           BODY=$(sed 's/^          //' <<'EOF'
           <!-- vaadin-flow-components:npm-package-bump-review -->
           This PR updates the `@NpmPackage` version. Because the default value of `vaadin.npm.minimumFrontendPackageAgeDays` is 1, I'm blocking it for now to avoid producing a failed snapshot for other projects.
@@ -62,15 +80,26 @@ jobs:
             -f event=REQUEST_CHANGES \
             -f body="$BODY"
 
+          # Schedule the follow-up unblock job in a separate run that PR pushes
+          # can't cancel or reset. A PAT/app token is required here: events sent
+          # with the default GITHUB_TOKEN do not trigger other workflows
+          # (anti-recursion rule).
+          gh api -X POST "repos/$REPO/dispatches" --input - \
+            <<<"{\"event_type\":\"npm-package-blocked\",\"client_payload\":{\"pr\":$PR_NUMBER}}"
+
   wait-and-unblock:
     name: Auto-unblock after 24h
-    needs: block
+    if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     # The Wait timer configured on this environment pauses the job for 24h
     # before it starts running.
     environment: 24h-gate
     permissions:
       contents: read
+    concurrency:
+      # One waiter per PR; never cancel, or we'd kill a pending 24h waiter.
+      group: npm-package-gate-wait-${{ github.event.client_payload.pr }}
+      cancel-in-progress: false
     steps:
       - name: Dismiss block and approve
         env:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,6 +27,10 @@ concurrency:
 
 env:
   FORK_COUNT: 4
+  # Internal validation has no reason to enforce the frontend package age
+  # requirement (it only protects downstream framework users), so accept
+  # freshly published @NpmPackage bumps.
+  MAVEN_OPTS: -Dvaadin.npm.minimumFrontendPackageAgeDays=0
 
 jobs:
   build:
@@ -221,61 +225,6 @@ jobs:
       - name: npm install
         if: matrix.type != 'unit'
         run: npm ci --ignore-scripts
-
-      - name: Detect @NpmPackage version changes
-        id: npm-changes
-        if: matrix.type != 'unit'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          changed=false
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Use the PR files API so we diff against the merge base, not against
-            # main's current tip — otherwise unrelated @NpmPackage commits already
-            # merged into main since the PR branched would trigger a false positive.
-            if gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
-                 --jq '.[] | select(.filename | endswith(".java")) | .patch // ""' \
-               | grep -qE '^\+.*@NpmPackage'; then
-              changed=true
-            fi
-          else
-            base="${{ github.base_ref || 'main' }}"
-            if git fetch --depth=1 origin "$base" 2>/dev/null && \
-               git diff FETCH_HEAD -- '*.java' | grep -q '@NpmPackage'; then
-              changed=true
-            fi
-          fi
-          if [ "$changed" = "true" ]; then
-            echo "MAVEN_OPTS=${MAVEN_OPTS} -Dvaadin.npm.minimumFrontendPackageAgeDays=0" >> "$GITHUB_ENV"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Start the separate block + 24h auto-unblock gate (npm-package-gate.yml).
-      # We only fire it once per block: if the block review already exists, the
-      # gate is already running and re-dispatching would spawn a second waiter.
-      - name: Trigger NpmPackage 24h gate
-        if: >-
-          matrix.type == 'war'
-          && steps.npm-changes.outputs.changed == 'true'
-          && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          MARKER="<!-- vaadin-flow-components:npm-package-bump-review -->"
-          existing=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq "[.[] | select(.state == \"CHANGES_REQUESTED\") | select(.body | contains(\"$MARKER\"))] | length")
-          if [ "$existing" -gt 0 ]; then
-            echo "Block review already present, gate already running."
-            exit 0
-          fi
-          # A PAT/app token is required here: events sent with the default
-          # GITHUB_TOKEN do not trigger other workflows (anti-recursion rule).
-          gh api -X POST "repos/$REPO/dispatches" --input - \
-            <<<"{\"event_type\":\"npm-package-blocked\",\"client_payload\":{\"pr\":$PR_NUMBER}}"
 
       - name: Merge ITs
         if: matrix.type == 'war'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,10 +27,6 @@ concurrency:
 
 env:
   FORK_COUNT: 4
-  # Internal validation has no reason to enforce the frontend package age
-  # requirement (it only protects downstream framework users), so accept
-  # freshly published @NpmPackage bumps.
-  MAVEN_OPTS: -Dvaadin.npm.minimumFrontendPackageAgeDays=0
 
 jobs:
   build:
@@ -229,6 +225,15 @@ jobs:
       - name: Merge ITs
         if: matrix.type == 'war'
         run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
+
+      # Let @vaadin/* web component bumps bypass the frontend package age check
+      - name: Configure pnpm package age exclude
+        if: matrix.type == 'war'
+        run: |
+          cat > integration-tests/pnpm-workspace.yaml <<'EOF'
+          minimumReleaseAgeExclude:
+            - '@vaadin/*'
+          EOF
 
       - name: Compute WAR cache key
         if: matrix.type == 'war'


### PR DESCRIPTION
Move the `@NpmPackage` version-bump gate out of `validation.yml`. The gate now triggers on `pull_request` itself (detect + block + schedule unblock), instead of being dispatched by validation.

`validation.yml` no longer detects `@NpmPackage` changes to disable the minimum release age check in Flow: instead it sets PNPM's `minimumReleaseAgeExclude` to disable the check for Vaadin prefixed packages only.
