### PR TITLE
refactor: deprecate DataCommunicatorBuilder and its constructors

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1354,10 +1354,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final GridArrayUpdater arrayUpdater;
 
-    private DataCommunicatorBuilder dataCommunicatorBuilder;
-
     private final CompositeDataGenerator<T> gridDataGenerator;
     private final DataCommunicator<T> dataCommunicator;
+    @SuppressWarnings("rawtypes")
+    private DataCommunicatorBuilder dataCommunicatorBuilder;
 
     private int nextColumnId = 0;
 
@@ -1741,8 +1741,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @return the new data communicator
      */
     protected DataCommunicator<T> createDataCommunicator() {
-        return dataCommunicatorBuilder.build(getElement(), gridDataGenerator,
-                arrayUpdater, this::getUniqueKeyProvider);
+        return dataCommunicatorBuilder.build(getElement(),
+                getCompositeDataGenerator(), getArrayUpdater(),
+                this::getUniqueKeyProvider);
     }
 
     /**
@@ -4517,6 +4518,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     protected GridArrayUpdater getArrayUpdater() {
         return arrayUpdater;
+    }
+
+    protected CompositeDataGenerator<T> getCompositeDataGenerator() {
+        return gridDataGenerator;
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4523,8 +4523,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
-     * Gets the {@link CompositeDataGenerator} that this Grid uses to
-     * generate data for the client side.
+     * Gets the {@link CompositeDataGenerator} that this Grid uses to generate
+     * data for the client side.
      *
      * @return the composite data generator
      *

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1739,6 +1739,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * data communication.
      *
      * @return the new data communicator
+     *
+     * @since 25.3
      */
     protected DataCommunicator<T> createDataCommunicator() {
         return dataCommunicatorBuilder.build(getElement(),
@@ -4520,6 +4522,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         return arrayUpdater;
     }
 
+    /**
+     * Gets the {@link CompositeDataGenerator} that this Grid uses to
+     * generate data for the client side.
+     *
+     * @return the composite data generator
+     *
+     * @since 25.3
+     */
     protected CompositeDataGenerator<T> getCompositeDataGenerator() {
         return gridDataGenerator;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1354,6 +1354,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final GridArrayUpdater arrayUpdater;
 
+    private DataCommunicatorBuilder dataCommunicatorBuilder;
+
     private final CompositeDataGenerator<T> gridDataGenerator;
     private final DataCommunicator<T> dataCommunicator;
 
@@ -1564,7 +1566,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the data communicator builder type
      * @param <U>
      *            the GridArrayUpdater type
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
             Class<T> beanType, B dataCommunicatorBuilder) {
         this(beanType, dataCommunicatorBuilder, true);
@@ -1597,7 +1602,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @param autoCreateColumns
      *            when <code>true</code>, columns are created automatically for
      *            the properties of the beanType
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
             Class<T> beanType, B dataCommunicatorBuilder,
             boolean autoCreateColumns) {
@@ -1625,12 +1633,15 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *            the data communicator builder type
      * @param <U>
      *            the GridArrayUpdater type
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
-    @SuppressWarnings("unchecked")
+    @Deprecated(since = "25.3", forRemoval = true)
     protected <U extends GridArrayUpdater, B extends DataCommunicatorBuilder<T, U>> Grid(
             int pageSize, B dataCommunicatorBuilder) {
         Objects.requireNonNull(dataCommunicatorBuilder,
                 "Data communicator builder can't be null");
+        this.dataCommunicatorBuilder = dataCommunicatorBuilder;
         arrayUpdater = createDefaultArrayUpdater();
         gridDataGenerator = new CompositeDataGenerator<>();
         gridDataGenerator.addDataGenerator(this::generateUniqueKeyData);
@@ -1640,9 +1651,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         gridDataGenerator.addDataGenerator(this::generateDragData);
         gridDataGenerator.addDataGenerator(this::generateSelectableData);
 
-        dataCommunicator = dataCommunicatorBuilder.build(getElement(),
-                gridDataGenerator, (U) arrayUpdater,
-                this::getUniqueKeyProvider);
+        dataCommunicator = createDataCommunicator();
 
         detailsManager = new DetailsManager(this);
         setPageSize(pageSize);
@@ -1726,6 +1735,17 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     /**
+     * Creates the {@link DataCommunicator} that this Grid uses to handle all
+     * data communication.
+     *
+     * @return the new data communicator
+     */
+    protected DataCommunicator<T> createDataCommunicator() {
+        return dataCommunicatorBuilder.build(getElement(), gridDataGenerator,
+                arrayUpdater, this::getUniqueKeyProvider);
+    }
+
+    /**
      * Builder for {@link DataCommunicator} object.
      *
      * @param <T>
@@ -1733,7 +1753,11 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      *
      * @param <U>
      *            the ArrayUpdater type
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             class and the constructors that accept it will be removed in
+     *             Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected static class DataCommunicatorBuilder<T, U extends ArrayUpdater>
             implements Serializable {
 
@@ -1753,6 +1777,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          *            communicator
          * @return the build data communicator object
          */
+        @Deprecated(since = "25.3", forRemoval = true)
         protected DataCommunicator<T> build(Element element,
                 CompositeDataGenerator<T> dataGenerator, U arrayUpdater,
                 SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -96,7 +96,10 @@ public class TreeGrid<T> extends Grid<T>
      * @param dataCommunicatorBuilder
      *            Builder for {@link DataCommunicator} implementation this Grid
      *            uses to handle all data communication.
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected TreeGrid(int pageSize,
             DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
         super(pageSize, dataCommunicatorBuilder);
@@ -186,12 +189,16 @@ public class TreeGrid<T> extends Grid<T>
      * @param dataCommunicatorBuilder
      *            Builder for {@link DataCommunicator} implementation this Grid
      *            uses to handle all data communication.
+     * @deprecated Override {@link #createDataCommunicator()} instead. This
+     *             constructor will be removed in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected TreeGrid(Class<T> beanType,
             DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder) {
         this(beanType, dataCommunicatorBuilder, true);
     }
 
+    @Deprecated(since = "25.3", forRemoval = true)
     private TreeGrid(Class<T> beanType,
             DataCommunicatorBuilder<T, GridArrayUpdater> dataCommunicatorBuilder,
             boolean autoCreateColumns) {


### PR DESCRIPTION
This PR deprecates DataCommunicatorBuilder together with the constructors that accept it in Grid and TreeGrid, and introduces a `createDataCommunicator()` method to Grid as a new override point.

Existing constructors keep their current behavior unchanged: the deprecated builder-based constructors store the builder in a field, and `createDataCommunicator()` uses it, which preserves backward compatibility for anyone with a custom DataCommunicatorBuilder. 

A new `getCompositeDataGenerator()` getter is added as well: it keeps the grid's composite data generator accessible for `createDataCommunicator()` overrides, since with DataCommunicatorBuilder deprecated, there would otherwise be no way to pass it into DataCommunicator.