### PR TITLE
fix: store composed path for deferred context menu open

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuTargetConnector.js
@@ -13,6 +13,11 @@ function init(target) {
       }
       e.preventDefault();
       e.stopPropagation();
+      // The menu is opened later, after a server round-trip, when the event has
+      // finished dispatching and `composedPath()` returns an empty array. Capture
+      // the composed path now so the menu can resolve the target inside a shadow
+      // root (e.g. a grid cell) instead of the retargeted host.
+      e.__composedPath = e.composedPath();
       this.$contextMenuTargetConnector.openEvent = e;
       let detail = {};
       if (target.getContextMenuBeforeOpenDetail) {


### PR DESCRIPTION
The context menu target connector opens the menu after a server round-trip: it stores the opening event, dispatches `vaadin-context-menu-before-open`, and the server later calls back `$contextMenuTargetConnector.openMenu`, which runs `contextMenu.open(storedEvent)`.

By then the event has finished dispatching, so `event.composedPath()` returns an empty array. The web component relies on the composed path to resolve the actual opening target inside a shadow root (e.g. a grid cell). With an empty path it falls back to the retargeted `event.target` (the shadow host), so the menu is positioned against the host instead of the deep element.

This stores the composed path on the event while it is still dispatching, so the web component can resolve the correct target when it opens the menu later.

## Changes

`contextMenuTargetConnector.js` captures `e.__composedPath = e.composedPath()` in `openOnHandler` before deferring. The web component reads `__composedPath` when `composedPath()` is empty (see the companion web-components change).

Related to vaadin/web-components#12007

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)