### PR TITLE
feat: add hideable columns and skip data for hidden columns

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridColumnTogglePage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridColumnTogglePage.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/column-toggle")
+public class GridColumnTogglePage extends Div {
+
+    public GridColumnTogglePage() {
+        Grid<Person> grid = new Grid<>();
+        grid.setItems(List.of(
+                new Person("John", "Doe", "john@example.com", 30, null, null),
+                new Person("Jane", "Roe", "jane@example.com", 25, null, null)));
+
+        // Marking columns as hideable makes the grid render its column toggle
+        // button automatically; no extra component or wrapper is needed.
+        Column<Person> firstName = grid.addColumn(Person::getFirstName)
+                .setHeader("First name").setHideable(true);
+        grid.addColumn(Person::getLastName).setHeader("Last name")
+                .setHideable(true);
+        grid.addColumn(Person::getEmail).setHeader("Email").setHideable(true);
+
+        // Not hideable (the default), so excluded from the toggle menu.
+        grid.addColumn(Person::getAge).setHeader("Age");
+
+        // Reflects the server-side visibility state and event source so the IT
+        // can verify the client toggle reached the server.
+        Div status = new Div();
+        status.setId("status");
+        firstName.addVisibilityChangedListener(event -> status
+                .setText(String.format("firstName visible=%s fromClient=%s",
+                        event.isVisible(), event.isFromClient())));
+
+        // Flips hideable on every column at runtime, so the IT can verify the
+        // toggle button automatically hides itself when no column is hideable.
+        NativeButton toggleHideable = new NativeButton("Toggle hideable",
+                event -> {
+                    boolean hideable = !firstName.isHideable();
+                    grid.getColumns()
+                            .forEach(column -> column.setHideable(hideable));
+                });
+        toggleHideable.setId("toggle-hideable");
+
+        add(grid, toggleHideable, status);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridColumnToggleIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridColumnToggleIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-grid/column-toggle")
+public class GridColumnToggleIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridElement.class).first();
+        waitUntil(driver -> grid.getRowCount() > 0);
+    }
+
+    @Test
+    public void menuListsOnlyHideableColumns() {
+        openMenu();
+        List<String> labels = menuItems().stream()
+                .map(TestBenchElement::getText).collect(Collectors.toList());
+        // "Age" is not hideable (the default) and is excluded.
+        Assert.assertEquals(List.of("First name", "Last name", "Email"),
+                labels);
+    }
+
+    @Test
+    public void toggleColumnOff_hidesColumnAndUpdatesServer() {
+        Assert.assertEquals(4, grid.getVisibleColumns().size());
+
+        openMenu();
+        clickItem("First name");
+
+        waitUntil(driver -> grid.getVisibleColumns().size() == 3);
+        Assert.assertEquals("firstName visible=false fromClient=true",
+                findElement(By.id("status")).getText());
+    }
+
+    @Test
+    public void toggleColumnOffAndOn_menuStaysOpen_repopulatesData() {
+        openMenu();
+
+        clickItem("First name");
+        waitUntil(driver -> grid.getVisibleColumns().size() == 3);
+
+        // The menu is still open (keepOpen), so a second toggle works without
+        // reopening it.
+        clickItem("First name");
+        waitUntil(driver -> grid.getVisibleColumns().size() == 4);
+
+        // The re-shown column's data is present again.
+        Assert.assertEquals("John", grid.getCell(0, 0).getText());
+    }
+
+    @Test
+    public void setHideableFalseOnAllColumns_toggleHidesAutomatically() {
+        Assert.assertTrue(columnToggle().isDisplayed());
+
+        // All columns become non-hideable -> the toggle button hides itself.
+        findElement(By.id("toggle-hideable")).click();
+        waitUntil(driver -> !columnToggle().isDisplayed());
+
+        // Columns become hideable again -> the toggle button reappears.
+        findElement(By.id("toggle-hideable")).click();
+        waitUntil(driver -> columnToggle().isDisplayed());
+    }
+
+    @Test
+    public void setHideable_whileColumnHiddenViaToggle_syncsHiddenColumn() {
+        // Hide "First name" through the toggle menu.
+        openMenu();
+        clickItem("First name");
+        waitUntil(driver -> grid.getVisibleColumns().size() == 3);
+        closeMenu();
+
+        // The server flips hideable=false on every column while "First name"
+        // is hidden. The change must also reach the hidden column: no hideable
+        // columns remain, so the toggle button hides itself.
+        findElement(By.id("toggle-hideable")).click();
+        waitUntil(driver -> !columnToggle().isDisplayed());
+
+        // Flip back: the toggle returns and offers the hidden column again.
+        findElement(By.id("toggle-hideable")).click();
+        waitUntil(driver -> columnToggle().isDisplayed());
+        openMenu();
+        List<String> labels = menuItems().stream()
+                .map(TestBenchElement::getText).collect(Collectors.toList());
+        Assert.assertEquals(List.of("First name", "Last name", "Email", "Age"),
+                labels);
+    }
+
+    private void closeMenu() {
+        new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
+        waitUntil(driver -> menuItems().stream()
+                .noneMatch(TestBenchElement::isDisplayed));
+    }
+
+    /**
+     * The column toggle context menu inside the grid's shadow root.
+     */
+    private TestBenchElement columnToggle() {
+        return grid.$(TestBenchElement.class).id("columnToggle");
+    }
+
+    private void openMenu() {
+        columnToggle().$("button").first().click();
+        // The menu (and its items) render inside the toggle's context menu.
+        waitUntil(driver -> !menuItems().isEmpty());
+    }
+
+    private List<TestBenchElement> menuItems() {
+        return columnToggle().$("vaadin-context-menu-item").all();
+    }
+
+    private void clickItem(String label) {
+        TestBenchElement item = menuItems().stream()
+                .filter(element -> label.equals(element.getText())).findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No menu item with label " + label));
+        item.click();
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -37,6 +37,7 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     protected final Grid<?> grid;
     private boolean headerRenderingScheduled;
     private boolean footerRenderingScheduled;
+    private boolean hideableSyncScheduled;
 
     private boolean sortingIndicators;
 
@@ -58,7 +59,16 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         addAttachListener(e -> {
             scheduleHeaderRendering();
             scheduleFooterRendering();
+            // An invisible column is attached to the client side as a
+            // placeholder without its properties, so hideable must be
+            // re-sent separately.
+            if (getElement().hasProperty("hideable")) {
+                scheduleHideableSync();
+            }
         });
+
+        getElement().addPropertyChangeListener("hideable",
+                event -> scheduleHideableSync());
     }
 
     /**
@@ -73,16 +83,85 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     /**
      * {@inheritDoc}
      * <p>
-     * Note that column related data is sent to the client side even if the
-     * column is invisible. Use {@link Grid#removeColumn(Column)} to remove
-     * column (or don't add the column all) and avoid sending extra data.
+     * While a column is invisible, its per-item data (cell content, tooltip and
+     * part information) is not sent to the client. When the column is made
+     * visible again, the grid's data is refreshed so that the rows already
+     * loaded on the client receive the column's data.
+     * <p>
+     * Use {@link Grid#removeColumn(Column)} to remove a column entirely (or
+     * don't add it at all).
      * </p>
      *
      * @see Grid#removeColumn(Column)
      */
     @Override
     public void setVisible(boolean visible) {
+        setVisible(visible, false);
+    }
+
+    /**
+     * Updates the visibility of this column, keeping track of whether the
+     * change originated from the client.
+     *
+     * @param visible
+     *            the new visibility
+     * @param fromClient
+     *            whether the change originated from the client
+     */
+    void setVisible(boolean visible, boolean fromClient) {
+        boolean wasVisible = isVisible();
         super.setVisible(visible);
+        if (wasVisible == visible) {
+            return;
+        }
+        // A column that becomes visible again needs its data re-sent, because
+        // it was skipped by the visibility-gated data generator while hidden.
+        if (visible && grid != null) {
+            grid.getDataCommunicator().reset();
+        }
+        onVisibilityChanged(visible, fromClient);
+    }
+
+    /**
+     * Called when this column's visibility has changed. Subclasses can override
+     * this to react, for example to fire a visibility change event.
+     *
+     * @param visible
+     *            the new visibility
+     * @param fromClient
+     *            whether the change originated from the client
+     */
+    protected void onVisibilityChanged(boolean visible, boolean fromClient) {
+        // NO-OP by default; overridden in Grid.Column.
+    }
+
+    /**
+     * Sends the {@code hideable} property to the client even while this column
+     * is invisible. Properties don't automatically synchronize to non-visible
+     * columns (see the {@code _flowId} handling in Grid#addColumn), but the
+     * grid's column toggle needs the up-to-date {@code hideable} state of
+     * hidden columns to decide whether to offer showing them again.
+     */
+    private void scheduleHideableSync() {
+        if (hideableSyncScheduled || grid == null) {
+            return;
+        }
+        hideableSyncScheduled = true;
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(grid, context -> {
+                    hideableSyncScheduled = false;
+                    // The visibility check runs here rather than at scheduling
+                    // time so it sees the final visibility of this round trip.
+                    // A visible column synchronizes the property normally.
+                    if (!isVisible() && getUI().isPresent()) {
+                        int nodeId = getElement().getNode().getId();
+                        String appId = ui.getInternals().getAppId();
+                        grid.getElement().executeJs(
+                                "Vaadin.Flow.clients[$0].getByNodeId($1).hideable = $2",
+                                appId, nodeId,
+                                getElement().getProperty("hideable", false));
+                    }
+                }));
     }
 
     private void scheduleHeaderRendering() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnBase.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnBase.java
