### PR TITLE
chore: serve WTR frontend imports from source

### DIFF
--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -103,7 +103,7 @@ async function runTests() {
       console.log(`Running tests in ${itFolder}`);
       try {
         const watchFlag = options.watch ? ' --watch' : '';
-        execSync(`npx web-test-runner --playwright ${wtrTestsFolderName}/**/*.test.ts --node-resolve${watchFlag}`, {
+        execSync(`npx web-test-runner --playwright ${wtrTestsFolderName}/**/*.test.ts${watchFlag}`, {
           cwd: itFolder,
           stdio: 'inherit'
         });

--- a/shared/shared-web-test-runner-config.mjs
+++ b/shared/shared-web-test-runner-config.mjs
@@ -1,10 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { defaultReporter, summaryReporter } from '@web/test-runner';
 import { junitReporter } from '@web/test-runner-junit-reporter';
 
+/**
+ * A plugin that serves connector files imported from `frontend/generated/jar-resources`
+ * from their original source in a component module's `META-INF/frontend` when it exists,
+ * instead of the stale build-time copy. The request URL stays in the flat `jar-resources`
+ * namespace, so cross-module sibling imports (e.g. `./contextMenuConnector.js`) continue
+ * to resolve the same way Flow's flattening makes them.
+ *
+ * @param {string[]} sourceDirs Absolute paths to `META-INF/frontend` directories to look up
+ * sources in, checked in order. Falls back to the build-time copy when no source matches.
+ */
+export function connectorSourcePlugin(sourceDirs) {
+  function resolveSourcePath(requestPath) {
+    const match = requestPath.match(/\/frontend\/generated\/jar-resources\/(.+)$/);
+    if (!match) {
+      return;
+    }
+    for (const dir of sourceDirs) {
+      const sourcePath = path.join(dir, match[1]);
+      if (fs.existsSync(sourcePath)) {
+        return sourcePath;
+      }
+    }
+  }
+
+  return {
+    name: 'connector-source',
+    serverStart({ fileWatcher }) {
+      sourceDirs.forEach((dir) => fileWatcher.add(dir));
+    },
+    serve(context) {
+      const sourcePath = resolveSourcePath(context.path);
+      if (sourcePath) {
+        return { body: fs.readFileSync(sourcePath, 'utf8') };
+      }
+    },
+    transform(context) {
+      const sourcePath = resolveSourcePath(context.path);
+      if (sourcePath) {
+        // Don't cache connector sources, so a rerun picks up the latest source
+        // instead of a transform cached from a previous run.
+        return { transformCache: false };
+      }
+    }
+  };
+}
+
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export const sharedConfig = {
   plugins: [esbuildPlugin({ ts: true })],
+  nodeResolve: true,
   testFramework: {
     config: {
       ui: 'bdd',

--- a/shared/shared-web-test-runner-config.mjs
+++ b/shared/shared-web-test-runner-config.mjs
@@ -5,7 +5,7 @@ import { defaultReporter, summaryReporter } from '@web/test-runner';
 import { junitReporter } from '@web/test-runner-junit-reporter';
 
 /**
- * A plugin that serves connector files imported from `frontend/generated/jar-resources`
+ * A plugin that serves frontend files imported from `frontend/generated/jar-resources`
  * from their original source in a component module's `META-INF/frontend` when it exists,
  * instead of the stale build-time copy. The request URL stays in the flat `jar-resources`
  * namespace, so cross-module sibling imports (e.g. `./contextMenuConnector.js`) continue
@@ -14,7 +14,7 @@ import { junitReporter } from '@web/test-runner-junit-reporter';
  * @param {string[]} sourceDirs Absolute paths to `META-INF/frontend` directories to look up
  * sources in, checked in order. Falls back to the build-time copy when no source matches.
  */
-export function connectorSourcePlugin(sourceDirs) {
+export function frontendSourcePlugin(sourceDirs) {
   function resolveSourcePath(requestPath) {
     const match = requestPath.match(/\/frontend\/generated\/jar-resources\/(.+)$/);
     if (!match) {
@@ -29,7 +29,7 @@ export function connectorSourcePlugin(sourceDirs) {
   }
 
   return {
-    name: 'connector-source',
+    name: 'frontend-source',
     serverStart({ fileWatcher }) {
       sourceDirs.forEach((dir) => fileWatcher.add(dir));
     },
@@ -42,7 +42,7 @@ export function connectorSourcePlugin(sourceDirs) {
     transform(context) {
       const sourcePath = resolveSourcePath(context.path);
       if (sourcePath) {
-        // Don't cache connector sources, so a rerun picks up the latest source
+        // Don't cache frontend sources, so a rerun picks up the latest source
         // instead of a transform cached from a previous run.
         return { transformCache: false };
       }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
@@ -1,12 +1,12 @@
 import path from 'node:path';
-import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
   ...sharedConfig,
 
   plugins: [
-    connectorSourcePlugin([
+    frontendSourcePlugin([
       path.resolve(import.meta.dirname, '../vaadin-combo-box-flow/src/main/resources/META-INF/frontend')
     ]),
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/web-test-runner.config.mjs
@@ -1,6 +1,15 @@
-import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import path from 'node:path';
+import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  ...sharedConfig
+  ...sharedConfig,
+
+  plugins: [
+    connectorSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-combo-box-flow/src/main/resources/META-INF/frontend')
+    ]),
+
+    ...sharedConfig.plugins
+  ]
 };

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
@@ -1,12 +1,12 @@
 import path from 'node:path';
-import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
   ...sharedConfig,
 
   plugins: [
-    connectorSourcePlugin([
+    frontendSourcePlugin([
       path.resolve(import.meta.dirname, '../vaadin-date-picker-flow/src/main/resources/META-INF/frontend')
     ]),
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/web-test-runner.config.mjs
@@ -1,6 +1,15 @@
-import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import path from 'node:path';
+import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  ...sharedConfig
+  ...sharedConfig,
+
+  plugins: [
+    connectorSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-date-picker-flow/src/main/resources/META-INF/frontend')
+    ]),
+
+    ...sharedConfig.plugins
+  ]
 };

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/web-test-runner.config.mjs
@@ -1,12 +1,12 @@
 import path from 'node:path';
-import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
   ...sharedConfig,
 
   plugins: [
-    connectorSourcePlugin([
+    frontendSourcePlugin([
       path.resolve(import.meta.dirname, '../vaadin-grid-flow/src/main/resources/META-INF/frontend')
     ]),
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/web-test-runner.config.mjs
@@ -1,6 +1,15 @@
-import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import path from 'node:path';
+import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  ...sharedConfig
+  ...sharedConfig,
+
+  plugins: [
+    connectorSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-grid-flow/src/main/resources/META-INF/frontend')
+    ]),
+
+    ...sharedConfig.plugins
+  ]
 };

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/web-test-runner.config.mjs
@@ -1,12 +1,12 @@
 import path from 'node:path';
-import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
   ...sharedConfig,
 
   plugins: [
-    connectorSourcePlugin([
+    frontendSourcePlugin([
       path.resolve(import.meta.dirname, '../vaadin-renderer-flow/src/main/resources/META-INF/frontend')
     ]),
 

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/web-test-runner.config.mjs
@@ -1,6 +1,15 @@
-import { sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+import path from 'node:path';
+import { connectorSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
 
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
-  ...sharedConfig
+  ...sharedConfig,
+
+  plugins: [
+    connectorSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-renderer-flow/src/main/resources/META-INF/frontend')
+    ]),
+
+    ...sharedConfig.plugins
+  ]
 };


### PR DESCRIPTION
WTR unit tests import frontend files (connectors, renderers) from `frontend/generated/jar-resources`, which are build-time copies created by the `flow:build-frontend` task. Because editing the source didn't refresh those copies, you'd soon find the tests running against stale code until you re-ran `scripts/wtr.js`, which was annoying.

This PR adds a shared dev-server plugin that serves these files from the component module's `META-INF/frontend` source when it exists, falling back to the build-time copy otherwise. The request URL stays in the flat `jar-resources` namespace, so cross-module sibling imports (e.g. `menubarConnector` importing `./contextMenuConnector.js`) keep resolving just as they did before. The plugin also watches the source directories so edits reload in watch mode, and skips caching the sources so reruns pick up the latest code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)