### PR TITLE
feat: validate navigation-related URL schemes (CP: 23.6)

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -35,6 +35,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
@@ -9,6 +9,9 @@
 package com.vaadin.flow.component.charts.model;
 
 import com.vaadin.flow.component.charts.model.style.Style;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 
 /**
  * Highchart by default puts a credits label in the lower right corner of the
@@ -56,8 +59,39 @@ public class Credits extends AbstractConfigurationObject {
      * The URL for the credits label.
      * <p>
      * Defaults to: http://www.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeHref(String)
      */
     public void setHref(String href) {
+        if (href != null && !UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
+        }
+        this.href = href;
+    }
+
+    /**
+     * Sets the URL for the credits label without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the URL for the credits label
+     */
+    public void setUnsafeHref(String href) {
         this.href = href;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
@@ -10,6 +10,10 @@ package com.vaadin.flow.component.charts.model;
 
 import java.util.Map;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
+
 /**
  * Options for the exporting module. For an overview on the matter, see
  * <a href="http://www.highcharts.com/docs/export-module/export-module-overview"
@@ -166,8 +170,41 @@ public class Exporting extends AbstractConfigurationObject {
      * for client side export in certain browsers.
      * <p>
      * Defaults to: https://code.highcharts.com/{version}/lib
+     *
+     * @throws IllegalArgumentException
+     *             if {@code libURL} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeLibURL(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeLibURL(String)
      */
     public void setLibURL(String libURL) {
+        if (libURL != null && !UrlUtil.isSafeUrl(libURL)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "libURL", libURL, "setUnsafeLibURL(String)"));
+        }
+        this.libURL = libURL;
+    }
+
+    /**
+     * Sets the path for the export module dependencies without validating its
+     * scheme.
+     * <p>
+     * Unlike {@link #setLibURL(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setLibURL(String)
+     *
+     * @param libURL
+     *            the path where Highcharts will look for export module
+     *            dependencies
+     */
+    public void setUnsafeLibURL(String libURL) {
         this.libURL = libURL;
     }
 
