### PR TITLE
refactor!: remove DataCommunicatorBuilder abstraction

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -81,7 +81,6 @@ import com.vaadin.flow.data.binder.Setter;
 import com.vaadin.flow.data.event.SortEvent;
 import com.vaadin.flow.data.event.SortEvent.SortNotifier;
 import com.vaadin.flow.data.provider.AbstractDataView;
-import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -1356,8 +1355,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final CompositeDataGenerator<T> gridDataGenerator;
     private final DataCommunicator<T> dataCommunicator;
-    @SuppressWarnings("rawtypes")
-    private DataCommunicatorBuilder dataCommunicatorBuilder;
 
     private int nextColumnId = 0;
 
@@ -1493,7 +1490,30 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the page size. Must be greater than zero.
      */
     public Grid(int pageSize) {
-        this(pageSize, new DataCommunicatorBuilder<>());
+        arrayUpdater = createDefaultArrayUpdater();
+        gridDataGenerator = new CompositeDataGenerator<>();
+        gridDataGenerator.addDataGenerator(this::generateUniqueKeyData);
+        gridDataGenerator.addDataGenerator(this::generatePartData);
+        gridDataGenerator.addDataGenerator(this::generateTooltipTextData);
+        gridDataGenerator.addDataGenerator(this::generateRowsDragAndDropAccess);
+        gridDataGenerator.addDataGenerator(this::generateDragData);
+        gridDataGenerator.addDataGenerator(this::generateSelectableData);
+
+        dataCommunicator = createDataCommunicator();
+
+        detailsManager = new DetailsManager(this);
+        setPageSize(pageSize);
+        setSelectionModel(SelectionMode.SINGLE.createModel(this),
+                SelectionMode.SINGLE);
+
+        columnLayers.add(new ColumnLayer(this));
+
+        addDragStartListener(this::onDragStart);
+        addDragEndListener(this::onDragEnd);
+
+        updateMultiSortPriority(defaultMultiSortPriority);
+
+        initSelectionPreservationHandler();
     }
 
     /**
@@ -1545,127 +1565,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public Grid(Class<T> beanType) {
         this(beanType, true);
-    }
-
-    /**
-     * Creates a new grid with an initial set of columns for each of the bean's
-     * properties. The property-values of the bean will be converted to Strings.
-     * Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
-     * <p>
-     * You can add columns for nested properties of the bean with
-     * {@link #addColumn(String)}.
-     *
-     * @param beanType
-     *            the bean type to use, not <code>null</code>
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @param <B>
-     *            the data communicator builder type
-     * @param <U>
-     *            the GridArrayUpdater type
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
-            Class<T> beanType, B dataCommunicatorBuilder) {
-        this(beanType, dataCommunicatorBuilder, true);
-    }
-
-    /**
-     * Creates a new grid with an initial set of columns for each of the bean's
-     * properties. The property-values of the bean will be converted to Strings.
-     * Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
-     * <p>
-     * When autoCreateColumns is <code>true</code>, only the direct properties
-     * of the bean are included and they will be in alphabetical order. Use
-     * {@link Grid#setColumns(String...)} to define which properties to include
-     * and in which order. You can also add a column for an individual property
-     * with {@link #addColumn(String)}. Both of these methods support also
-     * sub-properties with dot-notation, eg.
-     * <code>"property.nestedProperty"</code>.
-     *
-     * @param beanType
-     *            the bean type to use, not <code>null</code>
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @param <B>
-     *            the data communicator builder type
-     * @param <U>
-     *            the GridArrayUpdater type
-     * @param autoCreateColumns
-     *            when <code>true</code>, columns are created automatically for
-     *            the properties of the beanType
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
-            Class<T> beanType, B dataCommunicatorBuilder,
-            boolean autoCreateColumns) {
-        this(50, dataCommunicatorBuilder);
-        Objects.requireNonNull(dataCommunicatorBuilder,
-                "Data communicator builder can't be null");
-        configureBeanType(beanType, autoCreateColumns);
-    }
-
-    /**
-     * Creates a new instance, with the specified page size and data
-     * communicator.
-     * <p>
-     * The page size influences the {@link Query#getLimit()} sent by the client,
-     * but it's up to the webcomponent to determine the actual query limit,
-     * based on the height of the component and scroll position. Usually the
-     * limit is 3 times the page size (e.g. 150 items with a page size of 50).
-     *
-     * @param pageSize
-     *            the page size. Must be greater than zero.
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @param <B>
-     *            the data communicator builder type
-     * @param <U>
-     *            the GridArrayUpdater type
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
-            int pageSize, B dataCommunicatorBuilder) {
-        Objects.requireNonNull(dataCommunicatorBuilder,
-                "Data communicator builder can't be null");
-        this.dataCommunicatorBuilder = dataCommunicatorBuilder;
-        arrayUpdater = createDefaultArrayUpdater();
-        gridDataGenerator = new CompositeDataGenerator<>();
-        gridDataGenerator.addDataGenerator(this::generateUniqueKeyData);
-        gridDataGenerator.addDataGenerator(this::generatePartData);
-        gridDataGenerator.addDataGenerator(this::generateTooltipTextData);
-        gridDataGenerator.addDataGenerator(this::generateRowsDragAndDropAccess);
-        gridDataGenerator.addDataGenerator(this::generateDragData);
-        gridDataGenerator.addDataGenerator(this::generateSelectableData);
-
-        dataCommunicator = createDataCommunicator();
-
-        detailsManager = new DetailsManager(this);
-        setPageSize(pageSize);
-        setSelectionModel(SelectionMode.SINGLE.createModel(this),
-                SelectionMode.SINGLE);
-
-        columnLayers.add(new ColumnLayer(this));
-
-        addDragStartListener(this::onDragStart);
-        addDragEndListener(this::onDragEnd);
-
-        updateMultiSortPriority(defaultMultiSortPriority);
-
-        initSelectionPreservationHandler();
     }
 
     private void generateUniqueKeyData(T item, ObjectNode jsonObject) {
@@ -1741,50 +1640,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @return the new data communicator
      */
     protected DataCommunicator<T> createDataCommunicator() {
-        return dataCommunicatorBuilder.build(getElement(),
-                getCompositeDataGenerator(), getArrayUpdater(),
-                this::getUniqueKeyProvider);
-    }
-
-    /**
-     * Builder for {@link DataCommunicator} object.
-     *
-     * @param <T>
-     *            the grid bean type
-     *
-     * @param <U>
-     *            the ArrayUpdater type
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             class and the constructors that accept it will be removed in
-     *             Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected static class DataCommunicatorBuilder<T, U extends ArrayUpdater>
-            implements Serializable {
-
-        /**
-         * Build a new {@link DataCommunicator} object for the given Grid
-         * instance.
-         *
-         * @param element
-         *            the target grid element
-         * @param dataGenerator
-         *            the {@link CompositeDataGenerator} for the data
-         *            communicator
-         * @param arrayUpdater
-         *            the {@link ArrayUpdater} for the data communicator
-         * @param uniqueKeyProviderSupplier
-         *            the unique key value provider supplier for the data
-         *            communicator
-         * @return the build data communicator object
-         */
-        @Deprecated(since = "25.3", forRemoval = true)
-        protected DataCommunicator<T> build(Element element,
-                CompositeDataGenerator<T> dataGenerator, U arrayUpdater,
-                SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {
-            return new GridDataCommunicator<>(element, dataGenerator,
-                    arrayUpdater);
-        }
+        return new GridDataCommunicator<>(getElement(),
+                getCompositeDataGenerator(), getArrayUpdater());
     }
 
     protected GridArrayUpdater createDefaultArrayUpdater() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1354,10 +1354,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final GridArrayUpdater arrayUpdater;
 
