### PR TITLE
chore: disable prod bundle generation for WTR tests (CP: 24.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ error-screenshots
 **/frontend/index.html
 **/frontend/*.tsx
 dev-bundle
-prod.bundle
 
 # Claude Code
 .claude/*.local.*

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -158,6 +158,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -164,6 +164,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -138,6 +138,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -133,6 +133,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -151,6 +151,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
@@ -128,6 +128,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -167,6 +167,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -147,6 +147,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -173,6 +173,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -159,6 +159,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -148,6 +148,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom.xml
@@ -132,6 +132,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -185,6 +185,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -143,6 +143,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
@@ -137,6 +137,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -146,6 +146,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -143,6 +143,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -135,6 +135,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -167,6 +167,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -152,6 +152,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -158,6 +158,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -240,6 +240,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -151,6 +151,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -137,6 +137,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -149,6 +149,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -146,6 +146,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -135,6 +135,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -138,6 +138,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
@@ -119,6 +119,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
@@ -157,6 +157,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/pom.xml
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/pom.xml
@@ -128,6 +128,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -136,6 +136,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -145,6 +145,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -156,6 +156,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -161,6 +161,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -146,6 +146,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -145,6 +145,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -155,6 +155,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -122,6 +122,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -166,6 +166,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -161,6 +161,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -128,6 +128,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -157,6 +157,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -215,6 +215,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -145,6 +145,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -148,6 +148,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -136,6 +136,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -144,6 +144,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -150,6 +150,9 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <generateBundle>false</generateBundle>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9599 to branch 24.10.

---

> The `build-frontend` goal generated an unnecessary production bundle when running `node scripts/wtr.js`. This bundle stayed out of sight because `.gitignore` excluded it, and `mvn clean` didn't delete it either, so it persisted across builds. When present, it could cause `build-frontend` to skip installing node modules which in turn made the WTR tests fail, and other similar issues.
>
> The PR sets `generateBundle=false` on the `flow-maven-plugin` in all IT modules to prevent the prod bundle from being generated, and drops it from `.gitignore` so it can be noticed if it shows up again.
>
> Bonus: this change also speeds up `node scripts/wtr.js`, since it no longer needs to run Vite to generate bundles.
