### PR TITLE
[DO NOT SQUASH] Backport Breadcrumbs component to 25.2

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.component.breadcrumbs;
 
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
@@ -27,6 +31,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.internal.JacksonUtils;
 
 /**
  * Breadcrumbs is a component for displaying a navigation trail that shows the
@@ -44,6 +49,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>,
         HasThemeVariant<BreadcrumbsVariant> {
 
+    private BreadcrumbsI18n i18n;
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
@@ -56,6 +63,62 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         if (!featureFlags.isEnabled(
                 BreadcrumbsFeatureFlagProvider.BREADCRUMBS_COMPONENT)) {
             throw new ExperimentalFeatureException();
+        }
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using
+     * {@link #setI18n(BreadcrumbsI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public BreadcrumbsI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization properties for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(BreadcrumbsI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+        getElement().setPropertyJson("i18n", JacksonUtils.beanToJson(i18n));
+    }
+
+    /**
+     * The internationalization properties for {@link Breadcrumbs}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class BreadcrumbsI18n implements Serializable {
+        private String moreItems;
+
+        /**
+         * Gets the accessible label announced by screen readers for the
+         * overflow button that reveals the hidden breadcrumb items.
+         *
+         * @return the translated label for the overflow button
+         */
+        public String getMoreItems() {
+            return moreItems;
+        }
+
+        /**
+         * Sets the accessible label announced by screen readers for the
+         * overflow button that reveals the hidden breadcrumb items.
+         *
+         * @param moreItems
+         *            the translated label for the overflow button
+         * @return this instance for method chaining
+         */
+        public BreadcrumbsI18n setMoreItems(String moreItems) {
+            this.moreItems = moreItems;
+            return this;
         }
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.breadcrumbs;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -26,8 +27,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponentsOfType;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
@@ -35,9 +39,20 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.HasDynamicTitle;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.RouteReference;
+import com.vaadin.flow.router.RouterState;
+import com.vaadin.flow.router.internal.RouteUtil;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -76,6 +91,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
     private boolean internalChildUpdate;
 
     private BreadcrumbsI18n i18n;