@@ -301,8 +338,40 @@ public class Exporting extends AbstractConfigurationObject {
      * format. By default this points to Highchart's free web service.
      * <p>
      * Defaults to: https://export.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code url} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeUrl(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeUrl(String)
      */
     public void setUrl(String url) {
+        if (url != null && !UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("url", url, "setUnsafeUrl(String)"));
+        }
+        this.url = url;
+    }
+
+    /**
+     * Sets the URL for the export server without validating its scheme.
+     * <p>
+     * Unlike {@link #setUrl(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setUrl(String)
+     *
+     * @param url
+     *            the URL for the server module converting the SVG string to an
+     *            image format
+     */
+    public void setUnsafeUrl(String url) {
         this.url = url;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+
+public class CreditsTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
+
+    @Test
+    public void setHref_safeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setHref("https://vaadin.com");
+
+        Assert.assertEquals("https://vaadin.com", credits.getHref());
+    }
+
+    @Test
+    public void setHref_unsafeScheme_throws() {
+        Credits credits = new Credits();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> credits.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeHref_unsafeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setUnsafeHref("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", credits.getHref());
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+
+public class ExportingTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
+
+    @Test
+    public void setUrl_safeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUrl("https://export.highcharts.com");
+
+        Assert.assertEquals("https://export.highcharts.com",
+                exporting.getUrl());
+    }
+
+    @Test
+    public void setUrl_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setUrl("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeUrl_unsafeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeUrl("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", exporting.getUrl());
+    }
+
+    @Test
+    public void setLibURL_safeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setLibURL("https://code.highcharts.com/lib");
+
+        Assert.assertEquals("https://code.highcharts.com/lib",
+                exporting.getLibURL());
+    }
+
+    @Test
+    public void setLibURL_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setLibURL("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeLibURL_unsafeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeLibURL("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", exporting.getLibURL());
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -32,6 +32,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <scope>test</scope>

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -18,7 +18,10 @@ import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.PropertyChangeListener;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.JsonSerializer;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -74,9 +77,40 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
      * action is defined a {@link AbstractLogin.LoginEvent} is not fired
      * anymore.
      *
+     * @throws IllegalArgumentException
+     *             if {@code action} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeAction(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     *
      * @see #getAction()
+     * @see #setUnsafeAction(String)
      */
     public void setAction(String action) {
+        if (action != null && !UrlUtil.isSafeUrl(action)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "action", action, "setUnsafeAction(String)"));
+        }
+        getElement().setProperty(PROP_ACTION, action);
+    }
+
+    /**
+     * Sets the action URL without validating its scheme.
+     * <p>
+     * Unlike {@link #setAction(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setAction(String)
+     *
+     * @param action
+     *            the action URL
+     */
+    public void setUnsafeAction(String action) {
         getElement().setProperty(PROP_ACTION, action);
     }
 

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -8,15 +8,43 @@
  */
 package com.vaadin.flow.component.login;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 
 public class LoginFormTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
 
     @Test
     public void onForgotPasswordEvent() {
@@ -55,5 +83,20 @@ public class LoginFormTest {
     public void loginFormHasStyle() {
         LoginForm loginForm = new LoginForm();
         Assert.assertTrue(loginForm instanceof HasStyle);
+    }
+
+    @Test
+    public void setActionWithUnsafeScheme_throws() {
+        final LoginForm form = new LoginForm();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> form.setAction("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeActionWithUnsafeScheme_actionSet() {
+        final LoginForm form = new LoginForm();
+        form.setUnsafeAction("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", form.getAction());
     }
 }


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9447 to branch 23.6.

Because URL scheme validation is disabled by default in 23.6 (see vaadin/flow#24942), and because some components differ from `main`, the backport was adapted:

- **Scope reduced to existing components**: `SideNavItem`, `BreadcrumbsItem` and `LoginOverlayTest` do not exist in 23.6, so only the Charts (`Credits`, `Exporting`) and Login (`AbstractLogin#setAction`) sinks are validated here.
- **Javadoc**: the `@throws` clauses reference `{@link DeploymentConfiguration#getUrlSafeSchemes()}`, matching the Flow 23.6 wording, since validation only rejects schemes that are not in the configured safe set (allow-all by default).
- **`AbstractLogin#setAction`**: kept 23.6's simple property-setting behavior (the default-login-listener handling from `main` does not exist here) plus the new validation and `setUnsafeAction`.
- **Tests**: converted to JUnit 4 (as used by these modules in 23.6) and mock `VaadinService`/`DeploymentConfiguration` to enable validation, since it is off by default. `mockito-inline` was added to the Charts and Login test dependencies for static mocking.

---

> ## Motivation
>
> Mirror the Flow URL-scheme validation ([vaadin/flow#24539](https://github.com/vaadin/flow/pull/24539)) for the navigation, action and link sinks in flow-components. A `javascript:` (or other non-allow-listed) scheme on a value that the browser later treats as a link, form action or script source is a familiar XSS shape; rejecting it at the setter closes that path while leaving an explicit escape hatch for trusted, hard-coded URLs.
>
> ## Changes
>
> Validating setters added across the affected components, each with a matching `setUnsafe*` variant that bypasses validation:
>
> - `SideNavItem.setPath` / `BreadcrumbsItem.setPath` — navigation link.
> - `Credits.setHref` — clickable Highcharts credits link.
> - `AbstractLogin.setAction` — the form `action` attribute the browser POSTs to on submit.
> - `Exporting.setUrl` — Highcharts posts SVG to this URL as a form action for export fallback.
> - `Exporting.setLibURL` — concatenated into `<script src="…">` to load offline-export dependencies at runtime.
>
> `SideNavItem` and `BreadcrumbsItem` constructors that take a `String path` validate transitively via `setPath`; their Javadoc now documents `@throws IllegalArgumentException` and explicit constructor tests cover the behaviour.
>
> Safe schemes are configured through the `com.vaadin.safeUrlSchemes` property and default to `http`, `https`, `mailto`, `tel`, `ftp`.
>
> Image, icon, SVG, Avatar, map tile and chart-resource URLs are intentionally **not** validated: `javascript:` cannot execute in `<img src>` / SVG `<image>` elements, and `data:` URLs are a legitimate, common use there.
>
> `LoginFormTest` and `LoginOverlayTest` already mock `LoggerFactory` to capture the existing "action attribute together with login listeners" warning. After merging Flow main, those tests started NPE-ing: Flow's `UrlUtil.isSafeUrl` debug-logs a fallback notice, going through `LoggerFactory.getLogger(UrlUtil.class)` which returned `null` inside the broad mock. The mock now uses `Mockito.CALLS_REAL_METHODS` so unrelated lookups fall through to the real factory; the explicit `LoginForm/Overlay.class` stubs still take precedence.
>
> Part of vaadin/flow#24539

---

🤖 Generated with Claude Code
