### PR TITLE
feat: validate navigation-related URL schemes (#9447) (CP: 25.2)

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -26,8 +26,10 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.dom.SignalBinding;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -73,6 +75,11 @@ public class BreadcrumbsItem extends Component
      *            the text of the item
      * @param path
      *            the path to link to
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public BreadcrumbsItem(String text, String path) {
         setPath(path);
@@ -120,6 +127,11 @@ public class BreadcrumbsItem extends Component
      *            the path to link to
      * @param prefixComponent
      *            the prefix component for the item (usually an icon)
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public BreadcrumbsItem(String text, String path,
             Component prefixComponent) {
@@ -225,6 +237,33 @@ public class BreadcrumbsItem extends Component
      * @see #setPath(Class)
      */
     public void setPath(String path) {
+        if (path != null && !UrlUtil.isSafeUrl(path)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "path", path, "setUnsafePath(String)"));
+        }
+        doSetPath(path);
+    }
+
+    /**
+     * Sets the path this item links to without validating its scheme.
+     * <p>
+     * Unlike {@link #setPath(String)}, this method does not reject paths based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for paths that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setPath(String)
+     *
+     * @param path
+     *            the path to link to, or {@code null} to remove the path and
+     *            render the item as the current page (a non-link)
+     */
+    public void setUnsafePath(String path) {
+        doSetPath(path);
+    }
+
+    private void doSetPath(String path) {
         if (path == null) {
             getElement().removeAttribute("path");
         } else {

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsItemTest.java
@@ -94,6 +94,35 @@ class BreadcrumbsItemTest {
     }
 
     @Test
+    void setPathWithUnsafeScheme_throws() {
+        var item = new BreadcrumbsItem("Docs");
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> item.setPath("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafePathWithUnsafeScheme_pathSet() {
+        var item = new BreadcrumbsItem("Docs");
+        item.setUnsafePath("javascript:alert(1)");
+
+        Assertions.assertEquals("javascript:alert(1)", item.getPath());
+    }
+
+    @Test
+    void constructor_textPath_unsafeScheme_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new BreadcrumbsItem("Docs", "javascript:alert(1)"));
+    }
+
+    @Test
+    void constructor_textPathPrefixComponent_unsafeScheme_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new BreadcrumbsItem("Docs", "javascript:alert(1)",
+                        new Div()));
+    }
+
+    @Test
     void setNullStringPath_pathAttributeRemoved() {
         var item = new BreadcrumbsItem("Docs", "/docs");
         item.setPath((String) null);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
@@ -9,6 +9,8 @@
 package com.vaadin.flow.component.charts.model;
 
 import com.vaadin.flow.component.charts.model.style.Style;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 
 /**
  * Highchart by default puts a credits label in the lower right corner of the
@@ -58,6 +60,28 @@ public class Credits extends AbstractConfigurationObject {
      * Defaults to: http://www.highcharts.com
      */
     public void setHref(String href) {
+        if (href != null && !UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
+        }
+        this.href = href;
+    }
+
+    /**
+     * Sets the URL for the credits label without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the URL for the credits label
+     */
+    public void setUnsafeHref(String href) {
         this.href = href;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
@@ -10,6 +10,9 @@ package com.vaadin.flow.component.charts.model;
 
 import java.util.Map;
 
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
+
 /**
  * Options for the exporting module. For an overview on the matter, see
  * <a href="http://www.highcharts.com/docs/export-module/export-module-overview"
@@ -166,8 +169,39 @@ public class Exporting extends AbstractConfigurationObject {
      * for client side export in certain browsers.
      * <p>
      * Defaults to: https://code.highcharts.com/{version}/lib
+     *
+     * @throws IllegalArgumentException
+     *             if {@code libURL} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeLibURL(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeLibURL(String)
      */
     public void setLibURL(String libURL) {
+        if (libURL != null && !UrlUtil.isSafeUrl(libURL)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "libURL", libURL, "setUnsafeLibURL(String)"));
+        }
+        this.libURL = libURL;
+    }
+
+    /**
+     * Sets the path for the export module dependencies without validating its
+     * scheme.
+     * <p>
+     * Unlike {@link #setLibURL(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setLibURL(String)
+     *
+     * @param libURL
+     *            the path where Highcharts will look for export module
+     *            dependencies
+     */
+    public void setUnsafeLibURL(String libURL) {
         this.libURL = libURL;
     }
 
