### PR TITLE
fix: add missing aura progress bar variants

### DIFF
--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBarVariant.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBarVariant.java
@@ -21,7 +21,12 @@ import com.vaadin.flow.component.shared.ThemeVariant;
  * Set of theme variants applicable for {@code vaadin-progress-bar} component.
  */
 public enum ProgressBarVariant implements ThemeVariant {
-    LUMO_CONTRAST("contrast"), LUMO_ERROR("error"), LUMO_SUCCESS("success");
+    LUMO_CONTRAST("contrast"),
+    LUMO_ERROR("error"),
+    LUMO_SUCCESS("success"),
+    AURA_WARNING("warning"),
+    ERROR("error"),
+    SUCCESS("success");
 
     private final String variant;
 

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBarVariant.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBarVariant.java
@@ -24,7 +24,6 @@ public enum ProgressBarVariant implements ThemeVariant {
     LUMO_CONTRAST("contrast"),
     LUMO_ERROR("error"),
     LUMO_SUCCESS("success"),
-    AURA_WARNING("warning"),
     ERROR("error"),
     SUCCESS("success");
 


### PR DESCRIPTION
## Description

Adds unprefixed `ERROR` and `SUCCESS` variants as those are supported by both Lumo and Aura.

Closes https://github.com/vaadin/flow-components/issues/9419

## Type of change

- Bugfix
