### PR TITLE
feat: add AURA_REVERSE to CheckboxVariant enum

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxVariant.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.shared.ThemeVariant;
 
 /**
  * Set of theme variants applicable for {@code vaadin-checkbox} component.
- * 
+ *
  * @since 25.0
  */
 public enum CheckboxVariant implements ThemeVariant {
@@ -42,6 +42,7 @@ public enum CheckboxVariant implements ThemeVariant {
      */
     @Deprecated(since = "25.2", forRemoval = true)
     HELPER_ABOVE("helper-above-field"),
+    AURA_REVERSE("reverse"),
     AURA_SMALL("small");
 
     private final String variant;


### PR DESCRIPTION
## Description

Added `AURA_REVERSE` for the `"reverse"` style variant supported by checkbox since https://github.com/vaadin/web-components/pull/12098.

## Type of change

- Feature