### PR TITLE
feat: accept Collection<? extends T> in TreeGrid expand / collapse

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -811,8 +811,8 @@ public class TreeGrid<T> extends Grid<T>
      *            the maximum depth of recursion
      */
     public void expandRecursively(Collection<? extends T> items, int depth) {
-        var expandedItems = getDataCommunicator().expand(
-                getItemsWithChildrenRecursively(new ArrayList<>(items), depth));
+        var expandedItems = getDataCommunicator()
+                .expand(getItemsWithChildrenRecursively(items, depth));
         fireEvent(new ExpandEvent<>(this, false, expandedItems));
     }
 
@@ -888,8 +888,8 @@ public class TreeGrid<T> extends Grid<T>
      *            the maximum depth of recursion
      */
     public void collapseRecursively(Collection<? extends T> items, int depth) {
-        var collapsedItems = getDataCommunicator().collapse(
-                getItemsWithChildrenRecursively(new ArrayList<>(items), depth));
+        var collapsedItems = getDataCommunicator()
+                .collapse(getItemsWithChildrenRecursively(items, depth));
         fireEvent(new CollapseEvent<>(this, false, collapsedItems));
     }
 
@@ -910,8 +910,8 @@ public class TreeGrid<T> extends Grid<T>
      * @return collection of given items and their children recursively until
      *         the given depth
      */
-    protected Collection<T> getItemsWithChildrenRecursively(Collection<T> items,
-            int depth) {
+    protected Collection<T> getItemsWithChildrenRecursively(
+            Collection<? extends T> items, int depth) {
         List<T> itemsWithChildren = new ArrayList<>();
         if (depth < 0) {
             return itemsWithChildren;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -760,8 +760,8 @@ public class TreeGrid<T> extends Grid<T>
      * @param items
      *            the items to expand
      */
-    public void expand(Collection<T> items) {
-        expand(items, false);
+    public void expand(Collection<? extends T> items) {
+        expand(new ArrayList<>(items), false);
     }
 
     /**
@@ -792,7 +792,7 @@ public class TreeGrid<T> extends Grid<T>
      * @param depth
      *            the maximum depth of recursion
      */
-    public void expandRecursively(Stream<T> items, int depth) {
+    public void expandRecursively(Stream<? extends T> items, int depth) {
         expandRecursively(items.toList(), depth);
     }
 
@@ -810,9 +810,9 @@ public class TreeGrid<T> extends Grid<T>
      * @param depth
      *            the maximum depth of recursion
      */
-    public void expandRecursively(Collection<T> items, int depth) {
-        var expandedItems = getDataCommunicator()
-                .expand(getItemsWithChildrenRecursively(items, depth));
+    public void expandRecursively(Collection<? extends T> items, int depth) {
+        var expandedItems = getDataCommunicator().expand(
+                getItemsWithChildrenRecursively(new ArrayList<>(items), depth));
         fireEvent(new ExpandEvent<>(this, false, expandedItems));
     }
 
@@ -837,8 +837,8 @@ public class TreeGrid<T> extends Grid<T>
      * @param items
      *            the collection of items to collapse
      */
-    public void collapse(Collection<T> items) {
-        collapse(items, false);
+    public void collapse(Collection<? extends T> items) {
+        collapse(new ArrayList<>(items), false);
     }
 
     /**
@@ -869,7 +869,7 @@ public class TreeGrid<T> extends Grid<T>
      * @param depth
      *            the maximum depth of recursion
      */
-    public void collapseRecursively(Stream<T> items, int depth) {
+    public void collapseRecursively(Stream<? extends T> items, int depth) {
         collapseRecursively(items.toList(), depth);
     }
 
@@ -887,9 +887,9 @@ public class TreeGrid<T> extends Grid<T>
      * @param depth
      *            the maximum depth of recursion
      */
-    public void collapseRecursively(Collection<T> items, int depth) {
-        var collapsedItems = getDataCommunicator()
-                .collapse(getItemsWithChildrenRecursively(items, depth));
+    public void collapseRecursively(Collection<? extends T> items, int depth) {
+        var collapsedItems = getDataCommunicator().collapse(
+                getItemsWithChildrenRecursively(new ArrayList<>(items), depth));
         fireEvent(new CollapseEvent<>(this, false, collapsedItems));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ExpandCollapseTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/treegrid/ExpandCollapseTest.java
@@ -106,4 +106,34 @@ class ExpandCollapseTest {
         Assertions.assertEquals(List.of("Item 0", "Item 0-0", "Item 0-0-0"),
                 collapseEvent.get().getItems());
     }
+
+    @Test
+    void expandCollapse_acceptCollectionOfSubtype() {
+        TreeGrid<CharSequence> grid = new TreeGrid<>();
+        var treeData = new TreeData<CharSequence>();
+        treeData.addRootItems("Item 0");
+        treeData.addItems("Item 0", "Item 0-0");
+        treeData.addItems("Item 0-0", "Item 0-0-0");
+        grid.setDataProvider(new TreeDataProvider<>(treeData));
+
+        // List<String> is a Collection<? extends CharSequence>
+        List<String> items = List.of("Item 0");
+
+        grid.expand(items);
+        Assertions.assertTrue(grid.isExpanded("Item 0"));
+        grid.collapse(items);
+        Assertions.assertFalse(grid.isExpanded("Item 0"));
+
+        grid.expandRecursively(items, 1);
+        Assertions.assertTrue(grid.isExpanded("Item 0"));
+        Assertions.assertTrue(grid.isExpanded("Item 0-0"));
+        grid.collapseRecursively(items, 1);
+        Assertions.assertFalse(grid.isExpanded("Item 0"));
+        Assertions.assertFalse(grid.isExpanded("Item 0-0"));
+
+        grid.expandRecursively(items.stream(), 0);
+        Assertions.assertTrue(grid.isExpanded("Item 0"));
+        grid.collapseRecursively(items.stream(), 0);
+        Assertions.assertFalse(grid.isExpanded("Item 0"));
+    }
 }


### PR DESCRIPTION
## Description

Fixes #1609

Widen the item collection and stream parameters of `expand`, `collapse`, `expandRecursively` and `collapseRecursively` to `Collection<? extends T>` / `Stream<? extends T>`, since the items are only read. This lets callers pass collections of a subtype.

Generated with [Claude Code](https://claude.ai/code)