### PR TITLE
fix: resolve Breadcrumbs router titles via Router.resolvePageTitle

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -39,7 +39,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
-import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
@@ -50,8 +49,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouteReference;
 import com.vaadin.flow.router.RouterState;
-import com.vaadin.flow.router.internal.RouteUtil;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 
@@ -430,10 +427,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
      */
     private String resolveTitle(RouteReference reference,
             QueryParameters queryParameters) {
-        Instantiator instantiator = VaadinService.getCurrent()
-                .getInstantiator();
-        return RouteUtil
-                .resolvePageTitle(instantiator, reference.navigationTarget(),
+        return ComponentUtil.getRouter(this)
+                .resolvePageTitle(reference.navigationTarget(),
                         reference.routeParameters(), queryParameters)
                 .orElse("");
     }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -365,11 +365,14 @@ class BreadcrumbsModeTest {
             routeConfiguration.setAnnotatedRoute(route);
         }
 
-        // A mock Router returns the application registry directly, avoiding
-        // Router#getRegistry()'s session-scoped wrapping (which would delegate
-        // to a parent registry that the mock service cannot provide).
-        Router router = Mockito.mock(Router.class);
-        Mockito.when(router.getRegistry()).thenReturn(routeRegistry);
+        // A spy over a real Router runs the real resolvePageTitle (used to
+        // resolve item titles) while getRegistry() is stubbed to return the
+        // application registry directly, avoiding Router#getRegistry()'s
+        // session-scoped wrapping (which would delegate to a parent registry
+        // that the mock service cannot provide). doReturn avoids calling the
+        // real getRegistry during stubbing.
+        Router router = Mockito.spy(new Router(routeRegistry));
+        Mockito.doReturn(routeRegistry).when(router).getRegistry();
         Mockito.when(ui.getService().getRouter()).thenReturn(router);
         // Title resolution reads the current service's instantiator.
         VaadinService.setCurrent(ui.getService());


### PR DESCRIPTION
Flow moved page-title resolution from the internal `RouteUtil` to the public `Router.resolvePageTitle` (vaadin/flow#24647), removing the `RouteUtil.resolvePageTitle(Instantiator, ...)` overload that `Breadcrumbs` relied on. This broke `vaadin-breadcrumbs-flow` compilation on `main`:

```
Breadcrumbs.java:[436,17] cannot find symbol
  symbol: method resolvePageTitle(Instantiator,Class<? extends Component>,RouteParameters,QueryParameters)
```

`Mode.ROUTER` item titles are now resolved through the public `Router.resolvePageTitle(target, routeParameters, queryParameters)`, obtained via `ComponentUtil.getRouter(this)`. This drops the manual `VaadinService.getCurrent().getInstantiator()` lookup, since the new API resolves the instantiator itself.

The unit test's mocked `Router` is replaced with a spy over a real `Router`, so the real `resolvePageTitle` runs (titles are asserted) while `getRegistry()` stays stubbed to return the application registry directly.

Related to vaadin/flow#24647

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)