### PR TITLE
feat: add inputMode API to TextField

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
+import com.vaadin.flow.component.InputMode;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -381,6 +382,39 @@ public class TextField extends TextFieldBase<TextField, String>
      */
     public String getPattern() {
         return getElement().getProperty("pattern");
+    }
+
+    /**
+     * Sets the {@link InputMode} that hints at the type of virtual keyboard to
+     * display when the user interacts with the field on a mobile device. If not
+     * set, the browser defaults to {@link InputMode#TEXT}.
+     *
+     * @param inputMode
+     *            the {@code inputmode} value, or {@code null} to unset
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">
+     *      inputmode attribute</a>
+     */
+    public void setInputMode(InputMode inputMode) {
+        if (inputMode == null) {
+            getElement().removeProperty("inputMode");
+        } else {
+            getElement().setProperty("inputMode", inputMode.getValue());
+        }
+    }
+
+    /**
+     * Gets the {@link InputMode} of the field.
+     *
+     * @return the {@code inputmode} value, or {@code null} if not set
+     * @see #setInputMode(InputMode)
+     */
+    public InputMode getInputMode() {
+        String inputMode = getElement().getProperty("inputMode");
+        if (inputMode == null || inputMode.isEmpty()) {
+            return null;
+        }
+        return InputMode.valueOf(inputMode.toUpperCase());
     }
 
     @Override

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -394,6 +394,7 @@ public class TextField extends TextFieldBase<TextField, String>
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">
      *      inputmode attribute</a>
+     * @since 25.3
      */
     public void setInputMode(InputMode inputMode) {
         if (inputMode == null) {
@@ -408,6 +409,7 @@ public class TextField extends TextFieldBase<TextField, String>
      *
      * @return the {@code inputmode} value, or {@code null} if not set
      * @see #setInputMode(InputMode)
+     * @since 25.3
      */
     public InputMode getInputMode() {
         String inputMode = getElement().getProperty("inputMode");

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.InputMode;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.HasTooltip;
@@ -112,6 +113,26 @@ class TextFieldTest {
 
         assertAutoselectPropertyValueEquals(textField, true);
         assertAutoselectPropertyValueEquals(textField, false);
+    }
+
+    @Test
+    void inputMode_defaultsToNull() {
+        TextField textField = new TextField();
+        Assertions.assertNull(textField.getInputMode());
+    }
+
+    @Test
+    void setInputMode_getInputMode() {
+        TextField textField = new TextField();
+
+        textField.setInputMode(InputMode.NUMERIC);
+        Assertions.assertEquals(InputMode.NUMERIC, textField.getInputMode());
+        Assertions.assertEquals("numeric",
+                textField.getElement().getProperty("inputMode"));
+
+        textField.setInputMode(null);
+        Assertions.assertNull(textField.getInputMode());
+        Assertions.assertNull(textField.getElement().getProperty("inputMode"));
     }
 
     @Test


### PR DESCRIPTION
Adds the `inputMode` API to the `TextField` Flow component, exposing the web component property added in vaadin/web-components#11979.

Depends on 
- https://github.com/vaadin/flow/pull/24856/

Closes #8903