### PR TITLE
refactor: reuse setupColumnEditor in setRenderer

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1124,12 +1124,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             Rendering<T> editorRendering = editorRenderer.render(getElement(),
                     null);
 
-            Optional<DataGenerator<T>> dataGenerator = editorRendering
-                    .getDataGenerator();
-            if (dataGenerator.isPresent()) {
-                editorDataGeneratorRegistration = grid
-                        .addDataGenerator((DataGenerator) dataGenerator.get());
-            }
+            editorDataGeneratorRegistration = editorRendering.getDataGenerator()
+                    .map(dataGenerator -> grid
+                            .addDataGenerator((DataGenerator) dataGenerator))
+                    .orElse(null);
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -547,13 +547,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             // The editor renderer is a wrapper around the regular renderer, so
             // we need to apply it again afterwards
             if (editorRenderer != null) {
-                Rendering<T> editorRendering = editorRenderer
-                        .render(getElement(), null);
-                editorDataGeneratorRegistration = editorRendering
-                        .getDataGenerator()
-                        .map(dataGenerator -> grid.addDataGenerator(
-                                (DataGenerator) dataGenerator))
-                        .orElse(null);
+                setupColumnEditor();
             }
 
             getGrid().refreshViewport();
@@ -1122,8 +1116,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
         private void setupColumnEditor() {
-            editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
-                    columnInternalId);
+            if (editorRenderer == null) {
+                editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
+                        columnInternalId);
+            }
 
             Rendering<T> editorRendering = editorRenderer.render(getElement(),
                     null);


### PR DESCRIPTION
When a column has an editor, `setRenderer` needs to apply the editor renderer again on top of the new regular renderer. This logic duplicated most of `setupColumnEditor`: rendering the editor renderer and registering its data generator.

`setupColumnEditor` now skips creating the `EditorRenderer` when it already exists, so `setRenderer` can call it instead of repeating the same steps.

Extracted from https://github.com/vaadin/flow-components/pull/6798

---

🤖 Generated with Claude Code