### PR TITLE
fix: ignore sortersChanged for non-existent columns

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4028,8 +4028,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             JsonNode sorter = sorters.get(i);
             Column<T> column = idToColumnMap.get(sorter.get("path").asString());
             if (column == null) {
-                throw new IllegalArgumentException(
-                        "Received a sorters changed call from the client for a non-existent column");
+                // The column may have been removed on the server between the
+                // client emitting the event and the server handling it. Skip
+                // the stale sorter instead of failing the whole call.
+                continue;
             }
             if (sorter.has("direction") && sorter.get("direction")
                     .getNodeType() == JsonNodeType.STRING) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4030,7 +4030,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             if (column == null) {
                 // The column may have been removed on the server between the
                 // client emitting the event and the server handling it. Skip
-                // the stale sorter instead of failing the whole call.
+                // the stale sorter.
                 continue;
             }
             if (sorter.has("direction") && sorter.get("direction")

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSortingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSortingTest.java
@@ -248,6 +248,32 @@ class GridSortingTest {
     }
 
     @Test
+    void sortersChanged_forRemovedColumn_sorterIgnored() {
+        // A sortersChanged call can reference a column that was removed on the
+        // server between the client emitting the event and the server handling
+        // it. Such stale sorters should be ignored, not throw.
+        ArrayNode sortersArray = JacksonUtils.createArrayNode();
+        sortersArray.add(createSortObject(getColumnId(nameColumn), "asc"));
+        sortersArray.add(createSortObject("non-existent-column", "desc"));
+        callSortersChanged(sortersArray);
+
+        assertSortOrdersEquals(GridSortOrder.asc(nameColumn).build(),
+                testSortListener.events.get(0).getSortOrder());
+    }
+
+    @Test
+    void sortersChanged_onlyRemovedColumn_sortCleared() {
+        setTestSorting();
+
+        ArrayNode sortersArray = JacksonUtils.createArrayNode();
+        sortersArray.add(createSortObject("non-existent-column", "asc"));
+        callSortersChanged(sortersArray);
+
+        assertSortOrdersEquals(List.of(),
+                testSortListener.events.get(1).getSortOrder());
+    }
+
+    @Test
     void template_renderer_non_comparable_property() {
         Column<Person> column = grid.addColumn(LitRenderer.<Person> of("")
                 .withProperty("address", Person::getAddress))


### PR DESCRIPTION
Following up on the AI reproduction, `Grid.sortersChanged` no longer throws when a sorter references a column that was removed on the server between the client emitting the event and the server handling it. The stale sorter is now skipped and any remaining valid sorters are still applied.

Fixes #1201

---
🤖 Generated with [Claude Code](https://claude.ai/code)