### PR TITLE
refactor: simplify column renderer setup and registration cleanup

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -466,14 +466,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          *            the renderer to use in this column, must not be
          *            {@code null}
          */
-        @SuppressWarnings("unchecked")
         public Column(Grid<T> grid, String columnId, Renderer<T> renderer) {
             super(grid);
-            Objects.requireNonNull(renderer);
             this.columnInternalId = columnId;
-
             comparator = (a, b) -> 0;
-
             setupRenderer(renderer);
         }
 
@@ -513,8 +509,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * @since 24.1
          */
         public Column<T> setRenderer(Renderer<T> renderer) {
-            Objects.requireNonNull(renderer, "Renderer must not be null.");
-
             setupRenderer(renderer);
 
             // The editor renderer is a wrapper around the regular renderer, so
@@ -529,10 +523,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
         private void setupRenderer(Renderer<T> renderer) {
+            this.renderer = Objects.requireNonNull(renderer,
+                    "Renderer must not be null.");
+
             rendererRegistrations.forEach(Registration::remove);
             rendererRegistrations.clear();
-
-            this.renderer = renderer;
 
             Rendering<T> rendering = renderer.render(getElement(),
                     (KeyMapper<T>) getGrid().getDataCommunicator()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -437,7 +437,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         private Component editorComponent;
         private EditorRenderer<T> editorRenderer;
-        private List<Registration> editorRendererRegistrations = new ArrayList<>();
+        private Registration editorRendererRegistration;
 
         private SortOrderProvider sortOrderProvider = direction -> {
             String key = getKey();
@@ -474,11 +474,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         }
 
         protected void destroyDataGenerators() {
-            rendererRegistrations.forEach(Registration::remove);
-            rendererRegistrations.clear();
+            if (rendererRegistrations != null) {
+                rendererRegistrations.forEach(Registration::remove);
+                rendererRegistrations.clear();
+            }
 
-            editorRendererRegistrations.forEach(Registration::remove);
-            editorRendererRegistrations.clear();
+            if (editorRendererRegistration != null) {
+                editorRendererRegistration.remove();
+                editorRendererRegistration = null;
+            }
         }
 
         protected String getInternalId() {
@@ -526,8 +530,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             this.renderer = Objects.requireNonNull(renderer,
                     "Renderer must not be null.");
 
-            rendererRegistrations.forEach(Registration::remove);
-            rendererRegistrations.clear();
+            if (rendererRegistrations != null) {
+                rendererRegistrations.forEach(Registration::remove);
+                rendererRegistrations.clear();
+            }
 
             Rendering<T> rendering = renderer.render(getElement(),
                     (KeyMapper<T>) getGrid().getDataCommunicator()
@@ -543,22 +549,21 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
         private void setupEditorRenderer() {
-            editorRendererRegistrations.forEach(Registration::remove);
-            editorRendererRegistrations.clear();
+            if (editorRendererRegistration != null) {
+                editorRendererRegistration.remove();
+            }
 
-            if (this.editorRenderer == null) {
-                this.editorRenderer = new EditorRenderer<>(
-                        (Editor) grid.getEditor(), columnInternalId);
+            if (editorRenderer == null) {
+                editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
+                        columnInternalId);
             }
 
             Rendering<T> rendering = editorRenderer.render(getElement(), null);
 
-            rendering.getDataGenerator().ifPresent(dataGenerator -> {
-                editorRendererRegistrations.add(
-                        grid.addDataGenerator((DataGenerator) dataGenerator));
-            });
-
-            editorRendererRegistrations.add(rendering.getRegistration());
+            editorRendererRegistration = rendering.getDataGenerator()
+                    .map(dataGenerator -> grid
+                            .addDataGenerator((DataGenerator) dataGenerator))
+                    .orElse(null);
         }
 
         /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -547,25 +547,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             rendererRegistrations.add(rendering.getRegistration());
         }
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        private void setupEditorRenderer() {
-            if (editorRendererRegistration != null) {
-                editorRendererRegistration.remove();
-            }
-
-            if (editorRenderer == null) {
-                editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
-                        columnInternalId);
-            }
-
-            Rendering<T> rendering = editorRenderer.render(getElement(), null);
-
-            editorRendererRegistration = rendering.getDataGenerator()
-                    .map(dataGenerator -> grid
-                            .addDataGenerator((DataGenerator) dataGenerator))
-                    .orElse(null);
-        }
-
         /**
          * Sets the width of this column as a CSS-string.
          * <p>
@@ -1124,6 +1105,18 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         @Override
         protected Column<?> getBottomLevelColumn() {
             return this;
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private void setupEditorRenderer() {
+            if (editorRenderer == null) {
+                editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
+                        columnInternalId);
+                editorRendererRegistration = grid
+                        .addDataGenerator((DataGenerator) editorRenderer);
+            }
+
+            editorRenderer.render(getElement(), null);
         }
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -556,7 +556,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                         (Editor) grid.getEditor(), columnInternalId);
             }
 
-            Rendering<T> rendering = renderer.render(getElement(), null);
+            Rendering<T> rendering = editorRenderer.render(getElement(), null);
 
             rendering.getDataGenerator().ifPresent(dataGenerator -> {
                 editorRendererRegistrations.add(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -437,6 +437,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         private Component editorComponent;
         private EditorRenderer<T> editorRenderer;
+        private List<Registration> editorRendererRegistrations = new ArrayList<>();
 
         private SortOrderProvider sortOrderProvider = direction -> {
             String key = getKey();
@@ -448,11 +449,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         private SerializableComparator<T> comparator;
 
-        private Registration columnDataGeneratorRegistration;
-        private Registration editorDataGeneratorRegistration;
-
         private Renderer<T> renderer;
-        private Rendering<T> rendering;
+        private List<Registration> rendererRegistrations = new ArrayList<>();
 
         private SerializableFunction<T, String> partNameGenerator = item -> null;
         private SerializableFunction<T, String> tooltipGenerator = item -> null;
@@ -473,31 +471,18 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             super(grid);
             Objects.requireNonNull(renderer);
             this.columnInternalId = columnId;
-            this.renderer = renderer;
 
             comparator = (a, b) -> 0;
 
-            rendering = renderer.render(getElement(), (KeyMapper<T>) getGrid()
-                    .getDataCommunicator().getKeyMapper());
-
-            Optional<DataGenerator<T>> dataGenerator = rendering
-                    .getDataGenerator();
-
-            if (dataGenerator.isPresent()) {
-                columnDataGeneratorRegistration = grid
-                        .addDataGenerator(dataGenerator.get());
-            }
+            setupRenderer(renderer);
         }
 
         protected void destroyDataGenerators() {
-            if (columnDataGeneratorRegistration != null) {
-                columnDataGeneratorRegistration.remove();
-                columnDataGeneratorRegistration = null;
-            }
-            if (editorDataGeneratorRegistration != null) {
-                editorDataGeneratorRegistration.remove();
-                editorDataGeneratorRegistration = null;
-            }
+            rendererRegistrations.forEach(Registration::remove);
+            rendererRegistrations.clear();
+
+            editorRendererRegistrations.forEach(Registration::remove);
+            editorRendererRegistrations.clear();
         }
 
         protected String getInternalId() {
@@ -528,30 +513,57 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * @since 24.1
          */
         public Column<T> setRenderer(Renderer<T> renderer) {
-            this.renderer = Objects.requireNonNull(renderer,
-                    "Renderer must not be null.");
+            Objects.requireNonNull(renderer, "Renderer must not be null.");
 
-            destroyDataGenerators();
-            if (rendering != null) {
-                rendering.getRegistration().remove();
-            }
-
-            rendering = renderer.render(getElement(), (KeyMapper<T>) getGrid()
-                    .getDataCommunicator().getKeyMapper());
-
-            columnDataGeneratorRegistration = rendering.getDataGenerator()
-                    .map(dataGenerator -> grid
-                            .addDataGenerator((DataGenerator) dataGenerator))
-                    .orElse(null);
+            setupRenderer(renderer);
 
             // The editor renderer is a wrapper around the regular renderer, so
             // we need to apply it again afterwards
             if (editorRenderer != null) {
-                setupColumnEditor();
+                setupEditorRenderer();
             }
 
             getGrid().refreshViewport();
             return this;
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private void setupRenderer(Renderer<T> renderer) {
+            rendererRegistrations.forEach(Registration::remove);
+            rendererRegistrations.clear();
+
+            this.renderer = renderer;
+
+            Rendering<T> rendering = renderer.render(getElement(),
+                    (KeyMapper<T>) getGrid().getDataCommunicator()
+                            .getKeyMapper());
+
+            rendering.getDataGenerator().ifPresent(dataGenerator -> {
+                rendererRegistrations.add(
+                        grid.addDataGenerator((DataGenerator) dataGenerator));
+            });
+
+            rendererRegistrations.add(rendering.getRegistration());
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private void setupEditorRenderer() {
+            editorRendererRegistrations.forEach(Registration::remove);
+            editorRendererRegistrations.clear();
+
+            if (this.editorRenderer == null) {
+                this.editorRenderer = new EditorRenderer<>(
+                        (Editor) grid.getEditor(), columnInternalId);
+            }
+
+            Rendering<T> rendering = renderer.render(getElement(), null);
+
+            rendering.getDataGenerator().ifPresent(dataGenerator -> {
+                editorRendererRegistrations.add(
+                        grid.addDataGenerator((DataGenerator) dataGenerator));
+            });
+
+            editorRendererRegistrations.add(rendering.getRegistration());
         }
 
         /**
@@ -997,7 +1009,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
             editorComponent = null;
             if (editorRenderer == null && componentCallback != null) {
-                setupColumnEditor();
+                setupEditorRenderer();
             }
             if (editorRenderer != null) {
                 editorRenderer.setComponentFunction(componentCallback);
@@ -1112,22 +1124,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         @Override
         protected Column<?> getBottomLevelColumn() {
             return this;
-        }
-
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        private void setupColumnEditor() {
-            if (editorRenderer == null) {
-                editorRenderer = new EditorRenderer<>((Editor) grid.getEditor(),
-                        columnInternalId);
-            }
-
-            Rendering<T> editorRendering = editorRenderer.render(getElement(),
-                    null);
-
-            editorDataGeneratorRegistration = editorRendering.getDataGenerator()
-                    .map(dataGenerator -> grid
-                            .addDataGenerator((DataGenerator) dataGenerator))
-                    .orElse(null);
         }
     }
 


### PR DESCRIPTION
`Column` stored each renderer registration in a separate field (`columnDataGeneratorRegistration`, `editorDataGeneratorRegistration`, `rendering`) and removed them in different places, which made the renderer lifecycle hard to follow.

Now the constructor and `setRenderer` share a `setupRenderer` method that removes the previous renderer's registrations and collects the new ones (data generator and rendering) into a single list. `destroyDataGenerators` removes them when the column is removed.

The editor renderer is registered as a data generator once when it's created. Since it wraps the column renderer, it stays registered when the renderer is replaced, and `setupEditorRenderer` only renders it again.

Extracted from https://github.com/vaadin/flow-components/pull/6798

---

🤖 Generated with Claude Code
