### PR TITLE
chore: update feature flag links (25.1)

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/AIComponentsFeatureFlagProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/AIComponentsFeatureFlagProvider.java
@@ -40,7 +40,7 @@ public class AIComponentsFeatureFlagProvider implements FeatureFlagProvider {
      */
     public static final Feature AI_COMPONENTS = new Feature("AI Components", // title
             FEATURE_FLAG_ID, // id
-            null, // moreInfoLink
+            "https://vaadin.com/docs/latest/flow/ai-support", // moreInfoLink
             false, // requiresServerRestart
             null); // componentClassName
 

--- a/vaadin-badge-flow-parent/vaadin-badge-flow/src/main/java/com/vaadin/flow/component/badge/BadgeFeatureFlagProvider.java
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow/src/main/java/com/vaadin/flow/component/badge/BadgeFeatureFlagProvider.java
@@ -23,8 +23,8 @@ import com.vaadin.experimental.FeatureFlagProvider;
 public class BadgeFeatureFlagProvider implements FeatureFlagProvider {
 
     public static final Feature BADGE_COMPONENT = new Feature("Badge component",
-            "badgeComponent", "github.com/vaadin/platform/issues/8530", true,
-            "com.vaadin.flow.component.badge.Badge");
+            "badgeComponent", "https://vaadin.com/docs/latest/components/badge",
+            true, "com.vaadin.flow.component.badge.Badge");
 
     @Override
     public List<Feature> getFeatures() {

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListAttachmentsFeatureFlagProvider.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListAttachmentsFeatureFlagProvider.java
@@ -41,7 +41,7 @@ public class MessageListAttachmentsFeatureFlagProvider
     public static final Feature MESSAGE_LIST_ATTACHMENTS = new Feature(
             "MessageList Attachments", // title
             FEATURE_FLAG_ID, // id
-            null, // moreInfoLink
+            "https://vaadin.com/docs/latest/components/message-list#attachments", // moreInfoLink
             false, // requiresServerRestart
             null); // componentClassName
 

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderFeatureFlagProvider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/SliderFeatureFlagProvider.java
@@ -24,7 +24,7 @@ public class SliderFeatureFlagProvider implements FeatureFlagProvider {
 
     public static final Feature SLIDER_COMPONENT = new Feature(
             "Slider component", "sliderComponent",
-            "https://github.com/vaadin/platform/issues/8397", true,
+            "https://vaadin.com/docs/latest/components/slider", true,
             "com.vaadin.flow.component.slider.Slider");
 
     @Override

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ModularUploadFeatureFlagProvider.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/ModularUploadFeatureFlagProvider.java
@@ -41,7 +41,7 @@ public class ModularUploadFeatureFlagProvider implements FeatureFlagProvider {
     public static final Feature MODULAR_UPLOAD = new Feature(
             "Modular Upload Components", // title
             FEATURE_FLAG_ID, // id
-            null, // moreInfoLink
+            "https://vaadin.com/docs/latest/components/upload/modular-upload", // moreInfoLink
             false, // requiresServerRestart
             null); // componentClassName
 


### PR DESCRIPTION
Update feature flag links to point at the docs, for the 25.1 branch.

Part of https://github.com/vaadin/flow-components/issues/9306