### PR TITLE
docs: document IllegalArgumentException on URL setters

### DIFF
--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java
@@ -234,8 +234,14 @@ public class BreadcrumbsItem extends Component
      * @param path
      *            the path to link to, or {@code null} to remove the path and
      *            render the item as the current page (a non-link)
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      *
      * @see #setPath(Class)
+     * @see #setUnsafePath(String)
      */
     public void setPath(String path) {
         if (path != null && !UrlUtil.isSafeUrl(path)) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
@@ -60,6 +60,13 @@ public class Credits extends AbstractConfigurationObject {
      * The URL for the credits label.
      * <p>
      * Defaults to: http://www.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeHref(String)
      */
     public void setHref(String href) {
         if (href != null && !UrlUtil.isSafeUrl(href)) {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -262,8 +262,14 @@ public class SideNavItem extends Component implements HasSideNavItems,
      * @param path
      *            The path to link to. Set to null to disable navigation for
      *            this item.
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      *
      * @see SideNavItem#setPath(Class)
+     * @see #setUnsafePath(String)
      */
     public void setPath(String path) {
         if (path != null && !UrlUtil.isSafeUrl(path)) {


### PR DESCRIPTION
Add the missing `@throws IllegalArgumentException` doclet to Credits#setHref, SideNavItem#setPath and BreadcrumbsItem#setPath. These setters validate the URL scheme and throw, but the behavior was undocumented, unlike the other validating setters (e.g. Exporting#setUrl). Also add a `@see` reference to the matching setUnsafe* variant.
