### PR TITLE
fix: assign data provider after $connector function are defined

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -19,6 +19,30 @@ describe('combo-box connector', () => {
     expect(comboBox.$connector).to.equal(connector);
   });
 
+  describe('initialization while opened', () => {
+    // Flow defers the connector initialization for an initially hidden combo
+    // box until it becomes visible. When the server makes it visible and opens
+    // it in the same round-trip, initLazy runs while the combo box is already
+    // opened. Assigning the data provider then synchronously triggers a
+    // first-page load that calls back into the connector, so all $connector
+    // functions must already be defined by that point (see issue #9622).
+    beforeEach(() => {
+      comboBox = fixtureSync('<vaadin-combo-box opened></vaadin-combo-box>');
+      init(comboBox);
+    });
+
+    it('should request the first page of data', () => {
+      expect(comboBox.$server.setViewportRange).to.be.calledOnce;
+    });
+
+    it('should load items into the dropdown', () => {
+      comboBox.$connector.set(0, [{ key: '1', label: 'one' }], '');
+      comboBox.$connector.confirm(1, '');
+
+      expect(comboBox.filteredItems).to.eql([{ key: '1', label: 'one' }]);
+    });
+  });
+
   describe('pending requests', () => {
     let dataProviderController: FlowComboBox['__dataProviderController'];
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -20,12 +20,10 @@ describe('combo-box connector', () => {
   });
 
   describe('initialization while opened', () => {
-    // Flow defers the connector initialization for an initially hidden combo
-    // box until it becomes visible. When the server makes it visible and opens
-    // it in the same round-trip, initLazy runs while the combo box is already
-    // opened. Assigning the data provider then synchronously triggers a
-    // first-page load that calls back into the connector, so all $connector
-    // functions must already be defined by that point (see issue #9622).
+    // When a combo box is made visible and opened in the same round-trip,
+    // initLazy runs while it is already opened. Assigning the data provider
+    // then triggers a first-page load that calls back into the connector, so
+    // all $connector functions must already be defined by then.
     beforeEach(() => {
       comboBox = fixtureSync('<vaadin-combo-box opened></vaadin-combo-box>');
       init(comboBox);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -19,26 +19,13 @@ describe('combo-box connector', () => {
     expect(comboBox.$connector).to.equal(connector);
   });
 
-  describe('initialization while opened', () => {
+  it('should not throw when initialized while opened', () => {
     // When a combo box is made visible and opened in the same round-trip,
     // initLazy runs while it is already opened. Assigning the data provider
     // then triggers a first-page load that calls back into the connector, so
     // all $connector functions must already be defined by then.
-    beforeEach(() => {
-      comboBox = fixtureSync('<vaadin-combo-box opened></vaadin-combo-box>');
-      init(comboBox);
-    });
-
-    it('should request the first page of data', () => {
-      expect(comboBox.$server.setViewportRange).to.be.calledOnce;
-    });
-
-    it('should load items into the dropdown', () => {
-      comboBox.$connector.set(0, [{ key: '1', label: 'one' }], '');
-      comboBox.$connector.confirm(1, '');
-
-      expect(comboBox.filteredItems).to.eql([{ key: '1', label: 'one' }]);
-    });
+    comboBox = fixtureSync('<vaadin-combo-box opened></vaadin-combo-box>');
+    expect(() => init(comboBox)).to.not.throw();
   });
 
   describe('pending requests', () => {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/comboBoxConnector.js
@@ -19,7 +19,7 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   let lastRequestedFilter = '';
   let needsDataCommunicatorReset = false;
 
-  comboBox.dataProvider = function (params, callback) {
+  const dataProvider = function (params, callback) {
     if (params.pageSize != comboBox.pageSize) {
       throw 'Invalid pageSize';
     }
@@ -236,6 +236,9 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
   comboBox.itemClassNameGenerator = function (item) {
     return item.className || '';
   };
+
+  // Assign last, after all `$connector` functions are defined.
+  comboBox.dataProvider = dataProvider;
 };
 
 window.Vaadin.ComboBoxPlaceholder = ComboBoxPlaceholder;


### PR DESCRIPTION
The connector assigned comboBox.dataProvider near the start of initLazy, before $connector.requestPage and the other $connector functions were defined. Since Vaadin 25.2 the web component runs the dataProvider property observer synchronously, so the assignment immediately triggered a first-page load that called back into $connector.requestPage while it was still undefined. The resulting error aborted connector initialization, leaving the dropdown stuck on the loading spinner with empty items.

Assign the data provider last, after all $connector functions exist, so the synchronous first-page load can safely call back into the connector.

Fixes #9622
