### PR TITLE
chore: commit pnpm-workspace.yaml to IT modules

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -223,15 +223,6 @@ jobs:
         if: matrix.type == 'war'
         run: node scripts/mergeITs.js ${{ needs.build.outputs.components }}
 
-      # Let @vaadin/* web component bumps bypass the frontend package age check
-      - name: Configure pnpm package age exclude
-        if: matrix.type == 'war'
-        run: |
-          cat > integration-tests/pnpm-workspace.yaml <<'EOF'
-          minimumReleaseAgeExclude:
-            - '@vaadin/*'
-          EOF
-
       - name: Setup JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules
 !/package.json
 !/package-lock.json
 pnpm*
+!**/pnpm-workspace.yaml
 .npmrc
 .pnpmfile.cjs
 error-screenshots

--- a/scripts/mergeITs.js
+++ b/scripts/mergeITs.js
@@ -223,6 +223,9 @@ async function copySources() {
     copyFolderRecursiveSync(`${parent}/${id}-integration-tests/frontend`, `${itFolder}`);
     // copy java sources
     copyFolderRecursiveSync(`${parent}/${id}-integration-tests/src`, `${itFolder}`);
+    // copy pnpm-workspace.yaml so @vaadin/* web component bumps bypass the
+    // frontend package age check (all modules ship an identical copy)
+    copyFileSync(`${parent}/${id}-integration-tests/pnpm-workspace.yaml`, `${itFolder}`);
   });
 
   // Always copy LumoAppShell, so that merged ITs run with Lumo theme applied. Some ITs do not work property with

--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -79,14 +79,6 @@ async function runTests() {
         fs.writeFileSync(packageJson, '{}');
       }
 
-      // Build the frontend with pnpm and let @vaadin/* web component bumps
-      // bypass the frontend package age check. Avoids failures when running
-      // checks for just-released @vaadin packages.
-      fs.writeFileSync(
-        `${itFolder}/pnpm-workspace.yaml`,
-        "minimumReleaseAgeExclude:\n  - '@vaadin/*'\n"
-      );
-
       // Install the IT module dependencies
       execSync(`mvn flow:prepare-frontend flow:build-frontend`, {
         cwd: itFolder,

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-spreadsheet-flow-parent/.gitignore
+++ b/vaadin-spreadsheet-flow-parent/.gitignore
@@ -23,6 +23,7 @@ node_modules
 .driver
 package*json
 pnpm*
+!**/pnpm-workspace.yaml
 .pnpm*
 error-screenshots
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pnpm-workspace.yaml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAgeExclude:
+  - '@vaadin/*'


### PR DESCRIPTION
ITs failed to run locally whenever a fresh `@vaadin` release came out because the `pnpm-workspace.yaml` containing `minimumReleaseAgeExclude` was only generated on the fly for `scripts/wtr.js` and the `war` job in `validation.yml`. To fix this, this PR commits `pnpm-workspace.yaml` to each IT package so the setting applies by default.