### PR TITLE
chore: preserve pnpm-workspace.yaml on mvn clean

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -103,7 +103,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
@@ -101,7 +101,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -105,7 +105,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
@@ -50,7 +50,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -81,7 +81,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
@@ -73,7 +73,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -76,7 +76,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
@@ -72,7 +72,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -96,7 +96,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
@@ -73,7 +73,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -104,7 +104,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -92,7 +92,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -118,7 +118,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -100,7 +100,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -92,7 +92,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -129,7 +129,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -87,7 +87,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
@@ -94,7 +94,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -91,7 +91,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -88,7 +88,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -76,7 +76,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -106,7 +106,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -97,7 +97,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -103,7 +103,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -172,7 +172,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -96,7 +96,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -82,7 +82,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -90,7 +90,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -86,7 +86,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -76,7 +76,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -80,7 +80,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
@@ -64,7 +64,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
@@ -100,7 +100,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -81,7 +81,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -86,7 +86,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -101,7 +101,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -98,7 +98,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -87,7 +87,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -87,7 +87,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -91,7 +91,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -67,7 +67,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -111,7 +111,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -102,7 +102,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -72,7 +72,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
@@ -73,7 +73,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -93,7 +93,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -165,7 +165,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -87,7 +87,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -92,7 +92,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -81,7 +81,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -85,7 +85,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -95,7 +95,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>pnpm*</include>
+                                <include>pnpm-lock.yaml</include>
                                 <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>


### PR DESCRIPTION
`mvn clean` currently removes `pnpm-workspace.yaml` files which are checked into git. This updates the clean config to only remove lock files.