### PR TITLE
fix: keep scroll position when setting item selectable provider

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionPage.java
@@ -89,6 +89,10 @@ public class TreeGridScrollPositionPage extends Div {
             treeGrid.getColumns().get(0)
                     .setPartNameGenerator(item -> "column-custom-part");
         });
+
+        addButton("set-item-selectable-provider", event -> {
+            treeGrid.setItemSelectableProvider(item -> true);
+        });
     }
 
     private void addButton(String id,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionIT.java
@@ -111,6 +111,13 @@ public class TreeGridScrollPositionIT extends AbstractComponentIT {
         });
     }
 
+    @Test
+    public void setItemSelectableProvider_scrollPositionNotChanged() {
+        assertScrollPositionNotChanged(() -> {
+            clickElementWithJs("set-item-selectable-provider");
+        });
+    }
+
     public void assertScrollPositionNotChanged(SerializableRunnable action) {
         var firstVisibleRowIndex = treeGrid.getFirstVisibleRowIndex();
         action.run();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3128,7 +3128,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public void setItemSelectableProvider(SerializablePredicate<T> provider) {
         selectableProvider = provider;
-        getDataCommunicator().reset();
+        refreshViewport();
 
         if (selectionModel instanceof AbstractGridMultiSelectionModel<T> multiSelectionModel) {
             multiSelectionModel.updateSelectAllCheckBoxVisibility();


### PR DESCRIPTION
This PR changes `setItemSelectableProvider` to use `refreshViewport()` instead of `dataCommunicator.reset()` to avoid resetting TreeGrid's scroll position and adds a corresponding test to `TreeGridScrollPositionIT`.