-    private DataCommunicatorBuilder dataCommunicatorBuilder;
-
     private final CompositeDataGenerator<T> gridDataGenerator;
     private final DataCommunicator<T> dataCommunicator;
+    @SuppressWarnings("rawtypes")
+    private DataCommunicatorBuilder dataCommunicatorBuilder;
 
     private int nextColumnId = 0;
 
@@ -1741,8 +1741,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @return the new data communicator
      */
     protected DataCommunicator<T> createDataCommunicator() {
-        return dataCommunicatorBuilder.build(getElement(), gridDataGenerator,
-                arrayUpdater, this::getUniqueKeyProvider);
+        return dataCommunicatorBuilder.build(getElement(),
+                getCompositeDataGenerator(), getArrayUpdater(),
+                this::getUniqueKeyProvider);
     }
 
     /**
@@ -4517,6 +4518,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     protected GridArrayUpdater getArrayUpdater() {
         return arrayUpdater;
+    }
+
+    protected CompositeDataGenerator<T> getCompositeDataGenerator() {
+        return gridDataGenerator;
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1354,6 +1354,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final GridArrayUpdater arrayUpdater;
 
+    private DataCommunicatorBuilder dataCommunicatorBuilder;
+
     private final CompositeDataGenerator<T> gridDataGenerator;
     private final DataCommunicator<T> dataCommunicator;
 
@@ -1564,7 +1566,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the data communicator builder type
      * @param <U>
      *            the GridArrayUpdater type
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
             Class<T> beanType, B dataCommunicatorBuilder) {
         this(beanType, dataCommunicatorBuilder, true);
@@ -1597,7 +1602,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @param autoCreateColumns
      *            when <code>true</code>, columns are created automatically for
      *            the properties of the beanType
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
             Class<T> beanType, B dataCommunicatorBuilder,
             boolean autoCreateColumns) {
@@ -1625,12 +1633,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the data communicator builder type
      * @param <U>
      *            the GridArrayUpdater type
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
-    @SuppressWarnings("unchecked")
+    @Deprecated(since = "25.3", forRemoval = true)
     protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
             int pageSize, B dataCommunicatorBuilder) {
         Objects.requireNonNull(dataCommunicatorBuilder,
                 "Data communicator builder can't be null");
+        this.dataCommunicatorBuilder = dataCommunicatorBuilder;
         arrayUpdater = createDefaultArrayUpdater();
         gridDataGenerator = new CompositeDataGenerator<>();
         gridDataGenerator.addDataGenerator(this::generateUniqueKeyData);
@@ -1640,9 +1651,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         gridDataGenerator.addDataGenerator(this::generateDragData);
         gridDataGenerator.addDataGenerator(this::generateSelectableData);
 
-        dataCommunicator = dataCommunicatorBuilder.build(getElement(),
-                gridDataGenerator, (U) arrayUpdater,
-                this::getUniqueKeyProvider);
+        dataCommunicator = createDataCommunicator();
 
         detailsManager = new DetailsManager(this);
         setPageSize(pageSize);
@@ -1726,6 +1735,17 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
+     * Creates the {@link DataCommunicator} that this Grid uses to handle all
+     * data communication.
+     *
+     * @return the new data communicator
+     */
+    protected DataCommunicator<T> createDataCommunicator() {
+        return dataCommunicatorBuilder.build(getElement(), gridDataGenerator,
+                arrayUpdater, this::getUniqueKeyProvider);
+    }
+
+    /**
      * Builder for {@link DataCommunicator} object.
      *
      * @param <T>
@@ -1733,7 +1753,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *
      * @param <U>
      *            the ArrayUpdater type
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             class and the constructors that accept it will be removed in
+     *             Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected static class DataCommunicatorBuilder<T, U extends ArrayUpdater>
             implements Serializable {
 
@@ -1753,6 +1777,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          *            communicator
          * @return the build data communicator object
          */
