### PR TITLE
chore: add instructions to run spotless before committing

### DIFF
--- a/.claude/rules/commits-and-prs.md
+++ b/.claude/rules/commits-and-prs.md
@@ -1,5 +1,7 @@
 # Git commits
 
+Always run the spotless formatter before committing.
+
 Write commit messages terse and exact, no fluff.
 
 ## Subject line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ node scripts/wtr.js {component} --files {file-or-glob}
 ### Code Quality
 
 ```sh
-# Format code
+# Format code, must be run before every commit
 mvn spotless:apply
 
 # Run checkstyle validation


### PR DESCRIPTION
Adds instructions to run the formatter before committing. Let's try this non-deterministic approach first, and consider adding a git commit hook as a follow up.