### PR TITLE
feat: add selectAllUnavailable to GridI18n

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridI18n.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridI18n.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GridI18n implements Serializable {
     private String selectAll;
+    private String selectAllUnavailable;
     private String selectRow;
     private String sorter;
 
@@ -54,6 +55,35 @@ public class GridI18n implements Serializable {
      */
     public GridI18n setSelectAll(String selectAll) {
         this.selectAll = selectAll;
+        return this;
+    }
+
+    /**
+     * Gets the accessible name announced for the selection column header cell
+     * when the select all checkbox is hidden (e.g. a data provider is used or
+     * conditional selection is enabled), rendered as a screen-reader-only label
+     * in the cell.
+     *
+     * @return the accessible name for the header cell when select all is
+     *         unavailable
+     */
+    public String getSelectAllUnavailable() {
+        return selectAllUnavailable;
+    }
+
+    /**
+     * Sets the accessible name announced for the selection column header cell
+     * when the select all checkbox is hidden (e.g. a data provider is used or
+     * conditional selection is enabled), rendered as a screen-reader-only label
+     * in the cell.
+     *
+     * @param selectAllUnavailable
+     *            the accessible name for the header cell when select all is
+     *            unavailable
+     * @return this instance for method chaining
+     */
+    public GridI18n setSelectAllUnavailable(String selectAllUnavailable) {
+        this.selectAllUnavailable = selectAllUnavailable;
         return this;
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridI18nTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridI18nTest.java
@@ -24,6 +24,7 @@ class GridI18nTest {
     void defaultValues_areNull() {
         GridI18n i18n = new GridI18n();
         Assertions.assertNull(i18n.getSelectAll());
+        Assertions.assertNull(i18n.getSelectAllUnavailable());
         Assertions.assertNull(i18n.getSelectRow());
         Assertions.assertNull(i18n.getSorter());
     }
@@ -33,6 +34,8 @@ class GridI18nTest {
         GridI18n i18n = new GridI18n();
         Assertions.assertSame(i18n, i18n.setSelectAll("Select all"));
         Assertions.assertSame(i18n,
+                i18n.setSelectAllUnavailable("Select All unavailable"));
+        Assertions.assertSame(i18n,
                 i18n.setSelectRow("Select row {rowHeader}"));
         Assertions.assertSame(i18n, i18n.setSorter("Sort by {column}"));
     }
@@ -40,9 +43,12 @@ class GridI18nTest {
     @Test
     void setters_updateValues() {
         GridI18n i18n = new GridI18n().setSelectAll("Select all")
+                .setSelectAllUnavailable("Select All unavailable")
                 .setSelectRow("Select row {rowHeader}")
                 .setSorter("Sort by {column}");
         Assertions.assertEquals("Select all", i18n.getSelectAll());
+        Assertions.assertEquals("Select All unavailable",
+                i18n.getSelectAllUnavailable());
         Assertions.assertEquals("Select row {rowHeader}", i18n.getSelectRow());
         Assertions.assertEquals("Sort by {column}", i18n.getSorter());
     }
@@ -70,11 +76,14 @@ class GridI18nTest {
     void grid_setI18n_setsElementProperty() {
         Grid<String> grid = new Grid<>();
         grid.setI18n(new GridI18n().setSelectAll("Select all")
+                .setSelectAllUnavailable("Select All unavailable")
                 .setSelectRow("Select row {rowHeader}")
                 .setSorter("Sort by {column}"));
 
         String json = grid.getElement().getPropertyRaw("i18n").toString();
         Assertions.assertTrue(json.contains("\"selectAll\":\"Select all\""));
+        Assertions.assertTrue(json.contains(
+                "\"selectAllUnavailable\":\"Select All unavailable\""));
         Assertions.assertTrue(
                 json.contains("\"selectRow\":\"Select row {rowHeader}\""));
         Assertions.assertTrue(json.contains("\"sorter\":\"Sort by {column}\""));


### PR DESCRIPTION
The Grid web component added a new `selectAllUnavailable` i18n property in vaadin/web-components#12080. It provides the accessible name announced for the selection column header cell when the select all checkbox is hidden (e.g. a data provider is used or conditional selection is enabled). This property was missing from the Flow `GridI18n` API, so Flow users could not customize or translate it.

This adds a matching `selectAllUnavailable` getter/setter to `GridI18n`, following the existing pattern of the other accessible-name properties.

Part of vaadin/web-components#12080

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)