@@ -301,8 +335,38 @@ public class Exporting extends AbstractConfigurationObject {
      * format. By default this points to Highchart's free web service.
      * <p>
      * Defaults to: https://export.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code url} uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeUrl(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeUrl(String)
      */
     public void setUrl(String url) {
+        if (url != null && !UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("url", url, "setUnsafeUrl(String)"));
+        }
+        this.url = url;
+    }
+
+    /**
+     * Sets the URL for the export server without validating its scheme.
+     * <p>
+     * Unlike {@link #setUrl(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setUrl(String)
+     *
+     * @param url
+     *            the URL for the server module converting the SVG string to an
+     *            image format
+     */
+    public void setUnsafeUrl(String url) {
         this.url = url;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CreditsTest {
+
+    @Test
+    void setHref_safeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setHref("https://vaadin.com");
+
+        Assertions.assertEquals("https://vaadin.com", credits.getHref());
+    }
+
+    @Test
+    void setHref_unsafeScheme_throws() {
+        Credits credits = new Credits();
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> credits.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeHref_unsafeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setUnsafeHref("javascript:alert(1)");
+
+        Assertions.assertEquals("javascript:alert(1)", credits.getHref());
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExportingTest {
+
+    @Test
+    void setUrl_safeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUrl("https://export.highcharts.com");
+
+        Assertions.assertEquals("https://export.highcharts.com",
+                exporting.getUrl());
+    }
+
+    @Test
+    void setUrl_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setUrl("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeUrl_unsafeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeUrl("javascript:alert(1)");
+
+        Assertions.assertEquals("javascript:alert(1)", exporting.getUrl());
+    }
+
+    @Test
+    void setLibURL_safeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setLibURL("https://code.highcharts.com/lib");
+
+        Assertions.assertEquals("https://code.highcharts.com/lib",
+                exporting.getLibURL());
+    }
+
+    @Test
+    void setLibURL_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setLibURL("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeLibURL_unsafeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeLibURL("javascript:alert(1)");
+
+        Assertions.assertEquals("javascript:alert(1)", exporting.getLibURL());
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -30,6 +30,8 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.PropertyChangeListener;
 import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 
@@ -111,10 +113,44 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
      * listeners added with {@link #addLoginListener(ComponentEventListener)}.
      * See class Javadoc for more information.
      *
+     * @throws IllegalArgumentException
+     *             if {@code action} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeAction(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     *
      * @see #getAction()
+     * @see #setUnsafeAction(String)
      * @see #addLoginListener(ComponentEventListener)
      */
     public void setAction(String action) {
+        if (action != null && !UrlUtil.isSafeUrl(action)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "action", action, "setUnsafeAction(String)"));
+        }
+        doSetAction(action);
+    }
+
+    /**
+     * Sets the action URL without validating its scheme.
+     * <p>
+     * Unlike {@link #setAction(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setAction(String)
+     *
+     * @param action
+     *            the action URL, or {@code null} to remove the action and
+     *            restore the default login listener handling
+     */
+    public void setUnsafeAction(String action) {
+        doSetAction(action);
+    }
+
+    private void doSetAction(String action) {
         if (action == null) {
             getElement().removeProperty(PROP_ACTION);
             if (registration == null) {

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -118,7 +118,7 @@ class LoginFormTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginForm.class))
                     .thenReturn(mockedLogger);
 
@@ -147,7 +147,7 @@ class LoginFormTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginForm.class))
                     .thenReturn(mockedLogger);
 
@@ -185,5 +185,20 @@ class LoginFormTest {
                 "Expected form being disabled by default listener");
         Assertions.assertFalse(form.isError(),
                 "Expected error status being reset by default listener");
+    }
+
+    @Test
+    void setActionWithUnsafeScheme_throws() {
+        final LoginForm form = new LoginForm();
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> form.setAction("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeActionWithUnsafeScheme_actionSet() {
+        final LoginForm form = new LoginForm();
+        form.setUnsafeAction("javascript:alert(1)");
+
+        Assertions.assertEquals("javascript:alert(1)", form.getAction());
     }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
@@ -75,7 +75,7 @@ class LoginOverlayTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginOverlay.class))
                     .thenReturn(mockedLogger);
 
@@ -104,7 +104,7 @@ class LoginOverlayTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginOverlay.class))
                     .thenReturn(mockedLogger);
 

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.internal.ConfigureRoutes;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
+import com.vaadin.flow.server.InitParameters;
 
 import tools.jackson.databind.node.ArrayNode;
 
@@ -86,6 +87,11 @@ public class SideNavItem extends Component implements HasSideNavItems,
      *            the label for the item
      * @param path
      *            the path to link to
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public SideNavItem(String label, String path) {
         setPath(path);
@@ -153,6 +159,11 @@ public class SideNavItem extends Component implements HasSideNavItems,
      *            the path to link to
      * @param prefixComponent
      *            the prefix component for the item (usually an icon)
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public SideNavItem(String label, String path, Component prefixComponent) {
         setPath(path);
@@ -251,6 +262,34 @@ public class SideNavItem extends Component implements HasSideNavItems,
      * @see SideNavItem#setPath(Class)
      */
     public void setPath(String path) {
+        if (path != null && !UrlUtil.isSafeUrl(path)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "path", path, "setUnsafePath(String)"));
+        }
+        doSetPath(path);
+    }
+
+    /**
+     * Sets the path this navigation item links to without validating its
+     * scheme.
+     * <p>
+     * Unlike {@link #setPath(String)}, this method does not reject paths based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for paths that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setPath(String)
+     *
+     * @param path
+     *            The path to link to. Set to null to disable navigation for
+     *            this item.
+     */
+    public void setUnsafePath(String path) {
+        doSetPath(path);
+    }
+
+    private void doSetPath(String path) {
         if (path == null) {
             getElement().removeAttribute("path");
         } else {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -139,6 +139,32 @@ class SideNavItemTest {
     }
 
     @Test
+    void setPathWithUnsafeScheme_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> sideNavItem.setPath("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafePathWithUnsafeScheme_pathSet() {
+        sideNavItem.setUnsafePath("javascript:alert(1)");
+
+        assertPath("javascript:alert(1)");
+    }
+
+    @Test
+    void constructor_labelPath_unsafeScheme_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new SideNavItem("Docs", "javascript:alert(1)"));
+    }
+
+    @Test
+    void constructor_labelPathPrefixComponent_unsafeScheme_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new SideNavItem("Docs", "javascript:alert(1)",
+                        new Div()));
+    }
+
+    @Test
     void setPathWithoutAliasesAsComponent_onlyPathUpdated() {
         runWithMockRouter(() -> {
             sideNavItem.setPath(TestRoute.class);


### PR DESCRIPTION
## Description

Manual cherry-pick of #9447 to `25.2` branch - automated cherry-pick failed due to missing `BreadcrumbsItem`.

## Type of change

- Cherry-pick