### PR TITLE
fix: reuse tooltip instance for composite components

### DIFF
--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/Tooltip.java
@@ -179,7 +179,10 @@ public class Tooltip implements Serializable {
         var tooltip = getForElement(component.getElement());
         if (tooltip == null) {
             tooltip = forElement(component.getElement());
-            ComponentUtil.setData(component, TOOLTIP_DATA_KEY, tooltip);
+            var innermostComponent = ComponentUtil
+                    .getInnermostComponent(component.getElement());
+            ComponentUtil.setData(innermostComponent, TOOLTIP_DATA_KEY,
+                    tooltip);
         }
         return tooltip;
     }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/TooltipTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.shared.Tooltip.AriaLinkMode;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
@@ -229,6 +230,14 @@ class TooltipTest {
     }
 
     @Test
+    void tooltipForCompositeTwice_sameReference() {
+        var composite = new CompositeComponent();
+        var tooltip = Tooltip.forComponent(composite);
+        var tooltip2 = Tooltip.forComponent(composite);
+        Assertions.assertSame(tooltip, tooltip2);
+    }
+
+    @Test
     void createTooltip_fluentAPI() {
         ui.add(component);
 
@@ -280,5 +289,12 @@ class TooltipTest {
 
     @Tag("test")
     private static class TestComponent extends Component {
+    }
+
+    private static class CompositeComponent extends Composite<TestComponent> {
+        @Override
+        protected TestComponent initContent() {
+            return new TestComponent();
+        }
     }
 }


### PR DESCRIPTION
Tooltip instances should be reused when calling `Tooltip.forComponent` repeatedly for the same component, as introduced in #4736. This did not work for composite components: the tooltip was stored on the original component, but the lookup in `Tooltip#getForElement` resolves the innermost content component instead, so the cached instance was never found and a new one was created on every call.

```java
Component composite = new MyComposite(); // extends Composite<Span>
Tooltip a = Tooltip.forComponent(composite);
Tooltip b = Tooltip.forComponent(composite);
// a != b before this fix
```

Store the cached tooltip on the innermost component in `forComponent`, so the write matches the read in `getForElement` (and the existing `forHasTooltip`, which already resolves the innermost component).

Fixes #9638

---

🤖 Generated with Claude Code