@@ -54,6 +54,47 @@ interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
     }
 
     /**
+     * Sets whether this column can be hidden by the user through the grid's
+     * column toggle menu. Columns are not hideable by default.
+     * <p>
+     * The grid renders a toggle button in its top corner while it has at least
+     * one hideable column; the button opens a menu with one checkbox per
+     * hideable column. With no hideable columns the button is not shown.
+     * <p>
+     * Setting this to {@code false} only removes the column from the column
+     * toggle menu; it does not change the column's current visibility. Use
+     * {@link com.vaadin.flow.component.Component#setVisible(boolean)} to change
+     * the visibility programmatically.
+     *
+     * @param hideable
+     *            whether the user can hide this column through the grid's
+     *            column toggle menu
+     * @return this column, for method chaining
+     */
+    @SuppressWarnings("unchecked")
+    default T setHideable(boolean hideable) {
+        getElement().setProperty("hideable", hideable);
+        return (T) this;
+    }
+
+    /**
+     * Gets whether this column can be hidden by the user through the grid's
+     * column toggle menu.
+     * <p>
+     * The value is intentionally not synchronized from the client: hideable is
+     * controlled by the server only. A {@code @Synchronize} listener would also
+     * make the client revert the hideable state that {@code AbstractColumn}
+     * pushes to hidden columns with JS, because client updates to invisible
+     * elements are rejected.
+     *
+     * @return whether the user can hide this column through the grid's column
+     *         toggle menu
+     */
+    default boolean isHideable() {
+        return getElement().getProperty("hideable", false);
+    }
+
+    /**
      * Sets this column's frozen state.
      * <p>
      * <strong>Note:</strong> Columns are frozen in-place, freeze columns from

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnVisibilityChangeDomEvent.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnVisibilityChangeDomEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+/**
+ * Internal DOM event used by {@link Grid} to learn when the user shows or hides
+ * a column on the client. The {@code column-visibility-changed} event is fired
+ * by the {@code <vaadin-grid>} element when a column is toggled through its
+ * column toggle menu and carries a reference to the toggled column element; its
+ * {@code _flowId} property maps back to the server-side {@link Grid.Column}.
+ *
+ * <p>
+ * For internal use only. Applications should listen to
+ * {@link ColumnVisibilityChangedEvent} through
+ * {@link Grid.Column#addVisibilityChangedListener} instead.
+ *
+ * @author Vaadin Ltd
+ */
+@DomEvent("column-visibility-changed")
+public class ColumnVisibilityChangeDomEvent extends ComponentEvent<Grid<?>> {
+
+    private final String columnInternalId;
+    private final boolean hidden;
+
+    public ColumnVisibilityChangeDomEvent(Grid<?> source, boolean fromClient,
+            @EventData("event.detail.column._flowId") String columnInternalId,
+            @EventData("event.detail.hidden") boolean hidden) {
+        super(source, fromClient);
+        this.columnInternalId = columnInternalId;
+        this.hidden = hidden;
+    }
+
+    String getColumnInternalId() {
+        return columnInternalId;
+    }
+
+    boolean isHidden() {
+        return hidden;
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnVisibilityChangedEvent.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnVisibilityChangedEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.ComponentEvent;
+
+/**
+ * Event fired when a {@link Grid.Column column's} visibility changes, either
+ * programmatically through {@link Grid.Column#setVisible(boolean)} or when the
+ * user shows or hides the column through the grid's column toggle menu.
+ *
+ * @param <T>
+ *            the grid bean type
+ *
+ * @author Vaadin Ltd
+ *
+ * @see Grid.Column#addVisibilityChangedListener(com.vaadin.flow.component.ComponentEventListener)
+ */
+public class ColumnVisibilityChangedEvent<T>
+        extends ComponentEvent<Grid.Column<T>> {
+
+    private final boolean visible;
+
+    /**
+     * Creates a new column visibility change event.
+     *
+     * @param source
+     *            the column whose visibility changed
+     * @param fromClient
+     *            <code>true</code> if the change originated from the client
+     *            (the user toggled the column in a column selector),
+     *            <code>false</code> if it originates from server-side logic
+     * @param visible
+     *            the new visibility of the column
+     */
+    public ColumnVisibilityChangedEvent(Grid.Column<T> source,
+            boolean fromClient, boolean visible) {
+        super(source, fromClient);
+        this.visible = visible;
+    }
+
+    /**
+     * Gets the column whose visibility changed.
+     *
+     * @return the column
+     */
+    public Grid.Column<T> getColumn() {
+        return getSource();
+    }
+
+    /**
+     * Gets the new visibility of the column.
+     *
+     * @return <code>true</code> if the column is now visible,
+     *         <code>false</code> otherwise
+     */
+    public boolean isVisible() {
+        return visible;
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -418,9 +418,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * Server-side component for the {@code <vaadin-grid-column>} element.
      *
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @param <T>
@@ -485,7 +485,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
             if (dataGenerator.isPresent()) {
                 columnDataGeneratorRegistration = grid
-                        .addDataGenerator(dataGenerator.get());
+                        .addDataGenerator(visibilityGated(dataGenerator.get()));
             }
         }
 
@@ -498,6 +498,66 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 editorDataGeneratorRegistration.remove();
                 editorDataGeneratorRegistration = null;
             }
+        }
+
+        /**
+         * Wraps the given data generator so that per-item data is only
+         * generated while the column is visible. This avoids sending cell data
+         * for hidden columns to the client. All other methods are delegated
+         * unchanged so the wrapped generator's state stays consistent.
+         *
+         * @param delegate
+         *            the data generator to wrap
+         * @return a visibility-gated data generator
+         */
+        private DataGenerator<T> visibilityGated(DataGenerator<T> delegate) {
+            return new DataGenerator<T>() {
+                @Override
+                public void generateData(T item, ObjectNode jsonObject) {
+                    if (isVisible()) {
+                        delegate.generateData(item, jsonObject);
+                    }
+                }
+
+                @Override
+                public void destroyData(T item) {
+                    delegate.destroyData(item);
+                }
+
+                @Override
+                public void refreshData(T item) {
+                    delegate.refreshData(item);
+                }
+
+                @Override
+                public void destroyAllData() {
+                    delegate.destroyAllData();
+                }
+            };
+        }
+
+        @Override
+        protected void onVisibilityChanged(boolean visible,
+                boolean fromClient) {
+            fireEvent(new ColumnVisibilityChangedEvent<>(this, fromClient,
+                    visible));
+        }
+
+        /**
+         * Adds a listener that is notified when this column's visibility
+         * changes, either programmatically through {@link #setVisible(boolean)}
+         * or when the user shows or hides the column through the grid's column
+         * toggle menu.
+         *
+         * @param listener
+         *            the listener to add, not {@code null}
+         * @return a handle that can be used to remove the listener
+         */
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public Registration addVisibilityChangedListener(
+                ComponentEventListener<ColumnVisibilityChangedEvent<T>> listener) {
+            return addListener(ColumnVisibilityChangedEvent.class,
+                    (ComponentEventListener) Objects.requireNonNull(listener));
         }
 
         protected String getInternalId() {
@@ -540,8 +600,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                     .getDataCommunicator().getKeyMapper());
 
             columnDataGeneratorRegistration = rendering.getDataGenerator()
-                    .map(dataGenerator -> grid
-                            .addDataGenerator((DataGenerator) dataGenerator))
+                    .map(dataGenerator -> grid.addDataGenerator(
+                            (DataGenerator) visibilityGated(dataGenerator)))
                     .orElse(null);
 
             // The editor renderer is a wrapper around the regular renderer, so
@@ -1643,6 +1703,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         addDragStartListener(this::onDragStart);
         addDragEndListener(this::onDragEnd);
 
+        addListener(ColumnVisibilityChangeDomEvent.class,
+                this::onClientColumnVisibilityChange);
+
         updateMultiSortPriority(defaultMultiSortPriority);
 
         initSelectionPreservationHandler();
@@ -1651,6 +1714,29 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     private void generateUniqueKeyData(T item, ObjectNode jsonObject) {
         if (uniqueKeyProperty != null && !jsonObject.has(uniqueKeyProperty)) {
             jsonObject.put(uniqueKeyProperty, getUniqueKey(item));
+        }
+    }
+
+    /**
+     * Applies a column visibility change made by the user through the grid's
+     * column toggle menu, so that {@link Column#isVisible()} stays correct and
+     * a {@link ColumnVisibilityChangedEvent} is fired for the affected column.
+     */
+    private void onClientColumnVisibilityChange(
+            ColumnVisibilityChangeDomEvent event) {
+        String columnId = event.getColumnInternalId();
+        if (columnId == null) {
+            return;
+        }
+        Column<T> column = getColumnByInternalId(columnId);
+        if (column == null) {
+            return;
+        }
+        boolean visible = !event.isHidden();
+        // Only update (and fire the visibility change event) when the server's
+        // state actually differs, avoiding a redundant round trip.
+        if (column.isVisible() != visible) {
+            column.setVisible(visible, true);
         }
     }
 
@@ -1764,9 +1850,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * see {@link #addColumn(Renderer)}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      * <p>
      * <em>NOTE:</em> This method is a shorthand for
@@ -1797,9 +1883,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * see {@link #addColumn(Renderer)}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @param valueProvider
@@ -1860,9 +1946,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * built in renderers or using {@link LitRenderer}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @param componentProvider
@@ -1888,9 +1974,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * {@link ValueProvider}.
      *
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @see Column#setComparator(ValueProvider)
@@ -1927,9 +2013,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * or using {@link LitRenderer}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      * <p>
      * <em>NOTE:</em> This method is a shorthand for
@@ -1965,9 +2051,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * or using {@link LitRenderer}.
      * </p>
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @param renderer
@@ -2072,9 +2158,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * from a bean type with {@link #Grid(Class)}.
      *
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * <p>
@@ -2113,9 +2199,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * from a bean type with {@link #Grid(Class)}.
      *
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @see #addColumn(String)
@@ -2190,9 +2276,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * from a bean type with {@link #Grid(Class)}.
      *
      * <p>
-     * Every added column sends data to the client side regardless of its
-     * visibility state. Don't add a new column at all or use
-     * {@link Grid#removeColumn(Column)} to avoid sending extra data.
+     * A hidden column does not send its per-item data to the client. To stop
+     * sending data entirely, don't add the column at all or use
+     * {@link Grid#removeColumn(Column)}.
      * </p>
      *
      * @param propertyNames
@@ -4384,6 +4470,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         idToColumnMap.forEach((id, column) -> {
+            if (!column.isVisible()) {
+                return;
+            }
             String cellTooltip = column.tooltipGenerator.apply(item);
             if (cellTooltip != null) {
                 tooltips.put(id, cellTooltip);
@@ -4404,6 +4493,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         idToColumnMap.forEach((id, column) -> {
+            if (!column.isVisible()) {
+                return;
+            }
             String cellPartName = column.getPartNameGenerator().apply(item);
             if (cellPartName != null) {
                 part.put(id, cellPartName);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnVisibilityTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnVisibilityTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.data.provider.CompositeDataGenerator;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.tests.MockUIExtension;
+
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Unit tests for the {@code hideable} flag, the visibility-gated data
+ * generation and the {@link ColumnVisibilityChangedEvent}.
+ */
+class GridColumnVisibilityTest {
+
+    @RegisterExtension
+    final MockUIExtension uiExtension = new MockUIExtension();
+
+    private Grid<String> grid;
+    private Column<String> firstColumn;
+    private Column<String> secondColumn;
+
+    @BeforeEach
+    void setup() {
+        grid = new Grid<>();
+        firstColumn = grid.addColumn(str -> str.toUpperCase());
+        secondColumn = grid.addColumn(str -> str.toLowerCase());
+    }
+
+    // hideable ---------------------------------------------------------------
+
+    @Test
+    void hideable_defaultsToFalse() {
+        Assertions.assertFalse(firstColumn.isHideable());
+    }
+
+    @Test
+    void setHideable_roundTrips() {
+        firstColumn.setHideable(true);
+        Assertions.assertTrue(firstColumn.isHideable());
+        firstColumn.setHideable(false);
+        Assertions.assertFalse(firstColumn.isHideable());
+    }
+
+    // hideable sync to hidden columns -----------------------------------------
+
+    // Flow doesn't send property changes to invisible elements, so hideable is
+    // pushed to hidden columns with JS through the grid element instead.
+
+    @Test
+    void setHideableOnHiddenColumn_sendsPropertyThroughGrid() {
+        uiExtension.add(grid);
+        firstColumn.setVisible(false);
+        firstColumn.setHideable(true);
+
+        uiExtension.fakeClientCommunication();
+
+        List<JavaScriptInvocation> invocations = hideableSyncInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals(true,
+                invocations.get(0).getParameters().get(2));
+    }
+
+    @Test
+    void setHideableThenHideColumn_sameRoundTrip_sendsPropertyThroughGrid() {
+        uiExtension.add(grid);
+        // hideable is set while the column is still visible, but the column is
+        // hidden within the same round trip, so the property change is not
+        // synchronized normally.
+        firstColumn.setHideable(true);
+        firstColumn.setVisible(false);
+
+        uiExtension.fakeClientCommunication();
+
+        Assertions.assertEquals(1, hideableSyncInvocations().size());
+    }
+
+    @Test
+    void setHideableOnVisibleColumn_synchronizesNormally_noJsNeeded() {
+        uiExtension.add(grid);
+        firstColumn.setHideable(true);
+
+        uiExtension.fakeClientCommunication();
+
+        Assertions.assertTrue(hideableSyncInvocations().isEmpty());
+    }
+
+    @Test
+    void attachGridWithHiddenHideableColumn_sendsPropertyThroughGrid() {
+        firstColumn.setVisible(false);
+        firstColumn.setHideable(true);
+        uiExtension.add(grid);
+
+        uiExtension.fakeClientCommunication();
+
+        List<JavaScriptInvocation> invocations = hideableSyncInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals(true,
+                invocations.get(0).getParameters().get(2));
+    }
+
+    private List<JavaScriptInvocation> hideableSyncInvocations() {
+        return uiExtension.dumpPendingJavaScriptInvocations().stream()
+                .map(PendingJavaScriptInvocation::getInvocation)
+                .filter(invocation -> invocation.getExpression()
+                        .contains(".hideable = "))
+                .toList();
+    }
+
+    // per-item data ----------------------------------------------------------
+
+    @Test
+    void visibleColumns_generateData() {
+        ObjectNode json = generateData("item");
+        Assertions.assertTrue(json.has(firstColumn.getInternalId()));
+        Assertions.assertTrue(json.has(secondColumn.getInternalId()));
+    }
+
+    @Test
+    void hiddenColumn_omitsData_otherColumnsUnaffected() {
+        firstColumn.setVisible(false);
+        ObjectNode json = generateData("item");
+        Assertions.assertFalse(json.has(firstColumn.getInternalId()));
+        Assertions.assertTrue(json.has(secondColumn.getInternalId()));
+    }
+
+    @Test
+    void shownAgain_generatesDataAgain() {
+        firstColumn.setVisible(false);
+        Assertions.assertFalse(
+                generateData("item").has(firstColumn.getInternalId()));
+        firstColumn.setVisible(true);
+        Assertions.assertTrue(
+                generateData("item").has(firstColumn.getInternalId()));
+    }
+
+    @Test
+    void hiddenColumn_omitsTooltipData() {
+        firstColumn.setTooltipGenerator(item -> "tooltip-" + item);
+        secondColumn.setTooltipGenerator(item -> "tooltip-" + item);
+
+        ObjectNode tooltips = (ObjectNode) generateData("item")
+                .get("gridtooltips");
+        Assertions.assertTrue(tooltips.has(firstColumn.getInternalId()));
+
+        firstColumn.setVisible(false);
+        ObjectNode json = generateData("item");
+        ObjectNode tooltipsHidden = (ObjectNode) json.get("gridtooltips");
+        Assertions.assertFalse(tooltipsHidden.has(firstColumn.getInternalId()));
+        Assertions.assertTrue(tooltipsHidden.has(secondColumn.getInternalId()));
+    }
+
+    @Test
+    void hiddenColumn_omitsPartData() {
+        firstColumn.setPartNameGenerator(item -> "part-first");
+        secondColumn.setPartNameGenerator(item -> "part-second");
+
+        ObjectNode part = (ObjectNode) generateData("item").get("part");
+        Assertions.assertTrue(part.has(firstColumn.getInternalId()));
+
+        firstColumn.setVisible(false);
+        ObjectNode partHidden = (ObjectNode) generateData("item").get("part");
+        Assertions.assertFalse(partHidden.has(firstColumn.getInternalId()));
+        Assertions.assertTrue(partHidden.has(secondColumn.getInternalId()));
+    }
+
+    // visibility change event ------------------------------------------------
+
+    @Test
+    void setVisible_firesVisibilityChangedEvent() {
+        AtomicReference<ColumnVisibilityChangedEvent<String>> captured = new AtomicReference<>();
+        firstColumn.addVisibilityChangedListener(captured::set);
+
+        firstColumn.setVisible(false);
+
+        ColumnVisibilityChangedEvent<String> event = captured.get();
+        Assertions.assertNotNull(event);
+        Assertions.assertFalse(event.isVisible());
+        Assertions.assertFalse(event.isFromClient());
+        Assertions.assertEquals(firstColumn, event.getColumn());
+        Assertions.assertFalse(firstColumn.isVisible());
+    }
+
+    @Test
+    void setVisibleToSameValue_doesNotFireEvent() {
+        AtomicReference<ColumnVisibilityChangedEvent<String>> captured = new AtomicReference<>();
+        firstColumn.addVisibilityChangedListener(captured::set);
+
+        firstColumn.setVisible(true); // already visible
+        Assertions.assertNull(captured.get());
+    }
+
+    // client -> server sync --------------------------------------------------
+
+    @Test
+    void clientHidesColumn_updatesVisibilityAndFiresEventFromClient() {
+        AtomicReference<ColumnVisibilityChangedEvent<String>> captured = new AtomicReference<>();
+        firstColumn.addVisibilityChangedListener(captured::set);
+
+        ComponentUtil.fireEvent(grid, new ColumnVisibilityChangeDomEvent(grid,
+                true, firstColumn.getInternalId(), true));
+
+        Assertions.assertFalse(firstColumn.isVisible());
+        Assertions.assertNotNull(captured.get());
+        Assertions.assertTrue(captured.get().isFromClient());
+        Assertions.assertFalse(captured.get().isVisible());
+    }
+
+    @Test
+    void clientShowsHiddenColumn_updatesVisibility() {
+        firstColumn.setVisible(false);
+
+        ComponentUtil.fireEvent(grid, new ColumnVisibilityChangeDomEvent(grid,
+                true, firstColumn.getInternalId(), false));
+
+        Assertions.assertTrue(firstColumn.isVisible());
+    }
+
+    @Test
+    void clientEventForUnknownColumn_isIgnored() {
+        // Should not throw for an unknown column id.
+        ComponentUtil.fireEvent(grid, new ColumnVisibilityChangeDomEvent(grid,
+                true, "no-such-column", true));
+        Assertions.assertTrue(firstColumn.isVisible());
+    }
+
+    @SuppressWarnings("unchecked")
+    private ObjectNode generateData(String item) {
+        ObjectNode json = JacksonUtils.createObjectNode();
+        CompositeDataGenerator<String> generator;
+        try {
+            Field field = Grid.class.getDeclaredField("gridDataGenerator");
+            field.setAccessible(true);
+            generator = (CompositeDataGenerator<String>) field.get(grid);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        generator.generateData(item, json);
+        return json;
+    }
+}


### PR DESCRIPTION
Adds the Flow side of the Grid column toggle (issue #1603) and stops sending
per-item data for hidden columns.

The toggle is a built-in grid feature: calling `setHideable(true)` on at least
one column makes the grid show its column toggle button. There is no separate
component to create or position.

Changes:
- `Grid.Column.setHideable(boolean)` / `isHideable()` (default `false`),
  mapped to the web component `hideable` property. The value also reaches
  columns that are currently hidden: Flow does not send property changes to
  invisible elements, so `AbstractColumn` pushes the value with JS through the
  grid element (same approach as the `_flowId` handling in `Grid#addColumn`).
  For the same reason `isHideable()` has no `@Synchronize`: a sync listener
  makes the client revert that pushed value (client updates to invisible
  elements are rejected), and hideable is a server-controlled flag.
- When the user shows or hides a column through the toggle menu, the
  `<vaadin-grid>` element fires `column-visibility-changed`. `Grid` listens
  with an internal `@DomEvent` and applies the change on the server, so
  `Column.isVisible()` stays correct. `event.detail.column._flowId` maps the
  toggled element back to the server column.
- `Column.addVisibilityChangedListener(...)` and `ColumnVisibilityChangedEvent`,
  fired for both programmatic and client-driven visibility changes.
- Performance: a hidden column no longer sends its per-item cell, tooltip or
  part data to the client. The column's data generator only runs while the
  column is visible, and `generateTooltipTextData` / `generatePartData` skip
  hidden columns. When a column becomes visible again, the data communicator is
  reset so already-loaded rows receive its data.
- Updated the `AbstractColumn.setVisible` / `addColumn` javadoc, which
  previously said data is always sent for invisible columns.

Draft until the sibling web-components PR is merged and released: the
`GridColumnToggleIT` runs against the published `@vaadin/grid` package, which
does not contain the column toggle yet. To test against local web-component
changes before that, overlay the local sources into the integration tests'
`node_modules/@vaadin/grid` and clear the Vite cache (`node_modules/.vite`).

Part of #1603
Sibling PR (web-components): https://github.com/vaadin/web-components/pull/12020

---

🤖 Generated with Claude Code
