### PR TITLE
chore: enable pnpm by default

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -306,7 +306,7 @@ jobs:
         if: matrix.type == 'war'
         run: |
           mvn package -pl integration-tests \
-            -Dvaadin.pnpm.enable -Drun-it -Drelease \
+            -Drun-it -Drelease \
             -Dvaadin.productionMode -Dvaadin.force.production.build=true \
             -Dmaven.test.skip=true -DskipJetty $MAVEN_ARGS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ mvn verify -am -pl vaadin-{component}-flow-parent/vaadin-{component}-flow-integr
 mvn verify -am -pl vaadin-{component}-flow-parent/vaadin-{component}-flow-integration-tests -Dit.test='{file-pattern}' -DskipUnitTests
 
 # Start integration test server for a component
-mvn package jetty:run -Dvaadin.pnpm.enable -Dvaadin.frontend.hotdeploy=true -am -B -q -DskipTests -pl vaadin-{component}-flow-parent/vaadin-{component}-flow-integration-tests
+mvn package jetty:run -Dvaadin.frontend.hotdeploy=true -am -B -q -DskipTests -pl vaadin-{component}-flow-parent/vaadin-{component}-flow-integration-tests
 ```
 
 **Notes on test commands**:

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <com.vaadin.tests.SharedBrowser.reuseBrowser>true</com.vaadin.tests.SharedBrowser.reuseBrowser>
         <com.vaadin.testbench.Parameters.testsInParallel>1</com.vaadin.testbench.Parameters.testsInParallel>
         <failIfNoTests>false</failIfNoTests>
-        <vaadin.pnpm.enable>false</vaadin.pnpm.enable>
+        <vaadin.pnpm.enable>true</vaadin.pnpm.enable>
         <osgi.bundle.license>http://www.apache.org/licenses/LICENSE-2.0</osgi.bundle.license>
         <osgi.export.package>default</osgi.export.package>
         <cvdlName/>

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -130,7 +130,6 @@ function runJetty(module, modeKey) {
   const args = [
     'package',
     'jetty:run',
-    '-Dvaadin.pnpm.enable',
     '-Dvaadin.frontend.hotdeploy=true',
     '-Djetty.scan=5',
     '-am',
@@ -156,7 +155,6 @@ function runUnitTests(module, modeKey, pattern = '') {
 function runIntegrationTests(module, modeKey, pattern = '') {
   const args = [
     'verify',
-    '-Dvaadin.pnpm.enable',
     '-Dvaadin.frontend.hotdeploy=true',
     '-am',
     '-B',

--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -88,7 +88,7 @@ async function runTests() {
       );
 
       // Install the IT module dependencies
-      execSync(`mvn -DskipTests -Dvaadin.pnpm.enable flow:prepare-frontend flow:build-frontend`, {
+      execSync(`mvn flow:prepare-frontend flow:build-frontend`, {
         cwd: itFolder,
         stdio: 'inherit'
       });

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/README.md
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/README.md
@@ -34,7 +34,7 @@ After applying the patch, for debugging the GWT code you have two options:
   # Start the GWT SuperDevMode code server (in a separate terminal)
   mvn -B -q -pl vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client -Psdm
   # Start the Jetty server for integration tests
-  mvn package jetty:run -Dvaadin.pnpm.enable -Dvaadin.frontend.hotdeploy=true -B -q -DskipTests -pl vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests
+  mvn package jetty:run -Dvaadin.frontend.hotdeploy=true -B -q -DskipTests -pl vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests
   ```
 - If not already, you need to install the bookmark as it is indicated in the next block
 


### PR DESCRIPTION
The `vaadin.pnpm.enable` property defaulted to `false`, so running integration tests or the Jetty dev server required passing `-Dvaadin.pnpm.enable` every time.

This flips the default to `true` in the root pom, so every module uses pnpm out of the box. The now-redundant flag is removed from the docs, the CI WAR package step, and the `run`/`wtr` scripts. Passing `-Dvaadin.pnpm.enable=false` still opts out.

🤖 Generated with Claude Code