### PR TITLE
refactor: deprecate ItemFilter select-all checkbox init method

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/ItemFilter.java
@@ -113,7 +113,12 @@ public class ItemFilter extends Div implements SpreadsheetFilter {
 
     /**
      * Creates the "Select All" filter component.
+     *
+     * @deprecated The "Select All" checkbox will be removed in Vaadin 26. It
+     *             will be replaced with dedicated "Select All" and "Clear"
+     *             buttons.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected void initAllItemsCheckbox() {
         allItems = new Checkbox("(Select All)", true);
         allItems.addValueChangeListener(event -> {


### PR DESCRIPTION
The "Select All" checkbox in the spreadsheet filter dropdown is ambiguous: its indeterminate state changes as options are selected/deselected, which is confusing (see discussion in #9323). It will be replaced with dedicated "Select All" and "Clear" buttons in Vaadin 26.

This deprecates `ItemFilter#initAllItemsCheckbox()`, the protected extension point backing the checkbox, so it keeps working until removal.

Part of #9323