### PR TITLE
fix: keep BreadcrumbsItem prefix component when setting text

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -19,14 +19,18 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * An item of the {@link Breadcrumbs} component, representing a single entry in
@@ -46,6 +50,11 @@ import com.vaadin.flow.server.InitParameters;
 @JsModule("@vaadin/breadcrumbs/src/vaadin-breadcrumbs-item.js")
 public class BreadcrumbsItem extends Component
         implements HasText, HasEnabled, HasPrefix {
+
+    private final Text textNode = new Text("");
+
+    private final SignalPropertySupport<String> textSupport = SignalPropertySupport
+            .create(this, this::updateText);
 
     /**
      * Creates a breadcrumbs item with the given text and no path. An item
@@ -164,6 +173,45 @@ public class BreadcrumbsItem extends Component
             RouteParameters params, Component prefixComponent) {
         this(text, view, params);
         setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Sets the given string as the text content of this item.
+     * <p>
+     * This method removes any existing content in the default slot and replaces
+     * it with the given text. Other slotted children (such as the prefix) are
+     * preserved.
+     *
+     * @param text
+     *            the text content to set, or {@code null} to remove existing
+     *            text
+     */
+    @Override
+    public void setText(String text) {
+        textSupport.set(text);
+    }
+
+    @Override
+    public String getText() {
+        return textSupport.get();
+    }
+
+    @Override
+    public SignalBinding<String> bindText(Signal<String> textSignal) {
+        return textSupport.bind(textSignal);
+    }
+
+    private void updateText(String text) {
+        textNode.setText(text);
+
+        if (text == null || text.isEmpty()) {
+            textNode.removeFromParent();
+            return;
+        }
+
+        if (textNode.getParent().isEmpty()) {
+            getElement().appendChild(textNode.getElement());
+        }
     }
 
     /**

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemSignalTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemSignalTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsTest;
+
+class BreadcrumbsItemSignalTest extends AbstractSignalsTest {
+
+    @Test
+    void bindText_updatesTextReactively() {
+        var signal = new ValueSignal<>("foo");
+        var item = new BreadcrumbsItem("init");
+        item.bindText(signal);
+        ui.add(item);
+
+        Assertions.assertEquals("foo", item.getText());
+
+        signal.set("bar");
+        Assertions.assertEquals("bar", item.getText());
+    }
+
+    @Test
+    void bindText_prefixPreserved() {
+        var signal = new ValueSignal<>("foo");
+        var item = new BreadcrumbsItem("init");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+        item.bindText(signal);
+        ui.add(item);
+
+        signal.set("bar");
+        Assertions.assertEquals("bar", item.getText());
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
+    @Test
+    void bindText_setTextThrows() {
+        var signal = new ValueSignal<>("foo");
+        var item = new BreadcrumbsItem("init");
+        item.bindText(signal);
+
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> item.setText("bar"));
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
@@ -172,6 +172,30 @@ class BreadcrumbsItemTest {
         Assertions.assertEquals(prefix, item.getPrefixComponent());
     }
 
+    @Test
+    void setTextAfterPrefix_prefixPreserved() {
+        var item = new BreadcrumbsItem("Inbox (2 items)");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+
+        item.setText("Inbox (3 items)");
+
+        Assertions.assertEquals("Inbox (3 items)", item.getText());
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
+    @Test
+    void setEmptyTextAfterPrefix_prefixPreserved() {
+        var item = new BreadcrumbsItem("Home");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+
+        item.setText("");
+
+        Assertions.assertEquals("", item.getText());
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
     @SafeVarargs
     private void runWithMockRouter(Runnable test,
             Class<? extends Component>... routes) {


### PR DESCRIPTION
`BreadcrumbsItem.setText` used the default `HasText#setText`, which replaces all of the item's content — so calling it after `setPrefixComponent` removed the prefix (e.g. an icon).

```java
BreadcrumbsItem item = new BreadcrumbsItem("Inbox (2 items)");
item.setPrefixComponent(new Icon(VaadinIcon.ENVELOPE));
item.setText("Inbox (3 items)"); // icon was lost
```

The text is now held in a dedicated text node managed through `SignalPropertySupport`, the same approach `Button` and `Badge` use. `setText`/`bindText` only update that text node, so the prefix (and any other slotted content) is preserved.

Fixes #9533

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)