### PR TITLE
refactor: reuse column visibility check for cell editable data

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -488,6 +488,18 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             setupRenderer(renderer);
         }
 
+        /**
+         * Adds a data generator for this column.
+         *
+         * @param dataGenerator
+         *            the data generator to add
+         * @return a registration for removing the data generator
+         */
+        protected Registration addDataGenerator(
+                DataGenerator<T> dataGenerator) {
+            return compositeDataGenerator.addDataGenerator(dataGenerator);
+        }
+
         private void generatePartData(T item, ObjectNode jsonObject) {
             String partName = partNameGenerator.apply(item);
             if (partName != null) {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -39,7 +39,6 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JacksonSerializer;
-import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.Registration;
 
 import tools.jackson.databind.node.ArrayNode;
@@ -105,8 +104,6 @@ public class GridPro<E> extends Grid<E> {
     }
 
     private void setup() {
-        addDataGenerator(this::generateCellEditableData);
-
         addItemPropertyChangedListener(e -> {
             if (e.getItem() == null) {
                 return;
@@ -214,9 +211,18 @@ public class GridPro<E> extends Grid<E> {
                 Renderer<T> renderer) {
             super(grid, columnId, renderer);
 
+            addDataGenerator(this::generateCellEditableData);
+
             addAttachListener(e -> this.getElement().executeJs(
                     "window.Vaadin.Flow.gridProConnector.initCellEditableProvider($0)",
                     this.getElement()));
+        }
+
+        private void generateCellEditableData(T item, ObjectNode jsonObject) {
+            if (cellEditableProvider != null) {
+                jsonObject.withObjectProperty("cellEditable")
+                        .put(getInternalId(), cellEditableProvider.test(item));
+            }
         }
 
         /**
@@ -524,30 +530,6 @@ public class GridPro<E> extends Grid<E> {
             String columnId) {
         EditColumn<E> column = new EditColumn<>(this, columnId, renderer);
         return column;
-    }
-
-    private void generateCellEditableData(E item, ObjectNode jsonObject) {
-        // Get visible edit columns with cell editable providers
-        List<EditColumn<E>> editColumns = getColumns().stream()
-                .filter(column -> column instanceof EditColumn<E> editColumn
-                        && editColumn.isVisible()
-                        && editColumn.cellEditableProvider != null)
-                .map(column -> (EditColumn<E>) column).toList();
-
-        // Don't generate any data if there are no columns with cell editable
-        // providers, assuming that all cells are editable
-        if (editColumns.isEmpty()) {
-            return;
-        }
-
-        // Generate data for each column
-        ObjectNode cellEditableData = JacksonUtils.createObjectNode();
-        editColumns.forEach(column -> {
-            boolean cellEditable = column.cellEditableProvider.test(item);
-            cellEditableData.put(column.getInternalId(), cellEditable);
-        });
-
-        jsonObject.set("cellEditable", cellEditableData);
     }
 
     /**


### PR DESCRIPTION
GridPro's cell editable data generation duplicated the column visibility check already present in each column's own compositeDataGenerator. It looped over all columns filtering for visible ones, instead of relying on that existing mechanism.

Move the cell editable data generation into `EditColumn` itself, registered through a new protected `Column.addDataGenerator` accessor, so it reuses the existing per-column visibility check.

Follow-up to #6798

---

🤖 Generated with Claude Code