### PR TITLE
feat: add Lumo and Aura theme variants to Breadcrumbs

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java
@@ -21,7 +21,7 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-breadcrumbs} component.
  */
 public enum BreadcrumbsVariant implements ThemeVariant {
-    SLASH("slash");
+    SLASH("slash"), LUMO_PRIMARY("primary"), AURA_ACCENT("accent");
 
     private final String variant;
 


### PR DESCRIPTION
The web component ships `primary` (Lumo) and `accent` (Aura) link-color theme variants, but `BreadcrumbsVariant` only exposed `SLASH`. Added missing `LUMO_PRIMARY` (`primary`) and `AURA_ACCENT` (`accent`) variants.

Related to vaadin/web-components#11868

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)