### PR TITLE
feat: add Grid selection column accessible name APIs

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-aria.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-aria.test.ts
@@ -42,18 +42,18 @@ describe('grid connector - selection column accessible names', () => {
     // First item carries a server-generated full aria-label, the second one
     // does not (no generator value for it).
     setRootItems(grid.$connector, [
-      { key: '0', name: 'foo', selectionAriaLabel: 'Select Row Foo' },
+      { key: '0', name: 'foo', selectRowCheckboxAriaLabel: 'Select Row Foo' },
       { key: '1', name: 'bar' }
     ]);
     await nextFrame();
   });
 
-  it('should use the per-item selectionAriaLabel as the row checkbox name', async () => {
+  it('should use the per-item selectRowCheckboxAriaLabel as the row checkbox name', async () => {
     await enterMultiSelectMode();
     expect(rowCheckboxes()[0].accessibleName).to.equal('Select Row Foo');
   });
 
-  it('should fall back to the default name for items without a selectionAriaLabel', async () => {
+  it('should fall back to the default name for items without a selectRowCheckboxAriaLabel', async () => {
     await enterMultiSelectMode();
     expect(rowCheckboxes()[1].accessibleName).to.equal('Select Row');
   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-aria.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-selection-aria.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, initSelectionColumn, setRootItems } from './shared.js';
+import type { FlowGrid, FlowGridSelectionColumn } from './shared.js';
+
+type Checkbox = HTMLElement & { accessibleName: string };
+
+describe('grid connector - selection column accessible names', () => {
+  let grid: FlowGrid;
+  let selectionColumn: FlowGridSelectionColumn;
+
+  function allCheckboxes(): Checkbox[] {
+    return [...grid.querySelectorAll<Checkbox>('vaadin-checkbox')];
+  }
+
+  function selectAllCheckbox(): Checkbox {
+    return allCheckboxes()[0];
+  }
+
+  function rowCheckboxes(): Checkbox[] {
+    const [, ...rows] = allCheckboxes();
+    return rows;
+  }
+
+  async function enterMultiSelectMode() {
+    grid.$connector.setSelectionMode('MULTI');
+    await nextFrame();
+  }
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-flow-selection-column></vaadin-grid-flow-selection-column>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    init(grid);
+
+    selectionColumn = grid.querySelector('vaadin-grid-flow-selection-column')!;
+    initSelectionColumn(grid, selectionColumn);
+
+    // First item carries a server-generated full aria-label, the second one
+    // does not (no generator value for it).
+    setRootItems(grid.$connector, [
+      { key: '0', name: 'foo', selectionAriaLabel: 'Select Row Foo' },
+      { key: '1', name: 'bar' }
+    ]);
+    await nextFrame();
+  });
+
+  it('should use the per-item selectionAriaLabel as the row checkbox name', async () => {
+    await enterMultiSelectMode();
+    expect(rowCheckboxes()[0].accessibleName).to.equal('Select Row Foo');
+  });
+
+  it('should fall back to the default name for items without a selectionAriaLabel', async () => {
+    await enterMultiSelectMode();
+    expect(rowCheckboxes()[1].accessibleName).to.equal('Select Row');
+  });
+
+  it('should use the select all checkbox accessible name', async () => {
+    selectionColumn.selectAllAccessibleName = 'Select All Items';
+    await enterMultiSelectMode();
+    expect(selectAllCheckbox().accessibleName).to.equal('Select All Items');
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -58,6 +58,7 @@ export type Item = {
   dragData?: Record<string, string>;
   dragDisabled?: boolean;
   dropDisabled?: boolean;
+  selectionAriaLabel?: string;
 };
 
 export type FlowGrid = Grid<Item> & {
@@ -81,6 +82,8 @@ export type FlowGridSorter = GridSorter & {
 
 export type FlowGridSelectionColumn = GridColumn & {
   selectAll: boolean;
+  selectAllAccessibleName: string;
+  selectRowAccessibleNameGenerator: (item: Item) => string | null;
   $server: GridServer;
 };
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -58,7 +58,7 @@ export type Item = {
   dragData?: Record<string, string>;
   dragDisabled?: boolean;
   dropDisabled?: boolean;
-  selectionAriaLabel?: string;
+  selectRowCheckboxAriaLabel?: string;
 };
 
 export type FlowGrid = Grid<Item> & {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.data.selection.SelectionListener;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.Signal;
@@ -65,6 +66,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
     private final GridSelectionColumn selectionColumn;
     private SelectAllCheckboxVisibility selectAllCheckBoxVisibility;
     private Registration selectionBindingCleanup;
+    private SerializableFunction<T, String> selectRowCheckboxAriaLabelGenerator;
 
     /**
      * Constructor for passing a reference of the grid to this implementation.
@@ -390,6 +392,12 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (isSelected(item)) {
             jsonObject.put("selected", true);
         }
+        if (selectRowCheckboxAriaLabelGenerator != null) {
+            String ariaLabel = selectRowCheckboxAriaLabelGenerator.apply(item);
+            if (ariaLabel != null) {
+                jsonObject.put("selectionAriaLabel", ariaLabel);
+            }
+        }
     }
 
     @Override
@@ -410,6 +418,18 @@ public abstract class AbstractGridMultiSelectionModel<T>
     @Override
     public boolean isDragSelect() {
         return selectionColumn.isDragSelect();
+    }
+
+    @Override
+    public void setSelectAllCheckboxAriaLabel(String ariaLabel) {
+        selectionColumn.setSelectAllCheckboxAriaLabel(ariaLabel);
+    }
+
+    @Override
+    public void setSelectRowCheckboxAriaLabelGenerator(
+            SerializableFunction<T, String> generator) {
+        this.selectRowCheckboxAriaLabelGenerator = generator;
+        getGrid().getDataCommunicator().reset();
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -395,7 +395,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (selectRowCheckboxAriaLabelGenerator != null) {
             String ariaLabel = selectRowCheckboxAriaLabelGenerator.apply(item);
             if (ariaLabel != null) {
-                jsonObject.put("selectionAriaLabel", ariaLabel);
+                jsonObject.put("selectRowCheckboxAriaLabel", ariaLabel);
             }
         }
     }
@@ -429,7 +429,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
     public void setSelectRowCheckboxAriaLabelGenerator(
             SerializableFunction<T, String> generator) {
         this.selectRowCheckboxAriaLabelGenerator = generator;
-        getGrid().getDataCommunicator().reset();
+        getGrid().refreshViewport();
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.data.selection.MultiSelect;
 import com.vaadin.flow.data.selection.MultiSelectionEvent;
 import com.vaadin.flow.data.selection.MultiSelectionListener;
 import com.vaadin.flow.data.selection.SelectionModel;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
 
@@ -187,4 +188,26 @@ public interface GridMultiSelectionModel<T>
      *         <code>false</code> otherwise
      */
     boolean isDragSelect();
+
+    /**
+     * Sets the accessible name (aria-label) for the select all checkbox in the
+     * header cell.
+     *
+     * @param ariaLabel
+     *            the accessible name for the select all checkbox
+     */
+    void setSelectAllCheckboxAriaLabel(String ariaLabel);
+
+    /**
+     * Sets a generator that produces the accessible name (aria-label) for each
+     * row's select row checkbox. The generator receives the row item and
+     * returns the full aria-label, e.g.
+     * <code>item -&gt; "Select Row " + item.getName()</code>.
+     *
+     * @param generator
+     *            the generator returning the accessible name for a row, or
+     *            {@code null} to reset to the default
+     */
+    void setSelectRowCheckboxAriaLabelGenerator(
+            SerializableFunction<T, String> generator);
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -83,6 +83,17 @@ public class GridSelectionColumn extends Component {
     }
 
     /**
+     * Sets the accessible name (aria-label) for the select all checkbox in the
+     * header cell.
+     *
+     * @param ariaLabel
+     *            the accessible name for the select all checkbox
+     */
+    public void setSelectAllCheckboxAriaLabel(String ariaLabel) {
+        getElement().setProperty("selectAllAccessibleName", ariaLabel);
+    }
+
+    /**
      * Sets this column's frozen state.
      *
      * @param frozen

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid-flow-selection-column.js
@@ -32,7 +32,7 @@ export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridCo
     super();
     // The full aria-label is generated server-side and sent as a per-item
     // property; fall back to the default when the app has no generator set.
-    this.selectRowAccessibleNameGenerator = (item) => item?.selectionAriaLabel ?? 'Select Row';
+    this.selectRowAccessibleNameGenerator = (item) => item?.selectRowCheckboxAriaLabel ?? 'Select Row';
   }
 
   /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid-flow-selection-column.js
@@ -28,6 +28,13 @@ export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin(GridCo
     };
   }
 
+  constructor() {
+    super();
+    // The full aria-label is generated server-side and sent as a per-item
+    // property; fall back to the default when the app has no generator set.
+    this.selectRowAccessibleNameGenerator = (item) => item?.selectionAriaLabel ?? 'Select Row';
+  }
+
   /**
    * Override method from `GridSelectionColumnBaseMixin` to add ID to select all
    * checkbox

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -845,7 +845,7 @@ class AbstractGridMultiSelectionModelTest {
                 .getSelectionModel();
         ObjectNode json = JacksonUtils.createObjectNode();
         selectionModel.generateData("foo", json);
-        Assertions.assertFalse(json.has("selectionAriaLabel"));
+        Assertions.assertFalse(json.has("selectRowCheckboxAriaLabel"));
     }
 
     @Test
@@ -858,7 +858,7 @@ class AbstractGridMultiSelectionModelTest {
         ObjectNode json = JacksonUtils.createObjectNode();
         selectionModel.generateData("foo", json);
         Assertions.assertEquals("Select Row foo",
-                json.get("selectionAriaLabel").asText());
+                json.get("selectRowCheckboxAriaLabel").asText());
     }
 
     @Test
@@ -869,7 +869,7 @@ class AbstractGridMultiSelectionModelTest {
         selectionModel.setSelectRowCheckboxAriaLabelGenerator(item -> null);
         ObjectNode json = JacksonUtils.createObjectNode();
         selectionModel.generateData("foo", json);
-        Assertions.assertFalse(json.has("selectionAriaLabel"));
+        Assertions.assertFalse(json.has("selectRowCheckboxAriaLabel"));
     }
 
     private DataProvider<String, ?> getInMemoryDataProvider() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelTest.java
@@ -33,7 +33,10 @@ import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.data.provider.*;
 import com.vaadin.flow.data.selection.SelectionListener;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
+
+import tools.jackson.databind.node.ObjectNode;
 
 class AbstractGridMultiSelectionModelTest {
     @RegisterExtension
@@ -822,6 +825,51 @@ class AbstractGridMultiSelectionModelTest {
                     Assertions.fail("Unexpected size query call");
                     return 0;
                 });
+    }
+
+    @Test
+    void setSelectAllCheckboxAriaLabel_setsElementProperty() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        AbstractGridMultiSelectionModel<String> selectionModel = (AbstractGridMultiSelectionModel<String>) grid
+                .getSelectionModel();
+        selectionModel.setSelectAllCheckboxAriaLabel("Select all items");
+        Assertions.assertEquals("Select all items",
+                selectionModel.getSelectionColumn().getElement()
+                        .getProperty("selectAllAccessibleName"));
+    }
+
+    @Test
+    void generateData_noGenerator_omitsSelectionAriaLabel() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        AbstractGridMultiSelectionModel<String> selectionModel = (AbstractGridMultiSelectionModel<String>) grid
+                .getSelectionModel();
+        ObjectNode json = JacksonUtils.createObjectNode();
+        selectionModel.generateData("foo", json);
+        Assertions.assertFalse(json.has("selectionAriaLabel"));
+    }
+
+    @Test
+    void generateData_withGenerator_writesSelectionAriaLabel() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        AbstractGridMultiSelectionModel<String> selectionModel = (AbstractGridMultiSelectionModel<String>) grid
+                .getSelectionModel();
+        selectionModel.setSelectRowCheckboxAriaLabelGenerator(
+                item -> "Select Row " + item);
+        ObjectNode json = JacksonUtils.createObjectNode();
+        selectionModel.generateData("foo", json);
+        Assertions.assertEquals("Select Row foo",
+                json.get("selectionAriaLabel").asText());
+    }
+
+    @Test
+    void generateData_generatorReturnsNull_omitsSelectionAriaLabel() {
+        grid.setSelectionMode(SelectionMode.MULTI);
+        AbstractGridMultiSelectionModel<String> selectionModel = (AbstractGridMultiSelectionModel<String>) grid
+                .getSelectionModel();
+        selectionModel.setSelectRowCheckboxAriaLabelGenerator(item -> null);
+        ObjectNode json = JacksonUtils.createObjectNode();
+        selectionModel.generateData("foo", json);
+        Assertions.assertFalse(json.has("selectionAriaLabel"));
     }
 
     private DataProvider<String, ?> getInMemoryDataProvider() {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/3471

Depends on https://github.com/vaadin/web-components/pull/12002

Added following APIs to `GridMultiSelectionModel`:

- `setSelectAllCheckboxAriaLabel(String ariaLabel)`
- `setSelectRowCheckboxAriaLabelGenerator(SerializableFunction<T, String> generator)`

Usage example:

```java
GridMultiSelectionModel<Person> selectionModel = grid.getSelectionModel();

// "Select all" checkbox
selectionModel.setSelectAllCheckboxAriaLabel("Select all items");

// "Select row" checkbox
selectionModel.setSelectRowCheckboxAriaLabelGenerator((item) -> {
    return "Select item %s".formatted(item.getName());
});
```

## Type of change

- Feature