### PR TITLE
refactor: update session context tool description

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -649,9 +649,13 @@ public class AIOrchestrator implements Serializable {
         SessionContextTool(String content) {
             this.content = content;
             this.description = """
-                    Read for current session context (e.g. date and time, user \
-                    locale). The content below is captured at the start of \
-                    this turn:
+                    Read for current session context. If a date/time is \
+                    included below, use it to resolve relative phrases in \
+                    the user's prompt — "today", "tomorrow", "yesterday", \
+                    "next Friday", "in two weeks", "end of next month", \
+                    etc. — into ISO date / date-time / time strings.
+
+                    Captured at the start of this turn:
 
                     """ + content;
         }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2509,6 +2509,34 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void sessionContextToolDescription_carriesRelativeDateGuidance() {
+        // Real LLMs often leave date fields empty on the first turn when the
+        // user writes "tomorrow" or "next Friday" because nothing in the
+        // tool surface tells them to anchor relative phrases against the
+        // date that the session-context tool carries. Pin the load-bearing
+        // phrases that close that gap; a regression here re-opens it.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var description = captor.getValue().explicitTools().getFirst()
+                .getDescription();
+
+        for (var anchor : List.of("relative", "tomorrow", "ISO", "phrase")) {
+            Assertions.assertTrue(description.contains(anchor),
+                    "Description must mention '" + anchor + "', got: "
+                            + description);
+        }
+    }
+
+    @Test
     void prompt_withCustomContextSupplier_replacesDefaultAndExposesContent() {
         stubAddMessage();
         Mockito.when(


### PR DESCRIPTION
## Description

There is an issue with relative date phrases like *"tomorrow"*, *"yesterday"*, *"two weeks from now"*, or *"next Friday"* in user prompts. The LLM either left date fields empty or wrote the phrase verbatim rather than resolving it into an ISO date.

This PR updates the `SessionContextTool` description in `AIOrchestrator` to lead with explicit guidance for resolving relative phrases against the date/time included in the session context, into ISO date / date-time / time strings. The orchestrator stays controller-agnostic. What to do with the resolved value is left to whichever controller is wired in.

Based on Form Filler DX test session findings.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.