### PR TITLE
fix: sync editor value to server when same value is typed again

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -151,7 +151,7 @@ public class GridPro<E> extends Grid<E> {
                 var itemKey = getDataCommunicator().getKeyMapper()
                         .key(e.getItem());
                 UI.getCurrentOrThrow().getPage().executeJs(
-                        "window.Vaadin.Flow.gridProConnector.selectAll($0, $1, $2)",
+                        "window.Vaadin.Flow.gridProConnector.handleCustomEditorValueUpdate($0, $1, $2)",
                         column.getEditorField().getElement(), itemKey,
                         this.getElement());
             }

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -7,6 +7,7 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
+import { isFirefox } from '@vaadin/component-base/src/browser-utils.js';
 import { iterateRowCells, updatePart } from '@vaadin/grid/src/vaadin-grid-helpers.js';
 
 function isEditedRow(grid, rowData) {
@@ -26,21 +27,10 @@ window.Vaadin.Flow.gridProConnector = {
 
     grid.toggleAttribute(LOADING_EDITOR_CELL_ATTRIBUTE, false);
 
-    const active = editor.getRootNode().activeElement;
-    const candidates = [editor.contains(active) ? active : null, editor, editor.focusElement];
-    const focusElement = candidates.find((c) => c instanceof HTMLInputElement);
-
-    if (focusElement) {
-      // The editor is focused before its value is set from the server. Firefox
-      // treats an input as unchanged when its value on blur equals the value it
-      // had on focus, ignoring programmatic changes in between, so typing the
-      // value from the previous edit again would not fire a change event and
-      // the cell would not update. Blurring and re-focusing the input after the
-      // value has been set (this runs after the property sync) recaptures the
-      // baseline, so a later change is detected.
-      focusElement.blur();
-      focusElement.focus();
-      focusElement.select();
+    if (editor instanceof HTMLInputElement) {
+      editor.select();
+    } else if (editor.focusElement && editor.focusElement instanceof HTMLInputElement) {
+      editor.focusElement.select();
     }
   },
 
@@ -72,6 +62,21 @@ window.Vaadin.Flow.gridProConnector = {
       stopCellEdit.apply(this, arguments);
       this._grid.toggleAttribute(LOADING_EDITOR_CELL_ATTRIBUTE, false);
     };
+
+    if (isFirefox && !component.__firefoxChangeWorkaroundInstalled) {
+      // The editor is focused before its value is set from the server. Firefox
+      // treats an input as unchanged when its value on blur equals the value it
+      // had on focus, ignoring programmatic changes in between. So typing the
+      // value from the previous edit again would not fire a change event and
+      // the cell would not update. As a workaround, always fire a synthetic
+      // change event when an input loses focus.
+      component.addEventListener('focusout', (e) => {
+        if (e.target instanceof HTMLInputElement) {
+          e.target.dispatchEvent(new Event('change'));
+        }
+      });
+      component.__firefoxChangeWorkaroundInstalled = true;
+    }
   },
 
   patchEditModeRenderer(column) {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -16,7 +16,7 @@ function isEditedRow(grid, rowData) {
 const LOADING_EDITOR_CELL_ATTRIBUTE = 'loading-editor';
 
 window.Vaadin.Flow.gridProConnector = {
-  selectAll: (editor, itemKey, grid) => {
+  handleCustomEditorValueUpdate: (editor, itemKey, grid) => {
     if (editor.__itemKey !== itemKey) {
       // This is an outdated call that can occur if the user starts editing a cell,
       // and quickly starts editing another cell on the same column before the editor
@@ -26,10 +26,21 @@ window.Vaadin.Flow.gridProConnector = {
 
     grid.toggleAttribute(LOADING_EDITOR_CELL_ATTRIBUTE, false);
 
-    if (editor instanceof HTMLInputElement) {
-      editor.select();
-    } else if (editor.focusElement && editor.focusElement instanceof HTMLInputElement) {
-      editor.focusElement.select();
+    const active = editor.getRootNode().activeElement;
+    const candidates = [editor.contains(active) ? active : null, editor, editor.focusElement];
+    const focusElement = candidates.find((c) => c instanceof HTMLInputElement);
+
+    if (focusElement) {
+      // The editor is focused before its value is set from the server. Firefox
+      // treats an input as unchanged when its value on blur equals the value it
+      // had on focus, ignoring programmatic changes in between, so typing the
+      // value from the previous edit again would not fire a change event and
+      // the cell would not update. Blurring and re-focusing the input after the
+      // value has been set (this runs after the property sync) recaptures the
+      // baseline, so a later change is detected.
+      focusElement.blur();
+      focusElement.focus();
+      focusElement.select();
     }
   },
 

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/resources/META-INF/resources/frontend/gridProConnector.js
@@ -72,7 +72,7 @@ window.Vaadin.Flow.gridProConnector = {
       // change event when an input loses focus.
       component.addEventListener('focusout', (e) => {
         if (e.target instanceof HTMLInputElement) {
-          e.target.dispatchEvent(new Event('change'));
+          e.target.dispatchEvent(new Event('change', { bubbles: true }));
         }
       });
       component.__firefoxChangeWorkaroundInstalled = true;


### PR DESCRIPTION
## Description

Since a recent change, Firefox treats input fields that have the same value on blur as they had on focus as unchanged, even if the value was changed programmatically in between. This is problematic for custom editors in GridPro, where the value is set programmatically from the server after the client-side component has already focused the editor. If, after starting editing, a user types exactly the same value that the input had before the server updated the editor value, no change event is fired and the editor value is never synced to the server where it would be used to update the item data:
- First edit:
  - User edits cell, types "foo", commits
  - "foo" is different from the value the editor had before focus (empty value), property is synced to the server
  - `item-property-change` fires, server detects change in the editor's value, item is updated on server
- Second edit (same column, different cell)
  - User starts editing, web component focuses editor component immediately
  - Initially the client-side value is still "foo", the server only updates the editor's value once it receives the `cell-edit-started` event, which eventually results in a client-side update of the editor value, let's say to "bar"
  - User types "foo" again, commits
  - "foo" is not different from the value the editor had before focusing it, no change event is fired for the editor, it's value is not synced back to the server
  - `item-property-change` fires, server does not detect a change in the editor's value, no item update

This change addresses the issue by always firing a synthetic change event whenever an input element loses focus. The fix is scoped only Firefox, and only to custom editors. For built-in editors no such fix is needed as the edited value is applied by the web component before focusing. The change is not covered by tests, as the issue only manifests in Firefox whereas tests only run in Chrome.

Fixes https://github.com/vaadin/flow-components/issues/9437

## Type of change

- Bugfix
