### PR TITLE
chore: update feature flag links

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/AIComponentsFeatureFlagProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/AIComponentsFeatureFlagProvider.java
@@ -40,7 +40,7 @@ public class AIComponentsFeatureFlagProvider implements FeatureFlagProvider {
      */
     public static final Feature AI_COMPONENTS = new Feature("AI Components", // title
             FEATURE_FLAG_ID, // id
-            null, // moreInfoLink
+            "https://vaadin.com/docs/latest/flow/ai-support", // moreInfoLink
             false, // requiresServerRestart
             null); // componentClassName
 

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsFeatureFlagProvider.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsFeatureFlagProvider.java
@@ -35,7 +35,7 @@ public class BreadcrumbsFeatureFlagProvider implements FeatureFlagProvider {
     public static final Feature BREADCRUMBS_COMPONENT = new Feature(
             "Breadcrumbs component", // title
             "breadcrumbsComponent", // id
-            "https://github.com/vaadin/web-components/issues/7960", // moreInfoLink
+            "https://vaadin.com/docs/latest/components/breadcrumbs", // moreInfoLink
             true, // requiresServerRestart
             "com.vaadin.flow.component.breadcrumbs.Breadcrumbs"); // componentClassName
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/AccessibleDisabledMenuItemsFeatureFlagProvider.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/AccessibleDisabledMenuItemsFeatureFlagProvider.java
@@ -25,8 +25,8 @@ public class AccessibleDisabledMenuItemsFeatureFlagProvider
 
     public static final Feature ACCESSIBLE_DISABLED_MENU_ITEMS = new Feature(
             "Accessible disabled menu items", "accessibleDisabledMenuItems",
-            "https://github.com/vaadin/web-components/issues/10415", true,
-            null);
+            "https://vaadin.com/docs/latest/components/context-menu#disabled-menu-items",
+            true, null);
 
     @Override
     public List<Feature> getFeatures() {


### PR DESCRIPTION
Update feature flag links to point at the docs.

Links point at docs `latest`, where those articles / sections should become available when docs are updated with the 25.2 release.

Part of https://github.com/vaadin/flow-components/issues/9306