### PR TITLE
chore: use PNPM for WTR tests

### DIFF
--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -79,8 +79,16 @@ async function runTests() {
         fs.writeFileSync(packageJson, '{}');
       }
 
+      // Build the frontend with pnpm and let @vaadin/* web component bumps
+      // bypass the frontend package age check. Avoids failures when running
+      // checks for just-released @vaadin packages.
+      fs.writeFileSync(
+        `${itFolder}/pnpm-workspace.yaml`,
+        "minimumReleaseAgeExclude:\n  - '@vaadin/*'\n"
+      );
+
       // Install the IT module dependencies
-      execSync(`mvn -DskipTests flow:prepare-frontend flow:build-frontend`, {
+      execSync(`mvn -DskipTests -Dvaadin.pnpm.enable flow:prepare-frontend flow:build-frontend`, {
         cwd: itFolder,
         stdio: 'inherit'
       });


### PR DESCRIPTION
https://github.com/vaadin/flow-components/pull/9525 changed the package WAR step so that the build installs NPM dependencies with PNPM and adds a release age check exclude for Vaadin packages, so that the build succeeds when running checks for PRs that bump versions.

However running WTR tests also requires installing dependencies, and they currently [fail for version bump PRs](https://github.com/vaadin/flow-components/pull/9582) as they still use NPM. This updates WTR tests to also use PNPM and the same release age check exclude.