### PR TITLE
refactor!: rename FormAIController API to include field

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -58,8 +58,10 @@ import tools.jackson.databind.JsonNode;
  *
  * <pre>
  * var controller = new FormAIController(formLayout, binder);
- * controller.describe(discountField, "Discount as a percentage, not an amount")
- *         .ignore(internalReferenceField);
+ * controller
+ *         .describeField(discountField,
+ *                 "Discount as a percentage, not an amount")
+ *         .ignoreField(internalReferenceField);
  * AIOrchestrator orchestrator = AIOrchestrator
  *         .builder(llmProvider, systemPrompt).withController(controller)
  *         .build();
@@ -74,33 +76,34 @@ import tools.jackson.databind.JsonNode;
  *
  * <p>
  * <b>Per-field configuration:</b> use the chained
- * {@link #describe(HasValue, String) describe}, {@link #ignore(HasValue)
- * ignore}, and {@link #valueOptions(ValueOptions) valueOptions} methods.
- * {@code valueOptions} takes a {@link ValueOptions} built via
+ * {@link #describeField(HasValue, String) describeField},
+ * {@link #ignoreField(HasValue) ignoreField}, and
+ * {@link #fieldValueOptions(ValueOptions) fieldValueOptions} methods.
+ * {@code fieldValueOptions} takes a {@link ValueOptions} built via
  * {@link ValueOptions#forField(HasValue) forField} — the compiler picks the
  * {@link ValueOptions#forField(MultiSelect) MultiSelect overload} automatically
  * for fields statically typed as {@link MultiSelect}. For fields whose value
  * type is anything other than {@link String}, the
- * {@link #valueOptions(ValueOptions, Function) two-argument overload} also
+ * {@link #fieldValueOptions(ValueOptions, Function) two-argument overload} also
  * accepts a label-to-value converter, which the controller applies per label;
  * for multi-select fields the resolved elements are then aggregated into a
  * {@link LinkedHashSet} before {@link HasValue#setValue}.
  * </p>
  *
  * <p>
- * <b>Hiding field values:</b> {@link #setValuesHidden(boolean)} keeps the
+ * <b>Hiding field values:</b> {@link #setFieldValuesHidden(boolean)} keeps the
  * current value of every field private while still letting the LLM see and fill
  * the fields — useful when the form may already hold data the AI should not
  * read (for example personal data the user typed in). To hide a single field
  * entirely, so the LLM does not even learn it exists, use
- * {@link #ignore(HasValue)}.
+ * {@link #ignoreField(HasValue)}.
  * </p>
  *
  * <p>
  * <b>How the LLM understands fields:</b> everything the LLM knows about a field
  * comes from the field's label, its helper text, and the
- * {@link #describe(HasValue, String)} hint. Make sure every field carries a
- * meaningful label, or add a {@code describe(...)} hint for fields whose
+ * {@link #describeField(HasValue, String)} hint. Make sure every field carries
+ * a meaningful label, or add a {@code describeField(...)} hint for fields whose
  * purpose is not evident from the label alone.
  * </p>
  *
@@ -111,11 +114,11 @@ import tools.jackson.databind.JsonNode;
  * {@code bindInstanceFields(this)}, or {@code @PropertyId}) the property name
  * is used as a default field description, so the LLM can recognize what the
  * field means even when it has no label. The default only applies when no
- * explicit {@link #describe(HasValue, String)} has been registered; calling
- * {@code describe(...)} always wins. Lambda-bound bindings carry no property
- * name and contribute no default. Second, the binder drives validation of the
- * values the LLM writes, including bean-level cross-field rules — see
- * <b>Validation</b> below.
+ * explicit {@link #describeField(HasValue, String)} has been registered;
+ * calling {@code describeField(...)} always wins. Lambda-bound bindings carry
+ * no property name and contribute no default. Second, the binder drives
+ * validation of the values the LLM writes, including bean-level cross-field
+ * rules — see <b>Validation</b> below.
  * </p>
  *
  * <p>
@@ -150,8 +153,8 @@ import tools.jackson.databind.JsonNode;
  * <b>Change tracking and highlight:</b> a listener registered through
  * {@link #addFieldValueChangedListener(SerializableConsumer)} fires once per
  * successful turn with the fields whose value changed during the turn — the
- * common driver for {@link #showHighlight(HasValue)} / {@link #hideHighlight}
- * to flash the AI's edits in the UI.
+ * common driver for {@link #showFieldHighlight(HasValue)} /
+ * {@link #hideFieldHighlight} to flash the AI's edits in the UI.
  * </p>
  *
  * <p>
@@ -159,8 +162,8 @@ import tools.jackson.databind.JsonNode;
  * After deserialization, create a new controller against the same form (and
  * binder, if any) and call
  * {@code orchestrator.reconnect(provider).withController(controller).apply()}.
- * Re-register the same {@code describe} / {@code valueOptions} / {@code ignore}
- * hints on the new controller.
+ * Re-register the same {@code describeField} / {@code fieldValueOptions} /
+ * {@code ignoreField} hints on the new controller.
  * </p>
  *
  * @author Vaadin Ltd
@@ -217,9 +220,10 @@ public class FormAIController implements AIController {
             Conventions:
             - Field ids are opaque session-scoped strings; never invent them \
             and never reuse an id across forms.
-            - Fields the application has hidden via .ignore() (and password \
-            fields) never appear in get_form_state and cannot be written by \
-            fill_form. Do not try, even if the user message asks for them.
+            - Fields the application has hidden via .ignoreField() (and \
+            password fields) never appear in get_form_state and cannot be \
+            written by fill_form. Do not try, even if the user message asks \
+            for them.
             - get_form_state lists every visible field. A field tagged \
             "disabled": true or "readOnly": true is context only — read its \
             value, but fill_form will reject any write to it. Such a field \
@@ -255,8 +259,9 @@ public class FormAIController implements AIController {
     private final String aiUserId = "vaadin-ai-" + UUID.randomUUID();
     /**
      * Per-field attach-listener registrations that re-apply the AI highlight
-     * after detach/re-attach. Populated on the first {@link #showHighlight}
-     * call for a field; entries are removed by {@link #hideHighlight}.
+     * after detach/re-attach. Populated on the first
+     * {@link #showFieldHighlight} call for a field; entries are removed by
+     * {@link #hideFieldHighlight}.
      */
     private final Map<HasValue<?, ?>, Registration> highlightedFields = new HashMap<>();
     private final List<SerializableConsumer<List<FieldValueChange>>> fieldValuesChangedListeners = new ArrayList<>();
@@ -282,7 +287,7 @@ public class FormAIController implements AIController {
     /**
      * Creates a new form AI controller for the given container and binder. For
      * every named binding on the binder, the bean property name is used as a
-     * default {@link #describe(HasValue, String) description} when the
+     * default {@link #describeField(HasValue, String) description} when the
      * developer has not registered one explicitly; lambda-bound bindings carry
      * no property name and contribute no default. The binder also drives
      * validation of the values the LLM writes: bound fields are validated
@@ -323,7 +328,8 @@ public class FormAIController implements AIController {
      *            the description text, not {@code null}
      * @return this controller, for chaining
      */
-    public FormAIController describe(HasValue<?, ?> field, String description) {
+    public FormAIController describeField(HasValue<?, ?> field,
+            String description) {
         Objects.requireNonNull(description, "Description must not be null");
         hintsFor(field).description = description;
         return this;
@@ -334,8 +340,8 @@ public class FormAIController implements AIController {
      * labels are presented to the LLM as the field's choices. No converter is
      * needed — the chosen label is itself the value written to the field. For
      * any non-{@link String} value type, use
-     * {@link #valueOptions(ValueOptions, Function) the two-argument overload}
-     * to supply a converter; this is enforced at compile time.
+     * {@link #fieldValueOptions(ValueOptions, Function) the two-argument
+     * overload} to supply a converter; this is enforced at compile time.
      * <p>
      * For {@link MultiSelect MultiSelect} fields the controller wraps the
      * chosen labels into a {@link LinkedHashSet} before
@@ -357,7 +363,7 @@ public class FormAIController implements AIController {
      *             field's value type is a Collection but the field does not
      *             implement {@link MultiSelect}
      */
-    public FormAIController valueOptions(ValueOptions<String> config) {
+    public FormAIController fieldValueOptions(ValueOptions<String> config) {
         Objects.requireNonNull(config, "Value options must not be null");
         return applyValueOptions(config, Function.identity());
     }
@@ -380,7 +386,7 @@ public class FormAIController implements AIController {
      * {@link HasValue#setValue}.
      * <p>
      * Later calls for the same field overwrite earlier ones. Use
-     * {@link #valueOptions(ValueOptions) the single-argument overload} for
+     * {@link #fieldValueOptions(ValueOptions) the single-argument overload} for
      * {@link String}-typed fields; the converter is implicit there.
      *
      * @param config
@@ -404,7 +410,7 @@ public class FormAIController implements AIController {
      *             field's value type is a Collection but the field does not
      *             implement {@link MultiSelect}
      */
-    public <V> FormAIController valueOptions(ValueOptions<V> config,
+    public <V> FormAIController fieldValueOptions(ValueOptions<V> config,
             Function<String, V> toValue) {
         Objects.requireNonNull(config, "Value options must not be null");
         Objects.requireNonNull(toValue, "Value converter must not be null");
@@ -442,7 +448,7 @@ public class FormAIController implements AIController {
                     "Field's value type is a Collection but the field does "
                             + "not implement MultiSelect. Collection-valued "
                             + "fields must implement MultiSelect to be "
-                            + "registered via valueOptions(...).");
+                            + "registered via fieldValueOptions(...).");
         }
         var hints = hintsFor(config.field());
         hints.valueOptionsToValue = toValue;
@@ -475,7 +481,7 @@ public class FormAIController implements AIController {
      *            the field to hide, not {@code null}
      * @return this controller, for chaining
      */
-    public FormAIController ignore(HasValue<?, ?> field) {
+    public FormAIController ignoreField(HasValue<?, ?> field) {
         hintsFor(field).ignored = true;
         return this;
     }
@@ -492,7 +498,7 @@ public class FormAIController implements AIController {
      * {@code enum} labels are still sent, since the LLM needs them to fill the
      * field. For choice fields whose option labels are themselves sensitive, or
      * to hide a single field's value or content entirely, use
-     * {@link #ignore(HasValue)}.
+     * {@link #ignoreField(HasValue)}.
      * <p>
      * Values can still reach the LLM through validation rejection messages,
      * which are sent as-is. A field stays fillable while its value is hidden,
@@ -506,7 +512,7 @@ public class FormAIController implements AIController {
      *            send values as usual
      * @return this controller, for chaining
      */
-    public FormAIController setValuesHidden(boolean valuesHidden) {
+    public FormAIController setFieldValuesHidden(boolean valuesHidden) {
         this.valuesHidden = valuesHidden;
         return this;
     }
@@ -517,9 +523,9 @@ public class FormAIController implements AIController {
      *
      * @return {@code true} when every field's value is hidden, {@code false}
      *         when values are sent
-     * @see #setValuesHidden(boolean)
+     * @see #setFieldValuesHidden(boolean)
      */
-    public boolean isValuesHidden() {
+    public boolean isFieldValuesHidden() {
         return valuesHidden;
     }
 
@@ -542,10 +548,10 @@ public class FormAIController implements AIController {
      * on the controller.
      * <p>
      * The listener runs on the UI thread with the session lock held, so it can
-     * update components and call {@link #showHighlight} /
-     * {@link #hideHighlight} directly without {@code ui.access(...)}. A typical
-     * use is to flash the AI's edits by calling {@code showHighlight} on every
-     * changed field.
+     * update components and call {@link #showFieldHighlight} /
+     * {@link #hideFieldHighlight} directly without {@code ui.access(...)}. A
+     * typical use is to flash the AI's edits by calling
+     * {@code showFieldHighlight} on every changed field.
      *
      * @param listener
      *            the listener to register, not {@code null}
@@ -563,7 +569,7 @@ public class FormAIController implements AIController {
     /**
      * Paints a highlight on the field via the {@code vaadin-field-highlighter}
      * web component. Repeated calls keep exactly one highlight on the field.
-     * Call {@link #hideHighlight} to clear it. The field can be any
+     * Call {@link #hideFieldHighlight} to clear it. The field can be any
      * {@link HasValue} {@link Component}, in or out of this controller's form,
      * and each field's highlight state is independent of the others.
      * <p>
@@ -573,10 +579,10 @@ public class FormAIController implements AIController {
      * session) as long as those consumers also use {@code addUser} /
      * {@code removeUser} rather than {@code setUsers}.
      * <p>
-     * The first {@code showHighlight} call on a field also registers an attach
-     * listener that re-applies the AI user every time the field re-enters the
-     * DOM, so the highlight survives detach/re-attach. The listener is removed
-     * by {@link #hideHighlight}.
+     * The first {@code showFieldHighlight} call on a field also registers an
+     * attach listener that re-applies the AI user every time the field
+     * re-enters the DOM, so the highlight survives detach/re-attach. The
+     * listener is removed by {@link #hideFieldHighlight}.
      *
      * @param field
      *            the field to highlight, not {@code null}; must be a
@@ -586,7 +592,7 @@ public class FormAIController implements AIController {
      * @throws IllegalArgumentException
      *             if {@code field} is not a {@link Component}
      */
-    public void showHighlight(HasValue<?, ?> field) {
+    public void showFieldHighlight(HasValue<?, ?> field) {
         var component = requireFieldComponent(field);
         var element = component.getElement();
         highlightedFields.computeIfAbsent(field,
@@ -597,13 +603,14 @@ public class FormAIController implements AIController {
 
     /**
      * Clears any highlight previously applied to the field via
-     * {@link #showHighlight}. A no-op when no highlight is currently shown.
-     * Only this controller's AI user is removed; other users on the field stay
-     * highlighted. The field can be any {@link HasValue} {@link Component}, in
-     * or out of this controller's form, and clearing one field's highlight has
-     * no effect on others. The re-attach listener registered by
-     * {@link #showHighlight} is also removed, so the highlight does not come
-     * back if the field leaves and returns to the DOM after this call.
+     * {@link #showFieldHighlight}. A no-op when no highlight is currently
+     * shown. Only this controller's AI user is removed; other users on the
+     * field stay highlighted. The field can be any {@link HasValue}
+     * {@link Component}, in or out of this controller's form, and clearing one
+     * field's highlight has no effect on others. The re-attach listener
+     * registered by {@link #showFieldHighlight} is also removed, so the
+     * highlight does not come back if the field leaves and returns to the DOM
+     * after this call.
      *
      * @param field
      *            the field to clear the highlight from, not {@code null}; must
@@ -613,7 +620,7 @@ public class FormAIController implements AIController {
      * @throws IllegalArgumentException
      *             if {@code field} is not a {@link Component}
      */
-    public void hideHighlight(HasValue<?, ?> field) {
+    public void hideFieldHighlight(HasValue<?, ?> field) {
         var element = requireFieldComponent(field).getElement();
         var registration = highlightedFields.remove(field);
         if (registration != null) {
@@ -764,7 +771,7 @@ public class FormAIController implements AIController {
      * Walks the binder's property names and defaults {@code hints.description}
      * for any bound field that does not already have an explicit description.
      * Called at the start of every turn so bindings added or removed between
-     * turns are reflected; an explicit {@link #describe(HasValue, String)}
+     * turns are reflected; an explicit {@link #describeField(HasValue, String)}
      * always wins because the seeding only fills in nulls. Safe to call when
      * the controller was built without a binder — {@link BinderReflection}
      * returns an empty map for a {@code null} binder.
@@ -807,8 +814,8 @@ public class FormAIController implements AIController {
     /**
      * Returns every {@link HasValue} in the form tree that the controller
      * tracks — i.e. all discovered fields minus those hidden via
-     * {@link #ignore(HasValue)}. Visibility and enabled state are NOT filtered,
-     * so this is the right set for the snapshot + diff used by
+     * {@link #ignoreField(HasValue)}. Visibility and enabled state are NOT
+     * filtered, so this is the right set for the snapshot + diff used by
      * {@link #addFieldValueChangedListener}: a field hidden at turn start may
      * be revealed during the turn, and a value cascaded into it should compare
      * against its real pre-turn value rather than {@code null}.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHighlighter.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHighlighter.java
@@ -19,8 +19,8 @@ import com.vaadin.flow.component.fieldhighlighter.FieldHighlighterInitializer;
 import com.vaadin.flow.dom.Element;
 
 /**
- * Bridges {@link FormAIController#showHighlight} /
- * {@link FormAIController#hideHighlight} to the
+ * Bridges {@link FormAIController#showFieldHighlight} /
+ * {@link FormAIController#hideFieldHighlight} to the
  * {@code vaadin-field-highlighter} web component. Each controller passes its
  * own {@code userId} so the AI user does not collide with any other user the
  * application may keep on the same field.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHints.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHints.java
@@ -23,14 +23,14 @@ import java.util.function.Function;
  * Mutable per-field hint state held by {@link FormAIController}, keyed by the
  * field's opaque id.
  * <p>
- * Set by {@link FormAIController#valueOptions(ValueOptions)
- * controller.valueOptions(...)}: {@link #valueOptionsQuery} carries the filter
- * callback (or a fixed-options snapshot wrapped in one), {@link #fixedOptions}
- * flags whether the schema should render the options as {@code enum} or
- * {@code queryable}, and {@link #valueOptionsToValue} resolves one label to one
- * element. For multi-select fields the controller wraps the resolved elements
- * into a {@link java.util.LinkedHashSet} before {@code setValue}; the hint
- * state is the same shape in both cases.
+ * Set by {@link FormAIController#fieldValueOptions(ValueOptions)
+ * controller.fieldValueOptions(...)}: {@link #valueOptionsQuery} carries the
+ * filter callback (or a fixed-options snapshot wrapped in one),
+ * {@link #fixedOptions} flags whether the schema should render the options as
+ * {@code enum} or {@code queryable}, and {@link #valueOptionsToValue} resolves
+ * one label to one element. For multi-select fields the controller wraps the
+ * resolved elements into a {@link java.util.LinkedHashSet} before
+ * {@code setValue}; the hint state is the same shape in both cases.
  *
  * @author Vaadin Ltd
  */

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldSchema.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldSchema.java
@@ -99,10 +99,10 @@ final class FormFieldSchema {
             applySelectionOptions(items, field, hints);
             return;
         }
-        // valueOptions turns any field into a constrained-choice field from
-        // the LLM's perspective: the LLM picks a label, valueOptionsToValue
-        // converts back. Emit type=string + enum/queryable so the LLM sees the
-        // signal regardless of the underlying value type.
+        // fieldValueOptions turns any field into a constrained-choice field
+        // from the LLM's perspective: the LLM picks a label,
+        // valueOptionsToValue converts back. Emit type=string + enum/queryable
+        // so the LLM sees the signal regardless of the underlying value type.
         if (type == FormFieldType.SINGLE_SELECT || hasValueOptions(hints)) {
             node.put(FIELD_TYPE, TYPE_STRING);
             applySelectionOptions(node, field, hints);
@@ -168,9 +168,9 @@ final class FormFieldSchema {
             node.putNull(FIELD_VALUE);
             return;
         }
-        // valueOptions rewrites the schema type to "string" + enum/queryable
-        // for non-selection fields; render the value as a string so the two
-        // halves of the payload agree.
+        // fieldValueOptions rewrites the schema type to "string" +
+        // enum/queryable for non-selection fields; render the value as a
+        // string so the two halves of the payload agree.
         if (hasValueOptions(hints) && type != FormFieldType.SINGLE_SELECT
                 && type != FormFieldType.MULTI_SELECT) {
             node.put(FIELD_VALUE, FormValueConverter.renderItem(field, value));

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormValueConverter.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/FormValueConverter.java
@@ -181,36 +181,38 @@ final class FormValueConverter {
      * {@link HasValue#setValue}. Returns the field's empty value when the JSON
      * node is {@code null} or a JSON {@code null}. Throws
      * {@link RejectedValueException} when the JSON shape doesn't match the
-     * field's type, or when the registered {@code valueOptions} cannot resolve
-     * a label.
+     * field's type, or when the registered {@code fieldValueOptions} cannot
+     * resolve a label.
      * <p>
-     * <b>Selection and {@code valueOptions} routing:</b> when a field has a
-     * {@code valueOptionsToValue} registered, the LLM sees the field as an
+     * <b>Selection and {@code fieldValueOptions} routing:</b> when a field has
+     * a {@code valueOptionsToValue} registered, the LLM sees the field as an
      * {@code enum} or {@code queryable} string in {@code get_form_state} and
      * picks one or more labels. The label-to-value resolution happens here so
      * the resulting object matches the field's value type before
      * {@link HasValue#setValue} sees it. Multi-select fields expect a JSON
      * array of labels; single-select and other label-routed fields expect a
-     * single string. A selection field without a {@code valueOptions}
+     * single string. A selection field without a {@code fieldValueOptions}
      * registration falls back to matching the supplied label(s) against the
      * field's own in-memory items (an eager {@code setItems(...)}), which carry
      * the same labels {@code get_form_state} advertised; only a field that has
-     * neither a {@code valueOptions} registration nor items is rejected with a
-     * curated reason naming the missing registration.
+     * neither a {@code fieldValueOptions} registration nor items is rejected
+     * with a curated reason naming the missing registration.
      */
     static Object convert(FormFieldDescriptor field, JsonNode value) {
         if (value == null || value.isNull()) {
             return field.field().getEmptyValue();
         }
         // Multi-select takes an array of labels and applies toValue per
-        // element; handled before the valueOptions check so the array shape
-        // is enforced even on fields whose value type is itself a String set.
+        // element; handled before the fieldValueOptions check so the array
+        // shape is enforced even on fields whose value type is itself a String
+        // set.
         if (field.type() == FormFieldType.MULTI_SELECT) {
             return convertMultiSelect(field, value);
         }
-        // Once valueOptions is registered the LLM picks a label, regardless
-        // of the field's underlying value type — type-driven parsing would
-        // hand setValue a raw String and the field would reject it.
+        // Once fieldValueOptions is registered the LLM picks a label,
+        // regardless of the field's underlying value type — type-driven
+        // parsing would hand setValue a raw String and the field would reject
+        // it.
         var hints = field.hints();
         if (hints != null && hints.valueOptionsToValue != null) {
             return convertSingleLabel(value, hints.valueOptionsToValue);
@@ -232,12 +234,12 @@ final class FormValueConverter {
 
     /**
      * Fallback resolver for a SINGLE_SELECT field that has no
-     * {@code valueOptions(...)} registered: matches the LLM-supplied label
+     * {@code fieldValueOptions(...)} registered: matches the LLM-supplied label
      * against the field's in-memory items via {@link #renderItem}. This is the
      * inverse of the schema path that emits the same items as an {@code enum}
      * array — both sides agree on the label set, so the LLM can write through
      * an eager {@code setItems(...)} field without the developer wiring up
-     * {@code valueOptions(...)} too.
+     * {@code fieldValueOptions(...)} too.
      */
     private static Object convertSingleSelectFromItems(
             FormFieldDescriptor field, JsonNode value) {
@@ -247,14 +249,15 @@ final class FormValueConverter {
         }
         var items = listDataProviderItems(field.field());
         if (items.isEmpty()) {
-            // No items and no valueOptions — the field has no option source at
-            // all. Point the developer at the missing wiring rather than the
-            // missing match, since the model couldn't have picked any label.
+            // No items and no fieldValueOptions — the field has no option
+            // source at all. Point the developer at the missing wiring rather
+            // than the missing match, since the model couldn't have picked any
+            // label.
             throw new RejectedValueException(
                     "Selection field has no value options registered — register "
-                            + "options via FormAIController.valueOptions(...) "
-                            + "or call setItems(...) so the AI knows what to "
-                            + "pick.");
+                            + "options via "
+                            + "FormAIController.fieldValueOptions(...) or call "
+                            + "setItems(...) so the AI knows what to pick.");
         }
         return resolveLabelAgainstItems(field.field(), value.asString(), items);
     }
@@ -298,11 +301,11 @@ final class FormValueConverter {
 
     /**
      * Fallback resolver for a MULTI_SELECT field that has no
-     * {@code valueOptions(...)} registered: matches each LLM-supplied label
-     * against the field's in-memory items via {@link #renderItem}. Mirrors
-     * {@link #convertSingleSelectFromItems} so eager-items
+     * {@code fieldValueOptions(...)} registered: matches each LLM-supplied
+     * label against the field's in-memory items via {@link #renderItem}.
+     * Mirrors {@link #convertSingleSelectFromItems} so eager-items
      * {@code MultiSelectComboBox<T>} and {@code CheckboxGroup<T>} are writable
-     * without the developer wiring up {@code valueOptions(...)} too.
+     * without the developer wiring up {@code fieldValueOptions(...)} too.
      */
     private static Object convertMultiSelectFromItems(FormFieldDescriptor field,
             JsonNode value) {
@@ -311,7 +314,7 @@ final class FormValueConverter {
             throw new RejectedValueException(
                     "Multi-select field has no value options registered — "
                             + "register options via "
-                            + "FormAIController.valueOptions(...) or call "
+                            + "FormAIController.fieldValueOptions(...) or call "
                             + "setItems(...) so the AI knows what to pick.");
         }
         var result = new LinkedHashSet<>();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/ValueOptions.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/form/ValueOptions.java
@@ -31,15 +31,15 @@ import com.vaadin.flow.data.selection.MultiSelect;
  * The label set is either fixed ({@link #options(Collection)}) or supplied on
  * demand by a callback ({@link #options(BiFunction)}); exactly one of the two
  * must be set, with the last call winning. Pass the configured registration to
- * {@link FormAIController#valueOptions(ValueOptions)
- * controller.valueOptions(...)} to apply it; the labels are then presented to
- * the LLM as the field's choices.
+ * {@link FormAIController#fieldValueOptions(ValueOptions)
+ * controller.fieldValueOptions(...)} to apply it; the labels are then presented
+ * to the LLM as the field's choices.
  * <p>
  * Labels are always {@link String} values, regardless of the field's value
  * type. For a non-{@link String} field, supply a label-to-value converter
- * through {@link FormAIController#valueOptions(ValueOptions, Function)
- * valueOptions(config, toValue)} — the converter resolves a chosen label to the
- * field's value type before the controller writes it.
+ * through {@link FormAIController#fieldValueOptions(ValueOptions, Function)
+ * fieldValueOptions(config, toValue)} — the converter resolves a chosen label
+ * to the field's value type before the controller writes it.
  *
  * @param <I>
  *            the per-label item type the converter must produce — the field's
@@ -64,9 +64,9 @@ public final class ValueOptions<I> {
      * Starts an options registration for a single-value field. The field's
      * value type {@code V} flows through; for any {@code V} other than
      * {@link String}, the controller's two-argument
-     * {@link FormAIController#valueOptions(ValueOptions, Function)} overload
-     * must be used to supply a label-to-value converter (a compile-time
-     * requirement, not a runtime check).
+     * {@link FormAIController#fieldValueOptions(ValueOptions, Function)}
+     * overload must be used to supply a label-to-value converter (a
+     * compile-time requirement, not a runtime check).
      *
      * @param field
      *            the single-value field whose options the LLM may pick from,
@@ -87,9 +87,9 @@ public final class ValueOptions<I> {
      * statically typed as {@link MultiSelect}. The per-element type {@code T}
      * flows through; for any {@code T} other than {@link String}, the
      * controller's two-argument
-     * {@link FormAIController#valueOptions(ValueOptions, Function)} overload
-     * must be used. The controller aggregates resolved per-label items into a
-     * {@link LinkedHashSet} before {@link HasValue#setValue}.
+     * {@link FormAIController#fieldValueOptions(ValueOptions, Function)}
+     * overload must be used. The controller aggregates resolved per-label items
+     * into a {@link LinkedHashSet} before {@link HasValue#setValue}.
      *
      * @param field
      *            the multi-select field whose options the LLM may pick from,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -94,7 +94,8 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.BinderReflection(\\$\\d+)?",
                 // ValueOptions is a transient registration helper: the
                 // controller copies its state into FormFieldHints during
-                // valueOptions(...) and discards the instance. It is not part
+                // fieldValueOptions(...) and discards the instance. It is not
+                // part
                 // of any serialized session state.
                 "com\\.vaadin\\.flow\\.component\\.ai\\.form\\.ValueOptions(\\$\\d+)?"));
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -143,7 +143,7 @@ class FillFormToolTest {
         secret.setLabel("Secret");
         secret.setValue("classified");
         var controller = controllerFor(visible, secret);
-        controller.ignore(secret);
+        controller.ignoreField(secret);
 
         var raw = fillFormPayload(controller, payload(visible, "\"Acme\""));
 
@@ -157,13 +157,14 @@ class FillFormToolTest {
 
     @Test
     void fillForm_writesFieldsButMasksValuesWhenValuesHidden() {
-        // setValuesHidden keeps every field writable: the AI can fill them.
+        // setFieldValuesHidden keeps every field writable: the AI can fill
+        // them.
         // The writes must land, but the response must still mask the values
         // (null + valueHidden) rather than echoing what was written.
         var name = new LabeledStringField();
         name.setLabel("Name");
         var controller = controllerFor(name);
-        controller.setValuesHidden(true);
+        controller.setFieldValuesHidden(true);
 
         var result = fillFormResult(controller, payload(name, "\"Acme Corp\""));
 
@@ -547,7 +548,7 @@ class FillFormToolTest {
         secret.setLabel("Secret");
         secret.setValue("original");
         var controller = controllerFor(visible, secret);
-        controller.ignore(secret);
+        controller.ignoreField(secret);
 
         var args = JacksonUtils.createObjectNode();
         args.put(idOf(visible), "set");
@@ -1289,12 +1290,12 @@ class FillFormToolTest {
     @Test
     void fillForm_singleSelect_writesResolvedValueViaValueOptionsToValue() {
         // The LLM speaks in labels for SINGLE_SELECT fields with
-        // valueOptions registered. The tool must apply toValue so the
+        // fieldValueOptions registered. The tool must apply toValue so the
         // field gets the domain instance, not the raw label string.
         var field = new SingleSelectField<Project>();
         var projects = Map.of("Apollo", new Project("P-1", "Apollo"));
         var controller = newController(field);
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("Apollo")), projects::get);
         controller.onRequest();
 
@@ -1308,7 +1309,7 @@ class FillFormToolTest {
 
     @Test
     void fillForm_singleSelect_withoutValueOptionsIsRejectedWithHint() {
-        // SINGLE_SELECT without a valueOptions registration means the
+        // SINGLE_SELECT without a fieldValueOptions registration means the
         // LLM has no labels to pick and the converter has no toValue to
         // resolve. The fill must fail loudly with a reason that points
         // at the missing registration so the developer can fix it.
@@ -1321,8 +1322,9 @@ class FillFormToolTest {
         Assertions.assertFalse(success(result));
         Assertions.assertEquals(List.of(idOf(field)), rejectedIds(result));
         Assertions.assertTrue(
-                rejectionReason(result, idOf(field)).contains("valueOptions"),
-                "Reason must point at the missing valueOptions "
+                rejectionReason(result, idOf(field))
+                        .contains("fieldValueOptions"),
+                "Reason must point at the missing fieldValueOptions "
                         + "registration; got: "
                         + rejectionReason(result, idOf(field)));
     }
@@ -1334,7 +1336,7 @@ class FillFormToolTest {
         // already surfaces its items as `enum`. The converter must resolve
         // an LLM-supplied label against those items via
         // FormValueConverter.renderItem so the field is writable without
-        // also requiring FormAIController.valueOptions(...).
+        // also requiring FormAIController.fieldValueOptions(...).
         var field = new SingleSelectField<String>();
         field.setItems("EUR", "USD", "GBP");
         var controller = controllerFor(field);
@@ -1396,7 +1398,7 @@ class FillFormToolTest {
         // pass null to setValue (which would silently clear the field).
         var field = new SingleSelectField<Project>();
         var controller = newController(field);
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("Apollo")), label -> null);
         controller.onRequest();
 
@@ -1413,12 +1415,12 @@ class FillFormToolTest {
 
     @Test
     void fillForm_multiSelect_writesResolvedSetViaValueOptions() {
-        // valueOptions on a MultiSelectField takes a single-item Function;
+        // fieldValueOptions on a MultiSelectField takes a single-item Function;
         // the converter accumulates per-label items into the Set<Project>
         // value type via an internal LinkedHashSet.
         var field = new MultiSelectField<Project>();
         var controller = newController(field);
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field)
                         .options((filter, limit) -> List.of("Apollo", "Vega")),
                 label -> new Project(label, label));
@@ -1441,8 +1443,8 @@ class FillFormToolTest {
 
         Assertions.assertEquals(Set.of(), field.getValue());
         Assertions.assertEquals(List.of(idOf(field)), rejectedIds(result));
-        Assertions.assertTrue(
-                rejectionReason(result, idOf(field)).contains("valueOptions"));
+        Assertions.assertTrue(rejectionReason(result, idOf(field))
+                .contains("fieldValueOptions"));
     }
 
     @Test
@@ -1452,7 +1454,7 @@ class FillFormToolTest {
         // `setItems(...)` has a non-empty ListDataProvider and the schema
         // surfaces the items as the `items.enum` of the array. The
         // converter must resolve each label against those items so the
-        // field is writable without also requiring valueOptions(...).
+        // field is writable without also requiring fieldValueOptions(...).
         var field = new MultiSelectField<String>();
         field.setItems("AI", "Cloud", "Security");
         var controller = controllerFor(field);
@@ -1519,7 +1521,7 @@ class FillFormToolTest {
         var existing = new Project("X", "X");
         field.setValue(Set.of(existing));
         var controller = newController(field);
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of()), label -> existing);
         controller.onRequest();
 
@@ -1538,7 +1540,7 @@ class FillFormToolTest {
         var existing = new Project("X", "X");
         field.setValue(Set.of(existing));
         var controller = newController(field);
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field)
                         .options((filter, limit) -> List.of("Apollo")),
                 label -> new Project(label, label));
@@ -1557,15 +1559,15 @@ class FillFormToolTest {
 
     @Test
     void fillForm_multiSelect_reregistrationOverwritesPriorOptions() {
-        // valueOptions called twice on the same MultiSelect field — the
+        // fieldValueOptions called twice on the same MultiSelect field — the
         // second call wins, including switching from fixed to queryable
         // and replacing the toValue function.
         var field = new MultiSelectField<Project>();
         var controller = newController(field);
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of("First")),
                 label -> new Project("v1", label));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field)
                         .options((filter, limit) -> List.of("Second")),
                 label -> new Project("v2", label));
@@ -1581,15 +1583,15 @@ class FillFormToolTest {
     }
 
     @Test
-    void fillForm_valueOptionsOnPrimitiveTypeUsesToValueNotTypeDrivenParsing() {
-        // Registering valueOptions(...) on a non-SELECT field still makes
+    void fillForm_fieldValueOptionsOnPrimitiveTypeUsesToValueNotTypeDrivenParsing() {
+        // Registering fieldValueOptions(...) on a non-SELECT field still makes
         // the LLM speak in labels (the schema advertises an enum/queryable
         // string). The converter must apply toValue and skip type-driven
         // parsing — otherwise the field would receive a raw String and a
         // typed setValue (e.g. ComboBox<Project>) would reject it.
         var field = new IntField();
         var controller = newController(field);
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field)
                         .options((filter, limit) -> List.of("low", "high")),
                 label -> "low".equals(label) ? 1 : 10);
@@ -1853,7 +1855,7 @@ class FillFormToolTest {
     /**
      * Builds a controller around a form attached to {@code MockUIExtension}'s
      * UI but stops short of {@code onRequest()} so callers can register
-     * {@code valueOptions} before the first turn. Attaching the form is
+     * {@code fieldValueOptions} before the first turn. Attaching the form is
      * required: {@code executeFill} throws {@link IllegalStateException} on a
      * detached form, matching the production contract.
      */

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -137,7 +137,7 @@ class FormAIControllerTest {
 
             for (var anchor : List.of("get_form_state", "fill_form",
                     "query_field_options", "queryable", "enum", "rejected",
-                    ".ignore()", "SAME turn", "newly-appeared",
+                    ".ignoreField()", "SAME turn", "newly-appeared",
                     // bean-level cross-field rejections key on the "__form__"
                     // sentinel id, not a real field id.
                     "__form__", "cross-field")) {
@@ -344,7 +344,7 @@ class FormAIControllerTest {
             var visible = new TestField();
             var hidden = new TestField();
             var controller = new FormAIController(new Div(visible, hidden));
-            controller.ignore(hidden);
+            controller.ignoreField(hidden);
 
             controller.onRequest();
 
@@ -378,18 +378,18 @@ class FormAIControllerTest {
 
         @Test
         void describedFieldIsLocked() {
-            // describe() registers a hint but does not ignore the field;
+            // describeField() registers a hint but does not ignore the field;
             // the controller must distinguish "has a hint entry" from "is
             // ignored". If they collapse, every described or
-            // valueOptions-bound field would silently escape locking.
+            // fieldValueOptions-bound field would silently escape locking.
             var described = new TestField();
             var controller = new FormAIController(new Div(described));
-            controller.describe(described, "the merchant name");
+            controller.describeField(described, "the merchant name");
 
             controller.onRequest();
 
             Assertions.assertTrue(described.isReadOnly(),
-                    "A field with a description hint but no ignore() call "
+                    "A field with a description hint but no ignoreField() call "
                             + "must still be locked during a fill");
         }
 
@@ -450,7 +450,7 @@ class FormAIControllerTest {
             controller.onRequest();
             controller.onResponse(null);
 
-            controller.ignore(field);
+            controller.ignoreField(field);
             controller.onRequest();
 
             Assertions.assertFalse(field.isReadOnly(),
@@ -467,11 +467,11 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div());
 
             Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.describe(null, "x"));
+                    () -> controller.describeField(null, "x"));
             Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.ignore(null));
+                    () -> controller.ignoreField(null));
             Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.valueOptions(null));
+                    () -> controller.fieldValueOptions(null));
             Assertions.assertThrows(NullPointerException.class,
                     () -> ValueOptions.forField((HasValue<?, String>) null));
             Assertions.assertThrows(NullPointerException.class,
@@ -485,7 +485,7 @@ class FormAIControllerTest {
             // filter on the supplied labels.
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
-            controller.valueOptions(ValueOptions.forField(field)
+            controller.fieldValueOptions(ValueOptions.forField(field)
                     .options(List.of("apple", "banana", "cherry")));
             controller.onRequest();
 
@@ -508,7 +508,7 @@ class FormAIControllerTest {
             var config = ValueOptions.forField(field);
 
             Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.describe(field, null));
+                    () -> controller.describeField(field, null));
             Assertions.assertThrows(NullPointerException.class,
                     () -> config.options(
                             (java.util.function.BiFunction<String, Integer, List<String>>) null));
@@ -517,7 +517,7 @@ class FormAIControllerTest {
             // A null converter passed to the controller's two-argument
             // overload throws NPE.
             Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.valueOptions(ValueOptions
+                    () -> controller.fieldValueOptions(ValueOptions
                             .forField(new IntField()).options(List.of("a")),
                             null));
             // An empty fixed-options list leaves the field un-fillable;
@@ -531,18 +531,18 @@ class FormAIControllerTest {
             // corresponding runtime test.
             Assertions.assertThrows(IllegalArgumentException.class,
                     () -> controller
-                            .valueOptions(ValueOptions.forField(field)));
+                            .fieldValueOptions(ValueOptions.forField(field)));
         }
 
         @Test
-        void valueOptionsAcceptsNonStringFieldWithToValueConverter() {
-            // valueOptions is generic over the field's value type — verify
+        void fieldValueOptionsAcceptsNonStringFieldWithToValueConverter() {
+            // fieldValueOptions is generic over the field's value type — verify
             // that an Integer-valued field can be registered with a label
             // -> Integer converter, and that the labels still flow through
             // the query tool unchanged.
             var field = new IntField();
             var controller = new FormAIController(new Div(field));
-            controller.valueOptions(ValueOptions.forField(field)
+            controller.fieldValueOptions(ValueOptions.forField(field)
                     .options(List.of("1", "2", "3")), Integer::parseInt);
             controller.onRequest();
 
@@ -559,9 +559,9 @@ class FormAIControllerTest {
             var fixedField = new TestField();
             var controller = new FormAIController(
                     new Div(queriedField, fixedField));
-            controller.valueOptions(ValueOptions.forField(queriedField)
+            controller.fieldValueOptions(ValueOptions.forField(queriedField)
                     .options((filter, limit) -> List.of("alpha", "beta")));
-            controller.valueOptions(ValueOptions.forField(fixedField)
+            controller.fieldValueOptions(ValueOptions.forField(fixedField)
                     .options(List.of("apple", "banana", "cherry")));
             controller.onRequest();
 
@@ -573,16 +573,17 @@ class FormAIControllerTest {
 
         @Test
         void reregisteringWithBiFunctionClearsPriorFixedOptionsFlag() {
-            // Each valueOptions call replaces the previous registration for
+            // Each fieldValueOptions call replaces the previous registration
+            // for
             // the same field. The fixed-options variant sets a flag that
             // makes the schema render options as 'enum'; re-registering with
             // a query callback must reset that flag so the schema rendering
             // matches the new registration (queryable, not enum).
             var combo = new SingleSelectField<String>();
             var controller = new FormAIController(new Div(combo));
-            controller.valueOptions(ValueOptions.forField(combo)
+            controller.fieldValueOptions(ValueOptions.forField(combo)
                     .options(List.of("EUR", "USD")));
-            controller.valueOptions(ValueOptions.forField(combo)
+            controller.fieldValueOptions(ValueOptions.forField(combo)
                     .options((filter, limit) -> List.of("EUR", "USD")));
 
             var schema = json(findTool(controller.getTools(), "get_form_state")
@@ -590,7 +591,7 @@ class FormAIControllerTest {
             var field = schema.path("fields").get(0);
 
             Assertions.assertTrue(field.path("queryable").asBoolean(),
-                    "Re-registering valueOptions with a BiFunction must "
+                    "Re-registering fieldValueOptions with a BiFunction must "
                             + "make the field queryable, got: " + field);
             Assertions.assertTrue(field.path("enum").isMissingNode(),
                     "Stale enum block must not survive re-registration with "
@@ -598,7 +599,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void valueOptionsForFieldOnUpcastMultiSelectReferenceThrowsIllegalArgument() {
+        void fieldValueOptionsForFieldOnUpcastMultiSelectReferenceThrowsIllegalArgument() {
             // A MultiSelect statically typed as such picks the MultiSelect-
             // typed forField overload at compile time. This runtime check
             // is for the upcast case: the developer holds a HasValue
@@ -610,7 +611,7 @@ class FormAIControllerTest {
             HasValue<?, java.util.Set<String>> upcast = multiSelect;
             var controller = new FormAIController(new Div(multiSelect));
             var ex = Assertions.assertThrows(IllegalArgumentException.class,
-                    () -> controller.valueOptions(
+                    () -> controller.fieldValueOptions(
                             ValueOptions.forField(upcast).options(List.of("a")),
                             label -> java.util.Set.of(label)));
             Assertions.assertTrue(ex.getMessage().contains("MultiSelect"),
@@ -620,14 +621,14 @@ class FormAIControllerTest {
         }
 
         @Test
-        void valueOptionsRejectsCollectionValuedFieldNotImplementingMultiSelect() {
+        void fieldValueOptionsRejectsCollectionValuedFieldNotImplementingMultiSelect() {
             // Collection-valued fields must implement MultiSelect; otherwise
             // there is no defined aggregation for per-label converter results
             // and the controller refuses to register them.
             var field = new FormTestFields.CollectionWithoutMultiSelectField();
             var controller = new FormAIController(new Div(field));
             var ex = Assertions.assertThrows(IllegalArgumentException.class,
-                    () -> controller.valueOptions(
+                    () -> controller.fieldValueOptions(
                             ValueOptions.forField(field).options(List.of("a")),
                             label -> List.of(label)));
             Assertions.assertTrue(
@@ -639,20 +640,20 @@ class FormAIControllerTest {
         }
 
         @Test
-        void valueOptionsAcceptsTypedMultiSelectFieldWithNonStringConverter() {
+        void fieldValueOptionsAcceptsTypedMultiSelectFieldWithNonStringConverter() {
             // Counterpart to the Collection-value rejection: a MultiSelect-
             // typed field with a non-String per-element type and an explicit
             // converter must remain accepted, even though its empty value is
             // itself a Collection.
             var field = new FormTestFields.MultiSelectField<Integer>();
             var controller = new FormAIController(new Div(field));
-            Assertions.assertDoesNotThrow(() -> controller.valueOptions(
+            Assertions.assertDoesNotThrow(() -> controller.fieldValueOptions(
                     ValueOptions.forField(field).options(List.of("1", "2")),
                     Integer::parseInt));
         }
 
         @Test
-        void valueOptionsConfigFixedAndQueryClearEachOther() {
+        void fieldValueOptionsConfigFixedAndQueryClearEachOther() {
             // The two options(...) overloads (fixed Collection, queryable
             // BiFunction) clear each other so a half-finished config can't
             // resurrect stale state. fixed-then-queryable lands as
@@ -661,10 +662,10 @@ class FormAIControllerTest {
             var fixedWins = new TestField();
             var controller = new FormAIController(
                     new Div(queryWins, fixedWins));
-            controller.valueOptions(
+            controller.fieldValueOptions(
                     ValueOptions.forField(queryWins).options(List.of("a", "b"))
                             .options((filter, limit) -> List.of("x", "y")));
-            controller.valueOptions(ValueOptions.forField(fixedWins)
+            controller.fieldValueOptions(ValueOptions.forField(fixedWins)
                     .options((filter, limit) -> List.of("x", "y"))
                     .options(List.of("a", "b")));
 
@@ -690,13 +691,13 @@ class FormAIControllerTest {
 
         @Test
         void multiSelectFixedOptionsRenderAsItemsEnum() {
-            // valueOptions on a MultiSelectField surfaces labels inside
+            // fieldValueOptions on a MultiSelectField surfaces labels inside
             // items.enum (multi-select schema) rather than at the node
             // level — pin that the same nesting path applies whether or
             // not the field is multi-select.
             var field = new FormTestFields.MultiSelectField<String>();
             var controller = new FormAIController(new Div(field));
-            controller.valueOptions(ValueOptions.forField(field)
+            controller.fieldValueOptions(ValueOptions.forField(field)
                     .options(List.of("alpha", "beta")));
 
             var schema = json(findTool(controller.getTools(), "get_form_state")
@@ -786,13 +787,14 @@ class FormAIControllerTest {
 
         @Test
         void describeOverridesBinderSeeding() {
-            // Explicit describe() always wins: seeding only fills nulls, so
+            // Explicit describeField() always wins: seeding only fills nulls,
+            // so
             // a developer's description suppresses the bean property name.
             var field = new LabeledField("Customer Name");
             var binder = new Binder<>(TestBean.class);
             binder.forField(field).bind("name");
             var controller = new FormAIController(new Div(field), binder);
-            controller.describe(field, "Full legal name");
+            controller.describeField(field, "Full legal name");
 
             controller.onRequest();
             var entry = formStateFields(controller).get(0);
@@ -801,7 +803,7 @@ class FormAIControllerTest {
             Assertions.assertEquals("Customer Name | Full legal name",
                     description);
             Assertions.assertFalse(description.contains("name | "),
-                    "Property name must not appear when describe() set "
+                    "Property name must not appear when describeField() set "
                             + "the description explicitly, got: "
                             + description);
         }
@@ -809,7 +811,8 @@ class FormAIControllerTest {
         @Test
         void lambdaBoundFieldHasNoSeededDescription() {
             // Lambda-bound bindings carry no property name; the description
-            // falls back to whatever label/helper/describe() provides — here
+            // falls back to whatever label/helper/describeField() provides —
+            // here
             // just the label.
             var field = new LabeledField("Email");
             var binder = new Binder<>(TestBean.class);
@@ -845,7 +848,7 @@ class FormAIControllerTest {
 
             Assertions.assertTrue(
                     unboundEntry.path("description").isMissingNode(),
-                    "Unbound field with no label / helper / describe() must "
+                    "Unbound field with no label / helper / describeField() must "
                             + "have no description, got: " + unboundEntry);
         }
 
@@ -1008,14 +1011,16 @@ class FormAIControllerTest {
 
         @Test
         void ignoredFieldsDoNotAppearEvenIfTheirValueChanged() {
-            // Application-driven cascades into a field marked ignore() must
-            // not leak into the change list — ignore() is the application's
+            // Application-driven cascades into a field marked ignoreField()
+            // must
+            // not leak into the change list — ignoreField() is the
+            // application's
             // opt-out from AI-driven tracking on either side of the lifecycle.
             var visible = new TestField();
             var ignored = new TestField();
             visible.addValueChangeListener(e -> ignored.setValue("cascade"));
             var controller = new FormAIController(new Div(visible, ignored));
-            controller.ignore(ignored);
+            controller.ignoreField(ignored);
             var captured = new AtomicReference<List<FieldValueChange>>();
             controller.addFieldValueChangedListener(captured::set);
 
@@ -1461,18 +1466,18 @@ class FormAIControllerTest {
         }
 
         @Test
-        void showHighlightQueuesAddUserWithSingleAIUser() {
+        void showFieldHighlightQueuesAddUserWithSingleAIUser() {
             var field = new TestField();
             var form = new Div(field);
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
+            controller.showFieldHighlight(field);
             var invocations = drainPendingJs();
             var scripts = scriptsOn(invocations, field);
 
             Assertions.assertEquals(1, scripts.size(),
-                    "showHighlight must queue exactly one script; got: "
+                    "showFieldHighlight must queue exactly one script; got: "
                             + scripts);
             var script = scripts.getFirst();
             Assertions.assertTrue(script.contains(
@@ -1490,18 +1495,18 @@ class FormAIControllerTest {
         }
 
         @Test
-        void hideHighlightQueuesRemoveUserWithControllerId() {
+        void hideFieldHighlightQueuesRemoveUserWithControllerId() {
             var field = new TestField();
             var form = new Div(field);
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.hideHighlight(field);
+            controller.hideFieldHighlight(field);
             var invocations = drainPendingJs();
             var scripts = scriptsOn(invocations, field);
 
             Assertions.assertEquals(1, scripts.size(),
-                    "hideHighlight must queue exactly one script; got: "
+                    "hideFieldHighlight must queue exactly one script; got: "
                             + scripts);
             var script = scripts.getFirst();
             Assertions.assertTrue(script.contains(
@@ -1518,7 +1523,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void showHighlightTwiceQueuesIdenticalScripts() {
+        void showFieldHighlightTwiceQueuesIdenticalScripts() {
             // The web component dedups by user id, so repeated addUser with
             // the same id collapses to one entry on the client. The Java
             // side simply queues the same script twice.
@@ -1527,12 +1532,12 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
-            controller.showHighlight(field);
+            controller.showFieldHighlight(field);
+            controller.showFieldHighlight(field);
             var scripts = pendingJsOn(field);
 
             Assertions.assertEquals(2, scripts.size(),
-                    "Each showHighlight call queues its own script; got: "
+                    "Each showFieldHighlight call queues its own script; got: "
                             + scripts);
             Assertions.assertEquals(scripts.get(0), scripts.get(1),
                     "Both invocations must produce identical scripts so the "
@@ -1551,9 +1556,9 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
-            controller.hideHighlight(field);
-            controller.showHighlight(field);
+            controller.showFieldHighlight(field);
+            controller.hideFieldHighlight(field);
+            controller.showFieldHighlight(field);
             var scripts = pendingJsOn(field);
 
             Assertions.assertEquals(3, scripts.size(),
@@ -1576,11 +1581,11 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div());
 
             var showNpe = Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.showHighlight(null));
+                    () -> controller.showFieldHighlight(null));
             Assertions.assertEquals("Field must not be null",
                     showNpe.getMessage());
             var hideNpe = Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.hideHighlight(null));
+                    () -> controller.hideFieldHighlight(null));
             Assertions.assertEquals("Field must not be null",
                     hideNpe.getMessage());
         }
@@ -1591,15 +1596,16 @@ class FormAIControllerTest {
             var nonComponent = new NonComponentField();
 
             Assertions.assertThrows(IllegalArgumentException.class,
-                    () -> controller.showHighlight(nonComponent));
+                    () -> controller.showFieldHighlight(nonComponent));
             Assertions.assertThrows(IllegalArgumentException.class,
-                    () -> controller.hideHighlight(nonComponent));
+                    () -> controller.hideFieldHighlight(nonComponent));
         }
 
         @Test
         void highlightWorksForFieldOutsideTheControllerForm() {
             // Controller's form intentionally does not contain `outsideField`.
-            // Pins the contract that showHighlight / hideHighlight operate on
+            // Pins the contract that showFieldHighlight / hideFieldHighlight
+            // operate on
             // any HasValue Component, regardless of form membership.
             var formField = new TestField();
             var outsideField = new TestField();
@@ -1609,11 +1615,11 @@ class FormAIControllerTest {
             ui.add(siblingDiv);
             var controller = new FormAIController(formDiv);
 
-            controller.showHighlight(outsideField);
+            controller.showFieldHighlight(outsideField);
             var scripts = pendingJsOn(outsideField);
 
             Assertions.assertEquals(1, scripts.size(),
-                    "showHighlight must queue a script even when the field "
+                    "showFieldHighlight must queue a script even when the field "
                             + "is outside the controller's form; got: "
                             + scripts);
             Assertions.assertTrue(isShowScript(scripts.getFirst()));
@@ -1629,7 +1635,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(highlighted);
+            controller.showFieldHighlight(highlighted);
 
             var dump = drainPendingJs();
             Assertions.assertEquals(1, scriptsOn(dump, highlighted).size());
@@ -1639,7 +1645,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void hideHighlightOnOneFieldDoesNotEmitJsForAnother() {
+        void hideFieldHighlightOnOneFieldDoesNotEmitJsForAnother() {
             // Sibling-independence check on the clearing path: hiding one
             // field's highlight must leave another field's script queue
             // untouched.
@@ -1649,7 +1655,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.hideHighlight(cleared);
+            controller.hideFieldHighlight(cleared);
 
             var dump = drainPendingJs();
             Assertions.assertEquals(1, scriptsOn(dump, cleared).size());
@@ -1657,7 +1663,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void hideHighlightLeavesOtherHighlightedFieldsAlone() {
+        void hideFieldHighlightLeavesOtherHighlightedFieldsAlone() {
             // Pin behavioural independence: with two fields already
             // highlighted, hiding one must only emit the clear-script on the
             // hidden field. The other field's queue keeps its show-script
@@ -1668,9 +1674,9 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(keep);
-            controller.showHighlight(clear);
-            controller.hideHighlight(clear);
+            controller.showFieldHighlight(keep);
+            controller.showFieldHighlight(clear);
+            controller.hideFieldHighlight(clear);
 
             var dump = drainPendingJs();
             var keepScripts = scriptsOn(dump, keep);
@@ -1694,7 +1700,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void showHighlightReappliesOnReattach() {
+        void showFieldHighlightReappliesOnReattach() {
             // Detach drops the client-side highlight; the controller's
             // attach listener must re-issue addUser on the next attach so
             // the user does not lose the visual cue.
@@ -1703,7 +1709,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
+            controller.showFieldHighlight(field);
             drainPendingJs();
 
             form.remove(field);
@@ -1717,7 +1723,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void hideHighlightCancelsReapplyOnReattach() {
+        void hideFieldHighlightCancelsReapplyOnReattach() {
             // hide removes the attach listener as well as queueing
             // removeUser; a subsequent detach/re-attach must not bring the
             // highlight back.
@@ -1726,8 +1732,8 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
-            controller.hideHighlight(field);
+            controller.showFieldHighlight(field);
+            controller.hideFieldHighlight(field);
             drainPendingJs();
 
             form.remove(field);
@@ -1742,7 +1748,7 @@ class FormAIControllerTest {
 
         @Test
         void repeatedShowDoesNotStackReapplyListeners() {
-            // Two showHighlight calls must register exactly one attach
+            // Two showFieldHighlight calls must register exactly one attach
             // listener. Otherwise re-attach would queue duplicate addUser
             // scripts and leak listeners across the field's lifetime.
             var field = new TestField();
@@ -1750,8 +1756,8 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
-            controller.showHighlight(field);
+            controller.showFieldHighlight(field);
+            controller.showFieldHighlight(field);
             drainPendingJs();
 
             form.remove(field);
@@ -1766,7 +1772,7 @@ class FormAIControllerTest {
         }
 
         @Test
-        void showHighlightAfterHideReinstallsReapply() {
+        void showFieldHighlightAfterHideReinstallsReapply() {
             // show → hide → show on the same field must end with a working
             // attach listener again, because hide removed the previous one
             // and the second show installs a fresh registration.
@@ -1775,9 +1781,9 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.showHighlight(field);
-            controller.hideHighlight(field);
-            controller.showHighlight(field);
+            controller.showFieldHighlight(field);
+            controller.hideFieldHighlight(field);
+            controller.showFieldHighlight(field);
             drainPendingJs();
 
             form.remove(field);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -91,7 +91,7 @@ class FormStateToolTest {
         var visible = new TestField();
         var hidden = new TestField();
         var controller = new FormAIController(new Div(visible, hidden));
-        controller.ignore(hidden);
+        controller.ignoreField(hidden);
 
         var fields = formStateFields(controller);
 
@@ -303,8 +303,8 @@ class FormStateToolTest {
         var password = new PasswordField();
         password.setValue("secret");
         var controller = new FormAIController(new Div(visible, password));
-        controller.describe(password, "Account password");
-        controller.valueOptions(
+        controller.describeField(password, "Account password");
+        controller.fieldValueOptions(
                 ValueOptions.forField(password).options(List.of("hunter2")));
 
         var fields = formStateFields(controller);
@@ -318,7 +318,8 @@ class FormStateToolTest {
     void getFormStateAutoIgnoresPasswordField() {
         // PasswordField is treated as UNSUPPORTED so secret values do not
         // flow into the LLM tool payload by default. The developer does not
-        // have to remember to call .ignore() for every form that happens to
+        // have to remember to call .ignoreField() for every form that happens
+        // to
         // include one.
         var visible = new TestField();
         var password = new PasswordField();
@@ -354,7 +355,7 @@ class FormStateToolTest {
         field.setLabel("Merchant");
         field.setHelperText("As shown on the receipt");
         var controller = new FormAIController(new Div(field));
-        controller.describe(field, "The vendor name");
+        controller.describeField(field, "The vendor name");
 
         var f = formStateFields(controller).get(0);
 
@@ -376,7 +377,7 @@ class FormStateToolTest {
         field.setLabel("Merchant.");
         field.setHelperText("As shown on the receipt.");
         var controller = new FormAIController(new Div(field));
-        controller.describe(field, "The vendor name.");
+        controller.describeField(field, "The vendor name.");
 
         var f = formStateFields(controller).get(0);
         var desc = f.get("description").asString();
@@ -404,7 +405,7 @@ class FormStateToolTest {
     void valuesHiddenDefaultsToFalse() {
         var controller = new FormAIController(new Div(new TestField()));
 
-        Assertions.assertFalse(controller.isValuesHidden(),
+        Assertions.assertFalse(controller.isFieldValuesHidden(),
                 "Values must be sent by default");
     }
 
@@ -419,7 +420,7 @@ class FormStateToolTest {
         number.setValue(58.4);
         var empty = new TestField();
         var controller = new FormAIController(new Div(text, number, empty));
-        controller.setValuesHidden(true);
+        controller.setFieldValuesHidden(true);
 
         var fields = formStateFields(controller);
 
@@ -447,7 +448,7 @@ class FormStateToolTest {
         combo.setItems("EUR", "USD");
         combo.setValue("EUR");
         var controller = new FormAIController(new Div(combo));
-        controller.setValuesHidden(true);
+        controller.setFieldValuesHidden(true);
 
         var f = formStateFields(controller).get(0);
 
@@ -624,19 +625,19 @@ class FormStateToolTest {
 
     @Test
     void getFormStateMultiSelectWithValueOptionsKeepsNodeShape() {
-        // Combining multi-select with valueOptions must still leave the
+        // Combining multi-select with fieldValueOptions must still leave the
         // node-level shape clean: array=true, no node-level type, and
         // queryable/enum sit inside the items block.
         var multi = new MultiSelectField<String>();
         var controller = new FormAIController(new Div(multi));
-        controller.valueOptions(ValueOptions.forField(multi)
+        controller.fieldValueOptions(ValueOptions.forField(multi)
                 .options((filter, limit) -> List.of("a", "b")));
 
         var f = formStateFields(controller).get(0);
 
         Assertions.assertTrue(f.path("array").asBoolean());
         Assertions.assertTrue(f.path("type").isMissingNode(),
-                "Multi-select with valueOptions must not set node-level "
+                "Multi-select with fieldValueOptions must not set node-level "
                         + "type, got: " + f);
         Assertions.assertTrue(f.path("queryable").isMissingNode(),
                 "queryable must live inside items, not on the node, got: " + f);
@@ -647,20 +648,21 @@ class FormStateToolTest {
     @Test
     void getFormStateMultiSelectWithValueOptionsRendersValueAsArray() {
         // Multi-select value is a Set; serialising it as a single string
-        // (the path taken when valueOptions on non-selection fields rewrites
+        // (the path taken when fieldValueOptions on non-selection fields
+        // rewrites
         // to string) would corrupt the payload. Pin that multi-select wins
-        // over the valueOptions value-rewrite.
+        // over the fieldValueOptions value-rewrite.
         var multi = new MultiSelectField<String>();
         multi.setItems("a", "b", "c");
         multi.setValue(Set.of("a", "c"));
         var controller = new FormAIController(new Div(multi));
-        controller.valueOptions(ValueOptions.forField(multi)
+        controller.fieldValueOptions(ValueOptions.forField(multi)
                 .options((filter, limit) -> List.of("a", "b", "c")));
 
         var f = formStateFields(controller).get(0);
 
         Assertions.assertTrue(f.path("value").isArray(),
-                "Multi-select with valueOptions must still render its value "
+                "Multi-select with fieldValueOptions must still render its value "
                         + "as a JSON array, got: " + f.path("value"));
         var rendered = new ArrayList<String>();
         f.path("value").forEach(n -> rendered.add(n.asString()));
@@ -673,14 +675,14 @@ class FormStateToolTest {
     void getFormStateSingleSelectWithValueOptionsRendersValueAsLabel() {
         // The mirror case for the multi-select test above: the
         // selection-aware path must keep using the field's own label
-        // renderer for the current value, not the generic valueOptions
+        // renderer for the current value, not the generic fieldValueOptions
         // value-rewrite branch.
         var combo = new SingleSelectField<Project>();
         combo.setItems(new Project("P-1", "Alpha"), new Project("P-2", "Beta"));
         combo.setItemLabelGenerator(p -> p.code() + " " + p.name());
         combo.setValue(new Project("P-2", "Beta"));
         var controller = new FormAIController(new Div(combo));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(combo).options(
                         (filter, limit) -> List.of("P-1 Alpha", "P-2 Beta")),
                 label -> null);
@@ -695,7 +697,7 @@ class FormStateToolTest {
 
     @Test
     void getFormStateDescribedFieldHasNoQueryableFlag() {
-        // describe() registers a hint without a valueOptions callback. The
+        // describe() registers a hint without a fieldValueOptions callback. The
         // schema must distinguish "has a hint entry" from "has a query
         // callback": only the latter is queryable. Otherwise the LLM would
         // call query_field_options against a field that has no registered
@@ -704,18 +706,18 @@ class FormStateToolTest {
         // branch entirely and would not exercise this regression.
         var combo = new SingleSelectField<String>();
         var controller = new FormAIController(new Div(combo));
-        controller.describe(combo, "Some descriptive text");
+        controller.describeField(combo, "Some descriptive text");
 
         var f = formStateFields(controller).get(0);
 
         Assertions.assertTrue(f.path("queryable").isMissingNode(),
-                "A field with describe() but no valueOptions must not carry "
+                "A field with describe() but no fieldValueOptions must not carry "
                         + "queryable=true, got: " + f);
     }
 
     @Test
     void getFormStateQueryableFieldDoesNotMixListDataProviderEnum() {
-        // When valueOptions(BiFunction) is registered on a selection
+        // When fieldValueOptions(BiFunction) is registered on a selection
         // component whose backing ListDataProvider also has items,
         // queryable=true must short-circuit before the data-provider items
         // would be enumerated as enum. Both signals in the same payload
@@ -724,7 +726,7 @@ class FormStateToolTest {
         var combo = new SingleSelectField<String>();
         combo.setItems("apple", "banana", "cherry");
         var controller = new FormAIController(new Div(combo));
-        controller.valueOptions(ValueOptions.forField(combo)
+        controller.fieldValueOptions(ValueOptions.forField(combo)
                 .options((filter, limit) -> List.of("apple", "banana")));
 
         var f = formStateFields(controller).get(0);
@@ -801,13 +803,13 @@ class FormStateToolTest {
 
     @Test
     void getFormStateEncodesEnumForFixedValueOptions() {
-        // Fixed valueOptions registered against a selection component
+        // Fixed fieldValueOptions registered against a selection component
         // surface in the JSON output as enum. The same registration against
         // a non-selection field would not (LLM uses query_field_options
         // instead).
         var combo = new SingleSelectField<String>();
         var controller = new FormAIController(new Div(combo));
-        controller.valueOptions(ValueOptions.forField(combo)
+        controller.fieldValueOptions(ValueOptions.forField(combo)
                 .options(List.of("EUR", "USD", "GBP")));
 
         var f = formStateFields(controller).get(0);
@@ -824,7 +826,7 @@ class FormStateToolTest {
     void getFormStateEncodesQueryableForBiFunctionValueOptions() {
         var combo = new SingleSelectField<String>();
         var controller = new FormAIController(new Div(combo));
-        controller.valueOptions(ValueOptions.forField(combo)
+        controller.fieldValueOptions(ValueOptions.forField(combo)
                 .options((filter, limit) -> List.of("Apollo", "Polaris")));
 
         var f = formStateFields(controller).get(0);
@@ -840,7 +842,7 @@ class FormStateToolTest {
     void getFormStateExposesEnumForFixedValueOptionsOnStringField() {
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options(List.of("EUR", "USD", "GBP")));
 
         var f = formStateFields(controller).get(0);
@@ -854,7 +856,7 @@ class FormStateToolTest {
     void getFormStateExposesQueryableForBiFunctionValueOptionsOnStringField() {
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("Apollo", "Polaris")));
 
         var f = formStateFields(controller).get(0);
@@ -887,7 +889,7 @@ class FormStateToolTest {
         f.path("enum").forEach(n -> values.add(n.asString()));
         Assertions.assertEquals(List.of("alpha", "beta", "gamma"), values,
                 "ListDataProvider items must populate the enum when no "
-                        + "valueOptions hint is registered");
+                        + "fieldValueOptions hint is registered");
     }
 
     @Test
@@ -1015,7 +1017,7 @@ class FormStateToolTest {
 
     @Test
     void getFormStateRendersStringValueWhenValueOptionsOverrideType() {
-        // valueOptions on a non-String field rewrites the schema type to
+        // fieldValueOptions on a non-String field rewrites the schema type to
         // "string" + enum, but applyValue keeps following the field's
         // original FormFieldType — so the value half of the payload
         // disagrees with the schema half. A strict consumer validating
@@ -1023,7 +1025,7 @@ class FormStateToolTest {
         var field = new IntField();
         field.setValue(2);
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of("1", "2", "3")),
                 Integer::parseInt);
 
@@ -1081,7 +1083,7 @@ class FormStateToolTest {
     void getFormStateMultiSelectQueryableUsesItemsQueryable() {
         var multi = new MultiSelectField<String>();
         var controller = new FormAIController(new Div(multi));
-        controller.valueOptions(ValueOptions.forField(multi)
+        controller.fieldValueOptions(ValueOptions.forField(multi)
                 .options((filter, limit) -> List.of("x")));
 
         var f = formStateFields(controller).get(0);
@@ -1161,10 +1163,10 @@ class FormStateToolTest {
 
         var form = new Div(merchant, amount, currency, date, category, notes);
         var controller = new FormAIController(form);
-        controller.describe(merchant, "The vendor name");
-        controller.valueOptions(ValueOptions.forField(currency)
+        controller.describeField(merchant, "The vendor name");
+        controller.fieldValueOptions(ValueOptions.forField(currency)
                 .options(List.of("EUR", "USD", "GBP")));
-        controller.valueOptions(ValueOptions.forField(category).options(
+        controller.fieldValueOptions(ValueOptions.forField(category).options(
                 List.of("Travel", "Meals", "Software", "Office", "Other")));
 
         // Execute first so the controller walks the form and assigns ids to
@@ -1235,7 +1237,7 @@ class FormStateToolTest {
 
         var field = new TestField();
         var controllerWithIgnored = new FormAIController(new Div(field));
-        controllerWithIgnored.ignore(field);
+        controllerWithIgnored.ignoreField(field);
         Assertions.assertTrue(
                 controllerWithIgnored.getTools().stream()
                         .anyMatch(t -> t.getName().equals("get_form_state")),

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormTestFields.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormTestFields.java
@@ -104,7 +104,7 @@ final class FormTestFields {
     }
 
     /**
-     * Integer-valued field used to exercise {@code valueOptions} with a
+     * Integer-valued field used to exercise {@code fieldValueOptions} with a
      * non-{@link String} value type, where {@code toValue} must convert the
      * chosen label into the field's actual value type.
      */
@@ -196,7 +196,7 @@ final class FormTestFields {
      * Collection-valued field that does not implement {@link MultiSelect}. Used
      * to verify the controller rejects this shape — Collection-valued fields
      * must implement {@code MultiSelect} to be registered via
-     * {@code valueOptions(...)}.
+     * {@code fieldValueOptions(...)}.
      */
     @Tag("collection-without-multiselect-field")
     static class CollectionWithoutMultiSelectField

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormValueConverterTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/FormValueConverterTest.java
@@ -231,8 +231,8 @@ class FormValueConverterTest {
     }
 
     @Test
-    void convert_singleSelectWithoutValueOptions_rejectedWithRegistrationHint() {
-        // Without a valueOptions(...) registration, the LLM has no labels
+    void convert_singleSelectWithoutFieldValueOptions_rejectedWithRegistrationHint() {
+        // Without a fieldValueOptions(...) registration, the LLM has no labels
         // to pick and the converter has no toValue function to resolve them
         // — fail loudly and point the developer at the right API.
         var field = wrap(new SingleSelectField<String>(),
@@ -241,27 +241,27 @@ class FormValueConverterTest {
         var json = json("\"any\"");
         var ex = Assertions.assertThrows(RejectedValueException.class,
                 () -> FormValueConverter.convert(field, json));
-        Assertions.assertTrue(ex.getMessage().contains("valueOptions"),
-                "Rejection reason must point at the missing valueOptions "
+        Assertions.assertTrue(ex.getMessage().contains("fieldValueOptions"),
+                "Rejection reason must point at the missing fieldValueOptions "
                         + "registration; got: " + ex.getMessage());
     }
 
     @Test
-    void convert_multiSelectWithoutValueOptions_rejectedWithRegistrationHint() {
+    void convert_multiSelectWithoutFieldValueOptions_rejectedWithRegistrationHint() {
         var field = wrap(new MultiSelectField<String>(),
                 FormFieldType.MULTI_SELECT);
 
         var json = json("[\"any\"]");
         var ex = Assertions.assertThrows(RejectedValueException.class,
                 () -> FormValueConverter.convert(field, json));
-        Assertions.assertTrue(ex.getMessage().contains("valueOptions"),
-                "Rejection reason must point at the missing valueOptions "
+        Assertions.assertTrue(ex.getMessage().contains("fieldValueOptions"),
+                "Rejection reason must point at the missing fieldValueOptions "
                         + "registration; got: " + ex.getMessage());
     }
 
     @Test
     void convert_singleSelectFromItems_nonStringJsonRejected() {
-        // Eager-items SINGLE_SELECT (no valueOptions registered, items
+        // Eager-items SINGLE_SELECT (no fieldValueOptions registered, items
         // populated via setItems) must reject a non-string JSON shape
         // before reaching renderItem-based matching — otherwise a JSON
         // boolean true coincidentally renders to "true" and could match
@@ -487,9 +487,9 @@ class FormValueConverterTest {
     }
 
     @Test
-    void convert_valueOptionsOnPrimitiveTypeRoutesThroughToValue() {
+    void convert_fieldValueOptionsOnPrimitiveTypeRoutesThroughToValue() {
         // Even when a field's underlying type is not SINGLE_SELECT (e.g.
-        // an Integer-typed text field), registering valueOptions(...)
+        // an Integer-typed text field), registering fieldValueOptions(...)
         // makes the LLM speak in labels. The converter must apply toValue
         // instead of trying to parse the label as an integer.
         var field = wrap(new IntField(), FormFieldType.INTEGER,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/IdStorageTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/IdStorageTest.java
@@ -41,7 +41,7 @@ class IdStorageTest {
         // production code reads it from.
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.describe(field, "X");
+        controller.describeField(field, "X");
 
         Assertions.assertNotNull(idOf(field),
                 "A Component that implements HasValue must receive an id "
@@ -54,7 +54,7 @@ class IdStorageTest {
         var controller = new FormAIController(new Div());
 
         var ex = Assertions.assertThrows(IllegalArgumentException.class,
-                () -> controller.describe(detached, "X"));
+                () -> controller.describeField(detached, "X"));
         Assertions.assertTrue(ex.getMessage().contains("Component"),
                 "Rejection message must point at the Component-backing "
                         + "requirement; got: " + ex.getMessage());
@@ -68,11 +68,11 @@ class IdStorageTest {
         var field = new TestField();
         var form = new Div(field);
         var firstController = new FormAIController(form);
-        firstController.describe(field, "X");
+        firstController.describeField(field, "X");
         var firstId = idOf(field);
 
         var secondController = new FormAIController(form);
-        secondController.describe(field, "Y");
+        secondController.describeField(field, "Y");
         var secondId = idOf(field);
 
         Assertions.assertEquals(firstId, secondId,
@@ -85,8 +85,8 @@ class IdStorageTest {
         var a = new TestField();
         var b = new TestField();
         var controller = new FormAIController(new Div(a, b));
-        controller.describe(a, "A");
-        controller.describe(b, "B");
+        controller.describeField(a, "A");
+        controller.describeField(b, "B");
 
         Assertions.assertNotEquals(idOf(a), idOf(b),
                 "Two distinct Components must get distinct field ids");

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/QueryFieldOptionsToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/form/QueryFieldOptionsToolTest.java
@@ -41,13 +41,14 @@ class QueryFieldOptionsToolTest {
 
     @Test
     void queryFieldOptionsReturnsRegisteredOptions() {
-        // End-to-end: register valueOptions on a field, then drive the tool
+        // End-to-end: register fieldValueOptions on a field, then drive the
+        // tool
         // the way an LLM would — call getTools().execute(...) with the field
-        // id. Pins the wiring from valueOptions registration through
+        // id. Pins the wiring from fieldValueOptions registration through
         // ToolCallbacks to the query function.
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options(List.of("apple", "banana", "cherry")));
         controller.onRequest();
 
@@ -58,21 +59,22 @@ class QueryFieldOptionsToolTest {
                         + "returned, got: " + result);
         Assertions.assertFalse(result.contains("Error"),
                 "Tool must not error for a field that was registered with "
-                        + "valueOptions, got: " + result);
+                        + "fieldValueOptions, got: " + result);
     }
 
     @Test
     void queryFieldOptionsReportsUnknownFieldId() {
         // When the LLM sends a field id the controller doesn't recognize
         // (hallucinated, stale, or for a field that was registered with
-        // describe()/ignore() but not valueOptions), the tool must surface a
+        // describeField()/ignoreField() but not fieldValueOptions), the tool
+        // must surface a
         // specific 'unknown field id' error including the id itself so the
         // LLM can correlate parallel tool calls and recover.
         var registered = new TestField();
         var unregistered = new TestField();
         var controller = new FormAIController(
                 new Div(registered, unregistered));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(registered).options(List.of("apple")));
         controller.onRequest();
 
@@ -92,7 +94,7 @@ class QueryFieldOptionsToolTest {
 
         Assertions.assertTrue(
                 resultFieldWithoutOptions.contains("Unknown field id"),
-                "Field that was never registered with valueOptions should "
+                "Field that was never registered with fieldValueOptions should "
                         + "produce the same unknown-id error, got: "
                         + resultFieldWithoutOptions);
         Assertions.assertTrue(
@@ -109,7 +111,7 @@ class QueryFieldOptionsToolTest {
         var field = new TestField();
         var capturedLimit = new AtomicInteger();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options((filter, limit) -> {
                     capturedLimit.set(limit);
                     return List.of();
@@ -150,7 +152,7 @@ class QueryFieldOptionsToolTest {
         var capturedFilter = new AtomicReference<String>();
         var capturedLimit = new AtomicInteger();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options((filter, limit) -> {
                     capturedFilter.set(filter);
                     capturedLimit.set(limit);
@@ -172,7 +174,7 @@ class QueryFieldOptionsToolTest {
         var capturedFilter = new AtomicReference<String>();
         var capturedLimit = new AtomicInteger();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options((filter, limit) -> {
                     capturedFilter.set(filter);
                     capturedLimit.set(limit);
@@ -190,7 +192,7 @@ class QueryFieldOptionsToolTest {
     void queryFieldOptionsEmitsOneLinePerLabel() {
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options(List.of("Apollo #P-1", "Polaris #P-2")));
         controller.onRequest();
 
@@ -204,7 +206,7 @@ class QueryFieldOptionsToolTest {
         var field = new TestField();
         var capturedLimit = new AtomicInteger();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options((filter, limit) -> {
                     capturedLimit.set(limit);
                     // Return more items than the cap so truncation kicks in.
@@ -238,7 +240,7 @@ class QueryFieldOptionsToolTest {
         // message should only appear when items were dropped.
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("only-one")));
         controller.onRequest();
 
@@ -256,7 +258,7 @@ class QueryFieldOptionsToolTest {
         // explicit signal rather than just "".
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of()));
         controller.onRequest();
 
@@ -276,7 +278,7 @@ class QueryFieldOptionsToolTest {
         // original label.
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(ValueOptions.forField(field)
+        controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("first\nsecond", "third")));
         controller.onRequest();
 
@@ -300,7 +302,7 @@ class QueryFieldOptionsToolTest {
                 + "TOKEN=abc123";
         var field = new TestField();
         var controller = new FormAIController(new Div(field));
-        controller.valueOptions(
+        controller.fieldValueOptions(
                 ValueOptions.forField(field).options((filter, limit) -> {
                     throw new IllegalStateException(sentinel);
                 }));


### PR DESCRIPTION
## Description

This PR renames `FormAIController` APIs to include "field" in order to make it clearer for the developer.

| Old | New |
| --- | --- |
| ignore | ignoreField |
| describe | describeField |
| valueOptions | fieldValueOptions |
| setValuesHidden | setFieldValuesHidden |
| isValuesHidden | isFieldValuesHidden |
| showHighlight | showFieldHighlight |
| hideHighlight | hideFieldHighlight |

Based on DX test session findings.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.