### PR TITLE
docs: add sortability requirements to addColumn(Renderer) JavaDoc

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2035,8 +2035,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * or using {@link LitRenderer}.
      * </p>
      * <p>
-     * <em>NOTE:</em> Columns created with a {@link Renderer} are not sortable by
-     * default. To make such a column sortable, either set a comparator with
+     * <em>NOTE:</em> Columns created with a {@link Renderer} are not sortable
+     * by default. To make such a column sortable, either set a comparator with
      * {@link Column#setComparator(Comparator)} for in-memory sorting, or define
      * the sort properties with {@link Column#setSortProperty(String...)} and
      * implement the sorting in the data provider for backend sorting.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2035,6 +2035,13 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * or using {@link LitRenderer}.
      * </p>
      * <p>
+     * <em>NOTE:</em> Columns created with a {@link Renderer} are not sortable by
+     * default. To make such a column sortable, either set a comparator with
+     * {@link Column#setComparator(Comparator)} for in-memory sorting, or define
+     * the sort properties with {@link Column#setSortProperty(String...)} and
+     * implement the sorting in the data provider for backend sorting.
+     * </p>
+     * <p>
      * <em>NOTE:</em> This method is a shorthand for
      * {@link #addColumn(Renderer, BiFunction)}
      * </p>
@@ -2048,6 +2055,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @see #addComponentColumn(ValueProvider)
      * @see #removeColumn(Column)
      * @see #addColumn(Renderer, BiFunction)
+     * @see Column#setComparator(Comparator)
+     * @see Column#setSortProperty(String...)
      */
     public Column<T> addColumn(Renderer<T> renderer) {
         BiFunction<Renderer<T>, String, Column<T>> defaultFactory = getDefaultColumnFactory();


### PR DESCRIPTION
Adds a note to the `addColumn(Renderer)` JavaDoc explaining that Renderer columns are not sortable by default, and how to make them sortable (comparator for in-memory, sort properties + data provider for backend).

Fixes #1104

Generated with [Claude Code](https://claude.ai/code)