### PR TITLE
fix!: update multi-select-combo-box to synchronize on change (CP: 25.1)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPushValueChangePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPushValueChangePage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.List;
+import java.util.Set;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.communication.PushMode;
+
+/**
+ * View that runs a server-side {@code setValue} between two push frames, which
+ * must not relay a spurious client-initiated value change with an empty value
+ * back to the server.
+ */
+@Route("vaadin-multi-select-combo-box/push-value-change")
+public class MultiSelectComboBoxPushValueChangePage extends Div {
+    public MultiSelectComboBoxPushValueChangePage() {
+        UI.getCurrent().getPushConfiguration().setPushMode(PushMode.AUTOMATIC);
+
+        Div log = new Div();
+        log.setId("value-change-log");
+
+        NativeButton runScenario = new NativeButton("Run scenario", event -> {
+            MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+            comboBox.setItems(List.of("1", "2", "3"));
+
+            comboBox.addValueChangeListener(e -> {
+                Div entry = new Div();
+                entry.setText("isFromClient=%s old=%s new=%s value=%s"
+                        .formatted(e.isFromClient(), e.getOldValue(),
+                                e.getValue(), comboBox.getValue()));
+                log.add(entry);
+            });
+
+            add(comboBox);
+
+            UI ui = UI.getCurrent();
+            ui.push();
+            comboBox.setValue(Set.of("1"));
+            ui.push();
+        });
+        runScenario.setId("run-scenario");
+
+        add(runScenario, log);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPushValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPushValueChangeIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * Verifies that with {@code @Push} enabled, a server-side {@code setValue}
+ * surrounded by two push frames does not produce a spurious client-initiated
+ * value change with an empty value.
+ */
+@TestPath("vaadin-multi-select-combo-box/push-value-change")
+public class MultiSelectComboBoxPushValueChangeIT extends AbstractComponentIT {
+    private TestBenchElement runScenario;
+    private TestBenchElement log;
+
+    @Before
+    public void init() {
+        open();
+        runScenario = $("button").waitForFirst();
+        log = $("div").id("value-change-log");
+    }
+
+    @Test
+    public void setValueWithPushFrames_noSpuriousEmptyClientValueChange() {
+        runScenario.click();
+
+        // Wait for the value change triggered by the server-side setValue
+        waitUntil(driver -> !log.getText().isEmpty());
+
+        List<String> entries = getLogEntries();
+
+        // No client-initiated value change with an empty value must occur
+        for (String entry : entries) {
+            boolean isFromClient = entry.contains("isFromClient=true");
+            boolean isEmptyValue = entry.contains("value=[]");
+            Assert.assertFalse(
+                    "Spurious client-initiated value change with empty value: "
+                            + entry,
+                    isFromClient && isEmptyValue);
+        }
+
+        // The final server value must remain ["1"]
+        String last = entries.get(entries.size() - 1);
+        Assert.assertTrue(
+                "Expected final value to remain [1], but log was: " + entries,
+                last.contains("value=[1]"));
+    }
+
+    private List<String> getLogEntries() {
+        return log.$("div").all().stream().map(TestBenchElement::getText)
+                .toList();
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangeIT.java
@@ -102,6 +102,16 @@ public class MultiSelectComboBoxValueChangeIT extends AbstractComponentIT {
         assertValueChange(Collections.emptySet(), "server");
     }
 
+    @Test
+    public void selectItems_deselectAll_valueCleared() {
+        comboBox.selectByText("Item 1");
+        comboBox.selectByText("Item 10");
+        comboBox.deselectAll();
+
+        assertSelectedItems(Collections.emptySet());
+        assertValueChange(Collections.emptySet(), "client");
+    }
+
     private void assertSelectedItems(Set<String> items) {
         List<String> selectedTexts = comboBox.getSelectedTexts();
         Assert.assertEquals("Number of selected items does not match",

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -135,6 +135,10 @@ public class MultiSelectComboBox<TItem>
                 MultiSelectComboBox::presentationToModel,
                 MultiSelectComboBox::modelToPresentation);
 
+        // Use change instead of the default selected-items-changed
+        // event to avoid notification for programmatic value changes.
+        setSynchronizedEvent("change");
+
         // Create the selection model that manages the currently selected items.
         // The model ensures that items are compared based on their data
         // provider identify, and that the selection only changes if items

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
@@ -33,6 +33,8 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.InputField;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+import com.vaadin.flow.shared.JsonConstants;
 
 import tools.jackson.databind.node.ArrayNode;
 
@@ -47,6 +49,22 @@ public class MultiSelectComboBoxTest extends ComboBoxBaseTest {
     public void initialValue() {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
         Assert.assertEquals(Collections.emptySet(), comboBox.getValue());
+    }
+
+    @Test
+    public void valueSynchronizedOnChangeEvent() {
+        MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>();
+        ElementListenerMap listeners = comboBox.getElement().getNode()
+                .getFeature(ElementListenerMap.class);
+        String syncExpression = JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN
+                + "selectedItems";
+
+        Assert.assertTrue("value should synchronize on the change event",
+                listeners.getExpressions("change").contains(syncExpression));
+        Assert.assertFalse(
+                "value should not synchronize on selected-items-changed",
+                listeners.getExpressions("selected-items-changed")
+                        .contains(syncExpression));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/src/main/java/com/vaadin/flow/component/combobox/testbench/MultiSelectComboBoxElement.java
@@ -93,18 +93,17 @@ public class MultiSelectComboBoxElement extends TestBenchElement implements
      */
     public void selectByText(String label) {
         setFilter(label);
-        //@formatter:off
-        String script =
-                "const combobox = arguments[0];" +
-                "const label = arguments[1];" +
-                "const itemToSelect = combobox.filteredItems.find(item => item.label === label);" +
-                "if (!itemToSelect) return false;" +
-                "const isSelected = combobox.selectedItems.some(item => item.key === itemToSelect.key);" +
-                "if (!isSelected) {" +
-                "  combobox.selectedItems = [...combobox.selectedItems, itemToSelect];" +
-                "}" +
-                "return true;";
-        //@formatter:on
+        String script = """
+                const combobox = arguments[0];
+                const label = arguments[1];
+                const itemToSelect = combobox.filteredItems.find(item => item.label === label);
+                if (!itemToSelect) return false;
+                const isSelected = combobox.selectedItems.some(item => item.key === itemToSelect.key);
+                if (!isSelected) {
+                  combobox.selectedItems = [...combobox.selectedItems, itemToSelect];
+                  combobox.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+                }
+                return true;""";
         Boolean success = (Boolean) executeScript(script, this, label);
         closePopup();
         if (!success) {
@@ -121,15 +120,14 @@ public class MultiSelectComboBoxElement extends TestBenchElement implements
      *            The label of the item to deselect
      */
     public void deselectByText(String label) {
-        //@formatter:off
-        String script =
-                "const combobox = arguments[0];" +
-                "const label = arguments[1];" +
-                "const isSelected = combobox.selectedItems.some(item => item.label === label);" +
-                "if (isSelected) {" +
-                "  combobox.selectedItems = combobox.selectedItems.filter(item => item.label !== label);" +
-                "}";
-        //@formatter:on
+        String script = """
+                const combobox = arguments[0];
+                const label = arguments[1];
+                const isSelected = combobox.selectedItems.some(item => item.label === label);
+                if (isSelected) {
+                  combobox.selectedItems = combobox.selectedItems.filter(item => item.label !== label);
+                  combobox.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+                }""";
         executeScript(script, this, label);
     }
 
@@ -137,7 +135,11 @@ public class MultiSelectComboBoxElement extends TestBenchElement implements
      * Deselects all items, effectively clearing the value.
      */
     public void deselectAll() {
-        String script = "const combobox = arguments[0]; combobox.selectedItems = [];";
+        String script = """
+                const combobox = arguments[0];
+                if (combobox.selectedItems.length) {
+                  combobox.clear();
+                }""";
         executeScript(script, this);
     }
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9631 to branch 25.1.

---

> ## Description
>
> Fixes #9611
>
> With `@Push` and two push frames around a server-side `setValue`, MultiSelectComboBox could reset its value to empty because the `selected-items-changed` notification also fires for programmatic changes and gets echoed back as a spurious client value change.
>
> - Synchronized the value on the web component `change` event instead of `selected-items-changed`, so only genuine user gestures are treated as client changes
> - Updated TestBench helpers to dispatch `change` (and `deselectAll` to use `clear()`)
> - Added integration tests for the push scenario and user value commits
>
> > [!WARNING]
> > Client-side changes to the web component `selectedItems` property no longer synchronize to the server unless a `change` event is dispatched. Server-side `setValue` and end-user interactions are unaffected.
>
> ## Type of change
>
> - Behavior altering fix
>
> ---
>
> 🤖 Generated with Claude Code
