### PR TITLE
refactor: simplify grid item details state handling

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewItemDetailsIT.java
@@ -92,30 +92,6 @@ public class GridViewItemDetailsIT extends AbstractComponentIT {
                         .contains("Hi! My name is Person 2!"));
     }
 
-    @Test
-    public void openDetails_scrollToEnd_scrollToStart_detailsOpenedItemsCountDoesNotIncrease() {
-        GridElement grid = $(GridElement.class).id("grid-with-details-row");
-
-        // Open details
-        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
-
-        // Check the detailsOpenedItems property (expected to be a list with one
-        // item)
-        Assert.assertEquals(1,
-                ((List<?>) grid.getProperty("detailsOpenedItems")).size());
-
-        // Scroll to end
-        grid.scrollToRow(grid.getRowCount() - 1);
-
-        // Scroll to start
-        grid.scrollToRow(0);
-
-        // Check that the detailsOpenedItems array does not increase / does not
-        // contain duplicates
-        Assert.assertEquals(1,
-                ((List<?>) grid.getProperty("detailsOpenedItems")).size());
-    }
-
     private void assertAmountOfOpenDetails(WebElement grid,
             int expectedAmount) {
         waitUntil(driver -> grid.findElements(By.className("custom-details"))

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -70,7 +70,6 @@ describe('grid connector - row details', () => {
   describe('updateFlatData', () => {
     it('should open details for updated items', async () => {
       grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
-      await nextFrame();
       expect(getDetailsCell(grid, 0)!.hidden).to.be.false;
     });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { getBodyCellContent, setRootItems } from './shared.js';
+import { getDetailsCell, getBodyCellContent, setRootItems } from './shared.js';
 import { init } from './shared.js';
 import type { FlowGrid } from './shared.js';
 
@@ -15,6 +15,10 @@ describe('grid connector - row details', () => {
     `);
 
     init(grid);
+
+    grid.rowDetailsRenderer = (root) => {
+      root.textContent = 'details';
+    };
 
     setRootItems(grid.$connector, [
       { key: '0', name: 'foo' },
@@ -46,8 +50,10 @@ describe('grid connector - row details', () => {
       { key: '0', name: 'foo', detailsOpened: true },
       { key: '1', name: 'bar' }
     ]);
-    expect(grid.detailsOpenedItems).to.have.lengthOf(1);
-    expect(grid.detailsOpenedItems[0].key).to.equal('0');
+    await nextFrame();
+
+    expect(getDetailsCell(grid, 0)!.hidden).to.be.false;
+    expect(getDetailsCell(grid, 1)!.hidden).to.be.true;
   });
 
   it('should close details for items closed from data', async () => {
@@ -57,30 +63,21 @@ describe('grid connector - row details', () => {
     ]);
 
     grid.$connector.set(0, [{ key: '0', name: 'foo' }]);
-    expect(grid.detailsOpenedItems).to.be.empty;
-  });
-
-  it('should close details for cleared items', async () => {
-    setRootItems(grid.$connector, [
-      { key: '0', name: 'foo', detailsOpened: true },
-      { key: '1', name: 'bar' }
-    ]);
-
-    grid.$connector.clear(0, 2);
-    expect(grid.detailsOpenedItems).to.be.empty;
+    expect(getDetailsCell(grid, 0)!.hidden).to.be.true;
+    expect(getDetailsCell(grid, 1)!.hidden).to.be.true;
   });
 
   describe('updateFlatData', () => {
-    it('should open details for updated items', () => {
+    it('should open details for updated items', async () => {
       grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
-      expect(grid.detailsOpenedItems).to.have.lengthOf(1);
-      expect(grid.detailsOpenedItems[0].key).to.equal('0');
+      await nextFrame();
+      expect(getDetailsCell(grid, 0)!.hidden).to.be.false;
     });
 
     it('should close details for updated items', () => {
       grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
       grid.$connector.updateFlatData([{ key: '0', name: 'foo' }]);
-      expect(grid.detailsOpenedItems).to.be.empty;
+      expect(getDetailsCell(grid, 0)!.hidden).to.be.true;
     });
   });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -153,12 +153,18 @@ export function getFooterCellContent(column: GridColumn): HTMLElement {
 }
 
 /**
- * Returns a cell in the grid body.
+ * Returns a row in the grid body.
+ */
+export function getBodyRow(grid: Grid, rowIndex: number): HTMLElement | null {
+  const row = [...grid.shadowRoot!.querySelectorAll('.row')].find((row) => (row as any).index === rowIndex);
+  return row as HTMLElement ?? null;
+}
+
+/**
+ * Returns a cell in a grid body row.
  */
 export function getBodyCell(grid: Grid, rowIndex: number, columnIndex: number): HTMLElement | null {
-  const items = grid.shadowRoot!.querySelector(`#items`)!;
-
-  const row = [...items.children].find((row) => (row as any).index === rowIndex);
+  const row = getBodyRow(grid, rowIndex);
   if (!row) {
     return null;
   }
@@ -170,6 +176,13 @@ export function getBodyCell(grid: Grid, rowIndex: number, columnIndex: number): 
   }).map(cell => cell as HTMLElement);
 
   return cellsInVisualOrder[columnIndex];
+}
+
+/**
+ * Returns the details cell in a grid body row.
+ */
+export function getDetailsCell(grid: Grid, rowIndex: number): HTMLElement | null {
+  return getBodyRow(grid, rowIndex)?.querySelector('.details-cell') ?? null;
 }
 
 /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -674,7 +674,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   grid._isDetailsOpened = function (item) {
     return item?.detailsOpened ?? false;
-  }
+  };
 
   function isRowFullyInViewport(row) {
     const rowRect = row.getBoundingClientRect();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts
@@ -316,14 +316,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     }
   }
 
-  function updateItemDetails(item) {
-    if (item.detailsOpened) {
-      grid.openItemDetails(item);
-    } else {
-      grid.closeItemDetails(item);
-    }
-  }
-
   grid.__updateRow = function (row, ...args) {
     if (preventRowUpdatesActive !== 0) {
       return;
@@ -341,8 +333,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     preventRowUpdates(() => {
       grid.$connector.doSelection(items.filter((item) => item.selected));
       grid.$connector.doDeselection(items.filter((item) => !item.selected && selectedKeys[item.key]));
-
-      items.forEach(updateItemDetails);
     });
 
     grid.__updateVisibleRows(startIndex, startIndex + items.length - 1);
@@ -365,8 +355,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       const { index } = itemContext;
       rootCache.items[index] = item;
 
-      preventRowUpdates(() => updateItemDetails(item));
-
       grid.__updateVisibleRows(index, index);
     });
   };
@@ -385,7 +373,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
     preventRowUpdates(() => {
       grid.$connector.doDeselection(items.filter((item) => selectedKeys[item.key]));
-      items.forEach((item) => grid.closeItemDetails(item));
     });
 
     rootCache.items.fill(undefined, index, index + length);
@@ -684,6 +671,10 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     // If there is no selectable data, assume the item is selectable
     return item?.selectable === undefined || item.selectable;
   };
+
+  grid._isDetailsOpened = function (item) {
+    return item?.detailsOpened ?? false;
+  }
 
   function isRowFullyInViewport(row) {
     const rowRect = row.getBoundingClientRect();


### PR DESCRIPTION
The grid connector used to sync the open/closed state of item details via the `openedItemDetails` array by manually calling `openItemDetails`/`closeItemDetails` on each item update, set, or clear. This PR refactors that in favor of overriding the `_isDetailsOpened` method exposed by the web component to read the state directly from the item, removing duplicate state bookkeeping. It also makes this consistent with the way treeGridConnector manages the expanded state.