### PR TITLE
feat: validate navigation-related URL schemes (CP: 14.14)

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -41,6 +41,16 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
@@ -25,6 +25,10 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
+
 /**
  * Highchart by default puts a credits label in the lower right corner of the
  * chart. This can be changed using these options.
@@ -70,8 +74,39 @@ public class Credits extends AbstractConfigurationObject {
      * The URL for the credits label.
      * <p>
      * Defaults to: http://www.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeHref(String)
      */
     public void setHref(String href) {
+        if (href != null && !UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
+        }
+        this.href = href;
+    }
+
+    /**
+     * Sets the URL for the credits label without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the URL for the credits label
+     */
+    public void setUnsafeHref(String href) {
         this.href = href;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
@@ -27,6 +27,10 @@ package com.vaadin.flow.component.charts.model;
 
 import java.util.Map;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
+
 /**
  * Options for the exporting module. For an overview on the matter, see
  * <a href="http://www.highcharts.com/docs/export-module/export-module-overview"
@@ -183,8 +187,41 @@ public class Exporting extends AbstractConfigurationObject {
      * for client side export in certain browsers.
      * <p>
      * Defaults to: https://code.highcharts.com/{version}/lib
+     *
+     * @throws IllegalArgumentException
+     *             if {@code libURL} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeLibURL(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeLibURL(String)
      */
     public void setLibURL(String libURL) {
+        if (libURL != null && !UrlUtil.isSafeUrl(libURL)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "libURL", libURL, "setUnsafeLibURL(String)"));
+        }
+        this.libURL = libURL;
+    }
+
+    /**
+     * Sets the path for the export module dependencies without validating its
+     * scheme.
+     * <p>
+     * Unlike {@link #setLibURL(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #setLibURL(String)
+     *
+     * @param libURL
+     *            the path where Highcharts will look for export module
+     *            dependencies
+     */
+    public void setUnsafeLibURL(String libURL) {
         this.libURL = libURL;
     }
 
