### PR TITLE
fix: allow filtering out all values in spreadsheet filter (CP: 25.1)

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -24,8 +23,6 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.checkbox.CheckboxGroupVariant;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.spreadsheet.PopupButton.PopupCloseEvent;
-import com.vaadin.flow.component.spreadsheet.PopupButton.PopupCloseListener;
 import com.vaadin.flow.component.spreadsheet.PopupButton.PopupOpenEvent;
 import com.vaadin.flow.component.spreadsheet.PopupButton.PopupOpenListener;
 import com.vaadin.flow.data.provider.ListDataProvider;
@@ -48,9 +45,7 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
     private ListDataProvider<String> filterOptionsProvider;
     private List<String> filterOptions = new ArrayList<>();
     private ArrayList<String> allCellValues;
-    private Collection<String> latestFilteredValues;
     private PopupButton popupButton;
-    private boolean firstUpdate = true;
     private boolean cancelValueChangeUpdate;
     private SpreadsheetFilterTable filterTable;
     private Set<Integer> filteredRows;
@@ -77,7 +72,6 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
 
         allCellValues = new ArrayList<>();
         filteredRows = new HashSet<>();
-        latestFilteredValues = new LinkedHashSet<>();
         initComponents();
         updateOptions();
     }
@@ -103,43 +97,11 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
     }
 
     /**
-     * Initializes pop-up close listener for verifying that filter selections
-     * match with what is currently shown.
+     * Initializes the pop-up open listener that refreshes the filter options
+     * whenever the pop-up is opened.
      */
     protected void initPopupButtonListeners() {
 
-        popupButton.addPopupCloseListener(new PopupCloseListener() {
-
-            @Override
-            public void onPopupClose(PopupCloseEvent event) {
-                // need to check that the filter wasn't left a different state
-                // than what is displayed, like in case when allItems and all
-                // options were left unchecked.
-                if (!allItems.getValue()) {
-                    Collection<String> currentValue = filterCheckbox.getValue();
-                    cancelValueChangeUpdate = true;
-                    if (currentValue.isEmpty()) {
-                        if (latestFilteredValues.isEmpty()
-                                || latestFilteredValues
-                                        .containsAll(allCellValues)) {
-                            allItems.setIndeterminate(false);
-                            allItems.setValue(true);
-                            filterCheckbox
-                                    .setValue(new HashSet<>(allCellValues));
-                        } else {
-                            filterCheckbox.setValue(
-                                    new HashSet<>(latestFilteredValues));
-                        }
-                    } else {
-                        if (currentValue.containsAll(allCellValues)) {
-                            allItems.setIndeterminate(false);
-                            allItems.setValue(true);
-                        }
-                    }
-                    cancelValueChangeUpdate = false;
-                }
-            }
-        });
         popupButton.addPopupOpenListener(new PopupOpenListener() {
 
             @Override
@@ -163,6 +125,7 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
                     updateFilteredItems(allCellValues);
                 } else {
                     filterCheckbox.setValue(Collections.emptySet());
+                    updateFilteredItems(Collections.emptySet());
                 }
                 cancelValueChangeUpdate = false;
             }
@@ -178,31 +141,21 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
         filterCheckbox.setItems(filterOptionsProvider);
         filterCheckbox.addThemeVariants(CheckboxGroupVariant.LUMO_VERTICAL);
         filterCheckbox.addValueChangeListener(event -> {
-            if (firstUpdate) {
-                firstUpdate = false;
-            } else {
-                if (!cancelValueChangeUpdate) {
-                    Collection<String> value = filterCheckbox.getValue();
-                    // value should not be updated when options are empty and
-                    // all
-                    // items is unchecked - just as in Excel
-                    if (!value.isEmpty()) {
-                        updateFilteredItems(value);
-                        cancelValueChangeUpdate = true;
-                        if (value.containsAll(allCellValues)) {
-                            allItems.setIndeterminate(false);
-                            if (!allItems.getValue()) {
-                                allItems.setValue(true);
-                            }
-                        } else {
-                            if (allItems.getValue()) {
-                                allItems.setValue(false);
-                                allItems.setIndeterminate(true);
-                            }
-                        }
-                        cancelValueChangeUpdate = false;
-                    }
+            if (!cancelValueChangeUpdate) {
+                Collection<String> value = filterCheckbox.getValue();
+                updateFilteredItems(value);
+                cancelValueChangeUpdate = true;
+                if (value.containsAll(allCellValues)) {
+                    allItems.setIndeterminate(false);
+                    allItems.setValue(true);
+                } else if (value.isEmpty()) {
+                    allItems.setIndeterminate(false);
+                    allItems.setValue(false);
+                } else {
+                    allItems.setValue(false);
+                    allItems.setIndeterminate(true);
                 }
+                cancelValueChangeUpdate = false;
             }
         });
     }
@@ -239,15 +192,26 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
             Collections.sort(filterOptions, byString);
         }
 
+        // Hide "Select All" when there are no values to control, i.e. all of
+        // this column's values are hidden by other columns' filters.
+        allItems.setVisible(!allCellValues.isEmpty());
+
         Set<String> visibleValues = getVisibleValues();
         cancelValueChangeUpdate = true;
-        allItems.setIndeterminate(!visibleValues.containsAll(allCellValues));
-        allItems.setValue(visibleValues.containsAll(allCellValues));
-        cancelValueChangeUpdate = false;
+        if (visibleValues.containsAll(allCellValues)) {
+            allItems.setIndeterminate(false);
+            allItems.setValue(true);
+        } else if (visibleValues.isEmpty()) {
+            allItems.setIndeterminate(false);
+            allItems.setValue(false);
+        } else {
+            allItems.setValue(false);
+            allItems.setIndeterminate(true);
+        }
         filterOptionsProvider = new ListDataProvider<>(filterOptions);
         filterCheckbox.setItems(filterOptionsProvider);
-        firstUpdate = true;
         filterCheckbox.setValue(visibleValues);
+        cancelValueChangeUpdate = false;
     }
 
     /**
@@ -310,7 +274,6 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
                 filteredRows.add(r);
             }
         }
-        latestFilteredValues = new ArrayList<>(visibleValues);
 
         filterTable.onFiltersUpdated();
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.spreadsheet.ItemFilter;
 import com.vaadin.flow.component.spreadsheet.PopupButton;
@@ -64,78 +65,78 @@ public class FilterTableTest {
 
     @Test
     public void init_filteredRows_empty() {
-        Assert.assertEquals(0, getItemFilter().getFilteredRows().size());
+        Assert.assertEquals(0, getItemFilter(1).getFilteredRows().size());
     }
 
     @Test
     public void filter_filteredRows_hasFilteredRow() {
         // Filter out row 4
-        getFilterCheckboxGroup().deselect("4");
+        getFilterCheckboxGroup(1).deselect("4");
 
-        Assert.assertEquals(1, getItemFilter().getFilteredRows().size());
-        Assert.assertEquals(3,
-                getItemFilter().getFilteredRows().iterator().next().intValue());
+        Assert.assertEquals(1, getItemFilter(1).getFilteredRows().size());
+        Assert.assertEquals(3, getItemFilter(1).getFilteredRows().iterator()
+                .next().intValue());
     }
 
     @Test
     public void filter_filteredRows_rowHidden() {
-        getFilterCheckboxGroup().deselect("4");
+        getFilterCheckboxGroup(1).deselect("4");
 
         Assert.assertTrue(spreadsheet.isRowHidden(3));
     }
 
     @Test
     public void init_clearButtonDisabled() {
-        Assert.assertFalse(getClearButton().isEnabled());
+        Assert.assertFalse(getClearButton(1).isEnabled());
     }
 
     @Test
     public void filter_filteredAllRows_clearButtonEnabled() {
-        getFilterCheckboxGroup().deselectAll();
+        getFilterCheckboxGroup(1).deselectAll();
 
-        Assert.assertTrue(getClearButton().isEnabled());
+        Assert.assertTrue(getClearButton(1).isEnabled());
     }
 
     @Test
     public void init_popupButtonInactive() {
-        Assert.assertFalse(getPopupButton().isActive());
+        Assert.assertFalse(getPopupButton(1).isActive());
     }
 
     @Test
     public void filter_popupButtonActive() {
-        getFilterCheckboxGroup().deselect("4");
+        getFilterCheckboxGroup(1).deselect("4");
 
-        Assert.assertTrue(getPopupButton().isActive());
+        Assert.assertTrue(getPopupButton(1).isActive());
     }
 
     @Test
     public void filter_clearAllButtonClick_filtersCleared() {
-        getFilterCheckboxGroup().deselect("4");
-        getClearButton().click();
+        getFilterCheckboxGroup(1).deselect("4");
+        getClearButton(1).click();
 
-        Assert.assertEquals(0, getItemFilter().getFilteredRows().size());
+        Assert.assertEquals(0, getItemFilter(1).getFilteredRows().size());
         Assert.assertFalse(spreadsheet.isRowHidden(3));
-        Assert.assertFalse(getClearButton().isEnabled());
-        Assert.assertFalse(getPopupButton().isActive());
+        Assert.assertFalse(getClearButton(1).isEnabled());
+        Assert.assertFalse(getPopupButton(1).isActive());
     }
 
     @Test
     public void filter_clearAndReload_filtersCleared() {
-        getFilterCheckboxGroup().deselect("4");
+        getFilterCheckboxGroup(1).deselect("4");
         table.clear();
         table.reload();
         table.onFiltersUpdated();
 
-        Assert.assertEquals(0, getItemFilter().getFilteredRows().size());
+        Assert.assertEquals(0, getItemFilter(1).getFilteredRows().size());
         Assert.assertFalse(spreadsheet.isRowHidden(3));
-        Assert.assertFalse(getClearButton().isEnabled());
-        Assert.assertFalse(getPopupButton().isActive());
+        Assert.assertFalse(getClearButton(1).isEnabled());
+        Assert.assertFalse(getPopupButton(1).isActive());
     }
 
     @Test
     public void filter_unregisterFilter_filtersCleared() {
-        getFilterCheckboxGroup().deselect("4");
-        table.unRegisterFilter(getPopupButton(), getItemFilter());
+        getFilterCheckboxGroup(1).deselect("4");
+        table.unRegisterFilter(getPopupButton(1), getItemFilter(1));
         table.onFiltersUpdated();
 
         Assert.assertFalse(spreadsheet.isRowHidden(3));
@@ -143,39 +144,114 @@ public class FilterTableTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void registerFilter_uknownPopupButton_throws() {
-        table.registerFilter(new PopupButton(), getItemFilter());
+        table.registerFilter(new PopupButton(), getItemFilter(1));
     }
 
     @Test
     public void filteredTable_unhideRowAndOpenPopup_rowIsUnhidden() {
-        getFilterCheckboxGroup().deselect("4");
+        getFilterCheckboxGroup(1).deselect("4");
 
         spreadsheet.setRowHidden(3, false);
-        getPopupButton().openPopup();
+        getPopupButton(1).openPopup();
 
         Assert.assertFalse(spreadsheet.isRowHidden(3));
     }
 
-    private CheckboxGroup<String> getFilterCheckboxGroup() {
-        return (CheckboxGroup<String>) getItemFilter().getChildren()
+    @Test
+    public void deselectAll_allRowsHidden() {
+        getSelectAllCheckbox(1).setValue(false);
+
+        Assert.assertEquals(4, getItemFilter(1).getFilteredRows().size());
+        Assert.assertTrue(spreadsheet.isRowHidden(2));
+        Assert.assertTrue(spreadsheet.isRowHidden(3));
+        Assert.assertTrue(spreadsheet.isRowHidden(4));
+        Assert.assertTrue(spreadsheet.isRowHidden(5));
+    }
+
+    @Test
+    public void deselectAll_reopenPopup_staysDeselectedAndHidden() {
+        getSelectAllCheckbox(1).setValue(false);
+
+        getPopupButton(1).openPopup();
+
+        Assert.assertFalse(getSelectAllCheckbox(1).getValue());
+        Assert.assertTrue(getFilterCheckboxGroup(1).getValue().isEmpty());
+        Assert.assertEquals(4, getItemFilter(1).getFilteredRows().size());
+        Assert.assertTrue(spreadsheet.isRowHidden(2));
+    }
+
+    @Test
+    public void deselectAll_reopenPopup_selectAllNotIndeterminate() {
+        getSelectAllCheckbox(1).setValue(false);
+
+        getPopupButton(1).openPopup();
+
+        Assert.assertFalse(getSelectAllCheckbox(1).isIndeterminate());
+        Assert.assertFalse(getSelectAllCheckbox(1).getValue());
+    }
+
+    @Test
+    public void allValuesHiddenByOtherFilter_selectAllHidden() {
+        // Hide every row through another column's filter
+        getFilterCheckboxGroup(2).deselectAll();
+
+        // Refresh this column's options by reopening its popup
+        getPopupButton(1).openPopup();
+
+        Assert.assertFalse(getSelectAllCheckbox(1).isVisible());
+    }
+
+    @Test
+    public void someValuesHiddenByOtherFilter_selectAllVisible() {
+        // Hide a single row through another column's filter
+        getFilterCheckboxGroup(2).deselect("4");
+
+        getPopupButton(1).openPopup();
+
+        Assert.assertTrue(getSelectAllCheckbox(1).isVisible());
+    }
+
+    @Test
+    public void deselectLastRemainingValue_lastRowHidden() {
+        // Keep only the value of row 5 selected, then deselect it too
+        CheckboxGroup<String> group = getFilterCheckboxGroup(1);
+        group.deselect("3");
+        group.deselect("4");
+        group.deselect("5");
+        // Only "6" (row 5) remains selected
+        group.deselect("6");
+
+        Assert.assertEquals(4, getItemFilter(1).getFilteredRows().size());
+        Assert.assertTrue(getFilterCheckboxGroup(1).getValue().isEmpty());
+        Assert.assertTrue(spreadsheet.isRowHidden(5));
+    }
+
+    private Checkbox getSelectAllCheckbox(int column) {
+        return (Checkbox) getItemFilter(column).getChildren()
+                .filter(component -> component instanceof Checkbox).findFirst()
+                .get();
+    }
+
+    private CheckboxGroup<String> getFilterCheckboxGroup(int column) {
+        return (CheckboxGroup<String>) getItemFilter(column).getChildren()
                 .filter(component -> component instanceof CheckboxGroup)
                 .findFirst().get();
     }
 
-    private ItemFilter getItemFilter() {
-        return (ItemFilter) getPopupButtonChildren().get(0);
+    private ItemFilter getItemFilter(int column) {
+        return (ItemFilter) getPopupButtonChildren(column).get(0);
     }
 
-    private Button getClearButton() {
-        return (Button) getPopupButtonChildren().get(1);
+    private Button getClearButton(int column) {
+        return (Button) getPopupButtonChildren(column).get(1);
     }
 
-    private List<Component> getPopupButtonChildren() {
-        return getPopupButton().getContent().getChildren()
+    private List<Component> getPopupButtonChildren(int column) {
+        return getPopupButton(column).getContent().getChildren()
                 .collect(Collectors.toList());
     }
 
-    private PopupButton getPopupButton() {
-        return table.getPopupButton(1);
+    private PopupButton getPopupButton(int column) {
+        return table.getPopupButton(column);
     }
 }


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9574 to branch 25.1.

---

> In the spreadsheet filter popup, unchecking "Select All" had no effect, and when unchecking values one by one, the last one didn't do anything either. The selection looked empty, but no filtering happened, and after closing the popup everything was selected again, which was confusing.
>
> Unchecking now hides the rows and the deselected state persists. The PR also hides the "Select All" checkbox entirely when all of a column's values are already filtered out by other columns.
>
> Fixes https://github.com/vaadin/flow-components/issues/9549
>
> 🤖 Generated with Claude Code
