### PR TITLE
chore: report failed WTR assertions instead of timing out

### DIFF
--- a/shared/shared-web-test-runner-config.mjs
+++ b/shared/shared-web-test-runner-config.mjs
@@ -65,9 +65,33 @@ export const sharedConfig = {
     <html>
       <body>
         <script type="module">
-          import { use } from 'chai';
+          import { use, Assertion } from 'chai';
           import sinonChai from 'sinon-chai';
           use(sinonChai);
+
+          // When a test fails, web-test-runner ships the error from the browser
+          // to the Node reporter, serializing it with structuredClone. sinon-chai
+          // sets the assertion error's \`actual\` to the spy function itself, and
+          // structuredClone throws on functions. That rejection kills the
+          // session-finished message, so the run reports a 120s "did not finish"
+          // timeout instead of the actual assertion failure. Drop any
+          // actual/expected that can't be cloned so the failure reports cleanly.
+          const assert = Assertion.prototype.assert;
+          Assertion.prototype.assert = function (...args) {
+            try {
+              return assert.apply(this, args);
+            } catch (error) {
+              for (const key of ['actual', 'expected']) {
+                try {
+                  structuredClone(error[key]);
+                } catch {
+                  delete error[key];
+                  error.showDiff = false;
+                }
+              }
+              throw error;
+            }
+          };
         </script>
         <script type="module" src="${testFramework}"></script>
       </body>


### PR DESCRIPTION
A failing sinon-chai assertion sets the error's `actual` to the spy function. web-test-runner serializes that error with structuredClone to send it from the browser to the Node reporter, and structuredClone throws on functions. The rejected send leaves the session unfinished, so the run reports a 120s "did not finish" timeout instead of the assertion failure.

Wrap chai's assert to drop any actual/expected that can't be cloned, so failures report cleanly.
