### PR TITLE
feat: add Tabs.getIndexOf and deprecate indexOf

### DIFF
--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabSheet.java
@@ -290,7 +290,7 @@ public class TabSheet extends Component implements HasPrefix, HasStyle, HasSize,
      * @return the index of the tab or -1 if the tab is not added
      */
     public int getIndexOf(Tab tab) {
-        return tabs.indexOf(tab);
+        return tabs.getIndexOf(tab);
     }
 
     /**

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -91,7 +91,7 @@ public class Tabs extends Component
     public Tabs() {
         setSelectedIndex(-1);
         getElement().addPropertyChangeListener(SELECTED, event -> {
-            int oldIndex = selectedTab != null ? indexOf(selectedTab) : -1;
+            int oldIndex = selectedTab != null ? getIndexOf(selectedTab) : -1;
             int newIndex = getSelectedIndex();
             if (newIndex >= getTabCount()) {
                 LoggerFactory.getLogger(getClass()).warn(String.format(
@@ -248,7 +248,7 @@ public class Tabs extends Component
      */
     public void remove(Tab... tabs) {
         int selectedIndex = getSelectedIndex();
-        int lowerIndices = (int) Stream.of(tabs).map(this::indexOf)
+        int lowerIndices = (int) Stream.of(tabs).map(this::getIndexOf)
                 .filter(index -> index >= 0 && index < selectedIndex).count();
 
         Tab selectedTab = getSelectedTab();
@@ -595,7 +595,7 @@ public class Tabs extends Component
             return;
         }
 
-        int selectedIndex = indexOf(selectedTab);
+        int selectedIndex = getIndexOf(selectedTab);
         if (selectedIndex < 0) {
             throw new IllegalArgumentException(
                     "Tab to select must be a child: " + selectedTab);
@@ -719,7 +719,7 @@ public class Tabs extends Component
      * @param component
      *            the tab to look up, can not be <code>null</code>
      * @return the index of the tab or -1 if the tab is not a child
-     * @deprecated since 24.0, use {@link #indexOf(Tab)} instead.
+     * @deprecated since 24.0, use {@link #getIndexOf(Tab)} instead.
      * @since 24.0
      */
     @Deprecated
@@ -729,7 +729,7 @@ public class Tabs extends Component
             throw new IllegalArgumentException(
                     "Adding a component other than a Tab is not supported.");
         }
-        return indexOf((Tab) component);
+        return getIndexOf((Tab) component);
     }
 
     /**
@@ -738,9 +738,23 @@ public class Tabs extends Component
      * @param tab
      *            the tab to look up, can not be <code>null</code>
      * @return the index of the tab or -1 if the tab is not a child
+     * @deprecated since 25.3, use {@link #getIndexOf(Tab)} instead.
      * @since 24.0
      */
+    @Deprecated
     public int indexOf(Tab tab) {
+        return getIndexOf(tab);
+    }
+
+    /**
+     * Returns the index of the given tab.
+     *
+     * @param tab
+     *            the tab to look up, can not be <code>null</code>
+     * @return the index of the tab or -1 if the tab is not a child
+     * @since 25.3
+     */
+    public int getIndexOf(Tab tab) {
         if (tab == null) {
             throw new IllegalArgumentException(
                     "The 'tab' parameter cannot be null");

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabSheetTest.java
@@ -347,28 +347,28 @@ class TabSheetTest {
     void addTab_addedAsLastTab() {
         tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add("Tab 1", new Span("Content 1"));
-        Assertions.assertEquals(1, tabs.indexOf(tab1));
+        Assertions.assertEquals(1, tabs.getIndexOf(tab1));
     }
 
     @Test
     void addTabToNegativeIndex_addedAsLastTab() {
         tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add(new Tab("Tab 1"), new Span("Content 1"), -1);
-        Assertions.assertEquals(1, tabs.indexOf(tab1));
+        Assertions.assertEquals(1, tabs.getIndexOf(tab1));
     }
 
     @Test
     void addTabToEndIndex_addedAsLastTab() {
         tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add(new Tab("Tab 1"), new Span("Content 1"), 1);
-        Assertions.assertEquals(1, tabs.indexOf(tab1));
+        Assertions.assertEquals(1, tabs.getIndexOf(tab1));
     }
 
     @Test
     void addTabToStartIndex_addedAsFirstTab() {
         tabSheet.add("Tab 0", new Span("Content 0"));
         var tab1 = tabSheet.add(new Tab("Tab 1"), new Span("Content 1"), 0);
-        Assertions.assertEquals(0, tabs.indexOf(tab1));
+        Assertions.assertEquals(0, tabs.getIndexOf(tab1));
     }
 
     @Test

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -303,4 +303,33 @@ class TabsTest {
         Assertions
                 .assertTrue(HasThemeVariant.class.isAssignableFrom(Tabs.class));
     }
+
+    @Test
+    void getIndexOf_returnsIndex() {
+        Tab tab1 = new Tab("Tab one");
+        Tab tab2 = new Tab("Tab two");
+        Tab tab3 = new Tab("Tab three");
+        Tabs tabs = new Tabs(tab1, tab2, tab3);
+
+        Assertions.assertEquals(0, tabs.getIndexOf(tab1));
+        Assertions.assertEquals(1, tabs.getIndexOf(tab2));
+        Assertions.assertEquals(2, tabs.getIndexOf(tab3));
+    }
+
+    @Test
+    void getIndexOf_tabNotChild_returnsMinusOne() {
+        Tab tab1 = new Tab("Tab one");
+        Tab orphan = new Tab("orphan");
+        Tabs tabs = new Tabs(tab1);
+
+        Assertions.assertEquals(-1, tabs.getIndexOf(orphan));
+    }
+
+    @Test
+    void getIndexOf_null_throws() {
+        Tabs tabs = new Tabs();
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> tabs.getIndexOf(null));
+    }
 }


### PR DESCRIPTION
## Description

Fixes #3822

Added `getIndexOf(Tab)` as the replacement for the deprecated `indexOf(Component)` and `indexOf(Tab)` methods, aligned with `TabSheet.getIndexOf(Tab)`.

## Type of change

- Feature