@@ -318,8 +355,40 @@ public class Exporting extends AbstractConfigurationObject {
      * format. By default this points to Highchart's free web service.
      * <p>
      * Defaults to: https://export.highcharts.com
+     *
+     * @throws IllegalArgumentException
+     *             if {@code url} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeUrl(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     * @see #setUnsafeUrl(String)
      */
     public void setUrl(String url) {
+        if (url != null && !UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("url", url, "setUnsafeUrl(String)"));
+        }
+        this.url = url;
+    }
+
+    /**
+     * Sets the URL for the export server without validating its scheme.
+     * <p>
+     * Unlike {@link #setUrl(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setUrl(String)
+     *
+     * @param url
+     *            the URL for the server module converting the SVG string to an
+     *            image format
+     */
+    public void setUnsafeUrl(String url) {
         this.url = url;
     }
 

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/CreditsTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+/*-
+ * #%L
+ * Vaadin Charts for Flow
+ * %%
+ * Copyright (C) 2014 - 2019 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ *
+ * See the file licensing.txt distributed with this software for more
+ * information about licensing.
+ *
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <https://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+
+public class CreditsTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes()).thenReturn(new HashSet<>(
+                Arrays.asList("http", "https", "mailto", "tel", "ftp")));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
+
+    @Test
+    public void setHref_safeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setHref("https://vaadin.com");
+
+        Assert.assertEquals("https://vaadin.com", credits.getHref());
+    }
+
+    @Test
+    public void setHref_unsafeScheme_throws() {
+        Credits credits = new Credits();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> credits.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeHref_unsafeScheme_hrefSet() {
+        Credits credits = new Credits();
+        credits.setUnsafeHref("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", credits.getHref());
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/model/ExportingTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See  {@literal <https://vaadin.com/commercial-license-and-service-terms>}  for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model;
+
+/*-
+ * #%L
+ * Vaadin Charts for Flow
+ * %%
+ * Copyright (C) 2014 - 2019 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ *
+ * See the file licensing.txt distributed with this software for more
+ * information about licensing.
+ *
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <https://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+
+public class ExportingTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes()).thenReturn(new HashSet<>(
+                Arrays.asList("http", "https", "mailto", "tel", "ftp")));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
+
+    @Test
+    public void setUrl_safeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUrl("https://export.highcharts.com");
+
+        Assert.assertEquals("https://export.highcharts.com",
+                exporting.getUrl());
+    }
+
+    @Test
+    public void setUrl_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setUrl("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeUrl_unsafeScheme_urlSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeUrl("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", exporting.getUrl());
+    }
+
+    @Test
+    public void setLibURL_safeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setLibURL("https://code.highcharts.com/lib");
+
+        Assert.assertEquals("https://code.highcharts.com/lib",
+                exporting.getLibURL());
+    }
+
+    @Test
+    public void setLibURL_unsafeScheme_throws() {
+        Exporting exporting = new Exporting();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> exporting.setLibURL("javascript:alert(1)"));
+    }
+
+    @Test
+    public void setUnsafeLibURL_unsafeScheme_libURLSet() {
+        Exporting exporting = new Exporting();
+        exporting.setUnsafeLibURL("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", exporting.getLibURL());
+    }
+}

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -46,6 +46,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>
             <version>${flow.version}</version>

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -17,7 +17,10 @@ import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.dom.DisabledUpdateMode;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.JsonSerializer;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -69,9 +72,40 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
      * action is defined a {@link AbstractLogin.LoginEvent} is not fired
      * anymore.
      *
+     * @throws IllegalArgumentException
+     *             if {@code action} uses a scheme that is not considered safe
+     *             according to
+     *             {@link DeploymentConfiguration#getUrlSafeSchemes()}; see
+     *             {@link #setUnsafeAction(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
+     *
      * @see #getAction()
+     * @see #setUnsafeAction(String)
      */
     public void setAction(String action) {
+        if (action != null && !UrlUtil.isSafeUrl(action)) {
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "action", action, "setUnsafeAction(String)"));
+        }
+        getElement().setProperty(PROP_ACTION, action);
+    }
+
+    /**
+     * Sets the action URL without validating its scheme.
+     * <p>
+     * Unlike {@link #setAction(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} URL. Passing untrusted input
+     * here can expose the application to cross-site scripting (XSS) attacks.
+     *
+     * @see #setAction(String)
+     *
+     * @param action
+     *            the action URL
+     */
+    public void setUnsafeAction(String action) {
         getElement().setProperty(PROP_ACTION, action);
     }
 

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -8,14 +8,43 @@
  */
 package com.vaadin.flow.component.login;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 
 public class LoginFormTest {
+
+    private static MockedStatic<VaadinService> vaadinServiceMock;
+
+    @BeforeClass
+    public static void enableUrlSchemeValidation() {
+        // URL scheme validation is disabled by default in this branch, so
+        // configure a strict set of safe schemes to exercise the validation.
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(config.getUrlSafeSchemes()).thenReturn(new HashSet<>(
+                Arrays.asList("http", "https", "mailto", "tel", "ftp")));
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+        vaadinServiceMock = Mockito.mockStatic(VaadinService.class);
+        vaadinServiceMock.when(VaadinService::getCurrent).thenReturn(service);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        vaadinServiceMock.close();
+    }
 
     @Test
     public void onForgotPasswordEvent() {
@@ -48,5 +77,19 @@ public class LoginFormTest {
 
         Assert.assertEquals(1, count.get());
         Assert.assertFalse(loginFormComponent.isEnabled());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setActionWithUnsafeScheme_throws() {
+        final LoginForm form = new LoginForm();
+        form.setAction("javascript:alert(1)");
+    }
+
+    @Test
+    public void setUnsafeActionWithUnsafeScheme_actionSet() {
+        final LoginForm form = new LoginForm();
+        form.setUnsafeAction("javascript:alert(1)");
+
+        Assert.assertEquals("javascript:alert(1)", form.getAction());
     }
 }


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9447 to branch 14.14.

Because URL scheme validation is disabled by default in 14.14 (`DeploymentConfiguration#getUrlSafeSchemes()` allows all schemes unless configured), and because some components differ from `main`, the backport was adapted:

- **Scope**: `SideNavItem` and `BreadcrumbsItem` do not exist in 14.14, and `LoginOverlayTest` is not present either, so they are excluded. Only Charts (`Credits`, `Exporting`) and Login (`AbstractLogin#setAction`) are validated.
- **Javadoc**: the `@throws` clauses reference `{@link DeploymentConfiguration#getUrlSafeSchemes()}`, since validation only rejects schemes that are not in the configured safe set (allow-all by default). This also adds the previously missing `@throws` on `Credits#setHref`.
- **`AbstractLogin#setAction`**: keeps the existing simple behavior of this branch plus the new validation and `setUnsafeAction`.
- **Tests**: use JUnit 4 (as used by these modules in 14.14) and mock `VaadinService`/`DeploymentConfiguration` to enable validation, since it is off by default. `mockito-inline` was added to the Charts and Login test dependencies for static mocking. The Login module is on JUnit 4.12, so its throwing test uses `@Test(expected = ...)`.

---

> ## Motivation
>
> Mirror the Flow URL-scheme validation ([vaadin/flow#24539](https://github.com/vaadin/flow/pull/24539)) for the navigation, action and link sinks in flow-components. A `javascript:` (or other non-allow-listed) scheme on a value that the browser later treats as a link, form action or script source is a familiar XSS shape; rejecting it at the setter closes that path while leaving an explicit escape hatch for trusted, hard-coded URLs.
>
> ## Changes
>
> Validating setters added across the affected components, each with a matching `setUnsafe*` variant that bypasses validation:
>
> - `SideNavItem.setPath` / `BreadcrumbsItem.setPath` — navigation link.
> - `Credits.setHref` — clickable Highcharts credits link.
> - `AbstractLogin.setAction` — the form `action` attribute the browser POSTs to on submit.
> - `Exporting.setUrl` — Highcharts posts SVG to this URL as a form action for export fallback.
> - `Exporting.setLibURL` — concatenated into `<script src="…">` to load offline-export dependencies at runtime.
>
> `SideNavItem` and `BreadcrumbsItem` constructors that take a `String path` validate transitively via `setPath`; their Javadoc now documents `@throws IllegalArgumentException` and explicit constructor tests cover the behaviour.
>
> Safe schemes are configured through the `com.vaadin.safeUrlSchemes` property and default to `http`, `https`, `mailto`, `tel`, `ftp`.
>
> Image, icon, SVG, Avatar, map tile and chart-resource URLs are intentionally **not** validated: `javascript:` cannot execute in `<img src>` / SVG `<image>` elements, and `data:` URLs are a legitimate, common use there.
>
> `LoginFormTest` and `LoginOverlayTest` already mock `LoggerFactory` to capture the existing "action attribute together with login listeners" warning. After merging Flow main, those tests started NPE-ing: Flow's `UrlUtil.isSafeUrl` debug-logs a fallback notice, going through `LoggerFactory.getLogger(UrlUtil.class)` which returned `null` inside the broad mock. The mock now uses `Mockito.CALLS_REAL_METHODS` so unrelated lookups fall through to the real factory; the explicit `LoginForm/Overlay.class` stubs still take precedence.
>
> Part of vaadin/flow#24539

---

🤖 Generated with Claude Code
