### PR TITLE
fix: keep scroll position when toggling Grid enabled state

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionPage.java
@@ -89,6 +89,10 @@ public class TreeGridScrollPositionPage extends Div {
             treeGrid.getColumns().get(0)
                     .setPartNameGenerator(item -> "column-custom-part");
         });
+
+        addButton("set-enabled", event -> {
+            treeGrid.setEnabled(!treeGrid.isEnabled());
+        });
     }
 
     private void addButton(String id,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollPositionIT.java
@@ -111,6 +111,13 @@ public class TreeGridScrollPositionIT extends AbstractComponentIT {
         });
     }
 
+    @Test
+    public void setEnabled_scrollPositionNotChanged() {
+        assertScrollPositionNotChanged(() -> {
+            clickElementWithJs("set-enabled");
+        });
+    }
+
     public void assertScrollPositionNotChanged(SerializableRunnable action) {
         var firstVisibleRowIndex = treeGrid.getFirstVisibleRowIndex();
         action.run();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4097,11 +4097,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         super.onEnabledStateChanged(enabled);
 
         /*
-         * The DataCommunicator needs to be reset so components rendered inside
-         * the cells can be updated to the new enabled state. The enabled state
-         * is passed as a property to the client via DataGenerators.
+         * The visible rows need to be re-rendered so that renderers relying on
+         * the enabled state, such as NativeButtonRenderer, can update the
+         * "disabled" property they push to the client via DataGenerators.
+         * Components rendered inside cells are updated automatically since they
+         * are part of the component tree.
          */
-        getDataCommunicator().reset();
+        refreshViewport();
     }
 
     /**


### PR DESCRIPTION
This PR changes `onEnabledStateChanged` to use `refreshViewport()` instead of `dataCommunicator.reset()` to avoid resetting TreeGrid's scroll position and adds a corresponding test to `TreeGridScrollPositionIT`.
