### PR TITLE
fix: render grid data when cache is populated before attach (CP: 25.2)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-lazy-attach.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-lazy-attach.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { aTimeout, nextFrame } from '@vaadin/testing-helpers';
+import {
+  init,
+  getBodyRowCount,
+  getBodyCellText,
+  setRootItems,
+  GRID_CONNECTOR_ROOT_REQUEST_DELAY
+} from './shared.js';
+import type { FlowGrid } from './shared.js';
+
+describe('grid connector - lazy attach to the DOM', () => {
+  let grid: FlowGrid;
+
+  beforeEach(async () => {
+    grid = document.createElement('vaadin-grid') as FlowGrid;
+    const column = document.createElement('vaadin-grid-column');
+    column.path = 'name';
+    grid.appendChild(column);
+    init(grid);
+  });
+
+  afterEach(() => {
+    grid.remove();
+  });
+
+  describe('populated before attach', () => {
+    beforeEach(async () => {
+      setRootItems(grid.$connector, [{ key: '0', name: 'foo' }]);
+      await nextFrame();
+      document.body.appendChild(grid);
+      await nextFrame();
+    });
+
+    it('should render rows after attach', () => {
+      expect(getBodyRowCount(grid)).to.equal(1);
+      expect(getBodyCellText(grid, 0, 0)).to.equal('foo');
+    });
+
+    it('should not request data after attach', async () => {
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setViewportRange).to.not.be.called;
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -370,6 +370,9 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
     // We're done applying changes from this batch, resolve pending
     // callbacks
     const { rootCache } = dataProviderController;
+
+    grid._hasData = true;
+
     Object.entries(rootCache.pendingRequests).forEach(([page, callback]) => {
       const lastAvailablePage = grid.size ? Math.ceil(grid.size / grid.pageSize) - 1 : 0;
       // It's possible that the lastRequestedRange includes a page that's beyond lastAvailablePage if the grid's size got reduced during an ongoing data request


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9689 to branch 25.2.

The connector on this branch doesn't have `resolvePendingCallbacks`, so the fix sets `_hasData` in `$connector.confirm` instead, which is where pending callbacks are resolved here. 

---

> When the connector receives data while the grid is still detached from the DOM, for example when a grid is rendered inside another grid's component renderer, there is no data provider call, so nothing sets the grid's `_hasData` property. After attaching, the grid then doesn't render the cached rows (the `_flatSizeChanged` observer only updates the virtualizer when `_hasData` is set) and also sends an unnecessary data request to the server. This change makes the connector set `_hasData` when resolving pending callbacks, which covers this case since populating the cache always ends with a `confirm` call.
>
> Fixes #9674

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
