### PR TITLE
fix!: decouple grid row details and selection from activeItem

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -87,16 +87,16 @@ describe('grid connector - row details', () => {
   });
 
   it('should set details hidden on selected item click', () => {
-    getBodyCellContent(grid, 0, 0)!.click();
+    grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
     getBodyCellContent(grid, 0, 0)!.click();
     expect(grid.$server.setDetailsVisible).to.be.calledWith(null);
   });
 
-  it('should not set details hidden on selected item click when deselect is disallowed', () => {
+  it('should set details hidden on selected item click when deselect is disallowed', () => {
     grid.__deselectDisallowed = true;
+    grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
     getBodyCellContent(grid, 0, 0)!.click();
-    getBodyCellContent(grid, 0, 0)!.click();
-    expect(grid.$server.setDetailsVisible).not.to.be.calledWith(null);
+    expect(grid.$server.setDetailsVisible).to.be.calledWith(null);
   });
 
   it('should not set details visible on click when details on click is disallowed', () => {
@@ -105,8 +105,8 @@ describe('grid connector - row details', () => {
     expect(grid.$server.setDetailsVisible).not.to.be.called;
   });
 
-  it('should set details visible for item selected from data', async () => {
+  it('should not set details visible for item selected from data', async () => {
     setRootItems(grid.$connector, [{ key: '0', name: 'foo', selected: true }]);
-    expect(grid.$server.setDetailsVisible).to.be.calledWith('0');
+    expect(grid.$server.setDetailsVisible).not.to.be.calledWith('0');
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -111,4 +111,16 @@ describe('grid connector - row details', () => {
     setRootItems(grid.$connector, [{ key: '0', name: 'foo', selected: true }]);
     expect(grid.$server.setDetailsVisible).not.to.be.calledWith('0');
   });
+
+  it('should not set details visible when clicking a still-loading row', async () => {
+    // Reset to a single row whose data hasn't loaded yet, so it renders in a
+    // loading state with no item in its model
+    grid.$connector.reset();
+    grid.$connector.updateSize(1);
+    await nextFrame();
+
+    getBodyCellContent(grid, 0, 0)!.click();
+
+    expect(grid.$server.setDetailsVisible).not.to.be.called;
+  });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -87,14 +87,16 @@ describe('grid connector - row details', () => {
   });
 
   it('should set details hidden on selected item click', () => {
-    grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
+    grid.$connector.setSelectionMode('SINGLE');
+    grid.$connector.updateFlatData([{ key: '0', name: 'foo', selected: true, detailsOpened: true }]);
     getBodyCellContent(grid, 0, 0)!.click();
     expect(grid.$server.setDetailsVisible).to.be.calledWith(null);
   });
 
   it('should set details hidden on selected item click when deselect is disallowed', () => {
+    grid.$connector.setSelectionMode('SINGLE');
     grid.__deselectDisallowed = true;
-    grid.$connector.updateFlatData([{ key: '0', name: 'foo', detailsOpened: true }]);
+    grid.$connector.updateFlatData([{ key: '0', name: 'foo', selected: true, detailsOpened: true }]);
     getBodyCellContent(grid, 0, 0)!.click();
     expect(grid.$server.setDetailsVisible).to.be.calledWith(null);
   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-row-details.test.ts
@@ -113,10 +113,8 @@ describe('grid connector - row details', () => {
   });
 
   it('should not set details visible when clicking a still-loading row', async () => {
-    // Reset to a single row whose data hasn't loaded yet, so it renders in a
-    // loading state with no item in its model
-    grid.$connector.reset();
-    grid.$connector.updateSize(1);
+    // Clear the loaded data so the row goes back to a loading state
+    grid.$connector.clear(0, 2);
     await nextFrame();
 
     getBodyCellContent(grid, 0, 0)!.click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -149,21 +149,10 @@ describe('grid connector - selection', () => {
         expect(grid.selectedItems).to.be.empty;
       });
 
-      it('should update activeItem when selecting an item', () => {
-        grid.$connector.doSelection([{ key: '0' }], false);
-        expect(grid.activeItem).to.deep.equal({ key: '0', selected: true });
-      });
-
       it('should deselect the item when selecting null', () => {
         grid.$connector.doSelection([{ key: '0' }], false);
         grid.$connector.doSelection([null], false);
         expect(grid.selectedItems).to.be.empty;
-      });
-
-      it('should reset activeItem when selecting null', () => {
-        grid.$connector.doSelection([{ key: '0' }], false);
-        grid.$connector.doSelection([null], false);
-        expect(grid.activeItem).not.to.exist;
       });
 
       it('should not request server to select already selected items', () => {
@@ -226,9 +215,6 @@ describe('grid connector - selection', () => {
         const updatedItems = items.map((item) => ({ ...item, selectable: false }));
         setRootItems(grid.$connector, updatedItems);
 
-        // active item still references the original item with selectable: true
-        expect(grid.activeItem!.selectable).to.be.true;
-
         // however clicking the row should not deselect the item
         getBodyCellContent(grid, 2, 0)!.click();
         expect(grid.selectedItems).to.deep.equal([updatedItems[2]]);
@@ -246,12 +232,10 @@ describe('grid connector - selection', () => {
         // non-selectable item
         grid.$connector.doSelection([items[0]], false);
         expect(grid.selectedItems).to.deep.equal([items[0]]);
-        expect(grid.activeItem).to.deep.equal(items[0]);
 
         // selectable item
         grid.$connector.doSelection([items[2]], false);
         expect(grid.selectedItems).to.deep.equal([items[2]]);
-        expect(grid.activeItem).to.deep.equal(items[2]);
       })
 
       it('should always allow deselection from server', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { init, getBodyCellContent, setRootItems } from './shared.js';
+import { sendKeys } from '@web/test-runner-commands';
+import { init, getBodyCell, getBodyCellContent, setRootItems } from './shared.js';
 import type { FlowGrid, Item } from './shared.js';
 import sinon from 'sinon';
 
@@ -37,6 +38,26 @@ describe('grid connector - selection', () => {
     it('should mark the item selected', () => {
       getBodyCellContent(grid, 0, 0)!.click();
       expect(grid.selectedItems[0].selected).to.be.true;
+    });
+
+    it('should select item on row Space key', async () => {
+      getBodyCell(grid, 0, 0)!.focus();
+      // Move from cell focus mode to row focus mode
+      await sendKeys({ press: 'ArrowLeft' });
+      // Activate the focused row, which fires `row-activate`
+      await sendKeys({ press: 'Space' });
+      expect(grid.selectedItems.length).to.equal(1);
+      expect(grid.selectedItems[0].key).to.equal('0');
+    });
+
+    it('should deselect item on row Space key', async () => {
+      getBodyCell(grid, 0, 0)!.focus();
+      // Move from cell focus mode to row focus mode
+      await sendKeys({ press: 'ArrowLeft' });
+      // Select, then deselect the focused row, which fires `row-activate`
+      await sendKeys({ press: 'Space' });
+      await sendKeys({ press: 'Space' });
+      expect(grid.selectedItems).to.be.empty;
     });
 
     it('should deselect old selection on another item click', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -40,22 +40,17 @@ describe('grid connector - selection', () => {
       expect(grid.selectedItems[0].selected).to.be.true;
     });
 
-    it('should select item on row Space key', async () => {
+    it('should toggle item on row Space key', async () => {
       getBodyCell(grid, 0, 0)!.focus();
       // Move from cell focus mode to row focus mode
       await sendKeys({ press: 'ArrowLeft' });
+
       // Activate the focused row, which fires `row-activate`
       await sendKeys({ press: 'Space' });
       expect(grid.selectedItems.length).to.equal(1);
       expect(grid.selectedItems[0].key).to.equal('0');
-    });
 
-    it('should deselect item on row Space key', async () => {
-      getBodyCell(grid, 0, 0)!.focus();
-      // Move from cell focus mode to row focus mode
-      await sendKeys({ press: 'ArrowLeft' });
-      // Select, then deselect the focused row, which fires `row-activate`
-      await sendKeys({ press: 'Space' });
+      // Activate the focused row again to deselect it
       await sendKeys({ press: 'Space' });
       expect(grid.selectedItems).to.be.empty;
     });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -62,6 +62,20 @@ describe('grid connector - selection', () => {
       expect(grid.selectedItems[0].key).to.equal('1');
     });
 
+    it('should not select when clicking a still-loading row', async () => {
+      // Reset to a single row whose data hasn't loaded yet, so it renders in a
+      // loading state with no item in its model
+      grid.$connector.reset();
+      grid.$connector.updateSize(1);
+      await nextFrame();
+
+      getBodyCellContent(grid, 0, 0)!.click();
+
+      expect(grid.selectedItems).to.be.empty;
+      expect(grid.$server.select).not.to.be.called;
+      expect(grid.$server.deselect).not.to.be.called;
+    });
+
     it('should mark the item deselected', () => {
       getBodyCellContent(grid, 0, 0)!.click();
       const item = grid.selectedItems[0];
@@ -209,6 +223,13 @@ describe('grid connector - selection', () => {
         expect(grid.$server.select).to.be.calledWith(items[2].key);
       });
 
+      it('should prevent selection of items on click after updateFlatData makes them non-selectable', () => {
+        grid.$connector.updateFlatData([{ ...items[2], selectable: false }]);
+        getBodyCellContent(grid, 2, 0)!.click();
+        expect(grid.selectedItems).to.be.empty;
+        expect(grid.$server.select).to.not.be.called;
+      });
+
       it('should prevent deselection of non-selectable items on click', () => {
         grid.$connector.doSelection([items[0]], false);
         getBodyCellContent(grid, 0, 0)!.click();
@@ -223,25 +244,19 @@ describe('grid connector - selection', () => {
         expect(grid.$server.deselect).to.not.be.called;
       });
 
-      it('should prevent deselection of non-selectable items on row click when active item data is stale', () => {
-        // item is selectable initially and is selected
-        grid.$connector.doSelection([items[2]], false);
-
-        // update grid items to make the item non-selectable
-        const updatedItems = items.map((item) => ({ ...item, selectable: false }));
-        setRootItems(grid.$connector, updatedItems);
-
-        // however clicking the row should not deselect the item
-        getBodyCellContent(grid, 2, 0)!.click();
-        expect(grid.selectedItems).to.deep.equal([updatedItems[2]]);
-        expect(grid.$server.deselect).to.not.be.called;
-      });
-
       it('should allow deselection of selectable items on row click', () => {
         grid.$connector.doSelection([items[2]], false);
         getBodyCellContent(grid, 2, 0)!.click();
         expect(grid.selectedItems).to.be.empty;
         expect(grid.$server.deselect).to.be.calledWith(items[2].key);
+      });
+
+      it('should prevent deselection of items on click after updateFlatData makes them non-selectable', () => {
+        grid.$connector.doSelection([items[2]], false);
+        grid.$connector.updateFlatData([{ ...items[2], selectable: false }]);
+        getBodyCellContent(grid, 2, 0)!.click();
+        expect(grid.selectedItems).to.deep.equal([items[2]]);
+        expect(grid.$server.deselect).to.not.be.called;
       });
 
       it('should always allow selection from server', () => {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection.test.ts
@@ -63,10 +63,8 @@ describe('grid connector - selection', () => {
     });
 
     it('should not select when clicking a still-loading row', async () => {
-      // Reset to a single row whose data hasn't loaded yet, so it renders in a
-      // loading state with no item in its model
-      grid.$connector.reset();
-      grid.$connector.updateSize(1);
+      // Clear the loaded data so the row goes back to a loading state
+      grid.$connector.clear(0, 2);
       await nextFrame();
 
       getBodyCellContent(grid, 0, 0)!.click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1267,14 +1267,17 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         /**
-         * Remove the displayed details and remove details item from the list
+         * Remove the displayed details but keep the item in the list of details,
+         * so that the details stay open when the item is rendered again (for
+         * example after collapsing and expanding its parent row, or scrolling
+         * the item out of and back into view). Consistent with
+         * {@link #destroyAllData()}.
          *
          * @param item
          *            item to removed
          */
         @Override
         public void destroyData(T item) {
-            detailsVisible.remove(getItemId(item));
             if (itemDetailsDataGenerator != null) {
                 itemDetailsDataGenerator.destroyData(item);
             }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1267,10 +1267,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         /**
-         * Remove the displayed details but keep the item in the list of details,
-         * so that the details stay open when the item is rendered again (for
-         * example after collapsing and expanding its parent row, or scrolling
-         * the item out of and back into view). Consistent with
+         * Remove the displayed details but keep the item in the list of
+         * details, so that the details stay open when the item is rendered
+         * again (for example after collapsing and expanding its parent row, or
+         * scrolling the item out of and back into view). Consistent with
          * {@link #destroyAllData()}.
          *
          * @param item

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -112,14 +112,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   function onItemActivate(event) {
     const item = event.detail.model?.item;
 
-    if (!grid.__disallowDetailsOnClick) {
-      if (item && !item.detailsOpened) {
-        grid.$server.setDetailsVisible(item.key);
-      } else {
-        grid.$server.setDetailsVisible(null);
-      }
-    }
-
     if (selectionMode === 'SINGLE') {
       if (item && item.selected && grid.__deselectDisallowed) {
         return;
@@ -129,6 +121,14 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
         grid.$connector.doSelection([item], true);
       } else {
         grid.$connector.doDeselection([...grid.selectedItems], true);
+      }
+    }
+
+    if (!grid.__disallowDetailsOnClick) {
+      if (item && !item.detailsOpened) {
+        grid.$server.setDetailsVisible(item.key);
+      } else {
+        grid.$server.setDetailsVisible(null);
       }
     }
   }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -116,45 +116,33 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     grid.selectedItems = updatedSelectedItems;
   };
 
-  grid.__activeItemChanged = function (newVal, oldVal) {
-    if (selectionMode !== 'SINGLE') {
-      return;
-    }
-    if (!newVal) {
-      if (oldVal && selectedKeys[oldVal.key]) {
-        if (grid.__deselectDisallowed) {
-          grid.activeItem = oldVal;
-        } else {
-          // The item instance may have changed since the item was stored as active item
-          // and information such as whether the item may be selected or deselected may
-          // be stale. Use data provider controller to get updated instance from grid
-          // cache.
-          oldVal = dataProviderController.getItemContext(oldVal).item;
-          grid.$connector.doDeselection([oldVal], true);
-        }
-      }
-    } else if (!selectedKeys[newVal.key]) {
-      grid.$connector.doSelection([newVal], true);
-    }
-  };
-  grid._createPropertyObserver('activeItem', '__activeItemChanged');
+  function onItemActivate(event) {
+    const item = event.detail.model?.item;
 
-  grid.__activeItemChangedDetails = function (newVal, oldVal) {
-    if (grid.__disallowDetailsOnClick) {
-      return;
+    if (!grid.__disallowDetailsOnClick) {
+      if (item && !item.detailsOpened) {
+        grid.$server.setDetailsVisible(item.key);
+      } else {
+        grid.$server.setDetailsVisible(null);
+      }
     }
-    // when grid is attached, newVal is not set and oldVal is undefined
-    // do nothing
-    if (newVal == null && oldVal === undefined) {
-      return;
+
+    if (selectionMode === 'SINGLE') {
+      if (item && item.selected && grid.__deselectDisallowed) {
+        grid.activeItem = grid.selectedItems[0];
+        return;
+      }
+
+      if (item && !item.selected) {
+        grid.$connector.doSelection([item], true);
+      } else {
+        grid.$connector.doDeselection([grid.selectedItems[0]], true);
+      }
     }
-    if (newVal && !newVal.detailsOpened) {
-      grid.$server.setDetailsVisible(newVal.key);
-    } else {
-      grid.$server.setDetailsVisible(null);
-    }
-  };
-  grid._createPropertyObserver('activeItem', '__activeItemChangedDetails');
+  }
+
+  grid.addEventListener('cell-activate', onItemActivate);
+  grid.addEventListener('row-activate', onItemActivate);
 
   grid.$connector.getRenderedRange = function () {
     const renderedRows = grid._getRenderedRows();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -72,13 +72,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
           grid.$server.select(item.key);
         }
       }
-
-      // FYI: In single selection mode, the server can send items = [null]
-      // which means a "Deselect All" command.
-      const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key !== grid.activeItem.key;
-      if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
-        grid.activeItem = item;
-      }
     });
 
     if (selectedItemsChanged) {
@@ -129,14 +122,13 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
     if (selectionMode === 'SINGLE') {
       if (item && item.selected && grid.__deselectDisallowed) {
-        grid.activeItem = grid.selectedItems[0];
         return;
       }
 
       if (item && !item.selected) {
         grid.$connector.doSelection([item], true);
       } else {
-        grid.$connector.doDeselection([grid.selectedItems[0]], true);
+        grid.$connector.doDeselection([...grid.selectedItems], true);
       }
     }
   }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -113,13 +113,9 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     const item = event.detail.model?.item;
 
     if (selectionMode === 'SINGLE') {
-      if (item && item.selected && grid.__deselectDisallowed) {
-        return;
-      }
-
       if (item && !item.selected) {
         grid.$connector.doSelection([item], true);
-      } else {
+      } else if (!grid.__deselectDisallowed) {
         grid.$connector.doDeselection([...grid.selectedItems], true);
       }
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -110,18 +110,22 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
   };
 
   function onItemActivate(event) {
-    const item = event.detail.model?.item;
+    const { item } = event.detail.model;
+    if (!item) {
+      // Item isn't loaded yet
+      return;
+    }
 
     if (selectionMode === 'SINGLE') {
-      if (item && !item.selected) {
+      if (!item.selected) {
         grid.$connector.doSelection([item], true);
       } else if (!grid.__deselectDisallowed) {
-        grid.$connector.doDeselection([...grid.selectedItems], true);
+        grid.$connector.doDeselection([item], true);
       }
     }
 
     if (!grid.__disallowDetailsOnClick) {
-      if (item && !item.detailsOpened) {
+      if (!item.detailsOpened) {
         grid.$server.setDetailsVisible(item.key);
       } else {
         grid.$server.setDetailsVisible(null);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -111,13 +111,14 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
 
   function onItemActivate(event) {
     const { item } = event.detail.model;
-    if (!item) {
-      // Item isn't loaded yet
+    // The row model can hold a stale item while its data is being loaded, so
+    // skip activation unless the item is actually loaded in the data cache
+    if (!dataProviderController.getItemContext(item)) {
       return;
     }
 
     if (selectionMode === 'SINGLE') {
-      if (!item.selected) {
+      if (!selectedKeys[item.key]) {
         grid.$connector.doSelection([item], true);
       } else if (!grid.__deselectDisallowed) {
         grid.$connector.doDeselection([item], true);

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -487,7 +487,7 @@ public class GridElement extends TestBenchElement {
                 checkbox.getWrappedElement().click();
             }
         } else if (!row.isSelected()) {
-            row.click();
+            row.getCell(getVisibleColumns().get(0)).click();
         }
     }
 
@@ -517,7 +517,7 @@ public class GridElement extends TestBenchElement {
                 checkbox.getWrappedElement().click();
             }
         } else if (row.isSelected()) {
-            row.click();
+            row.getCell(getVisibleColumns().get(0)).click();
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -531,10 +531,11 @@ public class GridElement extends TestBenchElement {
      *            the row to activate
      */
     private void activateRow(GridTRElement row) {
-        executeScript(
-                "arguments[0].dispatchEvent(new CustomEvent('row-activate', "
-                        + "{ detail: { model: { item: arguments[1]._item } } }))",
-                this, row);
+        executeScript("""
+                arguments[0].dispatchEvent(new CustomEvent('row-activate', {
+                    detail: { model: { item: arguments[1]._item } }
+                }))
+                """, this, row);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -486,8 +486,8 @@ public class GridElement extends TestBenchElement {
             if (!checkbox.isChecked()) {
                 checkbox.getWrappedElement().click();
             }
-        } else {
-            setActiveItem(row);
+        } else if (!row.isSelected()) {
+            row.click();
         }
     }
 
@@ -516,19 +516,9 @@ public class GridElement extends TestBenchElement {
             if (checkbox.isChecked()) {
                 checkbox.getWrappedElement().click();
             }
-        } else {
-            removeActiveItem(row);
+        } else if (row.isSelected()) {
+            row.click();
         }
-    }
-
-    private void setActiveItem(GridTRElement row) {
-        executeScript("arguments[0].activeItem=arguments[1]._item", this, row);
-    }
-
-    private void removeActiveItem(GridTRElement row) {
-        final String JS_DEACTIVATE_IF_ACTIVE = "if(arguments[0]._itemsEqual(arguments[0].activeItem, "
-                + "arguments[1]._item)) { arguments[0].activeItem=null;}";
-        executeScript(JS_DEACTIVATE_IF_ACTIVE, this, row);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -487,7 +487,7 @@ public class GridElement extends TestBenchElement {
                 checkbox.getWrappedElement().click();
             }
         } else if (!row.isSelected()) {
-            row.getCell(getVisibleColumns().get(0)).click();
+            activateRow(row);
         }
     }
 
@@ -517,8 +517,24 @@ public class GridElement extends TestBenchElement {
                 checkbox.getWrappedElement().click();
             }
         } else if (row.isSelected()) {
-            row.getCell(getVisibleColumns().get(0)).click();
+            activateRow(row);
         }
+    }
+
+    /**
+     * Activates the row by dispatching a {@code row-activate} event, the same
+     * event the grid fires when a row is activated with the keyboard. This
+     * drives single-selection (and row details) through the connector without a
+     * real click, so it doesn't trigger item-click listeners as a side effect.
+     *
+     * @param row
+     *            the row to activate
+     */
+    private void activateRow(GridTRElement row) {
+        executeScript(
+                "arguments[0].dispatchEvent(new CustomEvent('row-activate', "
+                        + "{ detail: { model: { item: arguments[1]._item } } }))",
+                this, row);
     }
 
     /**


### PR DESCRIPTION
Row details and single-selection both relied on `activeItem` property observers. Routing both through `activeItem` caused several bugs, which the updated WTR tests now cover:

- With deselect disallowed, clicking a row with open details failed to close them. The selection observer reverted `activeItem`, which prevented the details observer from running.
- Selecting an item from server data opened its details, because the programmatic `activeItem` change triggered the details observer as if the row had been clicked.

The PR replaces the two `activeItem` observers with `cell-activate` and `row-activate` listeners that read `detailsOpened` and `selected` from the event. These events only fire on user interaction, so programmatic changes don't trigger them. There's also no longer any need to mirror selection onto `activeItem` when selection changes come from the server. As a result, details and selection are now fully independent of `activeItem` and only react to real clicks.

> [!WARNING]
> This should be a relatively safe change, since rows were always rendered as selected via the `selected` attribute/part rather than `active`, and the same applies to `details-opened`. That said, the `activeItem` property is no longer populated, which could affect apps that did something based on it in their custom logic.
