### PR TITLE
docs: update Flow component testing guidelines

### DIFF
--- a/guidelines/12-testing.md
+++ b/guidelines/12-testing.md
@@ -47,8 +47,19 @@ void isSerializable() throws Exception {
 }
 ```
 
-Also add `{Component}VariantTest` (each enum value → expected token) and
-`{Component}I18nTest` where applicable.
+### Interface test
+
+Assert a component declares an expected mixin interface:
+
+```java
+@Test
+void implementsHasThemeVariant() {
+    Assertions.assertTrue(
+            HasThemeVariant.class.isAssignableFrom(Breadcrumbs.class));
+}
+```
+
+Also add `{Component}I18nTest` where applicable.
 
 ## TestBench element
 

--- a/guidelines/12-testing.md
+++ b/guidelines/12-testing.md
@@ -71,7 +71,9 @@ for common interactions (`open()`, `selectByText(String)`). Keep it lean.
 JUnit 4 + TestBench, served by Jetty, extending `AbstractComponentIT`. A test
 view (`{Component}Page` under `src/main/.../tests`) with `@Route` exposes
 elements by `id`; the IT (`{Component}IT` under `src/test/.../tests`) with a
-matching `@TestPath` drives a real browser.
+matching `@TestPath` drives a real browser. The module includes a
+`TestAppShell` (`AppShellConfigurator`) applying the Lumo theme, so ITs run
+against Lumo-styled components.
 
 ```java
 @TestPath("vaadin-example")


### PR DESCRIPTION
- Add an "Interface test" example under Unit tests, asserting a component declares an expected mixin interface via `isAssignableFrom`.
- Drop the `{Component}VariantTest` note (enum value → token), keeping only the `{Component}I18nTest` reference.

🤖 Generated with Claude Code