### PR TITLE
feat: validate navigation-related URL schemes (CP: 24.10)

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
@@ -9,6 +9,9 @@
 package com.vaadin.flow.component.charts.model;
 
 import com.vaadin.flow.component.charts.model.style.Style;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 
 /**
  * Highchart by default puts a credits label in the lower right corner of the
@@ -56,8 +59,39 @@ public class Credits extends AbstractConfigurationObject {
      * The URL for the credits label.
      * <p>
      * Defaults to: http://www.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeHref(String)
      */
     public void setHref(String href) {
+        if (href != null && !UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
+        }
+        this.href = href;
+    }
+
+    /**
+     * Sets the URL for the credits label without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the URL for the credits label
+     */
+    public void setUnsafeHref(String href) {
         this.href = href;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
@@ -10,6 +10,10 @@ package com.vaadin.flow.component.charts.model;
 
 import java.util.Map;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
+
 /**
  * Options for the exporting module. For an overview on the matter, see
  * <a href="http://www.highcharts.com/docs/export-module/export-module-overview"
@@ -166,8 +170,41 @@ public class Exporting extends AbstractConfigurationObject {
      * for client side export in certain browsers.
      * <p>
      * Defaults to: https://code.highcharts.com/{version}/lib
+     *
+     * @throws IllegalArgumentException
+     *             if {@code libURL} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeLibURL(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeLibURL(String)
      */
     public void setLibURL(String libURL) {
+        if (libURL != null && !UrlUtil.isSafeUrl(libURL)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "libURL", libURL, "setUnsafeLibURL(String)"));
+        }
+        this.libURL = libURL;
+    }
+
+    /**
+     * Sets the path for the export module dependencies without validating its
+     * scheme.
+     * <p>
+     * Unlike {@link #setLibURL(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setLibURL(String)
+     *
+     * @param libURL
+     *            the path where Highcharts will look for export module
+     *            dependencies
+     */
+    public void setUnsafeLibURL(String libURL) {
         this.libURL = libURL;
     }
 
@@ -301,8 +338,40 @@ public class Exporting extends AbstractConfigurationObject {
      * format. By default this points to Highchart's free web service.
      * <p>
      * Defaults to: https://export.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code url} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeUrl(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeUrl(String)
      */
     public void setUrl(String url) {
+        if (url != null && !UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("url", url, "setUnsafeUrl(String)"));
+        }
+        this.url = url;
+    }
+
+    /**
+     * Sets the URL for the export server without validating its scheme.
+     * <p>
+     * Unlike {@link #setUrl(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setUrl(String)
+     *
+     * @param url
+     *            the URL for the server module converting the SVG string to an
+     *            image format
+     */
+    public void setUnsafeUrl(String url) {
         this.url = url;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+
+public class CreditsTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
+
+    @Test
+    public void setHref_safeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setHref("https://vaadin.com");
+
+        Assert.assertEquals("https://vaadin.com", credits.getHref());
+    }
+
+    @Test
+    public void setHref_unsafeScheme_throws() {
+        Credits credits = new Credits();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> credits.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeHref_unsafeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setUnsafeHref("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", credits.getHref());
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+
+public class ExportingTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
+
+    @Test
+    public void setUrl_safeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUrl("https://export.highcharts.com");
+
+        Assert.assertEquals("https://export.highcharts.com",
+                exporting.getUrl());
+    }
+
+    @Test
+    public void setUrl_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setUrl("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeUrl_unsafeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeUrl("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", exporting.getUrl());
+    }
+
+    @Test
+    public void setLibURL_safeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setLibURL("https://code.highcharts.com/lib");
+
+        Assert.assertEquals("https://code.highcharts.com/lib",
+                exporting.getLibURL());
+    }
+
+    @Test
+    public void setLibURL_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setLibURL("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeLibURL_unsafeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeLibURL("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", exporting.getLibURL());
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -28,7 +28,10 @@ import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.PropertyChangeListener;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.JsonSerializer;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.JsonNull;
@@ -109,10 +112,46 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
      * listeners added with {@link #addLoginListener(ComponentEventListener)}.
      * See class Javadoc for more information.
      *
+     * @throws IllegalArgumentException
+     *             if {@code action} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeAction(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     *
      * @see #getAction()
+     * @see #setUnsafeAction(String)
      * @see #addLoginListener(ComponentEventListener)
      */
     public void setAction(String action) {
+        if (action != null && !UrlUtil.isSafeUrl(action)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "action", action, "setUnsafeAction(String)"));
+        }
+        doSetAction(action);
+    }
+
+    /**
+     * Sets the action URL without validating its scheme.
+     * <p>
+     * Unlike {@link #setAction(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setAction(String)
+     *
+     * @param action
+     *            the action URL, or {@code null} to remove the action and
+     *            restore the default login listener handling
+     */
+    public void setUnsafeAction(String action) {
+        doSetAction(action);
+    }
+
+    private void doSetAction(String action) {
         if (action == null) {
             getElement().removeProperty(PROP_ACTION);
             if (registration == null) {

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -15,9 +15,12 @@
  */
 package com.vaadin.flow.component.login;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -26,9 +29,32 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
 
 public class LoginFormTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
 
     @Test
     public void onForgotPasswordEvent() {
@@ -118,7 +144,7 @@ public class LoginFormTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginForm.class))
                     .thenReturn(mockedLogger);
 
@@ -147,7 +173,7 @@ public class LoginFormTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginForm.class))
                     .thenReturn(mockedLogger);
 
@@ -188,5 +214,20 @@ public class LoginFormTest {
         Assert.assertFalse(
                 "Expected error status being reset by default listener",
                 form.isError());
+    }
+
+    @Test
+    public void setActionWithUnsafeScheme_throws() {
+        final LoginForm form = new LoginForm();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> form.setAction("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeActionWithUnsafeScheme_actionSet() {
+        final LoginForm form = new LoginForm();
+        form.setUnsafeAction("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", form.getAction());
     }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
@@ -75,7 +75,7 @@ public class LoginOverlayTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginOverlay.class))
                     .thenReturn(mockedLogger);
 
