### PR TITLE
fix: reset grid column width when setWidth(null) is called

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -625,12 +625,16 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
          * @see #setFlexGrow(int)
          *
          * @param width
-         *            the width to set this column to, as a CSS-string, not
-         *            {@code null}
+         *            the width to set this column to, as a CSS-string, or
+         *            {@code null} to reset the width to the default
          * @return this column, for method chaining
          */
         public Column<T> setWidth(String width) {
-            getElement().setProperty("width", width);
+            if (width != null) {
+                getElement().setProperty("width", width);
+            } else {
+                getElement().removeProperty("width");
+            }
             return this;
         }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -150,6 +150,23 @@ class GridColumnTest {
     }
 
     @Test
+    void setWidth_getWidth() {
+        firstColumn.setWidth("100px");
+        Assertions.assertEquals("100px", firstColumn.getWidth());
+        Assertions.assertTrue(
+                firstColumn.getElement().hasProperty("width"));
+    }
+
+    @Test
+    void setWidthNull_widthPropertyRemoved() {
+        firstColumn.setWidth("100px");
+        firstColumn.setWidth(null);
+        Assertions.assertNull(firstColumn.getWidth());
+        Assertions.assertFalse(
+                firstColumn.getElement().hasProperty("width"));
+    }
+
+    @Test
     void addColumn_defaultComparator() {
         Grid<Person> grid = new Grid<>();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -153,8 +153,7 @@ class GridColumnTest {
     void setWidth_getWidth() {
         firstColumn.setWidth("100px");
         Assertions.assertEquals("100px", firstColumn.getWidth());
-        Assertions.assertTrue(
-                firstColumn.getElement().hasProperty("width"));
+        Assertions.assertTrue(firstColumn.getElement().hasProperty("width"));
     }
 
     @Test
@@ -162,8 +161,7 @@ class GridColumnTest {
         firstColumn.setWidth("100px");
         firstColumn.setWidth(null);
         Assertions.assertNull(firstColumn.getWidth());
-        Assertions.assertFalse(
-                firstColumn.getElement().hasProperty("width"));
+        Assertions.assertFalse(firstColumn.getElement().hasProperty("width"));
     }
 
     @Test


### PR DESCRIPTION
Calling `Column.setWidth(null)` set the web component's `width` property to `null` instead of removing it, causing the column to render with a very large width rather than its default. Now a `null` width removes the property.

Fixes #6811

---

🤖 Generated with [Claude Code](https://claude.ai/code)