### PR TITLE
chore: disable prod bundle generation for WTR tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ error-screenshots
 **/frontend/index.html
 **/frontend/*.tsx
 dev-bundle
-prod.bundle
 .vaadin-node-tasks.lock
 
 # Claude Code

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -160,6 +160,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
@@ -156,6 +156,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -162,6 +162,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
@@ -107,6 +107,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -138,6 +138,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
@@ -130,6 +130,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -133,6 +133,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
@@ -129,6 +129,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -153,6 +153,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
@@ -130,6 +130,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -161,6 +161,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -149,6 +149,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -175,6 +175,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -157,6 +157,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -149,6 +149,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -186,6 +186,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -144,6 +144,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
@@ -151,6 +151,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -148,6 +148,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -145,6 +145,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -133,6 +133,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -163,6 +163,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -154,6 +154,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -160,6 +160,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -229,6 +229,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -153,6 +153,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -139,6 +139,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -147,6 +147,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -143,6 +143,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -133,6 +133,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -137,6 +137,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
@@ -121,6 +121,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
@@ -157,6 +157,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -138,6 +138,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -143,6 +143,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -158,6 +158,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -155,6 +155,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -144,6 +144,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -144,6 +144,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -148,6 +148,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -124,6 +124,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -168,6 +168,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -159,6 +159,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -129,6 +129,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
@@ -130,6 +130,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -150,6 +150,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -222,6 +222,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -144,6 +144,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -149,6 +149,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -138,6 +138,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -142,6 +142,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -152,6 +152,7 @@
                         <artifactId>flow-maven-plugin</artifactId>
                         <configuration>
                             <frontendDirectory>./frontend</frontendDirectory>
+                            <generateBundle>false</generateBundle>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
The `build-frontend` goal generated an unnecessary production bundle when running `node scripts/wtr.js`. This bundle stayed out of sight because `.gitignore` excluded it, and `mvn clean` didn't delete it either, so it persisted across builds. When present, it could cause `build-frontend` to skip installing node modules which in turn made the WTR tests fail, and other similar issues.

The PR sets `generateBundle=false` on the `flow-maven-plugin` in all IT modules to prevent the prod bundle from being generated, and drops it from `.gitignore` so it can be noticed if it shows up again.

Bonus: this change also speeds up `node scripts/wtr.js`, since it no longer needs to run Vite to generate bundles.