### PR TITLE
chore: rename integration-test build profiles

### DIFF
--- a/scripts/templates/pom-integration-tests.xml
+++ b/scripts/templates/pom-integration-tests.xml
@@ -71,7 +71,7 @@
 
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -87,7 +87,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -147,7 +147,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -166,7 +166,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
@@ -143,7 +143,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -162,7 +162,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -149,7 +149,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -168,7 +168,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
@@ -94,7 +94,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -113,7 +113,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -125,7 +125,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -144,7 +144,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
@@ -117,7 +117,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -136,7 +136,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -120,7 +120,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -139,7 +139,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
@@ -116,7 +116,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -135,7 +135,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -140,7 +140,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -159,7 +159,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
@@ -117,7 +117,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -136,7 +136,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -148,7 +148,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -167,7 +167,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -136,7 +136,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -155,7 +155,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -162,7 +162,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -181,7 +181,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -144,7 +144,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -163,7 +163,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -136,7 +136,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -155,7 +155,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -173,7 +173,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -192,7 +192,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -131,7 +131,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -150,7 +150,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
@@ -138,7 +138,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -157,7 +157,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -135,7 +135,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -154,7 +154,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -132,7 +132,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -151,7 +151,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -120,7 +120,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -139,7 +139,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -150,7 +150,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -169,7 +169,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -141,7 +141,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -160,7 +160,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -147,7 +147,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -166,7 +166,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -216,7 +216,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -235,7 +235,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -140,7 +140,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -159,7 +159,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -126,7 +126,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -145,7 +145,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -134,7 +134,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -153,7 +153,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -130,7 +130,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -149,7 +149,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -120,7 +120,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -139,7 +139,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -124,7 +124,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -143,7 +143,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
@@ -108,7 +108,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -127,7 +127,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
@@ -144,7 +144,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -163,7 +163,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -125,7 +125,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -144,7 +144,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -130,7 +130,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -149,7 +149,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -145,7 +145,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -164,7 +164,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -142,7 +142,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -161,7 +161,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -131,7 +131,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -150,7 +150,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -131,7 +131,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -150,7 +150,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -135,7 +135,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -154,7 +154,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -111,7 +111,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -130,7 +130,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -155,7 +155,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -174,7 +174,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -146,7 +146,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -165,7 +165,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -116,7 +116,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -135,7 +135,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
@@ -117,7 +117,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -136,7 +136,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -137,7 +137,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -156,7 +156,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -209,7 +209,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -228,7 +228,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -131,7 +131,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -150,7 +150,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -136,7 +136,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -155,7 +155,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -125,7 +125,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -144,7 +144,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -129,7 +129,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -148,7 +148,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -139,7 +139,7 @@
     </build>
     <profiles>
         <profile>
-            <id>build-frontend</id>
+            <id>frontend</id>
             <activation>
                 <property>
                     <name>!skipFrontend</name>
@@ -158,7 +158,7 @@
             </build>
         </profile>
         <profile>
-            <id>run-jetty</id>
+            <id>jetty</id>
             <activation>
                 <property>
                     <name>!skipJetty</name>


### PR DESCRIPTION
The `build-frontend` profile id in the integration-test poms collided with the Vaadin `build-frontend` Maven goal, which was confusing. The `run-jetty` profile had a similar mismatch with the flag that controls it.

This renames the profiles to `frontend` and `jetty`, so they align with the `-DskipFrontend` and `-DskipJetty` flags that toggle them.
