### PR TITLE
chore: add code-review workflow

### DIFF
--- a/.github/claude/post-review.js
+++ b/.github/claude/post-review.js
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+/**
+ * Post the code-review findings to the PR as one review.
+ *
+ * Runs in code-review.yml as a plain workflow step, after the claude-code-action
+ * step. Reads the action's execution file and takes the input of the last
+ * ReportFindings tool call. No ReportFindings call at all means the review was lost
+ * (background-subagent failure mode): the script exits non-zero instead of
+ * posting, so a lost review is never mistaken for a clean one. An empty
+ * findings array is a real result and posts a body-only "no findings" review.
+ *
+ * Every finding is posted as its own inline review thread, demoted
+ * line-level → file-level → summary list as anchoring fails. The summary body
+ * holds the overview line, a table over all findings, and the full prose of
+ * any findings that could not be attached to the diff.
+ *
+ * Posting uses the GraphQL pending-review flow so all threads and the summary
+ * are posted as one review (single notification).
+ *
+ * Reads from the environment (set by GitHub Actions):
+ *   PR_NUMBER / argv[2]  pull request number reviewed
+ *   EXECUTION_FILE       JSON transcript of the review run
+ *   GITHUB_REPOSITORY    owner/repo
+ *   GH_TOKEN             token for the gh CLI; its identity is the review
+ *                        author
+ *   DRY_RUN              if set, print the routing and rendered bodies and
+ *                        exit without calling the GitHub API
+ *
+ * Usage:
+ *   node .github/claude/post-review.js <pr-number>
+ */
+
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const MAX_BUFFER = 100 * 1024 * 1024;
+
+function capture(file, args) {
+  return execFileSync(file, args, {
+    encoding: 'utf8',
+    maxBuffer: MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} must be set`);
+    process.exit(2);
+  }
+  return value;
+}
+
+// Run a GraphQL query/mutation via gh. Numbers go through -F so they arrive
+// typed; everything else as strings (valid over the wire for enums and IDs).
+function graphql(query, variables = {}) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+  }
+  return JSON.parse(capture('gh', args)).data;
+}
+
+// The action writes the execution file as a single JSON array of events.
+function readEvents(executionFile) {
+  const events = JSON.parse(fs.readFileSync(executionFile, 'utf8'));
+  if (!Array.isArray(events)) {
+    throw new Error('Execution file is not a JSON array of events');
+  }
+  return events;
+}
+
+// The input of the last ReportFindings tool_use in the transcript.
+function extractReport(executionFile) {
+  let report = null;
+  for (const event of readEvents(executionFile)) {
+    if (event.type !== 'assistant') continue;
+    for (const block of event.message?.content ?? []) {
+      if (block.type === 'tool_use' && block.name === 'ReportFindings') {
+        report = block.input;
+      }
+    }
+  }
+  return report;
+}
+
+function normalize(finding) {
+  return {
+    ...finding,
+    category: (finding.category || 'uncategorized').toLowerCase(),
+    verdict: (finding.verdict || 'plausible').toLowerCase(),
+  };
+}
+
+// --- Rendering ------------------------------------------------------------
+// Every finding starts with a category emoji on the title and ends in the
+// same meta line: file link, category, verdict.
+
+const CATEGORY_EMOJI = {
+  correctness: '⚠️',
+  simplification: '🧹',
+  reuse: '🧹',
+  conventions: '🧹',
+  efficiency: '⚡',
+};
+
+function categoryEmoji(finding) {
+  return CATEGORY_EMOJI[finding.category] || '👀';
+}
+
+function findingTitle(finding) {
+  return `**${categoryEmoji(finding)} ${finding.summary}**`;
+}
+
+// Pipes would break the table; newlines can't appear inside a cell.
+function tableCell(text) {
+  return text.replace(/\|/g, '\\|').replace(/\s*\n\s*/g, ' ');
+}
+
+// One table over ALL findings, commented and unanchored alike, in report
+// order (most severe first). The first column holds only the category emoji.
+function findingsTable(findings) {
+  return [
+    '| | Finding |',
+    '| --- | --- |',
+    ...findings.map((f) => `| ${categoryEmoji(f)} | ${tableCell(f.summary)} |`),
+  ].join('\n');
+}
+
+function fileLabel(finding) {
+  return finding.line ? `${finding.file}:${finding.line}` : finding.file;
+}
+
+// Link to the blob at the head SHA so non-anchored findings stay clickable.
+function fileLink(repo, headSha, finding) {
+  if (!finding.file) return null;
+  const base = finding.file.split('/').pop();
+  const label = finding.line ? `${base}:${finding.line}` : base;
+  const anchor = finding.line ? `#L${finding.line}` : '';
+  return `[${label}](https://github.com/${repo}/blob/${headSha}/${encodeURI(finding.file)}${anchor})`;
+}
+
+function findingMeta(repo, headSha, finding) {
+  const meta = [
+    fileLink(repo, headSha, finding),
+    `\`${finding.category}\``,
+    `\`${finding.verdict}\``,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return `<sub>${meta}</sub>`;
+}
+
+function findingBlock(repo, headSha, finding) {
+  const scenario = (finding.failure_scenario || '').trim();
+  return [findingTitle(finding), scenario, findingMeta(repo, headSha, finding)]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function threadBody(repo, headSha, finding, { aroundLine } = {}) {
+  const parts = [];
+  if (aroundLine) {
+    parts.push(`_Around line ${aroundLine} — could not attach to the exact diff line._`);
+  }
+  parts.push(
+    findingTitle(finding),
+    finding.failure_scenario || '',
+    findingMeta(repo, headSha, finding)
+  );
+  return parts.filter(Boolean).join('\n\n');
+}
+
+function pluralize(count, noun) {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+function joinNaturally(parts) {
+  if (parts.length <= 1) return parts.join('');
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
+}
+
+// One-line overview that opens every summary body; doubles as the whole body
+// when there is nothing else to show, so "reviewed, nothing found" stays
+// distinguishable from "review never happened".
+function overviewLine(unanchored, inlineCount) {
+  const clauses = [];
+  if (inlineCount) {
+    clauses.push(
+      inlineCount === 1 ? 'left **1 comment**' : `left **${inlineCount} comments**`
+    );
+  }
+  if (unanchored.length) {
+    clauses.push(
+      `collected ${pluralize(unanchored.length, 'finding')} below that could not be attached to the diff`
+    );
+  }
+  if (!clauses.length) {
+    return '✅ Nothing to flag — the changes look good.';
+  }
+  return `Reviewed the changes — ${joinNaturally(clauses)}.`;
+}
+
+// Summary body: overview line, then the table over all findings, then the
+// full prose of the findings whose inline anchoring failed (visible, not
+// collapsed) — commented findings keep their prose in the inline comment.
+// Zero-findings runs still post.
+function summaryBody(repo, headSha, findings, unanchored, inlineCount) {
+  const parts = [overviewLine(unanchored, inlineCount)];
+  if (findings.length) {
+    parts.push(findingsTable(findings));
+  }
+  if (unanchored.length) {
+    parts.push(unanchored.map((f) => findingBlock(repo, headSha, f)).join('\n\n'));
+  }
+  return parts.join('\n\n');
+}
+
+// --- Posting ----------------------------------------------------------------
+
+const PR_QUERY = `query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      headRefOid
+      reviews(states: PENDING, first: 10) { nodes { id } }
+    }
+  }
+}`;
+
+// Only works on PENDING reviews, and pending reviews are only visible to
+// their author — so everything the query above returns is a leftover of ours
+// (a crashed previous run would otherwise block creating a new one forever).
+const DELETE_PENDING = `mutation($reviewId: ID!) {
+  deletePullRequestReview(input: {pullRequestReviewId: $reviewId}) {
+    pullRequestReview { id }
+  }
+}`;
+
+const ADD_PENDING = `mutation($prId: ID!) {
+  addPullRequestReview(input: {pullRequestId: $prId}) {
+    pullRequestReview { id }
+  }
+}`;
+
+const ADD_BODY_ONLY = `mutation($prId: ID!, $body: String!) {
+  addPullRequestReview(input: {pullRequestId: $prId, event: COMMENT, body: $body}) {
+    pullRequestReview { url author { login } }
+  }
+}`;
+
+const ADD_LINE_THREAD = `mutation($reviewId: ID!, $path: String!, $line: Int!, $body: String!) {
+  addPullRequestReviewThread(input: {
+    pullRequestReviewId: $reviewId, path: $path, line: $line, side: RIGHT,
+    subjectType: LINE, body: $body
+  }) { thread { id } }
+}`;
+
+const ADD_FILE_THREAD = `mutation($reviewId: ID!, $path: String!, $body: String!) {
+  addPullRequestReviewThread(input: {
+    pullRequestReviewId: $reviewId, path: $path, subjectType: FILE, body: $body
+  }) { thread { id } }
+}`;
+
+const SUBMIT_REVIEW = `mutation($reviewId: ID!, $body: String!) {
+  submitPullRequestReview(input: {pullRequestReviewId: $reviewId, event: COMMENT, body: $body}) {
+    pullRequestReview { url author { login } }
+  }
+}`;
+
+// Try-then-demote: line-level → file-level → summary list. Anchoring rules
+// (line must be in the PR diff; renamed/deleted/binary files) are GitHub's to
+// judge — any failure demotes, nothing breaks the review. A failure is either
+// a GraphQL error OR a 200 with thread: null — GitHub reports a line outside
+// the diff the latter way, without an error.
+function tryAddThread(mutation, variables) {
+  try {
+    return Boolean(graphql(mutation, variables).addPullRequestReviewThread?.thread?.id);
+  } catch {
+    return false;
+  }
+}
+
+function postThread(repo, headSha, reviewId, finding) {
+  if (finding.file && finding.line) {
+    const created = tryAddThread(ADD_LINE_THREAD, {
+      reviewId,
+      path: finding.file,
+      line: finding.line,
+      body: threadBody(repo, headSha, finding),
+    });
+    if (created) return true;
+    console.warn(`Line thread failed for ${fileLabel(finding)}, retrying file-level`);
+  }
+  if (finding.file) {
+    const created = tryAddThread(ADD_FILE_THREAD, {
+      reviewId,
+      path: finding.file,
+      body: threadBody(repo, headSha, finding, { aroundLine: finding.line }),
+    });
+    if (created) return true;
+    console.warn(`File thread failed for ${finding.file}, demoting to summary`);
+  }
+  return false;
+}
+
+function logPosted(review) {
+  console.log(`Posted review ${review.url} as ${review.author.login}`);
+}
+
+function main() {
+  const prNumber = process.argv[2] || process.env.PR_NUMBER;
+  if (!prNumber) {
+    console.error('PR number required (argv[2] or PR_NUMBER)');
+    process.exit(2);
+  }
+  const repo = requireEnv('GITHUB_REPOSITORY');
+  const executionFile = requireEnv('EXECUTION_FILE');
+
+  const report = extractReport(executionFile);
+  if (!report) {
+    console.error(
+      'No ReportFindings call in the execution file — the review was lost; refusing to post.'
+    );
+    process.exit(1);
+  }
+  const findings = (Array.isArray(report.findings) ? report.findings : []).map(normalize);
+  console.log(`Findings: ${findings.length} total`);
+
+  if (process.env.DRY_RUN) {
+    console.log('\n--- inline thread bodies ---');
+    for (const finding of findings) {
+      console.log(`\n[${fileLabel(finding)}]\n${threadBody(repo, 'HEAD', finding)}`);
+    }
+    console.log('\n--- summary body ---\n');
+    console.log(summaryBody(repo, 'HEAD', findings, [], findings.length));
+    return;
+  }
+
+  const [owner, name] = repo.split('/');
+  const pr = graphql(PR_QUERY, { owner, name, number: Number(prNumber) }).repository.pullRequest;
+
+  for (const stale of pr.reviews.nodes) {
+    console.warn(`Deleting stale pending review ${stale.id}`);
+    graphql(DELETE_PENDING, { reviewId: stale.id });
+  }
+
+  if (!findings.length) {
+    const body = summaryBody(repo, pr.headRefOid, [], [], 0);
+    const result = graphql(ADD_BODY_ONLY, { prId: pr.id, body });
+    logPosted(result.addPullRequestReview.pullRequestReview);
+    return;
+  }
+
+  const pending = graphql(ADD_PENDING, { prId: pr.id });
+  const reviewId = pending.addPullRequestReview.pullRequestReview.id;
+
+  const unanchored = [];
+  let posted = 0;
+  for (const finding of findings) {
+    if (postThread(repo, pr.headRefOid, reviewId, finding)) {
+      posted += 1;
+    } else {
+      unanchored.push(finding);
+    }
+  }
+
+  const body = summaryBody(repo, pr.headRefOid, findings, unanchored, posted);
+  const result = graphql(SUBMIT_REVIEW, { reviewId, body });
+  logPosted(result.submitPullRequestReview.pullRequestReview);
+}
+
+main();

--- a/.github/claude/prepare-review.js
+++ b/.github/claude/prepare-review.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Prepare the review scope for the CI code review.
+ *
+ * It pre-computes everything the review needs so the review agent never has to
+ * derive it, then writes a markdown overview file that points at each input by
+ * absolute path.
+ *
+ * Reads from the environment (set by GitHub Actions):
+ *   PR_NUMBER / argv[2]  pull request number to review
+ *   RUNNER_TEMP          base dir for generated files
+ *   GITHUB_REPOSITORY    owner/repo, for the compare API
+ *   GITHUB_WORKSPACE     PR head checkout (the review's working tree)
+ *   GH_TOKEN             token for the gh CLI
+ *
+ * Produces under $RUNNER_TEMP/pr-review:
+ *   pr.diff, pr-files.txt, pr-meta.json, base/ (merge-base worktree), overview.md
+ * Prints the overview path to stdout.
+ *
+ * Usage:
+ *   node .github/claude/prepare-review.js <pr-number>
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+// Diffs can be large; give captured output room.
+const MAX_BUFFER = 100 * 1024 * 1024;
+
+// Run a command, capture stdout as a string, let stderr pass through.
+function capture(file, args) {
+  return execFileSync(file, args, {
+    encoding: 'utf8',
+    maxBuffer: MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} must be set`);
+    process.exit(2);
+  }
+  return value;
+}
+
+function buildOverview({
+  metaPath,
+  diffPath,
+  filesPath,
+  headPath,
+  basePath,
+  flowPath,
+  webComponentsPath,
+}) {
+  return `# Code review inputs
+
+This file names the absolute path of every prepared input for the review.
+Read the paths below and use them; do not compute your own diff or fetch
+your own PR data.
+
+- **PR metadata**: \`${metaPath}\` — title, description, author, labels. The
+  title and description state the intent the change is reviewed against.
+- **Diff**: \`${diffPath}\` — the complete review scope, exactly as GitHub
+  renders it.
+- **Changed files**: \`${filesPath}\`.
+- **Head**: \`${headPath}\` — the PR head checkout and the review's working tree;
+  read related and surrounding code here.
+- **Base (pre-change state)**: \`${basePath}\` — a checkout of the merge-base;
+  consult it when a finding depends on prior behavior.
+- **Reference — Vaadin Flow framework** (read-only): \`${flowPath}\` — base
+  component classes, the \`Element\` API, framework internals.
+- **Reference — Vaadin web components** (read-only): \`${webComponentsPath}\` —
+  client-side properties, events, and DOM behavior of the wrapped components.
+
+The reference checkouts are side-trip context: consult them only when this
+repository's code does not answer the question.
+`;
+}
+
+function main() {
+  const prNumber = process.argv[2] || process.env.PR_NUMBER;
+  if (!prNumber) {
+    console.error('PR number required (argv[2] or PR_NUMBER)');
+    process.exit(2);
+  }
+  const runnerTemp = requireEnv('RUNNER_TEMP');
+  const repo = requireEnv('GITHUB_REPOSITORY');
+  const headPath = process.env.GITHUB_WORKSPACE || process.cwd();
+
+  const scopeDir = path.join(runnerTemp, 'pr-review');
+  fs.mkdirSync(scopeDir, { recursive: true });
+
+  const diffPath = path.join(scopeDir, 'pr.diff');
+  const filesPath = path.join(scopeDir, 'pr-files.txt');
+  const metaPath = path.join(scopeDir, 'pr-meta.json');
+  const basePath = path.join(scopeDir, 'base');
+  const overviewPath = path.join(scopeDir, 'overview.md');
+
+  // Cloned by a separate workflow step into this dir; recorded here so the
+  // overview is the single source of every path.
+  const referenceDir = path.join(runnerTemp, 'reference');
+  const flowPath = path.join(referenceDir, 'flow');
+  const webComponentsPath = path.join(referenceDir, 'web-components');
+
+  // The diff exactly as GitHub renders it, the changed-file list, and metadata.
+  fs.writeFileSync(diffPath, capture('gh', ['pr', 'diff', prNumber]));
+  fs.writeFileSync(filesPath, capture('gh', ['pr', 'diff', prNumber, '--name-only']));
+  fs.writeFileSync(
+    metaPath,
+    capture('gh', [
+      'pr', 'view', prNumber,
+      '--json', 'title,body,author,labels,baseRefName,headRefName',
+    ])
+  );
+
+  // Merge-base = the pre-change state, resolved by the compare API regardless
+  // of local history or where the base branch has moved since.
+  const headSha = capture('gh', ['pr', 'view', prNumber, '--json', 'headRefOid', '--jq', '.headRefOid']).trim();
+  const baseRefSha = capture('gh', ['pr', 'view', prNumber, '--json', 'baseRefOid', '--jq', '.baseRefOid']).trim();
+  const baseSha = capture('gh', ['api', `repos/${repo}/compare/${baseRefSha}...${headSha}`, '--jq', '.merge_base_commit.sha']).trim();
+
+  execFileSync('git', ['fetch', '--depth=1', 'origin', baseSha], { stdio: 'inherit' });
+  execFileSync('git', ['worktree', 'add', basePath, baseSha], { stdio: 'inherit' });
+
+  fs.writeFileSync(
+    overviewPath,
+    buildOverview({ metaPath, diffPath, filesPath, headPath, basePath, flowPath, webComponentsPath })
+  );
+
+  console.log(overviewPath);
+}
+
+main();

--- a/.github/claude/review-prompt.md
+++ b/.github/claude/review-prompt.md
@@ -1,0 +1,148 @@
+You are reviewing a GitHub pull request for **precision**: every finding you
+surface should be one a maintainer would act on.
+
+## Phase 0 — Gather the review inputs
+
+Everything the review needs was prepared before this session. Read the overview file
+at `{{OVERVIEW_PATH}}` first: it names every input by absolute path — the PR metadata
+(title, description, author, labels), the diff, the changed-file list, the PR head
+checkout (the working tree), a checkout of the merge-base (the pre-change state), and
+read-only reference checkouts of related repositories.
+
+Read the prepared diff and treat it as the review scope — do not compute your own
+diff. Read the PR metadata and treat the title and description as the intent the
+change is reviewed against — do not fetch PR data yourself. In the findings, `file`
+is the path relative to the repository root, as it appears in the diff.
+
+## Phase 1 — Find candidates (3 correctness angles + 3 cleanup angles + 1 altitude angle + 1 conventions angle, up to 6 each)
+
+Run **8 independent finder angles** via the Agent tool. Each
+surfaces **up to 6 candidate findings** with `file`, `line`, a one-line
+`summary`, and a concrete `failure_scenario`.
+
+### Angle A — line-by-line diff scan
+
+Read every hunk in the diff, line by line. Then Read the enclosing function for
+each hunk — bugs in unchanged lines of a touched function are in scope (the PR
+re-exposes or fails to fix them). For every line ask: what input, state, timing,
+or platform makes this line wrong? Look for inverted/wrong conditions,
+off-by-one, null/undefined deref, missing `await`, falsy-zero checks,
+wrong-variable copy-paste, error swallowed in catch, unescaped regex metachars.
+
+### Angle B — removed-behavior auditor
+
+For every line the diff DELETES or replaces, name the invariant or behavior it
+enforced, then search the new code for where that invariant is re-established.
+If you can't find it, that's a candidate: a removed guard, a dropped error
+path, a narrowed validation, a deleted test that was covering a real case.
+
+### Angle C — cross-file tracer
+
+For each function the diff changes, find its callers (Grep for the symbol) and
+check whether the change breaks any call site: a new precondition, a changed
+return shape, a new exception, a timing/ordering dependency. Also check callees:
+does a parallel change in the same PR make a call unsafe?
+
+### Reuse
+
+The angles above hunt for bugs; this one and the next two hunt for cleanup in
+the changed code. Flag new code that re-implements something the codebase
+already has — Grep shared/utility modules and files adjacent to the change,
+and name the existing helper to call instead.
+
+### Simplification
+
+Flag unnecessary complexity the diff adds: redundant or derivable state,
+copy-paste with slight variation, deep nesting, dead code left behind. Name
+the simpler form that does the same job.
+
+### Efficiency
+
+Flag wasted work the diff introduces: redundant computation or repeated I/O,
+independent operations run sequentially, blocking work added to startup or
+hot paths. Also flag long-lived objects built from closures or captured
+environments — they keep the entire enclosing scope alive for the object's
+lifetime (a memory leak when that scope holds large values); prefer a
+class/struct that copies only the fields it needs. Name the cheaper
+alternative.
+
+### Altitude
+
+Check that each change is implemented at the right depth, not as a fragile
+bandaid. Special cases layered on shared infrastructure are a sign the fix
+isn't deep enough — prefer generalizing the underlying mechanism over adding
+special cases.
+
+### Conventions (CLAUDE.md)
+
+Find the CLAUDE.md files that govern the changed code: the user-level
+~/.claude/CLAUDE.md, the repo-root CLAUDE.md, plus any CLAUDE.md or
+CLAUDE.local.md in a directory that is an ancestor of a changed file (a
+directory's CLAUDE.md only applies to files at or below it). Read each one
+that exists, then check the diff for clear violations of the rules they state.
+Only flag a violation when you can quote the exact rule and the exact line
+that breaks it — no style preferences, no vague "spirit of the doc"
+inferences. In the finding, name the CLAUDE.md path and quote the rule so the
+report can cite it. If no CLAUDE.md applies, return nothing for this angle.
+
+Cleanup, altitude, and conventions candidates use the same
+`file`/`line`/`summary` shape; in `failure_scenario`, state the concrete
+cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule
+is broken) instead of a crash. Correctness bugs always outrank cleanup,
+altitude, and conventions findings when the output cap forces a cut.
+
+Pass every candidate with a nameable failure scenario through — finders that
+silently drop half-believed candidates bypass the verify step and are the
+dominant cause of misses.
+
+## Phase 2 — Verify (1-vote, 3-state)
+
+Dedup candidates that point at the same line/mechanism, keeping the one with
+the most concrete failure scenario. For each remaining candidate, run **one
+verifier** via the Agent tool: give it the diff, the relevant
+file(s), and the candidate, and have it return exactly one of:
+
+- **CONFIRMED** — can name the inputs/state that trigger it and the wrong
+  output or crash. Quote the line.
+- **PLAUSIBLE** — mechanism is real, trigger is uncertain (timing, env,
+  config). State what would confirm it.
+- **REFUTED** — factually wrong (code doesn't say that) or guarded elsewhere.
+  Quote the line that proves it.
+
+Keep candidates where the vote is CONFIRMED or PLAUSIBLE.
+
+## Phase 3 — Write each finding for a fast read
+
+Findings are read by a busy maintainer in a PR comment. Before reporting,
+rewrite each surviving finding's `summary` and `failure_scenario` so the point
+lands on first read. These fields are rendered as Markdown, so use it.
+
+- **Code symbols in backticks.** Wrap every identifier, method, type, field,
+  and compared literal in backticks — `resolveLabel`, `HTMLInputElement`,
+  `"No matching option"` — so code stands out from prose.
+- **Plain, common developer language.** No invented or clever-sounding labels.
+  Do not use terms like "split-brain", "foot-gun", "spooky action", "split
+  personality". Name the problem in ordinary words.
+- **`summary`: one short plain sentence** naming what is wrong — not a retelling
+  of the whole mechanism.
+- **`failure_scenario`: two short paragraphs**, separated by a blank line, never
+  one dense block. First paragraph: the concrete trigger and what goes wrong
+  (the inputs, state, or steps that reach the bug). Second paragraph: the
+  resulting impact and, when it is clear, the fix. Add a third short paragraph
+  only if the issue genuinely needs it.
+- **Keep it tight.** No longer than the finder already wrote, and shorter when
+  you can. Drop restated call chains and line-number traces that do not help
+  understanding; keep the one detail that makes the problem concrete.
+
+## Output
+
+Call the ReportFindings tool once to report this review's results
+with `{level, findings}`. `findings` is at most 8 entries ranked
+most-severe first; each entry has `file`, `line`, `summary`,
+`failure_scenario` (both written per Phase 3), and `category` — a short
+kebab-case slug for the angle that produced it (`correctness`,
+`simplification`, `efficiency`, `reuse`, `altitude`, `conventions`, or a more
+specific slug like `test-coverage` when one fits better) — plus `verdict` when
+a verify pass produced one. If more than 8 survive, keep the 8 most severe. If
+nothing survives verification, call it with an empty array. Do not also print
+the findings as text.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,173 @@
+name: Code Review
+
+# Reviews a pull request, triggered automatically when a PR is opened 
+# (eligibility rules on the job condition) or by a "/code-review" PR comment.
+# A prepare step pre-computes the review input (diff, metadata, merge-base
+# checkout), the claude-code-action runs the review and reports findings via
+# the ReportFindings tool, and a posting step posts them as one review.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened]
+    branches: [main]
+
+# One review per PR at a time; a re-trigger queues instead of aborting a run
+# that may be mid-posting.
+concurrency:
+  group: code-review-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+
+jobs:
+  review:
+    # Comment trigger: collaborators only. Auto trigger on opened PRs skips
+    # drafts, chore PRs, known bots, and non-collaborators (also keeps fork
+    # PRs out, which would fail on missing secrets anyway).
+    if: |
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.body == '/code-review' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft == false &&
+       !contains(fromJSON('["dependabot[bot]", "vaadin-bot"]'), github.event.pull_request.user.login) &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+       !startsWith(github.event.pull_request.title, 'chore:') &&
+       !startsWith(github.event.pull_request.title, 'chore('))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: React to trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            target="issues/comments/${{ github.event.comment.id }}"
+          else
+            target="issues/$PR_NUMBER"
+          fi
+          gh api "repos/${{ github.repository }}/$target/reactions" \
+            -f content=eyes
+
+      - name: Checkout repository
+        # Default branch first, so the trusted infra staged below never comes
+        # from the PR branch. This matters twice here: PR branches must not be
+        # able to modify the review prompt or scripts, and the synthetic
+        # reproduction PRs used for testing have base branches that reconstruct
+        # old repo states without this infra at all.
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Stage action infra
+        run: |
+          cp .github/claude/review-prompt.md "${{ runner.temp }}/review-prompt.md"
+          cp .github/claude/prepare-review.js "${{ runner.temp }}/prepare-review.js"
+          cp .github/claude/post-review.js "${{ runner.temp }}/post-review.js"
+          cp .github/claude/summary.js "${{ runner.temp }}/summary.js"
+
+      - name: Checkout PR branch
+        # The review investigates related code in the PR head tree.
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          fetch-depth: 1
+
+      - name: Prepare review scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node "${{ runner.temp }}/prepare-review.js" "$PR_NUMBER"
+
+      - name: Clone upstream references (read-only context)
+        run: |
+          git clone --depth 1 https://github.com/vaadin/flow.git \
+            "${{ runner.temp }}/reference/flow"
+          git clone --depth 1 https://github.com/vaadin/web-components.git \
+            "${{ runner.temp }}/reference/web-components"
+
+      - name: Build review prompt
+        id: build-prompt
+        run: |
+          {
+            echo 'prompt<<PROMPT_EOF'
+            sed "s|{{OVERVIEW_PATH}}|${{ runner.temp }}/pr-review/overview.md|" \
+              "${{ runner.temp }}/review-prompt.md"
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code review
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS forces synchronous subagent
+        # dispatch. Without it the Agent tool may launch subagents in the
+        # background (nondeterministic, feature-flag driven); the headless
+        # session then ends while they are still running and the review is
+        # silently lost — job green, no findings reported. The CLI (2.1.198)
+        # checks this variable directly in the dispatch decision, so with it
+        # set every subagent runs inline; batched Agent calls still run in
+        # parallel. A step-level env reaches the CLI because the base action
+        # spawns it with a copy of its own process env.
+        env:
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Extra working directories go through settings instead of --add-dir:
+          # the action's claude_args parser takes only a single value per
+          # --add-dir flag and overwrites repeated flags, silently dropping all
+          # but one directory (see base-action/src/parse-sdk-options.ts).
+          settings: |
+            {
+              "permissions": {
+                "additionalDirectories": [
+                  "${{ runner.temp }}/pr-review",
+                  "${{ runner.temp }}/reference/flow",
+                  "${{ runner.temp }}/reference/web-components",
+                  "/tmp"
+                ]
+              }
+            }
+          prompt: ${{ steps.build-prompt.outputs.prompt }}
+          claude_args: |
+            --allowedTools "Agent,Task,ReportFindings,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(head:*),Bash(tail:*),Bash(wc:*)"
+
+      - name: Post review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: node "${{ runner.temp }}/post-review.js" "$PR_NUMBER"
+
+      - name: Summarize Claude session
+        if: always() && steps.claude.outputs.execution_file != ''
+        run: node "${{ runner.temp }}/summary.js" "${{ steps.claude.outputs.execution_file }}"
+
+      - name: Extract findings
+        if: always() && steps.claude.outputs.execution_file != ''
+        run: |
+          jq -e '[.[] | select(.type == "assistant") | .message.content[]?
+                  | select(.type == "tool_use" and .name == "ReportFindings") | .input] | last' \
+            "${{ steps.claude.outputs.execution_file }}" > "${{ runner.temp }}/findings.json" \
+            || rm -f "${{ runner.temp }}/findings.json"
+
+      - name: Upload findings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-review-findings-pr${{ env.PR_NUMBER }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/findings.json
+          if-no-files-found: ignore
+
+      - name: Upload Claude execution log
+        if: always() && vars.CLAUDE_DEBUG == 'true' && steps.claude.outputs.execution_file != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-review-execution-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.claude.outputs.execution_file }}
+          retention-days: 7

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: React to trigger
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
         run: |
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             target="issues/comments/${{ github.event.comment.id }}"
@@ -65,6 +65,7 @@ jobs:
         # old repo states without this infra at all.
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Stage action infra
@@ -73,6 +74,11 @@ jobs:
           cp .github/claude/prepare-review.js "${{ runner.temp }}/prepare-review.js"
           cp .github/claude/post-review.js "${{ runner.temp }}/post-review.js"
           cp .github/claude/summary.js "${{ runner.temp }}/summary.js"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
 
       - name: Checkout PR branch
         # The review investigates related code in the PR head tree.
@@ -105,7 +111,7 @@ jobs:
 
       - name: Run Claude Code review
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@37b464ce72700f7b2c5ff8d2db7fa7b15df792f5 # v1.0.169
         # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS forces synchronous subagent
         # dispatch. Without it the Agent tool may launch subagents in the
         # background (nondeterministic, feature-flag driven); the headless
@@ -140,7 +146,7 @@ jobs:
 
       - name: Post review
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: node "${{ runner.temp }}/post-review.js" "$PR_NUMBER"
 


### PR DESCRIPTION
Adds a GitHub workflow for doing code review using Claude Code:

- Triggered either when a pull request is opened or a maintainer comments with `/code-review`
- Prepares code review inputs deterministically via script (PR metadata, changes files, diff)
- Runs Claude Code with a customized version of the `/code-review` skill prompt
- Posts results deterministically via script (one comment per finding, summary with overview)
- Reviews are posted as `vaadin-review-bot`, using `claude` is not possible as the GH token for that user is only available in the Claude action

Example PR using this setup: https://github.com/sissbruecker/flow-components/pull/31