### PR TITLE
fix: preserve custom editors and scope the display callback (CP: 25.1)

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.tests;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-spreadsheet/custom-editor-reload")
+public class CustomEditorReloadPage extends VerticalLayout {
+
+    static final String[] FRUITS = { "Apple", "Banana", "Cherry" };
+
+    private int callbackCount;
+    private final Span callbackCounter = new Span("0");
+    private final Spreadsheet spreadsheet = new Spreadsheet();
+
+    public CustomEditorReloadPage() {
+        setSizeFull();
+
+        callbackCounter.setId("callbackCount");
+
+        Button reload = new Button("Reload visible cell contents",
+                e -> spreadsheet.reloadVisibleCellContents());
+        reload.setId("reloadBtn");
+
+        spreadsheet.setSpreadsheetComponentFactory(new ComboBoxEditorFactory());
+        spreadsheet.setSizeFull();
+
+        Div spreadsheetContainer = new Div(spreadsheet);
+        spreadsheetContainer.setSizeFull();
+
+        add(new HorizontalLayout(callbackCounter, reload),
+                spreadsheetContainer);
+        setFlexGrow(1, spreadsheetContainer);
+    }
+
+    private class ComboBoxEditorFactory implements SpreadsheetComponentFactory {
+
+        @Override
+        public Component getCustomComponentForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            return null;
+        }
+
+        @Override
+        public Component getCustomEditorForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            // Editor in B2. A new instance is returned on every call to
+            // exercise the editor-preservation logic.
+            if (rowIndex == 1 && columnIndex == 1) {
+                ComboBox<String> comboBox = new ComboBox<>();
+                comboBox.setItems(FRUITS);
+                comboBox.setWidthFull();
+                return comboBox;
+            }
+            return null;
+        }
+
+        @Override
+        public void onCustomEditorDisplayed(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet,
+                Component customEditor) {
+            callbackCount++;
+            callbackCounter.setText(String.valueOf(callbackCount));
+            if (customEditor instanceof ComboBox<?> comboBox) {
+                @SuppressWarnings("unchecked")
+                ComboBox<String> typed = (ComboBox<String>) comboBox;
+                typed.setValue(FRUITS[columnIndex % FRUITS.length]);
+            }
+        }
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("vaadin-spreadsheet/custom-editor-reload")
+public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
+
+    @Before
+    public void init() {
+        open();
+        setSpreadsheet($(SpreadsheetElement.class).single());
+        $("vaadin-combo-box").waitForFirst();
+    }
+
+    @Test
+    public void editorSelected_scrolledAwayAndBack_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        getSpreadsheet().scroll(5000);
+        getCommandExecutor().waitForVaadin();
+        getSpreadsheet().scroll(0);
+        getCommandExecutor().waitForVaadin();
+        waitUntil(driver -> !getSpreadsheet()
+                .findElements(By.tagName("vaadin-combo-box")).isEmpty());
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_columnSelected_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        selectColumn("B");
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_rangeSelected_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        selectCell("B5", false, true);
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_rowResized_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        resizeRow(2);
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_columnResized_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        resizeColumn("B");
+
+        Assert.assertEquals("1", getCallbackCount());
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+    }
+
+    @Test
+    public void editorSelected_visibleContentsReloaded_editorRecreated() {
+        selectEditorCellB2();
+        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+
+        clickReload();
+        getCommandExecutor().waitForVaadin();
+        Assert.assertEquals("", getComboBoxValue("B2"));
+    }
+
+    private void selectEditorCellB2() {
+        // Select the editor cell B2 via keyboard (select a plain cell, then
+        // Tab) rather than clicking the combobox, which is an unreliable way to
+        // change the selection.
+        selectCell("A2");
+        getSpreadsheet().sendKeys(Keys.TAB);
+        getCommandExecutor().waitForVaadin();
+    }
+
+    private void resizeColumn(String column) {
+        int index = column.charAt(0) - 'A' + 1;
+        var handle = getSpreadsheet().getColumnHeader(index).getResizeHandle();
+        var target = getSpreadsheet().getColumnHeader(index + 1);
+        new Actions(getDriver()).dragAndDrop(handle, target).perform();
+        getCommandExecutor().waitForVaadin();
+    }
+
+    private void resizeRow(int row) {
+        var handle = getSpreadsheet().getRowHeader(row).getResizeHandle();
+        var target = getSpreadsheet().getRowHeader(row + 1);
+        new Actions(getDriver()).dragAndDrop(handle, target).perform();
+        getCommandExecutor().waitForVaadin();
+    }
+
+    private String getCallbackCount() {
+        return $(TestBenchElement.class).id("callbackCount").getText();
+    }
+
+    private void clickReload() {
+        $("vaadin-button").id("reloadBtn").click();
+    }
+
+    private String getComboBoxValue(String cellAddress) {
+        var cell = getSpreadsheet().getCellAt(cellAddress);
+        try {
+            var slotName = cell.findElement(By.tagName("slot"))
+                    .getDomAttribute("name");
+            return getSpreadsheet()
+                    .findElement(By.cssSelector("[slot='" + slotName + "']"))
+                    .findElement(By.cssSelector("input"))
+                    .getDomProperty("value");
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -224,7 +224,25 @@ public class Spreadsheet extends Component
 
     private boolean sheetProtected;
 
-    private HashMap<String, String> cellKeysToEditorIdMap;
+    /**
+     * Editor instance currently shown for each cell key. Used to reuse the same
+     * editor across re-renders that keep the same cells visible (scroll,
+     * selection, resize) instead of re-creating it from the factory, which
+     * would discard editor state such as an uncommitted ComboBox value.
+     * Editor-only; cleared whenever editors are recreated from the factory (see
+     * {@link #setCellKeyToEditorMap(Map)}).
+     */
+    private Map<String, Component> cellKeyToEditor = new HashMap<>();
+
+    /**
+     * Cell key and editor instance that {@code onCustomEditorDisplayed} was
+     * last invoked for, so the callback fires only on a real selection change
+     * and not on re-renders that keep the same selection (scroll, resize,
+     * extending a range).
+     */
+    private String lastEditorCallbackKey;
+
+    private Component lastEditorCallbackComponent;
 
     private HashMap<String, String> componentIDtoCellKeysMap;
 
@@ -349,10 +367,6 @@ public class Spreadsheet extends Component
 
     private boolean isSheetProtected() {
         return sheetProtected;
-    }
-
-    private HashMap<String, String> getCellKeysToEditorIdMap() {
-        return cellKeysToEditorIdMap;
     }
 
     HashMap<String, String> getComponentIDtoCellKeysMap() {
@@ -558,11 +572,31 @@ public class Spreadsheet extends Component
         getElement().setProperty("workbookProtected", workbookProtected);
     }
 
-    private void setCellKeysToEditorIdMap(
-            HashMap<String, String> cellKeysToEditorIdMap) {
-        this.cellKeysToEditorIdMap = cellKeysToEditorIdMap;
-        getElement().setProperty("cellKeysToEditorIdMap",
-                Serializer.serialize(cellKeysToEditorIdMap));
+    /**
+     * Sets the cell-key-to-editor map and pushes it to the client. The client
+     * property maps each cell key to its editor's node id, derived from the
+     * live editor instances so it cannot drift from the server-side map.
+     * <p>
+     * Passing {@code null} clears the server map and the callback tracker and
+     * sends a {@code null} property. A {@code null} property has different
+     * client semantics than an empty map (see
+     * {@code SpreadsheetConnector.setupCustomEditors}), so the reset paths
+     * (sheet switch, factory removal/replacement, forced refresh) rely on it.
+     */
+    private void setCellKeyToEditorMap(Map<String, Component> cellKeyToEditor) {
+        if (cellKeyToEditor == null) {
+            this.cellKeyToEditor.clear();
+            resetEditorCallbackTracker();
+            getElement().setProperty("cellKeysToEditorIdMap",
+                    Serializer.serialize((HashMap<String, String>) null));
+        } else {
+            this.cellKeyToEditor = cellKeyToEditor;
+            HashMap<String, String> editorIds = new HashMap<>();
+            cellKeyToEditor.forEach((key, editor) -> editorIds.put(key,
+                    getComponentNodeId(editor)));
+            getElement().setProperty("cellKeysToEditorIdMap",
+                    Serializer.serialize(editorIds));
+        }
     }
 
     private void setComponentIDtoCellKeysMap(
@@ -1741,11 +1775,11 @@ public class Spreadsheet extends Component
             loadOrUpdateOverlays();
         }
 
-        if (componentIDtoCellKeysMap != null || cellKeysToEditorIdMap != null) {
+        if (componentIDtoCellKeysMap != null || !cellKeyToEditor.isEmpty()) {
             // The node id's of custom components may no longer be valid after a
             // detach/attach. Remove all custom components and reload them (with
             // updated node id's).
-            loadCustomComponents();
+            loadCustomComponents(true);
         }
     }
 
@@ -1904,7 +1938,7 @@ public class Spreadsheet extends Component
         // if the currently active sheet was protected, the protection for the
         // currently selected cell might have changed
         if (sheetPOIIndex == workbook.getActiveSheetIndex()) {
-            loadCustomComponents();
+            loadCustomComponents(true);
             selectionManager.reSelectSelectedCell();
         }
     }
@@ -3580,7 +3614,7 @@ public class Spreadsheet extends Component
      * comments and cells' contents. Also updates styles for the visible area.
      */
     public void reloadVisibleCellContents() {
-        loadCustomComponents();
+        loadCustomComponents(true);
         updateRowAndColumnRangeCellData(firstRow, firstColumn, lastRow,
                 lastColumn);
     }
@@ -3704,7 +3738,7 @@ public class Spreadsheet extends Component
         setSheetIndex(
                 getSpreadsheetSheetIndex(workbook.getActiveSheetIndex()) + 1);
         setSheetProtected(getActiveSheet().getProtect());
-        setCellKeysToEditorIdMap(null);
+        setCellKeyToEditorMap(null);
         setHyperlinksTooltips(null);
         setComponentIDtoCellKeysMap(null);
         setOverlays(null);
@@ -3763,32 +3797,41 @@ public class Spreadsheet extends Component
             final short col = selectedCellReference.getCol();
             final int row = selectedCellReference.getRow();
             final String key = SpreadsheetUtil.toKey(col + 1, row + 1);
-            var currentCellKeysToEditorIdMap = getCellKeysToEditorIdMap();
-            if (currentCellKeysToEditorIdMap != null
-                    && currentCellKeysToEditorIdMap.containsKey(key)
-                    && customComponents != null) {
-                String componentId = currentCellKeysToEditorIdMap.get(key);
-                for (Component c : customComponents) {
-                    if (getComponentNodeId(c).equals(componentId)) {
-                        insideCustomEditorCallback = true;
-                        try {
-                            customComponentFactory.onCustomEditorDisplayed(
-                                    getCell(row, col), row, col, this,
-                                    getActiveSheet(), c);
-                        } catch (Exception e) {
-                            LOGGER.warn(
-                                    "Error in onCustomEditorDisplayed for cell ({}, {})",
-                                    col + 1, row + 1, e);
-                        } finally {
-                            insideCustomEditorCallback = false;
-                        }
-                        return;
-                    }
+            Component editor = cellKeyToEditor.get(key);
+            if (editor != null) {
+                // Fire only on a real selection change. Re-renders that keep
+                // the same selection (scroll, resize, extending a range) re-run
+                // this method; re-firing would re-run the user's setValue and
+                // clobber in-progress editor input.
+                if (key.equals(lastEditorCallbackKey)
+                        && editor == lastEditorCallbackComponent) {
+                    return;
                 }
+                lastEditorCallbackKey = key;
+                lastEditorCallbackComponent = editor;
+                insideCustomEditorCallback = true;
+                try {
+                    customComponentFactory.onCustomEditorDisplayed(
+                            getCell(row, col), row, col, this, getActiveSheet(),
+                            editor);
+                } catch (Exception e) {
+                    LOGGER.warn(
+                            "Error in onCustomEditorDisplayed for cell ({}, {})",
+                            col + 1, row + 1, e);
+                } finally {
+                    insideCustomEditorCallback = false;
+                }
+                return;
             }
-            setCellKeysToEditorIdMap(currentCellKeysToEditorIdMap == null ? null
-                    : new HashMap<>(currentCellKeysToEditorIdMap));
+            // Selected cell has no custom editor: forget the last-fired editor
+            // so a later return to an editor cell fires the callback again.
+            resetEditorCallbackTracker();
         }
+    }
+
+    private void resetEditorCallbackTracker() {
+        lastEditorCallbackKey = null;
+        lastEditorCallbackComponent = null;
     }
 
     private void reloadSheetNames() {
@@ -4018,7 +4061,10 @@ public class Spreadsheet extends Component
      */
     protected void loadCells(int firstRow, int firstColumn, int lastRow,
             int lastColumn) {
-        loadCustomComponents();
+        // Reuse the editors already shown for cells instead of recreating them.
+        // For all existing callers of this method (scrolling, selection,
+        // row/column resize) it makes sense to preserve editor state.
+        loadCustomComponents(false);
         loadHyperLinks();
         loadCellComments();
         loadOrUpdateOverlays();
@@ -4605,18 +4651,32 @@ public class Spreadsheet extends Component
     /**
      * Loads the custom components for the currently viewed cells and clears
      * previous components that are not currently visible.
+     *
+     * @param recreateEditors
+     *            {@code true} to recreate custom editors from the factory, used
+     *            when the application forces a refresh, changes the factory, or
+     *            the sheet changes; {@code false} to reuse the editor already
+     *            shown for a cell so its state survives the re-render, used
+     *            when the same cells stay visible (scrolling, selection,
+     *            resize).
      */
-    private void loadCustomComponents() {
+    private void loadCustomComponents(boolean recreateEditors) {
+        if (recreateEditors) {
+            // Drop the cached editors (and the callback tracker) so the loop
+            // below asks the factory for fresh instances and the callback fires
+            // again for the selected cell.
+            setCellKeyToEditorMap(null);
+        }
         if (customComponentFactory != null) {
-            // Preserve custom editor mappings to maintain StateNode connections
-            HashMap<String, String> _cellKeysToEditorIdMap = getCellKeysToEditorIdMap() != null
-                    ? new HashMap<>(getCellKeysToEditorIdMap())
-                    : new HashMap<>();
             HashMap<String, String> _componentIDtoCellKeysMap = new HashMap<>();
             if (customComponents == null) {
                 customComponents = new HashSet<Component>();
             }
             HashSet<Component> newCustomComponents = new HashSet<Component>();
+            // Carry over the editor-instance cache so editors are reused
+            // (state preserved) instead of re-created from the factory.
+            HashMap<String, Component> _cellKeyToEditor = new HashMap<>(
+                    cellKeyToEditor);
             Set<Integer> rowsWithComponents = new HashSet<Integer>();
             // iteration indexes 0-based
             int verticalSplitPosition = getLastFrozenRow();
@@ -4624,23 +4684,23 @@ public class Spreadsheet extends Component
             if (verticalSplitPosition > 0 && horizontalSplitPosition > 0) {
                 // top left pane
                 loadRangeComponents(newCustomComponents, rowsWithComponents,
-                        _cellKeysToEditorIdMap, _componentIDtoCellKeysMap, 1, 1,
+                        _componentIDtoCellKeysMap, _cellKeyToEditor, 1, 1,
                         verticalSplitPosition, horizontalSplitPosition);
             }
             if (verticalSplitPosition > 0) {
                 // top right pane
                 loadRangeComponents(newCustomComponents, rowsWithComponents,
-                        _cellKeysToEditorIdMap, _componentIDtoCellKeysMap, 1,
+                        _componentIDtoCellKeysMap, _cellKeyToEditor, 1,
                         firstColumn, verticalSplitPosition, lastColumn);
             }
             if (horizontalSplitPosition > 0) {
                 // bottom left pane
                 loadRangeComponents(newCustomComponents, rowsWithComponents,
-                        _cellKeysToEditorIdMap, _componentIDtoCellKeysMap,
-                        firstRow, 1, lastRow, horizontalSplitPosition);
+                        _componentIDtoCellKeysMap, _cellKeyToEditor, firstRow,
+                        1, lastRow, horizontalSplitPosition);
             }
             loadRangeComponents(newCustomComponents, rowsWithComponents,
-                    _cellKeysToEditorIdMap, _componentIDtoCellKeysMap, firstRow,
+                    _componentIDtoCellKeysMap, _cellKeyToEditor, firstRow,
                     firstColumn, lastRow, lastColumn);
 
             // Keep custom editors registered to preserve StateNode connections
@@ -4648,19 +4708,23 @@ public class Spreadsheet extends Component
                     .hasNext();) {
                 Component c = i.next();
                 if (!newCustomComponents.contains(c)) {
-                    String nodeId = getComponentNodeId(c);
-                    if (_cellKeysToEditorIdMap.containsValue(nodeId)) {
+                    if (_cellKeyToEditor.containsValue(c)) {
                         newCustomComponents.add(c);
                     } else {
                         unRegisterCustomComponent(c);
-                        _componentIDtoCellKeysMap.remove(nodeId);
+                        _componentIDtoCellKeysMap.remove(getComponentNodeId(c));
                         i.remove();
                     }
                 }
             }
             customComponents = newCustomComponents;
 
-            setCellKeysToEditorIdMap(_cellKeysToEditorIdMap);
+            // Drop cache entries whose editor is no longer registered (e.g. a
+            // cell that lost its editor); keep those still in use, including
+            // out-of-view cells whose editors remain registered.
+            _cellKeyToEditor.values().retainAll(customComponents);
+
+            setCellKeyToEditorMap(_cellKeyToEditor);
             setComponentIDtoCellKeysMap(_componentIDtoCellKeysMap);
 
             if (!rowsWithComponents.isEmpty()) {
@@ -4668,7 +4732,7 @@ public class Spreadsheet extends Component
             }
 
         } else {
-            setCellKeysToEditorIdMap(null);
+            setCellKeyToEditorMap(null);
             setComponentIDtoCellKeysMap(null);
             if (customComponents != null && !customComponents.isEmpty()) {
                 for (Component c : customComponents) {
@@ -4682,9 +4746,9 @@ public class Spreadsheet extends Component
 
     void loadRangeComponents(HashSet<Component> newCustomComponents,
             Set<Integer> rowsWithComponents,
-            HashMap<String, String> cellKeysToEditorIdMap,
-            HashMap<String, String> componentIDtoCellKeysMap, int row1,
-            int col1, int row2, int col2) {
+            HashMap<String, String> componentIDtoCellKeysMap,
+            Map<String, Component> cellKeyToEditor, int row1, int col1,
+            int row2, int col2) {
         for (int r = row1 - 1; r < row2; r++) {
             final Row row = getActiveSheet().getRow(r);
             for (int c = col1 - 1; c < col2; c++) {
@@ -4713,19 +4777,24 @@ public class Spreadsheet extends Component
                     } else if (!isCellLocked(new CellAddress(r, c))) {
                         // no custom component and not locked, check if
                         // the cell has a custom editor
-                        Component customEditor = customComponentFactory
-                                .getCustomEditorForCell(cell, r, c, this,
-                                        getActiveSheet());
+                        final String key = SpreadsheetUtil.toKey(c + 1, r + 1);
+                        // Reuse the editor already shown for this cell so
+                        // its state (e.g. an uncommitted ComboBox value)
+                        // survives the re-render. Only ask the factory when
+                        // the cell does not have an editor yet.
+                        Component customEditor = cellKeyToEditor.get(key);
+                        if (customEditor == null) {
+                            customEditor = customComponentFactory
+                                    .getCustomEditorForCell(cell, r, c, this,
+                                            getActiveSheet());
+                        }
                         if (customEditor != null) {
-                            final String key = SpreadsheetUtil.toKey(c + 1,
-                                    r + 1);
                             if (!newCustomComponents.contains(customEditor)
                                     && !customComponents
                                             .contains(customEditor)) {
                                 registerCustomComponent(customEditor);
                             }
-                            cellKeysToEditorIdMap.put(key,
-                                    getComponentNodeId(customEditor));
+                            cellKeyToEditor.put(key, customEditor);
                             newCustomComponents.add(customEditor);
                             rowsWithComponents.add(r);
                         }
@@ -4853,10 +4922,12 @@ public class Spreadsheet extends Component
             SpreadsheetComponentFactory customComponentFactory) {
         this.customComponentFactory = customComponentFactory;
         if (firstRow != -1) {
-            loadCustomComponents();
+            // A new factory produces its own editors, so recreate them instead
+            // of reusing the previous factory's by cell-key.
+            loadCustomComponents(true);
             loadCustomEditorOnSelectedCell();
         } else {
-            setCellKeysToEditorIdMap(null);
+            setCellKeyToEditorMap(null);
             if (customComponents != null && !customComponents.isEmpty()) {
                 for (Component c : customComponents) {
                     unRegisterCustomComponent(c);


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9493 to branch 25.1.

---

> When a `SpreadsheetComponentFactory` returns a new editor instance from `getCustomEditorForCell` (the common pattern, e.g. `return new ComboBox<>()`), that editor was re-created on every re-render that kept the same cells visible — scrolling, changing the selection, or resizing a row or column. This wiped any value the user had typed but not yet written into the cell, left orphaned editor instances registered on the client, and re-fired `onCustomEditorDisplayed` even when the selected cell never changed.
>
> To reproduce: a factory whose `getCustomEditorForCell` returns a new `ComboBox` for a cell. Select the cell, pick or type a value, then scroll, select another cell or range, or resize a row or column. The value is cleared, and `onCustomEditorDisplayed` runs again for the same selection.
>
> ## Changes
>
> - Keep one server-side map from cell key to the editor instance already shown there. When `loadCells` re-renders the same visible cells (scroll, selection, row/column resize), reuse that instance instead of asking the factory for a new one, so editor state (such as an uncommitted value) survives. The factory is only called the first time a cell needs an editor.
> - Recreate editors from the factory only when the application forces it: `reloadVisibleCellContents()`, a factory change, a sheet change, or a detach/attach reload. These paths drop the cache so the factory is asked for fresh instances, keeping the existing public-API behavior unchanged.
> - Fire `onCustomEditorDisplayed` only when the selected cell or its editor actually changes, not on every re-render of the same selection.
> - Derive the client `cellKeysToEditorIdMap` property (cell key to editor node id) from the single editor map each time it is sent, instead of storing a second map, so the two can no longer drift apart.
> - Manage the editor map through one `setCellKeyToEditorMap` setter: a non-null map replaces the server map and pushes the derived node ids to the client; a `null` clears the server map, resets the callback tracker, and sends a `null` property (which has different client semantics than an empty map).
>
> Part of #9180
