### PR TITLE
fix: set aria-label on the correct CRUD filter element

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/BasicUseIT.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/BasicUseIT.java
@@ -98,7 +98,7 @@ public class BasicUseIT extends AbstractComponentIT {
     public void filterHasAriaLabel() {
         CrudElement crud = $(CrudElement.class).waitForFirst();
         Assert.assertEquals("Filter by First Name",
-                crud.getFilterFields().get(0).getDomAttribute("aria-label"));
+                crud.getFilterFields().get(0).getDomProperty("accessibleName"));
     }
 
     @Test

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/CrudGrid.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/CrudGrid.java
@@ -73,7 +73,7 @@ public class CrudGrid<E> extends Grid<E> {
         getColumns().forEach(column -> {
             final TextField field = new TextField();
             field.getElement().setAttribute("crud-role", "Search");
-            field.getElement().setAttribute("aria-label", "Filter by "
+            field.setAriaLabel("Filter by "
                     + SharedUtil.propertyIdToHumanFriendly(column.getKey()));
 
             field.addValueChangeListener(event -> {


### PR DESCRIPTION
## Description

Updated `CrudGrid` to use `setAriaLabel()` instead of `setAttribute("aria-label")`.
This makes `aria-label` set on the `<input>` element as expected.

### Before

<img width="587" height="245" alt="Screenshot 2026-06-24 at 13 06 33" src="https://github.com/user-attachments/assets/20fd972b-31cd-4830-85b4-5098a921fa5d" />

### After

<img width="619" height="173" alt="Screenshot 2026-06-24 at 13 05 24" src="https://github.com/user-attachments/assets/2d2d0bd5-9aa2-48a1-9fbd-f179d8232ede" />

## Type of change

- Bugfix