### PR TITLE
feat: add GridI18n API for selection and sorter accessible names

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
@@ -74,14 +74,6 @@ describe('grid connector - header and footer renderers', () => {
         expect(sorter).to.exist;
         expect(sorter.textContent).to.equal('Name');
       });
-
-      it('should set aria-label on the sorter', async () => {
-        grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
-        await nextFrame();
-
-        const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
-        expect(sorter.getAttribute('aria-label')).to.equal('Sort by Name');
-      });
     });
   });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1362,6 +1362,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     private GridSelectionModel<T> selectionModel;
     private SelectionMode selectionMode;
     private SerializablePredicate<T> selectableProvider;
+    private GridI18n i18n;
 
     private final DetailsManager detailsManager;
 
@@ -3151,6 +3152,32 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     boolean isItemSelectable(T item) {
         return selectableProvider == null || selectableProvider.test(item);
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using {@link #setI18n(GridI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     * @since 25.3
+     */
+    public GridI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     * @since 25.3
+     */
+    public void setI18n(GridI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n object should not be null");
+        getElement().setPropertyJson("i18n", JacksonUtils.beanToJson(i18n));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridI18n.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridI18n.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * The internationalization properties for {@link Grid}. This can be used to
+ * customize and translate the accessible names used by the grid.
+ *
+ * @see Grid#setI18n(GridI18n)
+ *
+ * @author Vaadin Ltd.
+ * @since 25.3
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GridI18n implements Serializable {
+    private String selectAll;
+    private String selectRow;
+    private String sorter;
+
+    /**
+     * Gets the accessible name (aria-label) for the select all checkbox in the
+     * selection column header cell.
+     *
+     * @return the accessible name for the select all checkbox
+     * @since 25.3
+     */
+    public String getSelectAll() {
+        return selectAll;
+    }
+
+    /**
+     * Sets the accessible name (aria-label) for the select all checkbox in the
+     * selection column header cell.
+     *
+     * @param selectAll
+     *            the accessible name for the select all checkbox
+     * @return this instance for method chaining
+     * @since 25.3
+     */
+    public GridI18n setSelectAll(String selectAll) {
+        this.selectAll = selectAll;
+        return this;
+    }
+
+    /**
+     * Gets the accessible name (aria-label) template for the select row
+     * checkbox in each selection column body cell.
+     *
+     * @return the accessible name template for the select row checkbox
+     */
+    public String getSelectRow() {
+        return selectRow;
+    }
+
+    /**
+     * Sets the accessible name (aria-label) template for the select row
+     * checkbox in each selection column body cell. The {@code {rowHeader}}
+     * placeholder is replaced with the text content of the row's row-header
+     * cell (see {@link Grid.Column#setRowHeader(boolean)}), or the 1-based row
+     * index when there is no row-header column.
+     *
+     * @param selectRow
+     *            the accessible name template for the select row checkbox
+     * @return this instance for method chaining
+     * @since 25.3
+     */
+    public GridI18n setSelectRow(String selectRow) {
+        this.selectRow = selectRow;
+        return this;
+    }
+
+    /**
+     * Gets the accessible name (aria-label) template for the grid sorters.
+     *
+     * @return the accessible name template for the sorters
+     * @since 25.3
+     */
+    public String getSorter() {
+        return sorter;
+    }
+
+    /**
+     * Sets the accessible name (aria-label) template for the grid sorters. The
+     * {@code {column}} placeholder is replaced with the column header text.
+     *
+     * @param sorter
+     *            the accessible name template for the sorters
+     * @return this instance for method chaining
+     * @since 25.3
+     */
+    public GridI18n setSorter(String sorter) {
+        this.sorter = sorter;
+        return this;
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridI18n.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridI18n.java
@@ -64,6 +64,7 @@ public class GridI18n implements Serializable {
      * checkbox in each selection column body cell.
      *
      * @return the accessible name template for the select row checkbox
+     * @since 25.3
      */
     public String getSelectRow() {
         return selectRow;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -434,10 +434,6 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       if (showSorter) {
         const sorter = document.createElement('vaadin-grid-sorter');
         sorter.setAttribute('path', sorterPath);
-        const ariaLabel = content instanceof Node ? content.textContent : content;
-        if (ariaLabel) {
-          sorter.setAttribute('aria-label', `Sort by ${ariaLabel}`);
-        }
         root.appendChild(sorter);
 
         // Use sorter as content root

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridI18nTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridI18nTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GridI18nTest {
+
+    @Test
+    void defaultValues_areNull() {
+        GridI18n i18n = new GridI18n();
+        Assertions.assertNull(i18n.getSelectAll());
+        Assertions.assertNull(i18n.getSelectRow());
+        Assertions.assertNull(i18n.getSorter());
+    }
+
+    @Test
+    void setters_returnSameInstance() {
+        GridI18n i18n = new GridI18n();
+        Assertions.assertSame(i18n, i18n.setSelectAll("Select all"));
+        Assertions.assertSame(i18n,
+                i18n.setSelectRow("Select row {rowHeader}"));
+        Assertions.assertSame(i18n, i18n.setSorter("Sort by {column}"));
+    }
+
+    @Test
+    void setters_updateValues() {
+        GridI18n i18n = new GridI18n().setSelectAll("Select all")
+                .setSelectRow("Select row {rowHeader}")
+                .setSorter("Sort by {column}");
+        Assertions.assertEquals("Select all", i18n.getSelectAll());
+        Assertions.assertEquals("Select row {rowHeader}", i18n.getSelectRow());
+        Assertions.assertEquals("Sort by {column}", i18n.getSorter());
+    }
+
+    @Test
+    void grid_getI18n_returnsNullByDefault() {
+        Assertions.assertNull(new Grid<String>().getI18n());
+    }
+
+    @Test
+    void grid_setI18n_getI18n_returnsSameInstance() {
+        Grid<String> grid = new Grid<>();
+        GridI18n i18n = new GridI18n();
+        grid.setI18n(i18n);
+        Assertions.assertSame(i18n, grid.getI18n());
+    }
+
+    @Test
+    void grid_setI18n_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new Grid<String>().setI18n(null));
+    }
+
+    @Test
+    void grid_setI18n_setsElementProperty() {
+        Grid<String> grid = new Grid<>();
+        grid.setI18n(new GridI18n().setSelectAll("Select all")
+                .setSelectRow("Select row {rowHeader}")
+                .setSorter("Sort by {column}"));
+
+        String json = grid.getElement().getPropertyRaw("i18n").toString();
+        Assertions.assertTrue(json.contains("\"selectAll\":\"Select all\""));
+        Assertions.assertTrue(
+                json.contains("\"selectRow\":\"Select row {rowHeader}\""));
+        Assertions.assertTrue(json.contains("\"sorter\":\"Sort by {column}\""));
+    }
+
+    @Test
+    void grid_setI18n_omitsUnsetValues() {
+        Grid<String> grid = new Grid<>();
+        grid.setI18n(new GridI18n().setSorter("Sort by {column}"));
+
+        String json = grid.getElement().getPropertyRaw("i18n").toString();
+        Assertions.assertFalse(json.contains("selectAll"));
+        Assertions.assertFalse(json.contains("selectRow"));
+        Assertions.assertTrue(json.contains("\"sorter\":\"Sort by {column}\""));
+    }
+}


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/3471

- Added `GridI18n`, `setI18n` and `getI18n` based on the web component `i18n` property. 
- Removed no longer needed logic for setting sorters `aria-label` from the connector.

## Type of change

- Feature