### PR TITLE
feat: add experimental Switch component

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/SwitchView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/SwitchView.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Test view for {@link Switch}.
+ */
+@Route("vaadin-switch")
+public class SwitchView extends Div {
+
+    /**
+     * Creates a new instance.
+     */
+    public SwitchView() {
+        Span value = new Span("false");
+        value.setId("value");
+
+        Switch field = new Switch("Notifications");
+        field.setId("default-switch");
+        field.addValueChangeListener(
+                event -> value.setText(String.valueOf(event.getValue())));
+
+        add(field, value);
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/resources/vaadin-featureflags.properties
@@ -1,0 +1,1 @@
+com.vaadin.experimental.switchComponent=true

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.checkbox.testbench.SwitchElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-switch")
+public class SwitchIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void clickSwitch_togglesCheckedAndUpdatesValue() {
+        SwitchElement field = $(SwitchElement.class).id("default-switch");
+        Assert.assertFalse(field.isChecked());
+
+        field.click();
+
+        Assert.assertTrue(field.isChecked());
+        Assert.assertEquals("true", findElement(By.id("value")).getText());
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/ExperimentalFeatureException.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/ExperimentalFeatureException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox;
+
+/**
+ * An exception which is thrown when somebody attempts to use the {@link Switch}
+ * component without activating the associated feature flag first.
+ *
+ * @author Vaadin Ltd
+ * @since 25.3
+ */
+public class ExperimentalFeatureException extends RuntimeException {
+    /**
+     * Creates a new exception with a default message.
+     */
+    public ExperimentalFeatureException() {
+        super("""
+                The Switch component is currently an experimental feature \
+                and needs to be explicitly enabled. The component can be \
+                enabled using Copilot, in the experimental features tab, \
+                or by adding a \
+                `src/main/resources/vaadin-featureflags.properties` file \
+                with the following content: \
+                `com.vaadin.experimental.switchComponent=true`""");
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.AbstractSinglePropertyField;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.flow.component.shared.HasValidationProperties;
+import com.vaadin.flow.component.shared.InputField;
+import com.vaadin.flow.component.shared.ValidationUtil;
+import com.vaadin.flow.component.shared.internal.ValidationController;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.HasValidator;
+import com.vaadin.flow.data.binder.Validator;
+import com.vaadin.flow.dom.PropertyChangeListener;
+
+/**
+ * Switch is an input field representing a binary on/off choice.
+ * <p>
+ * This component is experimental and needs to be enabled with the
+ * {@code com.vaadin.experimental.switchComponent} feature flag.
+ * <p>
+ * Switch is functionally equivalent to {@link Checkbox}, but it is presented as
+ * an on/off toggle and is intended for a single setting that takes effect
+ * immediately. Unlike Checkbox, Switch has no indeterminate state.
+ * <h2>Validation</h2>
+ * <p>
+ * Switch comes with a built-in validation mechanism that verifies that the
+ * field is selected when {@link #setRequiredIndicatorVisible(boolean) required}
+ * is enabled.
+ * <p>
+ * Validation is triggered whenever the user toggles the switch. Programmatic
+ * toggling triggers validation as well. If validation fails, the component is
+ * marked as invalid and an error message is displayed below the input.
+ * <p>
+ * The required error message can be configured using either
+ * {@link SwitchI18n#setRequiredErrorMessage(String)} or
+ * {@link #setErrorMessage(String)}.
+ * <p>
+ * For more advanced validation that requires custom rules, you can use
+ * {@link Binder}. Please note that Binder provides its own API for the required
+ * validation, see {@link Binder.BindingBuilder#asRequired(String)
+ * asRequired()}.
+ * <p>
+ * However, if Binder doesn't fit your needs and you want to implement fully
+ * custom validation logic, you can disable the built-in validation by setting
+ * {@link #setManualValidation(boolean)} to true. This will allow you to control
+ * the invalid state and the error message manually using
+ * {@link #setInvalid(boolean)} and {@link #setErrorMessage(String)} API.
+ *
+ * @author Vaadin Ltd
+ * @since 25.3
+ */
+@Tag("vaadin-switch")
+@NpmPackage(value = "@vaadin/switch", version = "25.3.0-alpha4")
+@JsModule("@vaadin/switch/src/vaadin-switch.js")
+public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
+        implements ClickNotifier<Switch>, Focusable<Switch>, HasAriaLabel,
+        HasValidationProperties, HasValidator<Boolean>,
+        InputField<AbstractField.ComponentValueChangeEvent<Switch, Boolean>, Boolean>,
+        HasThemeVariant<SwitchVariant> {
+
+    private final NativeLabel labelElement;
+
+    private static final PropertyChangeListener NO_OP = event -> {
+    };
+
+    private SwitchI18n i18n;
+
+    private Validator<Boolean> defaultValidator = (value, context) -> {
+        boolean fromComponent = context == null;
+
+        // Do the required check only if the validator is called from the
+        // component, and not from Binder. Binder has its own implementation
+        // of required validation.
+        boolean isRequired = fromComponent && isRequiredIndicatorVisible();
+        return ValidationUtil.validateRequiredConstraint(
+                getI18nErrorMessage(SwitchI18n::getRequiredErrorMessage),
+                isRequired, getValue(), getEmptyValue());
+    };
+
+    private ValidationController<Switch, Boolean> validationController = new ValidationController<>(
+            this);
+
+    /**
+     * Default constructor.
+     */
+    public Switch() {
+        super("checked", false, false);
+        getElement().setProperty("manualValidation", true);
+        getElement().addPropertyChangeListener("checked", "checked-changed",
+                NO_OP);
+        // Initialize property value unless it has already been set from a
+        // template
+        if (getElement().getProperty("checked") == null) {
+            setPresentationValue(false);
+        }
+
+        // Initialize custom label
+        labelElement = new NativeLabel();
+        labelElement.getElement().setAttribute("slot", "label");
+
+        addValueChangeListener(e -> validate());
+    }
+
+    /**
+     * Constructs a switch with the initial label text.
+     *
+     * @param labelText
+     *            the label text to set
+     * @see #setLabel(String)
+     */
+    public Switch(String labelText) {
+        this();
+        setLabel(labelText);
+    }
+
+    /**
+     * Constructs a switch with the initial value.
+     *
+     * @param initialValue
+     *            the initial value
+     * @see AbstractField#setValue(Object)
+     */
+    public Switch(boolean initialValue) {
+        this();
+        setValue(initialValue);
+    }
+
+    /**
+     * Constructs a switch with the initial label text and value.
+     *
+     * @param labelText
+     *            the label text to set
+     * @param initialValue
+     *            the initial value
+     * @see #setLabel(String)
+     * @see AbstractField#setValue(Object)
+     */
+    public Switch(String labelText, boolean initialValue) {
+        this(labelText);
+        setValue(initialValue);
+    }
+
+    /**
+     * Constructs a switch with the initial label text and value change
+     * listener.
+     *
+     * @param label
+     *            the label text to set
+     * @param listener
+     *            the value change listener to add
+     * @see #setLabel(String)
+     * @see #addValueChangeListener(ValueChangeListener)
+     */
+    public Switch(String label,
+            ValueChangeListener<ComponentValueChangeEvent<Switch, Boolean>> listener) {
+        this(label);
+        addValueChangeListener(listener);
+    }
+
+    /**
+     * Constructs a switch with the initial value and value change listener.
+     *
+     * @param initialValue
+     *            the initial value
+     * @param listener
+     *            the value change listener to add
+     * @see AbstractField#setValue(Object)
+     * @see #addValueChangeListener(ValueChangeListener)
+     */
+    public Switch(boolean initialValue,
+            ValueChangeListener<ComponentValueChangeEvent<Switch, Boolean>> listener) {
+        this(initialValue);
+        addValueChangeListener(listener);
+    }
+
+    /**
+     * Constructs a switch with the initial value, label text and value change
+     * listener.
+     *
+     * @param labelText
+     *            the label text to set
+     * @param initialValue
+     *            the initial value
+     * @param listener
+     *            the value change listener to add
+     * @see #setLabel(String)
+     * @see AbstractField#setValue(Object)
+     * @see #addValueChangeListener(ValueChangeListener)
+     */
+    public Switch(String labelText, boolean initialValue,
+            ValueChangeListener<ComponentValueChangeEvent<Switch, Boolean>> listener) {
+        this(labelText, initialValue);
+        addValueChangeListener(listener);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        checkFeatureFlag(attachEvent.getUI());
+    }
+
+    private void checkFeatureFlag(UI ui) {
+        FeatureFlags featureFlags = FeatureFlags
+                .get(ui.getSession().getService().getContext());
+        if (!featureFlags
+                .isEnabled(SwitchFeatureFlagProvider.SWITCH_COMPONENT)) {
+            throw new ExperimentalFeatureException();
+        }
+    }
+
+    /**
+     * Sets whether the user is required to switch on the control. When
+     * required, an indicator appears next to the label and the field
+     * invalidates if the switch is first turned on and then turned off.
+     * <p>
+     * NOTE: The required indicator is only visible when the field has a label,
+     * see {@link #setLabel(String)}.
+     *
+     * @param required
+     *            {@code true} to make the field required, {@code false}
+     *            otherwise
+     * @see SwitchI18n#setRequiredErrorMessage(String)
+     */
+    @Override
+    public void setRequiredIndicatorVisible(boolean required) {
+        super.setRequiredIndicatorVisible(required);
+    }
+
+    /**
+     * Gets whether the user is required to switch on the control.
+     *
+     * @return {@code true} if the field is required, {@code false} otherwise
+     * @see #setRequiredIndicatorVisible(boolean)
+     */
+    @Override
+    public boolean isRequiredIndicatorVisible() {
+        return super.isRequiredIndicatorVisible();
+    }
+
+    /**
+     * Get the current label text.
+     *
+     * @return the current label text
+     */
+    @Override
+    public String getLabel() {
+        return getElement().getProperty("label");
+    }
+
+    /**
+     * Set the current label text of this switch.
+     *
+     * @param label
+     *            the label text to set
+     */
+    @Override
+    public void setLabel(String label) {
+        if (getElement().equals(labelElement.getElement().getParent())) {
+            getElement().removeChild(labelElement.getElement());
+        }
+        getElement().setProperty("label", label == null ? "" : label);
+    }
+
+    /**
+     * Replaces the label content with the given label component.
+     *
+     * @param component
+     *            the component to be added to the label.
+     */
+    public void setLabelComponent(Component component) {
+        setLabel("");
+        getElement().appendChild(labelElement.getElement());
+        labelElement.removeAll();
+        labelElement.add(component);
+    }
+
+    @Override
+    public void setAriaLabel(String ariaLabel) {
+        getElement().setProperty("accessibleName", ariaLabel);
+    }
+
+    @Override
+    public Optional<String> getAriaLabel() {
+        return Optional.ofNullable(getElement().getProperty("accessibleName"));
+    }
+
+    @Override
+    public void setAriaLabelledBy(String ariaLabelledBy) {
+        getElement().setProperty("accessibleNameRef", ariaLabelledBy);
+    }
+
+    @Override
+    public Optional<String> getAriaLabelledBy() {
+        return Optional
+                .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * Set the switch to be input focused when the page loads.
+     *
+     * @param autofocus
+     *            the boolean value to set
+     */
+    public void setAutofocus(boolean autofocus) {
+        getElement().setProperty("autofocus", autofocus);
+    }
+
+    /**
+     * Get the state for the auto-focus property of the switch.
+     * <p>
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     *
+     * @return the {@code autofocus} property from the switch
+     */
+    public boolean isAutofocus() {
+        return getElement().getProperty("autofocus", false);
+    }
+
+    @Override
+    public void setManualValidation(boolean enabled) {
+        validationController.setManualValidation(enabled);
+    }
+
+    @Override
+    public Validator<Boolean> getDefaultValidator() {
+        return defaultValidator;
+    }
+
+    /**
+     * Validates the current value against the constraints and sets the
+     * {@code invalid} property and the {@code errorMessage} property based on
+     * the result. If a custom error message is provided with
+     * {@link #setErrorMessage(String)}, it is used. Otherwise, the error
+     * message defined in the i18n object is used.
+     * <p>
+     * The method does nothing if the manual validation mode is enabled.
+     */
+    protected void validate() {
+        validationController.validate(getValue());
+    }
+
+    /**
+     * Gets the internationalization object previously set for this component.
+     * <p>
+     * NOTE: Updating the instance that is returned from this method will not
+     * update the component if not set again using {@link #setI18n(SwitchI18n)}
+     *
+     * @return the i18n object or {@code null} if no i18n object has been set
+     */
+    public SwitchI18n getI18n() {
+        return i18n;
+    }
+
+    /**
+     * Sets the internationalization object for this component.
+     *
+     * @param i18n
+     *            the i18n object, not {@code null}
+     */
+    public void setI18n(SwitchI18n i18n) {
+        this.i18n = Objects.requireNonNull(i18n,
+                "The i18n properties object should not be null");
+    }
+
+    private String getI18nErrorMessage(Function<SwitchI18n, String> getter) {
+        return Optional.ofNullable(i18n).map(getter).orElse("");
+    }
+
+    /**
+     * The internationalization properties for {@link Switch}.
+     */
+    public static class SwitchI18n implements Serializable {
+
+        private String requiredErrorMessage;
+
+        /**
+         * Gets the error message displayed when the field is required but
+         * empty.
+         *
+         * @return the error message or {@code null} if not set
+         * @see Switch#isRequiredIndicatorVisible()
+         * @see Switch#setRequiredIndicatorVisible(boolean)
+         */
+        public String getRequiredErrorMessage() {
+            return requiredErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the field is required but
+         * empty.
+         * <p>
+         * Note, custom error messages set with
+         * {@link Switch#setErrorMessage(String)} take priority over i18n error
+         * messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see Switch#isRequiredIndicatorVisible()
+         * @see Switch#setRequiredIndicatorVisible(boolean)
+         */
+        public SwitchI18n setRequiredErrorMessage(String errorMessage) {
+            requiredErrorMessage = errorMessage;
+            return this;
+        }
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
@@ -332,9 +332,6 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
 
     /**
      * Get the state for the auto-focus property of the switch.
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
      *
      * @return the {@code autofocus} property from the switch
      */
@@ -400,8 +397,8 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
         private String requiredErrorMessage;
 
         /**
-         * Gets the error message displayed when the field is required but
-         * empty.
+         * Gets the error message displayed when the field is required but not
+         * checked.
          *
          * @return the error message or {@code null} if not set
          * @see Switch#isRequiredIndicatorVisible()
@@ -412,8 +409,8 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
         }
 
         /**
-         * Sets the error message to display when the field is required but
-         * empty.
+         * Sets the error message to display when the field is required but not
+         * checked.
          * <p>
          * Note, custom error messages set with
          * {@link Switch#setErrorMessage(String)} take priority over i18n error

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
@@ -41,7 +41,6 @@ import com.vaadin.flow.component.shared.internal.ValidationController;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.HasValidator;
 import com.vaadin.flow.data.binder.Validator;
-import com.vaadin.flow.dom.PropertyChangeListener;
 
 /**
  * Switch is an input field representing a binary on/off choice.
@@ -91,9 +90,6 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
 
     private final NativeLabel labelElement;
 
-    private static final PropertyChangeListener NO_OP = event -> {
-    };
-
     private SwitchI18n i18n;
 
     private Validator<Boolean> defaultValidator = (value, context) -> {
@@ -117,8 +113,6 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
     public Switch() {
         super("checked", false, false);
         getElement().setProperty("manualValidation", true);
-        getElement().addPropertyChangeListener("checked", "checked-changed",
-                NO_OP);
         // Initialize property value unless it has already been set from a
         // template
         if (getElement().getProperty("checked") == null) {
@@ -235,7 +229,7 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
                 .get(ui.getSession().getService().getContext());
         if (!featureFlags
                 .isEnabled(SwitchFeatureFlagProvider.SWITCH_COMPONENT)) {
-            throw new ExperimentalFeatureException();
+            throw new SwitchExperimentalFeatureException();
         }
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/SwitchExperimentalFeatureException.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/SwitchExperimentalFeatureException.java
@@ -22,11 +22,11 @@ package com.vaadin.flow.component.checkbox;
  * @author Vaadin Ltd
  * @since 25.3
  */
-public class ExperimentalFeatureException extends RuntimeException {
+public class SwitchExperimentalFeatureException extends RuntimeException {
     /**
      * Creates a new exception with a default message.
      */
-    public ExperimentalFeatureException() {
+    public SwitchExperimentalFeatureException() {
         super("""
                 The Switch component is currently an experimental feature \
                 and needs to be explicitly enabled. The component can be \

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/SwitchFeatureFlagProvider.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/SwitchFeatureFlagProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox;
+
+import java.util.List;
+
+import com.vaadin.experimental.Feature;
+import com.vaadin.experimental.FeatureFlagProvider;
+
+/**
+ * Provides the Switch component feature flag, gating the experimental
+ * {@link Switch} component.
+ *
+ * @author Vaadin Ltd
+ * @since 25.3
+ */
+public class SwitchFeatureFlagProvider implements FeatureFlagProvider {
+
+    /**
+     * The Switch component feature flag. When enabled, allows use of the
+     * experimental {@link Switch} component.
+     */
+    public static final Feature SWITCH_COMPONENT = new Feature(
+            "Switch component", // title
+            "switchComponent", // id
+            "https://vaadin.com/docs/latest/components/switch", // moreInfoLink
+            true, // requiresServerRestart
+            "com.vaadin.flow.component.checkbox.Switch"); // componentClassName
+
+    @Override
+    public List<Feature> getFeatures() {
+        return List.of(SWITCH_COMPONENT);
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/SwitchVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/SwitchVariant.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox;
+
+import com.vaadin.flow.component.shared.ThemeVariant;
+
+/**
+ * Set of theme variants applicable for the {@code vaadin-switch} component.
+ *
+ * @since 25.3
+ */
+public enum SwitchVariant implements ThemeVariant {
+    AURA_REVERSE("reverse"), AURA_SMALL("small"), ICON("icon");
+
+    private final String variant;
+
+    SwitchVariant(String variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the variant name.
+     *
+     * @return variant name
+     */
+    public String getVariantName() {
+        return variant;
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/resources/META-INF/services/com.vaadin.experimental.FeatureFlagProvider
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/resources/META-INF/services/com.vaadin.experimental.FeatureFlagProvider
@@ -1,0 +1,1 @@
+com.vaadin.flow.component.checkbox.SwitchFeatureFlagProvider

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchFeatureFlagTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchFeatureFlagTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.checkbox.ExperimentalFeatureException;
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.checkbox.SwitchFeatureFlagProvider;
+import com.vaadin.tests.EnableFeatureFlagExtension;
+import com.vaadin.tests.MockUIExtension;
+
+class SwitchFeatureFlagTest {
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
+
+    @RegisterExtension
+    EnableFeatureFlagExtension featureFlagExtension = new EnableFeatureFlagExtension(
+            SwitchFeatureFlagProvider.SWITCH_COMPONENT);
+
+    @Test
+    void featureEnabled_attach_doesNotThrow() {
+        var field = new Switch();
+        Assertions.assertDoesNotThrow(() -> ui.add(field));
+    }
+
+    @Test
+    void featureDisabled_attach_throws() {
+        featureFlagExtension.disableFeature();
+
+        var field = new Switch();
+        Assertions.assertThrows(ExperimentalFeatureException.class,
+                () -> ui.add(field));
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchFeatureFlagTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchFeatureFlagTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.vaadin.flow.component.checkbox.ExperimentalFeatureException;
 import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.checkbox.SwitchExperimentalFeatureException;
 import com.vaadin.flow.component.checkbox.SwitchFeatureFlagProvider;
 import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
@@ -45,7 +45,7 @@ class SwitchFeatureFlagTest {
         featureFlagExtension.disableFeature();
 
         var field = new Switch();
-        Assertions.assertThrows(ExperimentalFeatureException.class,
+        Assertions.assertThrows(SwitchExperimentalFeatureException.class,
                 () -> ui.add(field));
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.shared.HasThemeVariant;
+import com.vaadin.tests.MockUIExtension;
+
+class SwitchTest {
+    @RegisterExtension
+    final MockUIExtension ui = new MockUIExtension();
+
+    @Test
+    void initialValue() {
+        Switch field = new Switch();
+        Assertions.assertFalse(field.getValue());
+
+        field = new Switch(true);
+        Assertions.assertTrue(field.getValue());
+
+        field = new Switch(false);
+        Assertions.assertFalse(field.getValue());
+    }
+
+    @Test
+    void setValue_reflectedInCheckedProperty() {
+        Switch field = new Switch();
+        Assertions
+                .assertFalse(field.getElement().getProperty("checked", false));
+
+        field.setValue(true);
+        Assertions.assertTrue(field.getElement().getProperty("checked", false));
+
+        field.setValue(false);
+        Assertions
+                .assertFalse(field.getElement().getProperty("checked", false));
+    }
+
+    @Test
+    void setLabel() {
+        Switch field = new Switch();
+        Assertions.assertNull(field.getLabel());
+
+        field.setLabel("Notifications");
+        Assertions.assertEquals("Notifications", field.getLabel());
+    }
+
+    @Test
+    void labelConstructor() {
+        Switch field = new Switch("Notifications");
+        Assertions.assertEquals("Notifications", field.getLabel());
+    }
+
+    @Test
+    void implementsHasThemeVariant() {
+        Assertions
+                .assertTrue(HasThemeVariant.class.isAssignableFrom(Switch.class));
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchTest.java
@@ -70,7 +70,7 @@ class SwitchTest {
 
     @Test
     void implementsHasThemeVariant() {
-        Assertions
-                .assertTrue(HasThemeVariant.class.isAssignableFrom(Switch.class));
+        Assertions.assertTrue(
+                HasThemeVariant.class.isAssignableFrom(Switch.class));
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/SwitchBasicValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/SwitchBasicValidationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.tests.validation.AbstractBasicValidationTest;
+
+class SwitchBasicValidationTest
+        extends AbstractBasicValidationTest<Switch, Boolean> {
+    @Test
+    void required_validate_emptyErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setValue(true);
+        testField.setValue(false);
+        Assertions.assertEquals("", testField.getErrorMessage());
+    }
+
+    @Test
+    void required_setI18nErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new Switch.SwitchI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setValue(true);
+        testField.setValue(false);
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
+    }
+
+    @Test
+    void setI18nAndCustomErrorMessage_validate_customErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new Switch.SwitchI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(true);
+        testField.setValue(false);
+        Assertions.assertEquals("Custom error message",
+                testField.getErrorMessage());
+    }
+
+    @Test
+    void setI18nAndCustomErrorMessage_validate_removeCustomErrorMessage_validate_i18nErrorMessageDisplayed() {
+        testField.setRequiredIndicatorVisible(true);
+        testField.setI18n(new Switch.SwitchI18n()
+                .setRequiredErrorMessage("Field is required"));
+        testField.setErrorMessage("Custom error message");
+        testField.setValue(true);
+        testField.setValue(false);
+        testField.setErrorMessage("");
+        testField.setValue(true);
+        testField.setValue(false);
+        Assertions.assertEquals("Field is required",
+                testField.getErrorMessage());
+    }
+
+    @Override
+    protected Switch createTestField() {
+        return new Switch();
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/SwitchBinderValidationTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/validation/SwitchBinderValidationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.BindingValidationStatus;
+import com.vaadin.flow.data.binder.BindingValidationStatusHandler;
+
+class SwitchBinderValidationTest {
+    private static final String BINDER_FAIL_MESSAGE = "BINDER_FAIL_MESSAGE";
+    private static final String BINDER_REQUIRED_MESSAGE = "REQUIRED";
+
+    private Switch field;
+
+    @Captor
+    private ArgumentCaptor<BindingValidationStatus<?>> statusCaptor;
+
+    @Mock
+    private BindingValidationStatusHandler statusHandlerMock;
+
+    public static class Bean {
+        private Boolean value;
+
+        public Boolean getValue() {
+            return value;
+        }
+
+        public void setValue(Boolean value) {
+            this.value = value;
+        }
+    }
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+        field = new Switch();
+    }
+
+    @Test
+    void elementWithBinderValidation_invalidValue_binderValidationFails() {
+        var binder = attachBinderToField();
+
+        field.setValue(true);
+        Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
+
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_FAIL_MESSAGE,
+                statusCaptor.getValue().getMessage().orElse(""));
+    }
+
+    @Test
+    void setRequiredOnBinder_validate_binderValidationFails() {
+        var binder = attachBinderToField(true);
+        binder.validate();
+
+        Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
+        Assertions.assertTrue(statusCaptor.getValue().isError());
+        Assertions.assertEquals(BINDER_REQUIRED_MESSAGE,
+                statusCaptor.getValue().getMessage().orElse(""));
+    }
+
+    @Test
+    void setRequiredOnComponent_validate_binderValidationPasses() {
+        var binder = attachBinderToField();
+        field.setRequiredIndicatorVisible(true);
+        binder.validate();
+
+        Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
+    }
+
+    @Test
+    void setRequiredOnBinder_setValidValue_binderValidationPasses() {
+        attachBinderToField(true);
+
+        field.setValue(true);
+
+        Mockito.verify(statusHandlerMock).statusChange(statusCaptor.capture());
+        Assertions.assertFalse(statusCaptor.getValue().isError());
+    }
+
+    private Binder<Bean> attachBinderToField() {
+        return attachBinderToField(false);
+    }
+
+    private Binder<Bean> attachBinderToField(boolean isRequired) {
+        var binder = new Binder<>(Bean.class);
+        var binding = binder.forField(field)
+                .withValidationStatusHandler(statusHandlerMock);
+
+        if (isRequired) {
+            binding.asRequired(BINDER_REQUIRED_MESSAGE);
+        } else {
+            // Consider un-checked as valid
+            binding.withValidator(value -> Boolean.FALSE.equals(value),
+                    BINDER_FAIL_MESSAGE);
+        }
+
+        binding.bind("value");
+
+        return binder;
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/SwitchElement.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/SwitchElement.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.testbench;
+
+import java.util.Collections;
+
+import com.vaadin.testbench.HasHelper;
+import com.vaadin.testbench.HasLabel;
+import com.vaadin.testbench.HasValidation;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;vaadin-switch&gt;</code>
+ * element.
+ */
+@Element("vaadin-switch")
+public class SwitchElement extends TestBenchElement
+        implements HasLabel, HasHelper, HasValidation {
+    /**
+     * Checks whether the switch is checked (on).
+     *
+     * @return <code>true</code> if the switch is on, <code>false</code> if it
+     *         is off
+     */
+    public boolean isChecked() {
+        return getPropertyBoolean("checked");
+    }
+
+    /**
+     * Sets whether the switch is checked (on).
+     *
+     * @param checked
+     *            <code>true</code> to turn the switch on, <code>false</code> to
+     *            turn it off
+     */
+    public void setChecked(boolean checked) {
+        setProperty("checked", checked);
+        dispatchEvent("change", Collections.singletonMap("bubbles", true));
+    }
+
+    @Override
+    public String getLabel() {
+        return $("label").first().getPropertyString("textContent");
+    }
+}


### PR DESCRIPTION
Add a Flow `Switch` component wrapping the `@vaadin/switch` web component. Switch is a binary on/off toggle for a single setting that takes effect immediately. It is functionally equivalent to `Checkbox` but presented as a toggle, so it lives in the checkbox module and reuses the same API shape.

The web component is experimental, so the Flow component is gated behind the `com.vaadin.experimental.switchComponent` feature flag. Using `Switch` without enabling the flag throws an `ExperimentalFeatureException` on attach. The same feature-flag properties file enables both the server-side component and the client-side element.

## Changes

- `Switch` — mirrors the `Checkbox` API (value, label, aria, autofocus, validation, i18n), minus the indeterminate state which a switch does not have. Read-only is inherited from the Flow field hierarchy.
- `SwitchVariant` — `AURA_REVERSE`, `AURA_SMALL` (Aura only), and `ICON` (both themes).
- `SwitchFeatureFlagProvider` + `ExperimentalFeatureException` + SPI registration, following the Breadcrumbs pattern.
- `SwitchElement` TestBench API and a `SwitchIT` smoke test (renders and toggles) with the feature flag enabled.
- Unit tests, including basic and Binder validation coverage.

Part of the Switch component effort (web component: `vaadin/web-components` `packages/switch`).

---

🤖 Generated with Claude Code