@@ -104,7 +104,7 @@ public class LoginOverlayTest {
 
         Logger mockedLogger = Mockito.mock(Logger.class);
         try (MockedStatic<LoggerFactory> context = Mockito
-                .mockStatic(LoggerFactory.class)) {
+                .mockStatic(LoggerFactory.class, Mockito.CALLS_REAL_METHODS)) {
             context.when(() -> LoggerFactory.getLogger(LoginOverlay.class))
                     .thenReturn(mockedLogger);
 

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/main/java/com/vaadin/flow/component/sidenav/SideNavItem.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.router.HasUrlParameter;
@@ -44,6 +45,7 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.internal.ConfigureRoutes;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
+import com.vaadin.flow.server.InitParameters;
 
 import elemental.json.JsonArray;
 
@@ -86,6 +88,13 @@ public class SideNavItem extends Component implements HasSideNavItems,
      *            the label for the item
      * @param path
      *            the path to link to
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public SideNavItem(String label, String path) {
         setPath(path);
@@ -153,6 +162,13 @@ public class SideNavItem extends Component implements HasSideNavItems,
      *            the path to link to
      * @param prefixComponent
      *            the prefix component for the item (usually an icon)
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public SideNavItem(String label, String path, Component prefixComponent) {
         setPath(path);
@@ -247,10 +263,46 @@ public class SideNavItem extends Component implements HasSideNavItems,
      * @param path
      *            The path to link to. Set to null to disable navigation for
      *            this item.
+     * @throws IllegalArgumentException
+     *             if {@code path} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafePath(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      *
      * @see SideNavItem#setPath(Class)
+     * @see #setUnsafePath(String)
      */
     public void setPath(String path) {
+        if (path != null && !UrlUtil.isSafeUrl(path)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "path", path, "setUnsafePath(String)"));
+        }
+        doSetPath(path);
+    }
+
+    /**
+     * Sets the path this navigation item links to without validating its
+     * scheme.
+     * <p>
+     * Unlike {@link #setPath(String)}, this method does not reject paths based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for paths that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setPath(String)
+     *
+     * @param path
+     *            The path to link to. Set to null to disable navigation for
+     *            this item.
+     */
+    public void setUnsafePath(String path) {
+        doSetPath(path);
+    }
+
+    private void doSetPath(String path) {
         if (path == null) {
             getElement().removeAttribute("path");
         } else {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/src/test/java/com/vaadin/flow/component/sidenav/tests/SideNavItemTest.java
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -34,6 +36,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.NotFoundException;
@@ -44,6 +47,7 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 
 import elemental.json.JsonArray;
@@ -51,7 +55,28 @@ import elemental.json.impl.JsonUtil;
 
 public class SideNavItemTest {
 
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
     private SideNavItem sideNavItem;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("http", "https", "mailto", "tel", "ftp"));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
 
     @Before
     public void setup() {
@@ -137,6 +162,32 @@ public class SideNavItemTest {
         sideNavItem.setPath("");
 
         assertPath("");
+    }
+
+    @Test
+    public void setPathWithUnsafeScheme_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> sideNavItem.setPath("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafePathWithUnsafeScheme_pathSet() {
+        sideNavItem.setUnsafePath("javascript:alert(1)");
+
+        assertPath("javascript:alert(1)");
+    }
+
+    @Test
+    public void constructor_labelPath_unsafeScheme_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new SideNavItem("Docs", "javascript:alert(1)"));
+    }
+
+    @Test
+    public void constructor_labelPathPrefixComponent_unsafeScheme_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new SideNavItem("Docs", "javascript:alert(1)",
+                        new Div()));
     }
 
     @Test


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9447 to branch 24.10.

Because URL scheme validation is disabled by default in 24.10 (`DeploymentConfiguration#getUrlSafeSchemes()` allows all schemes unless configured), and because some components differ from `main`, the backport was adapted:

- **Scope**: `BreadcrumbsItem` does not exist in 24.10, so it is excluded. Charts (`Credits`, `Exporting`), Login (`AbstractLogin#setAction`) and SideNav (`SideNavItem`) are all validated.
- **Javadoc**: the `@throws` clauses reference `{@link DeploymentConfiguration#getUrlSafeSchemes()}`, since validation only rejects schemes that are not in the configured safe set (allow-all by default). This also adds the previously missing `@throws` on `Credits#setHref` and `SideNavItem#setPath`.
- **Tests**: converted to JUnit 4 (as used by these modules in 24.10) and mock `VaadinService`/`DeploymentConfiguration` to enable validation, since it is off by default.

---

> ## Motivation
>
> Mirror the Flow URL-scheme validation ([vaadin/flow#24539](https://github.com/vaadin/flow/pull/24539)) for the navigation, action and link sinks in flow-components. A `javascript:` (or other non-allow-listed) scheme on a value that the browser later treats as a link, form action or script source is a familiar XSS shape; rejecting it at the setter closes that path while leaving an explicit escape hatch for trusted, hard-coded URLs.
>
> ## Changes
>
> Validating setters added across the affected components, each with a matching `setUnsafe*` variant that bypasses validation:
>
> - `SideNavItem.setPath` / `BreadcrumbsItem.setPath` — navigation link.
> - `Credits.setHref` — clickable Highcharts credits link.
> - `AbstractLogin.setAction` — the form `action` attribute the browser POSTs to on submit.
> - `Exporting.setUrl` — Highcharts posts SVG to this URL as a form action for export fallback.
> - `Exporting.setLibURL` — concatenated into `<script src="…">` to load offline-export dependencies at runtime.
>
> `SideNavItem` and `BreadcrumbsItem` constructors that take a `String path` validate transitively via `setPath`; their Javadoc now documents `@throws IllegalArgumentException` and explicit constructor tests cover the behaviour.
>
> Safe schemes are configured through the `com.vaadin.safeUrlSchemes` property and default to `http`, `https`, `mailto`, `tel`, `ftp`.
>
> Image, icon, SVG, Avatar, map tile and chart-resource URLs are intentionally **not** validated: `javascript:` cannot execute in `<img src>` / SVG `<image>` elements, and `data:` URLs are a legitimate, common use there.
>
> `LoginFormTest` and `LoginOverlayTest` already mock `LoggerFactory` to capture the existing "action attribute together with login listeners" warning. After merging Flow main, those tests started NPE-ing: Flow's `UrlUtil.isSafeUrl` debug-logs a fallback notice, going through `LoggerFactory.getLogger(UrlUtil.class)` which returned `null` inside the broad mock. The mock now uses `Mockito.CALLS_REAL_METHODS` so unrelated lookups fall through to the real factory; the explicit `LoginForm/Overlay.class` stubs still take precedence.
>
> Part of vaadin/flow#24539

---

🤖 Generated with Claude Code