+        @Deprecated(since = "25.3", forRemoval = true)
         protected DataCommunicator<T> build(Element element,
                 CompositeDataGenerator<T> dataGenerator, U arrayUpdater,
                 SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -81,7 +81,6 @@ import com.vaadin.flow.data.binder.Setter;
 import com.vaadin.flow.data.event.SortEvent;
 import com.vaadin.flow.data.event.SortEvent.SortNotifier;
 import com.vaadin.flow.data.provider.AbstractDataView;
-import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -1481,8 +1480,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final CompositeDataGenerator<T> gridDataGenerator;
     private final DataCommunicator<T> dataCommunicator;
-    @SuppressWarnings("rawtypes")
-    private DataCommunicatorBuilder dataCommunicatorBuilder;
 
     private int nextColumnId = 0;
 
@@ -1624,7 +1621,30 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the page size. Must be greater than zero.
      */
     public Grid(int pageSize) {
-        this(pageSize, new DataCommunicatorBuilder<>());
+        arrayUpdater = createDefaultArrayUpdater();
+        gridDataGenerator = new CompositeDataGenerator<>();
+        gridDataGenerator.addDataGenerator(this::generateUniqueKeyData);
+        gridDataGenerator.addDataGenerator(this::generatePartData);
+        gridDataGenerator.addDataGenerator(this::generateTooltipTextData);
+        gridDataGenerator.addDataGenerator(this::generateRowsDragAndDropAccess);
+        gridDataGenerator.addDataGenerator(this::generateDragData);
+        gridDataGenerator.addDataGenerator(this::generateSelectableData);
+
+        dataCommunicator = createDataCommunicator();
+
+        detailsManager = new DetailsManager(this);
+        setPageSize(pageSize);
+        setSelectionModel(SelectionMode.SINGLE.createModel(this),
+                SelectionMode.SINGLE);
+
+        columnLayers.add(new ColumnLayer(this));
+
+        addDragStartListener(this::onDragStart);
+        addDragEndListener(this::onDragEnd);
+
+        updateMultiSortPriority(defaultMultiSortPriority);
+
+        initSelectionPreservationHandler();
     }
 
     /**
@@ -1677,130 +1697,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public Grid(Class<T> beanType) {
         this(beanType, true);
-    }
-
-    /**
-     * Creates a new grid with an initial set of columns for each of the bean's
-     * properties. The property-values of the bean will be converted to Strings.
-     * Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
-     * <p>
-     * You can add columns for nested properties of the bean with
-     * {@link #addColumn(String)}.
-     *
-     * @param beanType
-     *            the bean type to use, not <code>null</code>
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @param <B>
-     *            the data communicator builder type
-     * @param <U>
-     *            the GridArrayUpdater type
-     * @since 24.9
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
-            Class<T> beanType, B dataCommunicatorBuilder) {
-        this(beanType, dataCommunicatorBuilder, true);
-    }
-
-    /**
-     * Creates a new grid with an initial set of columns for each of the bean's
-     * properties. The property-values of the bean will be converted to Strings.
-     * Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
-     * <p>
-     * When autoCreateColumns is <code>true</code>, only the direct properties
-     * of the bean are included and they will be in alphabetical order. Use
-     * {@link Grid#setColumns(String...)} to define which properties to include
-     * and in which order. You can also add a column for an individual property
-     * with {@link #addColumn(String)}. Both of these methods support also
-     * sub-properties with dot-notation, eg.
-     * <code>"property.nestedProperty"</code>.
-     *
-     * @param beanType
-     *            the bean type to use, not <code>null</code>
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @param <B>
-     *            the data communicator builder type
-     * @param <U>
-     *            the GridArrayUpdater type
-     * @param autoCreateColumns
-     *            when <code>true</code>, columns are created automatically for
-     *            the properties of the beanType
-     * @since 24.9
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
-            Class<T> beanType, B dataCommunicatorBuilder,
-            boolean autoCreateColumns) {
-        this(50, dataCommunicatorBuilder);
-        Objects.requireNonNull(dataCommunicatorBuilder,
-                "Data communicator builder can't be null");
-        configureBeanType(beanType, autoCreateColumns);
-    }
-
-    /**
-     * Creates a new instance, with the specified page size and data
-     * communicator.
-     * <p>
-     * The page size influences the {@link Query#getLimit()} sent by the client,
-     * but it's up to the webcomponent to determine the actual query limit,
-     * based on the height of the component and scroll position. Usually the
-     * limit is 3 times the page size (e.g. 150 items with a page size of 50).
-     *
-     * @param pageSize
-     *            the page size. Must be greater than zero.
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @param <B>
-     *            the data communicator builder type
-     * @param <U>
-     *            the GridArrayUpdater type
-     * @since 24.9
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
-            int pageSize, B dataCommunicatorBuilder) {
-        Objects.requireNonNull(dataCommunicatorBuilder,
-                "Data communicator builder can't be null");
-        this.dataCommunicatorBuilder = dataCommunicatorBuilder;
-        arrayUpdater = createDefaultArrayUpdater();
-        gridDataGenerator = new CompositeDataGenerator<>();
-        gridDataGenerator.addDataGenerator(this::generateUniqueKeyData);
-        gridDataGenerator.addDataGenerator(this::generatePartData);
-        gridDataGenerator.addDataGenerator(this::generateTooltipData);
-        gridDataGenerator.addDataGenerator(this::generateRowsDragAndDropAccess);
-        gridDataGenerator.addDataGenerator(this::generateDragData);
-        gridDataGenerator.addDataGenerator(this::generateSelectableData);
-
-        dataCommunicator = createDataCommunicator();
-
-        detailsManager = new DetailsManager(this);
-        setPageSize(pageSize);
-        setSelectionModel(SelectionMode.SINGLE.createModel(this),
-                SelectionMode.SINGLE);
-
-        columnLayers.add(new ColumnLayer(this));
-
-        addDragStartListener(this::onDragStart);
-        addDragEndListener(this::onDragEnd);
-
-        updateMultiSortPriority(defaultMultiSortPriority);
-
-        initSelectionPreservationHandler();
     }
 
     private void generateUniqueKeyData(T item, ObjectNode jsonObject) {
@@ -1878,52 +1774,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @since 25.3
      */
     protected DataCommunicator<T> createDataCommunicator() {
-        return dataCommunicatorBuilder.build(getElement(),
-                getCompositeDataGenerator(), getArrayUpdater(),
-                this::getUniqueKeyProvider);
-    }
-
-    /**
-     * Builder for {@link DataCommunicator} object.
-     *
-     * @param <T>
-     *            the grid bean type
-     *
-     * @param <U>
-     *            the ArrayUpdater type
-     * @since 1.1
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             class and the constructors that accept it will be removed in
-     *             Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected static class DataCommunicatorBuilder<T, U extends ArrayUpdater>
-            implements Serializable {
-
-        /**
-         * Build a new {@link DataCommunicator} object for the given Grid
-         * instance.
-         *
-         * @param element
-         *            the target grid element
-         * @param dataGenerator
-         *            the {@link CompositeDataGenerator} for the data
-         *            communicator
-         * @param arrayUpdater
-         *            the {@link ArrayUpdater} for the data communicator
-         * @param uniqueKeyProviderSupplier
-         *            the unique key value provider supplier for the data
-         *            communicator
-         * @return the build data communicator object
-         * @since 2.0
-         */
-        @Deprecated(since = "25.3", forRemoval = true)
-        protected DataCommunicator<T> build(Element element,
-                CompositeDataGenerator<T> dataGenerator, U arrayUpdater,
-                SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {
-            return new GridDataCommunicator<>(element, dataGenerator,
-                    arrayUpdater);
-        }
+        return new GridDataCommunicator<>(getElement(),
+                getCompositeDataGenerator(), getArrayUpdater());
     }
 
     protected GridArrayUpdater createDefaultArrayUpdater() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.GridArrayUpdater;
 import com.vaadin.flow.component.grid.dataview.GridDataView;
 import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
@@ -38,7 +37,6 @@ import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.data.binder.PropertyDefinition;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
-import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
@@ -53,10 +51,8 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.dom.DisabledUpdateMode;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.shared.Registration;
 
@@ -82,7 +78,7 @@ public class TreeGrid<T> extends Grid<T>
      * automatically sets up columns based on the type of presented data.
      */
     public TreeGrid() {
-        this(50, new TreeDataCommunicatorBuilder<T>());
+        this(50);
     }
 
     /**
@@ -93,16 +89,9 @@ public class TreeGrid<T> extends Grid<T>
      *
      * @param pageSize
      *            the page size. Must be greater than zero.
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
      */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected TreeGrid(int pageSize,
-            DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
-        super(pageSize, dataCommunicatorBuilder);
+    protected TreeGrid(int pageSize) {
+        super(pageSize);
 
         setUniqueKeyProperty("key");
         addTreeDataGenerator();
@@ -174,35 +163,7 @@ public class TreeGrid<T> extends Grid<T>
      *            the properties of the beanType
      */
     public TreeGrid(Class<T> beanType, boolean autoCreateColumns) {
-        this(beanType, new TreeDataCommunicatorBuilder<>(), autoCreateColumns);
-    }
-
-    /**
-     * Creates a new {@code TreeGrid} with an initial set of columns for each of
-     * the bean's properties. The property-values of the bean will be converted
-     * to Strings. Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
-     *
-     * @param beanType
-     *            the bean type to use, not {@code null}
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected TreeGrid(Class<T> beanType,
-            DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
-        this(beanType, dataCommunicatorBuilder, true);
-    }
-
-    @Deprecated(since = "25.3", forRemoval = true)
-    private TreeGrid(Class<T> beanType,
-            DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder,
-            boolean autoCreateColumns) {
-        super(beanType, dataCommunicatorBuilder, autoCreateColumns);
+        super(beanType, autoCreateColumns);
 
         setUniqueKeyProperty("key");
         addTreeDataGenerator();
@@ -223,17 +184,11 @@ public class TreeGrid<T> extends Grid<T>
         setDataProvider(dataProvider);
     }
 
-    private static class TreeDataCommunicatorBuilder<T>
-            extends DataCommunicatorBuilder<T, GridArrayUpdater> {
-
-        @Override
-        protected DataCommunicator<T> build(Element element,
-                CompositeDataGenerator<T> dataGenerator,
-                GridArrayUpdater arrayUpdater,
-                SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {
-            return new TreeGridDataCommunicator<>(element, dataGenerator,
-                    arrayUpdater, uniqueKeyProviderSupplier);
-        }
+    @Override
+    protected DataCommunicator<T> createDataCommunicator() {
+        return new TreeGridDataCommunicator<>(getElement(),
+                getCompositeDataGenerator(), getArrayUpdater(),
+                this::getUniqueKeyProvider);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -96,7 +96,10 @@ public class TreeGrid<T> extends Grid<T>
      * @param dataCommunicatorBuilder
      *            Builder for {@link DataCommunicator} implementation this Grid
      *            uses to handle all data communication.
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected TreeGrid(int pageSize,
             DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
         super(pageSize, dataCommunicatorBuilder);
@@ -186,12 +189,16 @@ public class TreeGrid<T> extends Grid<T>
      * @param dataCommunicatorBuilder
      *            Builder for {@link DataCommunicator} implementation this Grid
      *            uses to handle all data communication.
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected TreeGrid(Class<T> beanType,
             DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
         this(beanType, dataCommunicatorBuilder, true);
     }
 
+    @Deprecated(since = "25.3", forRemoval = true)
     private TreeGrid(Class<T> beanType,
             DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder,
             boolean autoCreateColumns) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.GridArrayUpdater;
 import com.vaadin.flow.component.grid.dataview.GridDataView;
 import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
 import com.vaadin.flow.component.grid.dataview.GridListDataView;
@@ -37,7 +36,6 @@ import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.data.binder.PropertyDefinition;
 import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
-import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
@@ -52,10 +50,8 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.LitRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.dom.DisabledUpdateMode;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.shared.Registration;
 
@@ -82,7 +78,7 @@ public class TreeGrid<T> extends Grid<T>
      * automatically sets up columns based on the type of presented data.
      */
     public TreeGrid() {
-        this(50, new TreeDataCommunicatorBuilder<T>());
+        this(50);
     }
 
     /**
@@ -93,17 +89,9 @@ public class TreeGrid<T> extends Grid<T>
      *
      * @param pageSize
      *            the page size. Must be greater than zero.
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @since 24.5
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
      */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected TreeGrid(int pageSize,
-            DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
-        super(pageSize, dataCommunicatorBuilder);
+    protected TreeGrid(int pageSize) {
+        super(pageSize);
 
         setUniqueKeyProperty("key");
         addTreeDataGenerator();
@@ -176,36 +164,7 @@ public class TreeGrid<T> extends Grid<T>
      * @since 24.5
      */
     public TreeGrid(Class<T> beanType, boolean autoCreateColumns) {
-        this(beanType, new TreeDataCommunicatorBuilder<>(), autoCreateColumns);
-    }
-
-    /**
-     * Creates a new {@code TreeGrid} with an initial set of columns for each of
-     * the bean's properties. The property-values of the bean will be converted
-     * to Strings. Full names of the properties will be used as the
-     * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
-     *
-     * @param beanType
-     *            the bean type to use, not {@code null}
-     * @param dataCommunicatorBuilder
-     *            Builder for {@link DataCommunicator} implementation this Grid
-     *            uses to handle all data communication.
-     * @since 24.5
-     * @deprecated Override {@link #createDataCommunicator()} instead. This
-     *             constructor will be removed in Vaadin 26.
-     */
-    @Deprecated(since = "25.3", forRemoval = true)
-    protected TreeGrid(Class<T> beanType,
-            DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
-        this(beanType, dataCommunicatorBuilder, true);
-    }
-
-    @Deprecated(since = "25.3", forRemoval = true)
-    private TreeGrid(Class<T> beanType,
-            DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder,
-            boolean autoCreateColumns) {
-        super(beanType, dataCommunicatorBuilder, autoCreateColumns);
+        super(beanType, autoCreateColumns);
 
         setUniqueKeyProperty("key");
         addTreeDataGenerator();
@@ -226,17 +185,11 @@ public class TreeGrid<T> extends Grid<T>
         setDataProvider(dataProvider);
     }
 
-    private static class TreeDataCommunicatorBuilder<T>
-            extends DataCommunicatorBuilder<T, GridArrayUpdater> {
-
-        @Override
-        protected DataCommunicator<T> build(Element element,
-                CompositeDataGenerator<T> dataGenerator,
-                GridArrayUpdater arrayUpdater,
-                SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {
-            return new TreeGridDataCommunicator<>(element, dataGenerator,
-                    arrayUpdater, uniqueKeyProviderSupplier);
-        }
+    @Override
+    protected DataCommunicator<T> createDataCommunicator() {
+        return new TreeGridDataCommunicator<>(getElement(),
+                getCompositeDataGenerator(), getArrayUpdater(),
+                this::getUniqueKeyProvider);
     }
 
     /**


### PR DESCRIPTION
Remove the DataCommunicatorBuilder indirection and the generic <U, B> constructor overloads it required. Grid and TreeGrid now build their DataCommunicator by overriding a simple createDataCommunicator() method instead of passing a builder instance through the constructor chain.

Depends on 
- https://github.com/vaadin/flow-components/pull/9667