+
+    private Registration navigationRegistration;
 
     /**
      * Creates a new breadcrumbs component in {@link Mode#ROUTER} mode.
@@ -129,9 +146,17 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
                     "Cannot change the mode while a children binding is active.");
         }
         this.mode = newMode;
-        // Listener register/unregister and the initial router rebuild are
-        // deferred to a later task; for now just clear the existing children.
+        // Clear the current trail so the new mode starts fresh.
         updateChildrenInternal(List.of());
+        if (newMode == Mode.ROUTER) {
+            // MANUAL -> ROUTER: start listening for navigation.
+            if (isAttached()) {
+                registerNavigationListener(getUI().orElseThrow());
+            }
+        } else {
+            // ROUTER -> MANUAL: stop listening for navigation.
+            unregisterNavigationListener();
+        }
     }
 
     @Override
@@ -245,6 +270,172 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         checkFeatureFlag(attachEvent.getUI());
+
+        if (mode == Mode.ROUTER) {
+            registerNavigationListener(attachEvent.getUI());
+        }
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        unregisterNavigationListener();
+        super.onDetach(detachEvent);
+    }
+
+    /**
+     * Registers the {@code AfterNavigationListener} that rebuilds the trail on
+     * each navigation and performs an initial synchronous rebuild from the
+     * current navigation state.
+     *
+     * @param ui
+     *            the UI to register the listener on
+     */
+    private void registerNavigationListener(UI ui) {
+        navigationRegistration = ui
+                .addAfterNavigationListener(this::rebuildFromRouter);
+
+        // Initial population: read the current navigation state from the UI for
+        // the case where the breadcrumbs is attached to an already-rendered
+        // view, so no navigation event is pending.
+        rebuildFromRouter(ui.routerStateSignal().peek());
+    }
+
+    /**
+     * Unregisters the {@code AfterNavigationListener} if it is currently
+     * registered.
+     */
+    private void unregisterNavigationListener() {
+        if (navigationRegistration != null) {
+            navigationRegistration.remove();
+            navigationRegistration = null;
+        }
+    }
+
+    /**
+     * Rebuilds the trail from the navigation state carried by an
+     * {@link AfterNavigationEvent}. Registered as an
+     * {@code AfterNavigationListener} while in {@link Mode#ROUTER}.
+     *
+     * @param event
+     *            the navigation event
+     */
+    void rebuildFromRouter(AfterNavigationEvent event) {
+        if (!isAttached()) {
+            return;
+        }
+        // The active chain is ordered leaf-first, so the current view is the
+        // first element.
+        List<HasElement> activeChain = event.getActiveChain();
+        HasElement currentView = activeChain.isEmpty() ? null
+                : activeChain.get(0);
+        Class<? extends Component> currentTarget = currentView instanceof Component
+                ? ((Component) currentView).getClass()
+                : null;
+        rebuildTrail(currentTarget, event.getRouteParameters(),
+                event.getLocation().getQueryParameters(), currentView);
+    }
+
+    /**
+     * Rebuilds the trail from the given {@link RouterState}. Used for the
+     * initial synchronous rebuild in {@link #onAttach(AttachEvent)} and on a
+     * {@code MANUAL -> ROUTER} mode switch.
+     *
+     * @param state
+     *            the current router state
+     */
+    void rebuildFromRouter(RouterState state) {
+        if (!isAttached()) {
+            return;
+        }
+        rebuildTrail(state.navigationTarget(), state.routeParameters(),
+                state.location().getQueryParameters(),
+                state.currentView().orElse(null));
+    }
+
+    /**
+     * Builds the breadcrumb trail for the given current navigation target and
+     * applies it via {@link #updateChildrenInternal(List)}.
+     * <p>
+     * The trail is produced by {@link RouteConfiguration#getRouteHierarchy}
+     * (the breadcrumb does no walking of its own). Ancestor labels are resolved
+     * without instantiating their views; the last (current) item prefers the
+     * live {@link HasDynamicTitle} of the already-instantiated current view.
+     * <p>
+     * The query parameters of the current navigation are applied only when
+     * resolving the current (last) item's title; ancestor titles and links are
+     * resolved without query parameters, since query parameters describe the
+     * current navigation as a whole and ancestor links never carry them.
+     *
+     * @param currentTarget
+     *            the current navigation target class, or {@code null} if it
+     *            cannot be resolved
+     * @param parameters
+     *            the route parameters of the current navigation
+     * @param queryParameters
+     *            the query parameters of the current navigation, applied to the
+     *            current item's title resolution only
+     * @param currentView
+     *            the current view instance, or {@code null} if not available
+     */
+    private void rebuildTrail(Class<? extends Component> currentTarget,
+            RouteParameters parameters, QueryParameters queryParameters,
+            HasElement currentView) {
+        if (currentTarget == null) {
+            updateChildrenInternal(List.of());
+            return;
+        }
+
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(ComponentUtil.getRouter(this).getRegistry());
+        List<RouteReference> hierarchy = routeConfiguration
+                .getRouteHierarchy(currentTarget, parameters);
+
+        List<BreadcrumbsItem> trail = new ArrayList<>(hierarchy.size());
+        for (int i = 0; i < hierarchy.size(); i++) {
+            RouteReference reference = hierarchy.get(i);
+            boolean isLast = i == hierarchy.size() - 1;
+            if (isLast) {
+                trail.add(new BreadcrumbsItem(resolveCurrentTitle(reference,
+                        queryParameters, currentView)));
+            } else {
+                String title = resolveTitle(reference, QueryParameters.empty());
+                trail.add(
+                        new BreadcrumbsItem(title, reference.navigationTarget(),
+                                reference.routeParameters()));
+            }
+        }
+
+        updateChildrenInternal(trail);
+    }
+
+    /**
+     * Resolves the label of the current (last) route, preferring the live
+     * {@link HasDynamicTitle} of the already-instantiated current view over the
+     * instance-free title resolution. The given query parameters are passed to
+     * the instance-free resolution so a query-parameter-dependent title
+     * generator resolves correctly.
+     */
+    private String resolveCurrentTitle(RouteReference reference,
+            QueryParameters queryParameters, HasElement currentView) {
+        if (currentView instanceof HasDynamicTitle) {
+            return ((HasDynamicTitle) currentView).getPageTitle();
+        }
+        return resolveTitle(reference, queryParameters);
+    }
+
+    /**
+     * Resolves the label of a route without instantiating its view, using the
+     * given query parameters and falling back to an empty string when the route
+     * declares no title.
+     */
+    private String resolveTitle(RouteReference reference,
+            QueryParameters queryParameters) {
+        Instantiator instantiator = VaadinService.getCurrent()
+                .getInstantiator();
+        return RouteUtil
+                .resolvePageTitle(instantiator, reference.navigationTarget(),
+                        reference.routeParameters(), queryParameters)
+                .orElse("");
     }
 
     private void checkFeatureFlag(UI ui) {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 
 /**
  * Breadcrumbs is a component for displaying a navigation trail that shows the
@@ -40,7 +41,8 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/breadcrumbs", version = "25.2.0-rc2")
 @JsModule("@vaadin/breadcrumbs/src/vaadin-breadcrumbs.js")
 public class Breadcrumbs extends Component implements HasSize, HasStyle,
-        HasAriaLabel, HasComponentsOfType<BreadcrumbsItem> {
+        HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>,
+        HasThemeVariant<BreadcrumbsVariant> {
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -16,7 +16,11 @@
 package com.vaadin.flow.component.breadcrumbs;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vaadin.experimental.FeatureFlags;
@@ -31,7 +35,10 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * Breadcrumbs is a component for displaying a navigation trail that shows the
@@ -65,6 +72,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
     }
 
     private Mode mode;
+
+    private boolean internalChildUpdate;
 
     private BreadcrumbsI18n i18n;
 
@@ -106,15 +115,130 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
      * @param newMode
      *            the mode that determines how the trail is populated, not
      *            {@code null}
+     * @throws IllegalStateException
+     *             if a children binding set via {@code bindChildren} is active;
+     *             such a binding takes over the trail and cannot be handed back
+     *             to component-controlled population
      */
     public void setMode(Mode newMode) {
         if (newMode == mode) {
             return;
         }
+        if (hasChildrenBinding()) {
+            throw new IllegalStateException(
+                    "Cannot change the mode while a children binding is active.");
+        }
         this.mode = newMode;
         // Listener register/unregister and the initial router rebuild are
         // deferred to a later task; for now just clear the existing children.
-        removeAll();
+        updateChildrenInternal(List.of());
+    }
+
+    @Override
+    public void add(BreadcrumbsItem... components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.add(components);
+    }
+
+    @Override
+    public void add(Collection<BreadcrumbsItem> components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.add(components);
+    }
+
+    @Override
+    public void remove(BreadcrumbsItem... components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.remove(components);
+    }
+
+    @Override
+    public void remove(Collection<BreadcrumbsItem> components) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.remove(components);
+    }
+
+    @Override
+    public void removeAll() {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.removeAll();
+    }
+
+    @Override
+    public void addComponentAsFirst(BreadcrumbsItem component) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.addComponentAsFirst(component);
+    }
+
+    @Override
+    public void addComponentAtIndex(int index, BreadcrumbsItem component) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.addComponentAtIndex(index, component);
+    }
+
+    @Override
+    public void replace(BreadcrumbsItem oldComponent,
+            BreadcrumbsItem newComponent) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.replace(oldComponent, newComponent);
+    }
+
+    @Override
+    public <V extends @Nullable Object, S extends Signal<V>> void bindChildren(
+            Signal<List<S>> list,
+            SerializableFunction<S, BreadcrumbsItem> childFactory) {
+        checkManualMutationAllowed();
+        HasComponentsOfType.super.bindChildren(list, childFactory);
+    }
+
+    /**
+     * Throws if manual child mutation is not allowed in the current mode.
+     * <p>
+     * Mutating children is rejected while in {@link Mode#ROUTER}, unless the
+     * internal {@link #internalChildUpdate} flag is set (i.e. the change
+     * originates from an internal child update such as a mode switch or a
+     * router-driven rebuild via {@link #updateChildrenInternal(List)}).
+     */
+    private void checkManualMutationAllowed() {
+        if (mode == Mode.ROUTER && !internalChildUpdate) {
+            throw new IllegalStateException(
+                    "Cannot modify breadcrumb items manually in Mode.ROUTER. "
+                            + "Switch to Mode.MANUAL to manage items directly.");
+        }
+    }
+
+    /**
+     * Replaces the current children with the given trail, bypassing the
+     * {@link Mode#ROUTER} mutation guard for the duration of the update. Used
+     * both for the router-driven rebuild and for clearing children on a mode
+     * switch.
+     *
+     * @param trail
+     *            the breadcrumb items to set as the new children
+     */
+    void updateChildrenInternal(List<BreadcrumbsItem> trail) {
+        internalChildUpdate = true;
+        try {
+            removeAll();
+            add(trail.toArray(BreadcrumbsItem[]::new));
+        } finally {
+            internalChildUpdate = false;
+        }
+    }
+
+    /**
+     * Checks whether a children binding (set via {@code bindChildren}) is
+     * currently active on this component's element. Mirrors the internal check
+     * Flow core performs, reading the binding state from the element node.
+     *
+     * @return {@code true} if a children binding is active
+     */
+    private boolean hasChildrenBinding() {
+        return getElement().getNode()
+                .getFeatureIfInitialized(SignalBindingFeature.class)
+                .map(feature -> feature
+                        .hasBinding(SignalBindingFeature.CHILDREN))
+                .orElse(false);
     }
 
     @Override

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -49,7 +49,73 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
         HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>,
         HasThemeVariant<BreadcrumbsVariant> {
 
+    /**
+     * The mode that determines how the breadcrumb trail is populated.
+     */
+    public enum Mode {
+        /**
+         * The trail is populated automatically from the active route hierarchy.
+         */
+        ROUTER,
+        /**
+         * The trail is populated manually by the application through
+         * {@code add} / {@code remove} methods.
+         */
+        MANUAL
+    }
+
+    private Mode mode;
+
     private BreadcrumbsI18n i18n;
+
+    /**
+     * Creates a new breadcrumbs component in {@link Mode#ROUTER} mode.
+     */
+    public Breadcrumbs() {
+        this(Mode.ROUTER);
+    }
+
+    /**
+     * Creates a new breadcrumbs component in the given mode.
+     *
+     * @param mode
+     *            the mode that determines how the trail is populated, not
+     *            {@code null}
+     */
+    public Breadcrumbs(Mode mode) {
+        this.mode = mode;
+    }
+
+    /**
+     * Gets the mode that determines how the breadcrumb trail is populated.
+     *
+     * @return the current mode
+     */
+    public Mode getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets the mode that determines how the breadcrumb trail is populated.
+     * <p>
+     * Switching to a different mode discards the existing children: both the
+     * {@code ROUTER -> MANUAL} and {@code MANUAL -> ROUTER} transitions clear
+     * the current trail so the new mode can start fresh. Setting the mode to
+     * its current value is a no-op and leaves the children untouched.
+     *
+     * @param newMode
+     *            the mode that determines how the trail is populated, not
+     *            {@code null}
+     */
+    public void setMode(Mode newMode) {
+        if (newMode == mode) {
+            return;
+        }
+        this.mode = newMode;
+        // Listener register/unregister and the initial router rebuild are
+        // deferred to a later task; for now just clear the existing children.
+        removeAll();
+    }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java
@@ -39,7 +39,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasThemeVariant;
-import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
@@ -50,8 +49,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouteReference;
 import com.vaadin.flow.router.RouterState;
-import com.vaadin.flow.router.internal.RouteUtil;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 
@@ -430,10 +427,8 @@ public class Breadcrumbs extends Component implements HasSize, HasStyle,
      */
     private String resolveTitle(RouteReference reference,
             QueryParameters queryParameters) {
-        Instantiator instantiator = VaadinService.getCurrent()
-                .getInstantiator();
-        return RouteUtil
-                .resolvePageTitle(instantiator, reference.navigationTarget(),
+        return ComponentUtil.getRouter(this)
+                .resolvePageTitle(reference.navigationTarget(),
                         reference.routeParameters(), queryParameters)
                 .orElse("");
     }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -19,12 +19,16 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
+import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
+import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.signals.Signal;
 
 /**
  * An item of the {@link Breadcrumbs} component, representing a single entry in
@@ -44,6 +48,11 @@ import com.vaadin.flow.router.RouteParameters;
 @JsModule("@vaadin/breadcrumbs/src/vaadin-breadcrumbs-item.js")
 public class BreadcrumbsItem extends Component
         implements HasText, HasEnabled, HasPrefix {
+
+    private final Text textNode = new Text("");
+
+    private final SignalPropertySupport<String> textSupport = SignalPropertySupport
+            .create(this, this::updateText);
 
     /**
      * Creates a breadcrumbs item with the given text and no path. An item
@@ -152,6 +161,45 @@ public class BreadcrumbsItem extends Component
             RouteParameters params, Component prefixComponent) {
         this(text, view, params);
         setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Sets the given string as the text content of this item.
+     * <p>
+     * This method removes any existing content in the default slot and replaces
+     * it with the given text. Other slotted children (such as the prefix) are
+     * preserved.
+     *
+     * @param text
+     *            the text content to set, or {@code null} to remove existing
+     *            text
+     */
+    @Override
+    public void setText(String text) {
+        textSupport.set(text);
+    }
+
+    @Override
+    public String getText() {
+        return textSupport.get();
+    }
+
+    @Override
+    public SignalBinding<String> bindText(Signal<String> textSignal) {
+        return textSupport.bind(textSignal);
+    }
+
+    private void updateText(String text) {
+        textNode.setText(text);
+
+        if (text == null || text.isEmpty()) {
+            textNode.removeFromParent();
+            return;
+        }
+
+        if (textNode.getParent().isEmpty()) {
+            getElement().appendChild(textNode.getElement());
+        }
     }
 
     /**

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -16,16 +16,26 @@
 package com.vaadin.flow.component.breadcrumbs;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteParameters;
 
 /**
  * An item of the {@link Breadcrumbs} component, representing a single entry in
  * the navigation trail.
+ * <p>
+ * An item carries the text shown in the trail and, optionally, a {@code path}
+ * it links to. An item without a path is the current page and is rendered as a
+ * non-link. The link target can be set as a plain URL string via
+ * {@link #setPath(String)} or resolved from a Flow route class via
+ * {@link #setPath(Class)} / {@link #setPath(Class, RouteParameters)}. An
+ * optional prefix component (typically an icon) can be shown before the text.
  *
  * @author Vaadin Ltd
  */
@@ -36,12 +46,180 @@ public class BreadcrumbsItem extends Component
         implements HasText, HasEnabled, HasPrefix {
 
     /**
-     * Creates a breadcrumbs item with the given text.
+     * Creates a breadcrumbs item with the given text and no path. An item
+     * without a path represents the current page and is rendered as a non-link.
      *
      * @param text
      *            the text of the item
      */
     public BreadcrumbsItem(String text) {
         setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text that links to the given
+     * path.
+     *
+     * @param text
+     *            the text of the item
+     * @param path
+     *            the path to link to
+     */
+    public BreadcrumbsItem(String text, String path) {
+        setPath(path);
+        setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text that links to the given
+     * view.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view) {
+        setPath(view);
+        setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text that links to the given
+     * view using the given route parameters.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     * @param params
+     *            the route parameters
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view,
+            RouteParameters params) {
+        setPath(view, params);
+        setText(text);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text and prefix component (like
+     * an icon) that links to the given path.
+     *
+     * @param text
+     *            the text of the item
+     * @param path
+     *            the path to link to
+     * @param prefixComponent
+     *            the prefix component for the item (usually an icon)
+     */
+    public BreadcrumbsItem(String text, String path,
+            Component prefixComponent) {
+        this(text, path);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text and prefix component (like
+     * an icon) that links to the given view.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     * @param prefixComponent
+     *            the prefix component for the item (usually an icon)
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view,
+            Component prefixComponent) {
+        this(text, view);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Creates a breadcrumbs item with the given text and prefix component (like
+     * an icon) that links to the given view using the given route parameters.
+     *
+     * @param text
+     *            the text of the item
+     * @param view
+     *            the view to link to
+     * @param params
+     *            the route parameters
+     * @param prefixComponent
+     *            the prefix component for the item (usually an icon)
+     */
+    public BreadcrumbsItem(String text, Class<? extends Component> view,
+            RouteParameters params, Component prefixComponent) {
+        this(text, view, params);
+        setPrefixComponent(prefixComponent);
+    }
+
+    /**
+     * Gets the path this item links to.
+     *
+     * @return the path this item links to, or {@code null} if the item has no
+     *         path
+     */
+    public String getPath() {
+        return getElement().getAttribute("path");
+    }
+
+    /**
+     * Sets the path, as a URL string, this item links to.
+     * <p>
+     * Note that there is also an alternative way of setting the link path via
+     * {@link #setPath(Class)}.
+     *
+     * @param path
+     *            the path to link to, or {@code null} to remove the path and
+     *            render the item as the current page (a non-link)
+     *
+     * @see #setPath(Class)
+     */
+    public void setPath(String path) {
+        if (path == null) {
+            getElement().removeAttribute("path");
+        } else {
+            getElement().setAttribute("path", path);
+        }
+    }
+
+    /**
+     * Resolves the URL of the given view via the Vaadin router and sets it as
+     * the path this item links to.
+     *
+     * @param view
+     *            the view to link to. The view should be annotated with the
+     *            {@link com.vaadin.flow.router.Route} annotation. Set to
+     *            {@code null} to remove the path.
+     *
+     * @see #setPath(String)
+     */
+    public void setPath(Class<? extends Component> view) {
+        setPath(view, RouteParameters.empty());
+    }
+
+    /**
+     * Resolves the URL of the given view via the Vaadin router using the given
+     * route parameters and sets it as the path this item links to.
+     *
+     * @param view
+     *            the view to link to. The view should be annotated with the
+     *            {@link com.vaadin.flow.router.Route} annotation. Set to
+     *            {@code null} to remove the path.
+     * @param parameters
+     *            the route parameters
+     *
+     * @see #setPath(String)
+     */
+    public void setPath(Class<? extends Component> view,
+            RouteParameters parameters) {
+        if (view == null) {
+            setPath((String) null);
+        } else {
+            RouteConfiguration routeConfiguration = RouteConfiguration
+                    .forRegistry(ComponentUtil.getRouter(this).getRegistry());
+            setPath(routeConfiguration.getUrl(view, parameters));
+        }
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs;
+
+import com.vaadin.flow.component.shared.ThemeVariant;
+
+/**
+ * Set of theme variants applicable for {@code vaadin-breadcrumbs} component.
+ */
+public enum BreadcrumbsVariant implements ThemeVariant {
+    SLASH("slash");
+
+    private final String variant;
+
+    BreadcrumbsVariant(String variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the variant name.
+     *
+     * @return variant name
+     */
+    @Override
+    public String getVariantName() {
+        return variant;
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsI18nTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsI18nTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.BreadcrumbsI18n;
+
+import tools.jackson.databind.node.ObjectNode;
+
+class BreadcrumbsI18nTest {
+
+    private Breadcrumbs breadcrumbs;
+
+    @BeforeEach
+    void setup() {
+        breadcrumbs = new Breadcrumbs();
+    }
+
+    @Test
+    void setMoreItems_returnsValue() {
+        Assertions.assertEquals("Show hidden items", new BreadcrumbsI18n()
+                .setMoreItems("Show hidden items").getMoreItems());
+    }
+
+    @Test
+    void setI18n() {
+        BreadcrumbsI18n i18n = new BreadcrumbsI18n()
+                .setMoreItems("Show hidden items");
+        breadcrumbs.setI18n(i18n);
+
+        Assertions.assertSame(i18n, breadcrumbs.getI18n());
+        Assertions.assertEquals("Show hidden items",
+                getI18nPropertyAsJson(breadcrumbs).get("moreItems").asString());
+    }
+
+    @Test
+    void setI18nToNull_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> breadcrumbs.setI18n(null));
+    }
+
+    private ObjectNode getI18nPropertyAsJson(Breadcrumbs breadcrumbs) {
+        return (ObjectNode) breadcrumbs.getElement().getPropertyRaw("i18n");
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemSignalTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemSignalTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsTest;
+
+class BreadcrumbsItemSignalTest extends AbstractSignalsTest {
+
+    @Test
+    void bindText_updatesTextReactively() {
+        var signal = new ValueSignal<>("foo");
+        var item = new BreadcrumbsItem("init");
+        item.bindText(signal);
+        ui.add(item);
+
+        Assertions.assertEquals("foo", item.getText());
+
+        signal.set("bar");
+        Assertions.assertEquals("bar", item.getText());
+    }
+
+    @Test
+    void bindText_prefixPreserved() {
+        var signal = new ValueSignal<>("foo");
+        var item = new BreadcrumbsItem("init");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+        item.bindText(signal);
+        ui.add(item);
+
+        signal.set("bar");
+        Assertions.assertEquals("bar", item.getText());
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
+    @Test
+    void bindText_setTextThrows() {
+        var signal = new ValueSignal<>("foo");
+        var item = new BreadcrumbsItem("init");
+        item.bindText(signal);
+
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> item.setText("bar"));
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
+
+class BreadcrumbsItemTest {
+
+    // CONSTRUCTOR TESTS
+
+    @Test
+    void allConstructorsArePresent() {
+        new BreadcrumbsItem("Text");
+        new BreadcrumbsItem("Text", "/path");
+        new BreadcrumbsItem("Text", "/path", new Div());
+        runWithMockRouter(() -> {
+            new BreadcrumbsItem("Text", TestRoute.class);
+            new BreadcrumbsItem("Text", TestRoute.class,
+                    RouteParameters.empty());
+            new BreadcrumbsItem("Text", TestRoute.class, new Div());
+            new BreadcrumbsItem("Text", TestRoute.class,
+                    RouteParameters.empty(), new Div());
+        }, TestRoute.class);
+    }
+
+    @Test
+    void createWithText_textSetAndNoPath() {
+        var item = new BreadcrumbsItem("Home");
+
+        Assertions.assertEquals("Home", item.getText());
+        Assertions.assertNull(item.getPath());
+        Assertions.assertFalse(item.getElement().hasAttribute("path"));
+    }
+
+    @Test
+    void createWithPath_pathAttributeSet() {
+        var item = new BreadcrumbsItem("Docs", "/docs");
+
+        Assertions.assertEquals("/docs", item.getPath());
+        Assertions.assertEquals("/docs",
+                item.getElement().getAttribute("path"));
+    }
+
+    @Test
+    void createWithViewAndPrefix_pathAndPrefixSet() {
+        runWithMockRouter(() -> {
+            var homeIcon = new Div();
+            var item = new BreadcrumbsItem("Home", TestRoute.class, homeIcon);
+
+            Assertions.assertEquals("foo/bar", item.getPath());
+            Assertions.assertEquals(homeIcon, item.getPrefixComponent());
+        }, TestRoute.class);
+    }
+
+    // PATH TESTS
+
+    @Test
+    void setStringPath_pathAttributeSet() {
+        var item = new BreadcrumbsItem("Docs");
+        item.setPath("/docs");
+
+        Assertions.assertEquals("/docs", item.getPath());
+        Assertions.assertEquals("/docs",
+                item.getElement().getAttribute("path"));
+    }
+
+    @Test
+    void setNullStringPath_pathAttributeRemoved() {
+        var item = new BreadcrumbsItem("Docs", "/docs");
+        item.setPath((String) null);
+
+        Assertions.assertNull(item.getPath());
+        Assertions.assertFalse(item.getElement().hasAttribute("path"));
+    }
+
+    @Test
+    void setViewPath_pathAttributeSetToViewUrl() {
+        runWithMockRouter(() -> {
+            var item = new BreadcrumbsItem("Foo");
+            item.setPath(TestRoute.class);
+
+            Assertions.assertEquals("foo/bar", item.getPath());
+        }, TestRoute.class);
+    }
+
+    @Test
+    void setViewPathWithRouteParameters_pathAttributeSetToParameterisedUrl() {
+        runWithMockRouter(() -> {
+            var item = new BreadcrumbsItem("Foo");
+            item.setPath(TestRouteWithRouteParams.class,
+                    new RouteParameters(Map.of("k1", "v1", "k2", "v2")));
+
+            Assertions.assertEquals("foo/v1/v2/bar", item.getPath());
+        }, TestRouteWithRouteParams.class);
+    }
+
+    @Test
+    void setNullViewPath_pathAttributeRemoved() {
+        var item = new BreadcrumbsItem("Docs", "/docs");
+        item.setPath((Class<? extends Component>) null);
+
+        Assertions.assertNull(item.getPath());
+        Assertions.assertFalse(item.getElement().hasAttribute("path"));
+    }
+
+    // PREFIX TESTS
+
+    @Test
+    void setPrefixComponent_getPrefixComponent() {
+        var item = new BreadcrumbsItem("Home");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
+    @SafeVarargs
+    private void runWithMockRouter(Runnable test,
+            Class<? extends Component>... routes) {
+        Router router = mockRouter(routes);
+        try (MockedStatic<ComponentUtil> mockComponentUtil = Mockito
+                .mockStatic(ComponentUtil.class)) {
+            mockComponentUtil.when(() -> ComponentUtil.getRouter(Mockito.any()))
+                    .thenReturn(router);
+            test.run();
+        }
+    }
+
+    @SafeVarargs
+    private Router mockRouter(Class<? extends Component>... navigationTargets) {
+        VaadinContext mockContext = Mockito.mock(VaadinContext.class);
+        ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
+                .getInstance(mockContext);
+        Router router = new Router(routeRegistry);
+
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(routeRegistry);
+        for (Class<? extends Component> navigationTarget : navigationTargets) {
+            routeConfiguration.setAnnotatedRoute(navigationTarget);
+        }
+        return router;
+    }
+
+    @Route("foo/bar")
+    private static class TestRoute extends Component {
+    }
+
+    @Route("foo/:k1/:k2/bar")
+    private static class TestRouteWithRouteParams extends Component {
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
@@ -143,6 +143,30 @@ class BreadcrumbsItemTest {
         Assertions.assertEquals(prefix, item.getPrefixComponent());
     }
 
+    @Test
+    void setTextAfterPrefix_prefixPreserved() {
+        var item = new BreadcrumbsItem("Inbox (2 items)");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+
+        item.setText("Inbox (3 items)");
+
+        Assertions.assertEquals("Inbox (3 items)", item.getText());
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
+    @Test
+    void setEmptyTextAfterPrefix_prefixPreserved() {
+        var item = new BreadcrumbsItem("Home");
+        var prefix = new Div();
+        item.setPrefixComponent(prefix);
+
+        item.setText("");
+
+        Assertions.assertEquals("", item.getText());
+        Assertions.assertEquals(prefix, item.getPrefixComponent());
+    }
+
     @SafeVarargs
     private void runWithMockRouter(Runnable test,
             Class<? extends Component>... routes) {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -19,14 +19,18 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
 import com.vaadin.flow.signals.local.ValueSignal;
-import com.vaadin.tests.AbstractSignalsTest;
+import com.vaadin.tests.MockUIExtension;
 
-class BreadcrumbsModeTest extends AbstractSignalsTest {
+class BreadcrumbsModeTest {
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
 
     @Test
     void defaultConstructor_modeIsRouter() {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -17,20 +17,58 @@ package com.vaadin.flow.component.breadcrumbs.tests;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsFeatureFlagProvider;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.DynamicPageTitle;
+import com.vaadin.flow.router.HasDynamicTitle;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.LocationChangeEvent;
+import com.vaadin.flow.router.NavigationTrigger;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.PageTitleContext;
+import com.vaadin.flow.router.PageTitleGenerator;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.RouteParent;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.internal.AfterNavigationHandler;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
 
 class BreadcrumbsModeTest {
 
     @RegisterExtension
     MockUIExtension ui = new MockUIExtension();
+
+    @RegisterExtension
+    EnableFeatureFlagExtension featureFlagExtension = new EnableFeatureFlagExtension(
+            BreadcrumbsFeatureFlagProvider.BREADCRUMBS_COMPONENT);
+
+    @AfterEach
+    void clearCurrentService() {
+        // installRouter sets the current service for title resolution; clear it
+        // so it does not leak into other tests.
+        VaadinService.setCurrent(null);
+    }
 
     @Test
     void defaultConstructor_modeIsRouter() {
@@ -131,5 +169,292 @@ class BreadcrumbsModeTest {
         // modes would clear them, so setMode must fail.
         Assertions.assertThrows(IllegalStateException.class,
                 () -> breadcrumbs.setMode(Mode.ROUTER));
+    }
+
+    // ROUTER-MODE LISTENER
+
+    @Test
+    void routerMode_attach_registersExactlyOneAfterNavigationListener() {
+        installRouter();
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+
+        Assertions.assertEquals(0, afterNavigationListeners().size());
+        ui.add(breadcrumbs);
+        Assertions.assertEquals(1, afterNavigationListeners().size());
+    }
+
+    @Test
+    void manualMode_attach_doesNotRegisterListener() {
+        installRouter();
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+
+        ui.add(breadcrumbs);
+        Assertions.assertEquals(0, afterNavigationListeners().size());
+    }
+
+    @Test
+    void routerMode_detach_unregistersListener() {
+        installRouter();
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+        Assertions.assertEquals(1, afterNavigationListeners().size());
+
+        ui.remove(breadcrumbs);
+        Assertions.assertEquals(0, afterNavigationListeners().size());
+    }
+
+    @Test
+    void routerMode_afterNavigationEvent_buildsTrailFromRouteHierarchy() {
+        installRouter(HomeView.class, CustomersView.class, AcmeView.class);
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+
+        fireAfterNavigation(breadcrumbs,
+                List.of(new AcmeView(), new CustomersView(), new HomeView()));
+
+        var items = breadcrumbs.getChildren().map(BreadcrumbsItem.class::cast)
+                .toList();
+        Assertions.assertEquals(3, items.size());
+
+        var routeConfiguration = routeConfiguration();
+        Assertions.assertEquals("Home", items.get(0).getText());
+        Assertions.assertEquals(routeConfiguration.getUrl(HomeView.class,
+                RouteParameters.empty()), items.get(0).getPath());
+
+        Assertions.assertEquals("Customers", items.get(1).getText());
+        Assertions.assertEquals(routeConfiguration.getUrl(CustomersView.class,
+                RouteParameters.empty()), items.get(1).getPath());
+
+        // The last (current) item carries no path.
+        Assertions.assertEquals("Acme", items.get(2).getText());
+        Assertions.assertNull(items.get(2).getPath());
+    }
+
+    @Test
+    void routerMode_currentViewHasDynamicTitle_usedForLastItem() {
+        installRouter(HomeView.class, CustomersView.class,
+                DynamicAcmeView.class);
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+
+        fireAfterNavigation(breadcrumbs, List.of(new DynamicAcmeView(),
+                new CustomersView(), new HomeView()));
+
+        var items = breadcrumbs.getChildren().map(BreadcrumbsItem.class::cast)
+                .toList();
+        Assertions.assertEquals(3, items.size());
+        // Dynamic title wins over the class @PageTitle ("Acme Static").
+        Assertions.assertEquals("Acme Dynamic", items.get(2).getText());
+        Assertions.assertNull(items.get(2).getPath());
+    }
+
+    @Test
+    void routerMode_currentItemTitle_resolvedWithQueryParameters() {
+        installRouter(HomeView.class, QueryTitleView.class);
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+
+        fireAfterNavigation(breadcrumbs,
+                List.of(new QueryTitleView(), new HomeView()),
+                QueryParameters.of("product", "5"));
+
+        var items = breadcrumbs.getChildren().map(BreadcrumbsItem.class::cast)
+                .toList();
+        Assertions.assertEquals(2, items.size());
+        // The current item's instance-free title generator sees the query
+        // parameters of the current navigation.
+        Assertions.assertEquals("Product 5", items.get(1).getText());
+    }
+
+    @Test
+    void routerMode_ancestorTitle_resolvedWithoutQueryParameters() {
+        installRouter(HomeView.class, QueryTitleView.class,
+                PlainLeafView.class);
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+
+        fireAfterNavigation(breadcrumbs, List.of(new PlainLeafView(),
+                new QueryTitleView(), new HomeView()),
+                QueryParameters.of("product", "5"));
+
+        var items = breadcrumbs.getChildren().map(BreadcrumbsItem.class::cast)
+                .toList();
+        Assertions.assertEquals(3, items.size());
+        // The ancestor's title generator is resolved without query parameters,
+        // so it falls back to the no-parameter label.
+        Assertions.assertEquals("Product", items.get(1).getText());
+        Assertions.assertEquals("Leaf", items.get(2).getText());
+    }
+
+    @Test
+    void routerMode_lateCallbackAfterDetach_isNoOp() {
+        installRouter(HomeView.class, CustomersView.class, AcmeView.class);
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+
+        // Capture the registered listener, then detach.
+        var listener = afterNavigationListeners().get(0);
+        ui.remove(breadcrumbs);
+
+        // A stray late callback after detach must be a no-op.
+        listener.afterNavigation(afterNavigationEvent(
+                List.of(new AcmeView(), new CustomersView(), new HomeView())));
+        Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+    }
+
+    @Test
+    void setModeRouter_onAttachedManualInstance_registersListenerAndBuildsTrail() {
+        installRouter(HomeView.class, CustomersView.class, AcmeView.class);
+        // Navigate so the initial rebuild has a current target to resolve.
+        ui.getUI().getInternals().updateRouterState(
+                new com.vaadin.flow.router.RouterState(new Location("acme"),
+                        RouteParameters.empty(), List.of(new AcmeView(),
+                                new CustomersView(), new HomeView()),
+                        AcmeView.class));
+
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        ui.add(breadcrumbs);
+        Assertions.assertEquals(0, afterNavigationListeners().size());
+
+        breadcrumbs.setMode(Mode.ROUTER);
+
+        Assertions.assertEquals(1, afterNavigationListeners().size());
+        // The initial rebuild built the trail from the current router state.
+        Assertions.assertEquals(3, breadcrumbs.getChildren().count());
+    }
+
+    @Test
+    void setModeManual_onAttachedRouterInstance_unregistersListenerAndClearsTrail() {
+        installRouter(HomeView.class, CustomersView.class, AcmeView.class);
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        ui.add(breadcrumbs);
+        fireAfterNavigation(breadcrumbs,
+                List.of(new AcmeView(), new CustomersView(), new HomeView()));
+        Assertions.assertEquals(3, breadcrumbs.getChildren().count());
+        Assertions.assertEquals(1, afterNavigationListeners().size());
+
+        breadcrumbs.setMode(Mode.MANUAL);
+
+        Assertions.assertEquals(0, afterNavigationListeners().size());
+        Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+    }
+
+    // TEST HELPERS
+
+    private List<AfterNavigationHandler> afterNavigationListeners() {
+        // UI stores after-navigation listeners under the internal handler type,
+        // so the listener must be queried with that exact key.
+        return ui.getUI().getInternals()
+                .getListeners(AfterNavigationHandler.class);
+    }
+
+    private RouteConfiguration routeConfiguration() {
+        return RouteConfiguration.forRegistry(
+                ui.getUI().getInternals().getRouter().getRegistry());
+    }
+
+    @SafeVarargs
+    private void installRouter(Class<? extends Component>... routes) {
+        VaadinContext mockContext = Mockito.mock(VaadinContext.class);
+        ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
+                .getInstance(mockContext);
+
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(routeRegistry);
+        for (Class<? extends Component> route : routes) {
+            routeConfiguration.setAnnotatedRoute(route);
+        }
+
+        // A mock Router returns the application registry directly, avoiding
+        // Router#getRegistry()'s session-scoped wrapping (which would delegate
+        // to a parent registry that the mock service cannot provide).
+        Router router = Mockito.mock(Router.class);
+        Mockito.when(router.getRegistry()).thenReturn(routeRegistry);
+        Mockito.when(ui.getService().getRouter()).thenReturn(router);
+        // Title resolution reads the current service's instantiator.
+        VaadinService.setCurrent(ui.getService());
+    }
+
+    private void fireAfterNavigation(Breadcrumbs breadcrumbs,
+            List<? extends Component> leafFirstChain) {
+        fireAfterNavigation(breadcrumbs, leafFirstChain,
+                QueryParameters.empty());
+    }
+
+    private void fireAfterNavigation(Breadcrumbs breadcrumbs,
+            List<? extends Component> leafFirstChain,
+            QueryParameters queryParameters) {
+        afterNavigationListeners().forEach(listener -> listener.afterNavigation(
+                afterNavigationEvent(leafFirstChain, queryParameters)));
+    }
+
+    private AfterNavigationEvent afterNavigationEvent(
+            List<? extends Component> leafFirstChain) {
+        return afterNavigationEvent(leafFirstChain, QueryParameters.empty());
+    }
+
+    private AfterNavigationEvent afterNavigationEvent(
+            List<? extends Component> leafFirstChain,
+            QueryParameters queryParameters) {
+        UI realUI = ui.getUI();
+        Router router = realUI.getInternals().getRouter();
+        List<HasElement> chain = List.copyOf(leafFirstChain);
+        LocationChangeEvent locationChangeEvent = new LocationChangeEvent(
+                router, realUI, NavigationTrigger.PROGRAMMATIC,
+                new Location("acme", queryParameters), chain);
+        return new AfterNavigationEvent(locationChangeEvent,
+                RouteParameters.empty());
+    }
+
+    // TEST VIEWS — @RouteParent chain Home -> Customers -> Acme
+
+    @Route("home")
+    @PageTitle("Home")
+    public static class HomeView extends Div {
+    }
+
+    @Route("customers")
+    @RouteParent(HomeView.class)
+    @PageTitle("Customers")
+    public static class CustomersView extends Div {
+    }
+
+    @Route("acme")
+    @RouteParent(CustomersView.class)
+    @PageTitle("Acme")
+    public static class AcmeView extends Div {
+    }
+
+    @Route("acme")
+    @RouteParent(CustomersView.class)
+    @PageTitle("Acme Static")
+    public static class DynamicAcmeView extends Div implements HasDynamicTitle {
+        @Override
+        public String getPageTitle() {
+            return "Acme Dynamic";
+        }
+    }
+
+    // Resolves its title via an instance-free PageTitleGenerator that reads the
+    // "product" query parameter, falling back to "Product" when it is absent.
+    @Route("query-title")
+    @RouteParent(HomeView.class)
+    @DynamicPageTitle(ProductTitleGenerator.class)
+    public static class QueryTitleView extends Div {
+    }
+
+    @Route("leaf")
+    @RouteParent(QueryTitleView.class)
+    @PageTitle("Leaf")
+    public static class PlainLeafView extends Div {
+    }
+
+    public static class ProductTitleGenerator implements PageTitleGenerator {
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            List<String> product = context.queryParameters()
+                    .getParameters("product");
+            return product.isEmpty() ? "Product" : "Product " + product.get(0);
+        }
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.breadcrumbs.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
+import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
+import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+
+class BreadcrumbsModeTest {
+
+    @Test
+    void defaultConstructor_modeIsRouter() {
+        Assertions.assertEquals(Mode.ROUTER, new Breadcrumbs().getMode());
+    }
+
+    @Test
+    void modeConstructor_modeIsSet() {
+        Assertions.assertEquals(Mode.MANUAL,
+                new Breadcrumbs(Mode.MANUAL).getMode());
+    }
+
+    @Test
+    void manualModeWithChildren_setModeRouter_clearsChildren() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        breadcrumbs.add(new BreadcrumbsItem("Home"),
+                new BreadcrumbsItem("Page"));
+        breadcrumbs.setMode(Mode.ROUTER);
+        Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+    }
+
+    @Test
+    void setModeSameValue_isNoOp_childrenUnchanged() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var item = new BreadcrumbsItem("Home");
+        breadcrumbs.add(item);
+        breadcrumbs.setMode(Mode.MANUAL);
+        Assertions.assertEquals(1, breadcrumbs.getChildren().count());
+        Assertions.assertEquals(item,
+                breadcrumbs.getChildren().findFirst().orElse(null));
+    }
+}

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -15,14 +15,18 @@
  */
 package com.vaadin.flow.component.breadcrumbs.tests;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs.Mode;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsTest;
 
-class BreadcrumbsModeTest {
+class BreadcrumbsModeTest extends AbstractSignalsTest {
 
     @Test
     void defaultConstructor_modeIsRouter() {
@@ -36,12 +40,68 @@ class BreadcrumbsModeTest {
     }
 
     @Test
-    void manualModeWithChildren_setModeRouter_clearsChildren() {
+    void manualMode_mutatingMethods_doNotThrow() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var home = new BreadcrumbsItem("Home");
+        var page = new BreadcrumbsItem("Page");
+
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.remove(home));
+        Assertions.assertDoesNotThrow(breadcrumbs::removeAll);
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.add(home));
+        Assertions.assertDoesNotThrow(() -> breadcrumbs.replace(home, page));
+        Assertions.assertDoesNotThrow(
+                () -> breadcrumbs.addComponentAsFirst(home));
+        Assertions.assertDoesNotThrow(
+                () -> breadcrumbs.addComponentAtIndex(0, page));
+    }
+
+    @Test
+    void routerMode_mutatingMethods_throw() {
+        var breadcrumbs = new Breadcrumbs(Mode.ROUTER);
+        var home = new BreadcrumbsItem("Home");
+        var page = new BreadcrumbsItem("Page");
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.add(home));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.remove(home));
+        Assertions.assertThrows(IllegalStateException.class,
+                breadcrumbs::removeAll);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.replace(home, page));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.addComponentAsFirst(home));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.addComponentAtIndex(0, page));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.bindChildren(null, null));
+    }
+
+    @Test
+    void getChildren_worksInBothModes() {
+        var manual = new Breadcrumbs(Mode.MANUAL);
+        manual.add(new BreadcrumbsItem("Home"));
+        Assertions.assertEquals(1, manual.getChildren().count());
+
+        var router = new Breadcrumbs(Mode.ROUTER);
+        Assertions.assertEquals(0, router.getChildren().count());
+    }
+
+    @Test
+    void manualModeWithChildren_setModeRouter_clearsChildrenAndReappliesGuard() {
         var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
         breadcrumbs.add(new BreadcrumbsItem("Home"),
                 new BreadcrumbsItem("Page"));
+
+        // MANUAL -> ROUTER clears manually-added children without throwing,
+        // exercising the updateChildrenInternal(List.of()) bypass.
         breadcrumbs.setMode(Mode.ROUTER);
         Assertions.assertEquals(0, breadcrumbs.getChildren().count());
+
+        // The bypass flag is reset afterwards, so a guarded add throws again.
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.add(new BreadcrumbsItem("Other")));
     }
 
     @Test
@@ -53,5 +113,19 @@ class BreadcrumbsModeTest {
         Assertions.assertEquals(1, breadcrumbs.getChildren().count());
         Assertions.assertEquals(item,
                 breadcrumbs.getChildren().findFirst().orElse(null));
+    }
+
+    @Test
+    void setMode_withActiveChildrenBinding_throws() {
+        var breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+        var itemSignal = new ValueSignal<>("Home");
+        var listSignal = new ValueSignal<>(List.of(itemSignal));
+        breadcrumbs.bindChildren(listSignal,
+                signal -> new BreadcrumbsItem(signal.peek()));
+
+        // A binding controls the children and cannot be removed; switching
+        // modes would clear them, so setMode must fail.
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> breadcrumbs.setMode(Mode.ROUTER));
     }
 }

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java
@@ -365,11 +365,14 @@ class BreadcrumbsModeTest {
             routeConfiguration.setAnnotatedRoute(route);
         }
 
-        // A mock Router returns the application registry directly, avoiding
-        // Router#getRegistry()'s session-scoped wrapping (which would delegate
-        // to a parent registry that the mock service cannot provide).
-        Router router = Mockito.mock(Router.class);
-        Mockito.when(router.getRegistry()).thenReturn(routeRegistry);
+        // A spy over a real Router runs the real resolvePageTitle (used to
+        // resolve item titles) while getRegistry() is stubbed to return the
+        // application registry directly, avoiding Router#getRegistry()'s
+        // session-scoped wrapping (which would delegate to a parent registry
+        // that the mock service cannot provide). doReturn avoids calling the
+        // real getRegistry during stubbing.
+        Router router = Mockito.spy(new Router(routeRegistry));
+        Mockito.doReturn(routeRegistry).when(router).getRegistry();
         Mockito.when(ui.getService().getRouter()).thenReturn(router);
         // Title resolution reads the current service's instantiator.
         VaadinService.setCurrent(ui.getService());

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.breadcrumbs.Breadcrumbs;
 import com.vaadin.flow.component.breadcrumbs.BreadcrumbsItem;
+import com.vaadin.flow.component.shared.HasThemeVariant;
 
 class BreadcrumbsTest {
 
@@ -38,5 +39,11 @@ class BreadcrumbsTest {
         Assertions.assertEquals("vaadin-breadcrumbs-item",
                 item.getElement().getTag());
         Assertions.assertEquals("Home", item.getText());
+    }
+
+    @Test
+    void implementsHasThemeVariant() {
+        Assertions.assertTrue(
+                HasThemeVariant.class.isAssignableFrom(Breadcrumbs.class));
     }
 }


### PR DESCRIPTION
## Description

Backported following PRs to `25.2` branch:

- #9380
- #9470
- #9473
- #9483
- #9523
- #9510
- #9531
- #9534

Must be merged together using "rebase and merge".

## Type of change

- Cherry-pick

## Note

Once this is merged, we can backport https://github.com/vaadin/flow-components/pull/9447