### PR TITLE
chore: move GridPro class annotations after the JavaDoc

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -45,11 +45,6 @@ import com.vaadin.flow.shared.Registration;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
-@Tag("vaadin-grid-pro")
-@NpmPackage(value = "@vaadin/grid-pro", version = "25.2.0")
-@JsModule("@vaadin/grid-pro/src/vaadin-grid-pro.js")
-@JsModule("@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js")
-@JsModule("./gridProConnector.js")
 /**
  * Grid Pro is an extension of the Grid component that provides inline editing
  * with full keyboard navigation.
@@ -60,6 +55,11 @@ import tools.jackson.databind.node.ObjectNode;
  *            the grid bean type
  *
  */
+@Tag("vaadin-grid-pro")
+@NpmPackage(value = "@vaadin/grid-pro", version = "25.2.0")
+@JsModule("@vaadin/grid-pro/src/vaadin-grid-pro.js")
+@JsModule("@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js")
+@JsModule("./gridProConnector.js")
 public class GridPro<E> extends Grid<E> {
 
     /**


### PR DESCRIPTION
## Description

Moved `GridPro` annotations after the JavaDoc for consistency with other public component classes.

## Type of change

- Internal change