### PR TITLE
refactor: use header and footer slots in Dialog

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogHeaderFooterIT.java
@@ -240,8 +240,59 @@ public class DialogHeaderFooterIT extends AbstractDialogIT {
         assertDialogNotContains(DialogHeaderFooterPage.ANOTHER_FOOTER_CONTENT);
     }
 
+    @Test
+    public void openedDialogWithHeaderContent_hasHeaderAttributeSet() {
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        verifyOpened();
+
+        assertStateAttribute("has-header", true);
+    }
+
+    @Test
+    public void openedDialogWithHeaderContents_removeAll_hasHeaderAttributeRemoved() {
+        clickButton(ADD_HEADER_CONTENT_BUTTON);
+        clickButton(ADD_SECOND_HEADER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        verifyOpened();
+        assertStateAttribute("has-header", true);
+
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(REMOVE_ALL_HEADER_CONTENTS_BUTTON);
+
+        assertStateAttribute("has-header", false);
+    }
+
+    @Test
+    public void openedDialogWithFooterContent_hasFooterAttributeSet() {
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        verifyOpened();
+
+        assertStateAttribute("has-footer", true);
+    }
+
+    @Test
+    public void openedDialogWithFooterContents_removeAll_hasFooterAttributeRemoved() {
+        clickButton(ADD_FOOTER_CONTENT_BUTTON);
+        clickButton(ADD_SECOND_FOOTER_CONTENT_BUTTON);
+        clickButton(OPEN_DIALOG_BUTTON);
+        verifyOpened();
+        assertStateAttribute("has-footer", true);
+
+        clickButton(MOVE_BUTTONS_BUTTON);
+        clickButton(REMOVE_ALL_FOOTER_CONTENTS_BUTTON);
+
+        assertStateAttribute("has-footer", false);
+    }
+
     private void clickButton(String id) {
         findElement(By.id(id)).click();
+    }
+
+    private void assertStateAttribute(String attribute, boolean present) {
+        waitUntil(driver -> (getDialog()
+                .getDomAttribute(attribute) != null) == present);
     }
 
     private void assertDialogContains(String text) {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogRemoveAllIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogRemoveAllIT.java
@@ -53,10 +53,16 @@ public class DialogRemoveAllIT extends AbstractComponentIT {
     public void removeAll_preservesHeaderAndFooterContent() {
         Assert.assertTrue(dialog.$("span").withText("Header content").exists());
         Assert.assertTrue(dialog.$("span").withText("Footer content").exists());
+        // The content is slotted, which the web component reflects as state
+        // attributes on the dialog element
+        Assert.assertNotNull(dialog.getDomAttribute("has-header"));
+        Assert.assertNotNull(dialog.getDomAttribute("has-footer"));
 
         dialog.$("button").id("replace-content").click();
 
         Assert.assertTrue(dialog.$("span").withText("Header content").exists());
         Assert.assertTrue(dialog.$("span").withText("Footer content").exists());
+        Assert.assertNotNull(dialog.getDomAttribute("has-header"));
+        Assert.assertNotNull(dialog.getDomAttribute("has-footer"));
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClientCallable;
@@ -594,9 +595,60 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     @Override
     public void addComponentAtIndex(int index, Component component) {
-        HasComponents.super.addComponentAtIndex(index, component);
+        Objects.requireNonNull(component, "Component should not be null");
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Cannot add a component with a negative index");
+        }
+        // The header/footer wrappers are also element children, so the content
+        // index must be translated to the matching element index that skips
+        // them. Otherwise a wrapper preceding the position would offset it.
+        HasComponents.super.addComponentAtIndex(toElementIndex(index),
+                component);
 
         updateVirtualChildNodeIds();
+    }
+
+    /**
+     * Translates an index into the main content (as seen by
+     * {@link #getChildren()}) to the corresponding index into the dialog
+     * element's children, which also include the slotted header/footer
+     * wrappers.
+     */
+    private int toElementIndex(int contentIndex) {
+        List<Element> children = getElement().getChildren()
+                .collect(Collectors.toList());
+        int contentSeen = 0;
+        for (int elementIndex = 0; elementIndex < children
+                .size(); elementIndex++) {
+            if (contentSeen == contentIndex) {
+                return elementIndex;
+            }
+            if (isContentChild(children.get(elementIndex))) {
+                contentSeen++;
+            }
+        }
+        if (contentSeen < contentIndex) {
+            throw new IllegalArgumentException(String.format(
+                    "Cannot add a component at index %d, there are only %d content components",
+                    contentIndex, contentSeen));
+        }
+        return children.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Only the main content components are returned. Components added to the
+     * header or footer via {@link #getHeader()} / {@link #getFooter()} live in
+     * separate slotted wrapper elements and are excluded.
+     */
+    @Override
+    public Stream<Component> getChildren() {
+        return super.getChildren().filter(child -> {
+            Element parent = child.getElement().getParent();
+            return parent == null || isContentChild(parent);
+        });
     }
 
     @Override
@@ -605,6 +657,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
         // innerHTML of the dialog element. This results in removing the content
         // elements created by the web component for slotting contents into its
         // overlay. To avoid this, we manually remove all children instead.
+        // getChildren() excludes header/footer content, so those are preserved.
         getChildren().forEach(this::remove);
     }
 
@@ -932,7 +985,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     final public static class DialogHeader extends DialogHeaderFooter {
         private DialogHeader(Dialog dialog) {
-            super("headerRenderer", dialog);
+            super("header-content", dialog);
         }
     }
 
@@ -943,132 +996,92 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     final public static class DialogFooter extends DialogHeaderFooter {
         private DialogFooter(Dialog dialog) {
-            super("footerRenderer", dialog);
+            super("footer", dialog);
         }
     }
 
     /**
      * This class defines the common behavior for adding/removing components to
-     * the header and footer parts. It also creates the root element where the
-     * components will be attached to as well as the renderer function used by
-     * the dialog.
+     * the header and footer parts. Components are added to a root wrapper
+     * element that is slotted into the dialog's {@code header-content} /
+     * {@code footer} slot.
      */
     abstract static class DialogHeaderFooter implements HasComponents {
         protected final Element root;
-        private final String rendererFunction;
         private final Component dialog;
-        boolean rendererCreated = false;
 
-        protected DialogHeaderFooter(String rendererFunction,
-                Component dialog) {
-            this.rendererFunction = rendererFunction;
+        protected DialogHeaderFooter(String slotName, Component dialog) {
             this.dialog = dialog;
             root = new Element("div");
+            root.setAttribute("slot", slotName);
             root.getStyle().set("display", "contents");
         }
 
         @Override
         public void add(Component... components) {
             HasComponents.super.add(components);
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void add(Collection<Component> components) {
             HasComponents.super.add(components);
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void add(String text) {
             HasComponents.super.add(text);
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void remove(Component... components) {
             HasComponents.super.remove(components);
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void remove(Collection<Component> components) {
             HasComponents.super.remove(components);
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void removeAll() {
             HasComponents.super.removeAll();
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void addComponentAtIndex(int index, Component component) {
             HasComponents.super.addComponentAtIndex(index, component);
-            updateRendererState();
+            updateSlotState();
         }
 
         @Override
         public void addComponentAsFirst(Component component) {
             HasComponents.super.addComponentAsFirst(component);
-            updateRendererState();
+            updateSlotState();
         }
 
-        private void updateRendererState() {
+        /**
+         * Attaches or detaches the slotted root wrapper based on whether it has
+         * any children.
+         * <p>
+         * The wrapper uses {@code display: contents} and is itself the node
+         * assigned to the {@code header-content} / {@code footer} slot. The web
+         * component sets the {@code has-header} / {@code has-footer} state
+         * attribute whenever the slot has an assigned node, so the wrapper must
+         * be removed from the DOM (not just cleared) when it becomes empty.
+         * Otherwise the header/footer part would stay visible without content.
+         */
+        private void updateSlotState() {
             if (root.getChildCount() == 0) {
-                removeRenderer();
-            } else if (!isRendererCreated()) {
-                initRenderer();
+                root.removeFromParent();
+            } else if (root.getParent() == null) {
+                dialog.getElement().appendChild(root);
             }
-        }
-
-        /**
-         * Method called to create the renderer function using
-         * {@link #rendererFunction} as the property name.
-         */
-        void initRenderer() {
-            if (root.getChildCount() == 0) {
-                return;
-            }
-            if (!dialog.getElement().equals(root.getParent())) {
-                dialog.getElement().appendVirtualChild(root);
-            }
-            dialog.getElement().executeJs("this." + rendererFunction
-                    + " = (root) => {" + "if (root.firstChild) { "
-                    + "   return;" + "}" + "root.appendChild($0);" + "}", root);
-            setRendererCreated(true);
-        }
-
-        private void removeRenderer() {
-            dialog.getElement()
-                    .executeJs("this." + rendererFunction + " = null;");
-            setRendererCreated(false);
-        }
-
-        /**
-         * Gets whether the renderer function exists or not
-         *
-         * @return the renderer function state
-         */
-        boolean isRendererCreated() {
-            return rendererCreated;
-        }
-
-        /**
-         * Sets the renderer function creation state. To avoid making a
-         * JavaScript execution to get the information from the client, this is
-         * done on the server by setting it to <code>true</code> on
-         * {@link #initRenderer()} and to <code>false</code> when the last child
-         * is removed in {@link #remove(Component...)} or when an auto attached
-         * dialog is closed.
-         *
-         * @param rendererCreated
-         *            {@code true} if the renderer function has been created,
-         *            {@code false} otherwise
-         */
-        void setRendererCreated(boolean rendererCreated) {
-            this.rendererCreated = rendererCreated;
         }
 
         @Override
@@ -1270,26 +1283,39 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     private void updateVirtualChildNodeIds() {
         // Add detach listeners (child may be removed with removeFromParent())
-        getElement().getChildren().forEach(child -> {
-            if (!childDetachListenerMap.containsKey(child)) {
-                childDetachListenerMap.put(child,
-                        child.addDetachListener(childDetachListener));
-            }
-        });
+        getElement().getChildren().filter(this::isContentChild)
+                .forEach(child -> {
+                    if (!childDetachListenerMap.containsKey(child)) {
+                        childDetachListenerMap.put(child,
+                                child.addDetachListener(childDetachListener));
+                    }
+                });
 
         this.getElement().setPropertyList("virtualChildNodeIds",
-                getElement().getChildren()
+                getElement().getChildren().filter(this::isContentChild)
                         .map(element -> element.getNode().getId())
                         .collect(Collectors.toList()));
 
         this.getElement().callJsFunction("requestContentUpdate");
     }
 
+    /**
+     * Checks whether the given child element holds main dialog content, as
+     * opposed to the header/footer wrapper elements which are slotted into the
+     * dialog's {@code header-content} / {@code footer} slots. Only content
+     * children are relayed through the {@code virtualChildNodeIds} renderer;
+     * the slotted wrappers must be excluded so they are not moved into the
+     * content renderer root.
+     */
+    private boolean isContentChild(Element child) {
+        return (dialogHeader == null || !child.equals(dialogHeader.root))
+                && (dialogFooter == null || !child.equals(dialogFooter.root));
+    }
+
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
 
-        initHeaderFooterRenderer();
         updateVirtualChildNodeIds();
         registerClientCloseHandler();
         applyModality();
@@ -1380,17 +1406,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
     protected void setAriaLabel(String ariaLabel) {
         getElement().setProperty("ariaLabel",
                 ariaLabel == null ? "" : ariaLabel);
-    }
-
-    private void initHeaderFooterRenderer() {
-        if (dialogHeader != null) {
-            dialogHeader.setRendererCreated(false);
-            dialogHeader.initRenderer();
-        }
-        if (dialogFooter != null) {
-            dialogFooter.setRendererCreated(false);
-            dialogFooter.initRenderer();
-        }
     }
 
     private void setDimension(String dimension, String value) {

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -600,40 +600,26 @@ public class Dialog extends Component implements HasComponents, HasSize,
             throw new IllegalArgumentException(
                     "Cannot add a component with a negative index");
         }
-        // The header/footer wrappers are also element children, so the content
-        // index must be translated to the matching element index that skips
-        // them. Otherwise a wrapper preceding the position would offset it.
-        HasComponents.super.addComponentAtIndex(toElementIndex(index),
-                component);
+
+        // getChildren() returns only the main content; the header/footer live
+        // in separate slotted wrappers. Translate the content index to the
+        // matching element index so the wrappers do not offset the position.
+        var children = getChildren().toList();
+        if (index > children.size()) {
+            throw new IllegalArgumentException(
+                    "Cannot add a component at index " + index
+                            + ", there are only " + children.size()
+                            + " content components");
+        }
+        if (index == children.size()) {
+            getElement().appendChild(component.getElement());
+        } else {
+            getElement().insertChild(
+                    getElement().indexOfChild(children.get(index).getElement()),
+                    component.getElement());
+        }
 
         updateVirtualChildNodeIds();
-    }
-
-    /**
-     * Translates an index into the main content (as seen by
-     * {@link #getChildren()}) to the corresponding index into the dialog
-     * element's children, which also include the slotted header/footer
-     * wrappers.
-     */
-    private int toElementIndex(int contentIndex) {
-        List<Element> children = getElement().getChildren()
-                .collect(Collectors.toList());
-        int contentSeen = 0;
-        for (int elementIndex = 0; elementIndex < children
-                .size(); elementIndex++) {
-            if (contentSeen == contentIndex) {
-                return elementIndex;
-            }
-            if (isContentChild(children.get(elementIndex))) {
-                contentSeen++;
-            }
-        }
-        if (contentSeen < contentIndex) {
-            throw new IllegalArgumentException(String.format(
-                    "Cannot add a component at index %d, there are only %d content components",
-                    contentIndex, contentSeen));
-        }
-        return children.size();
     }
 
     /**
@@ -645,10 +631,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     @Override
     public Stream<Component> getChildren() {
-        return super.getChildren().filter(child -> {
-            Element parent = child.getElement().getParent();
-            return parent == null || isContentChild(parent);
-        });
+        return super.getChildren().filter(
+                child -> isContentChild(child.getElement().getParent()));
     }
 
     @Override
@@ -1282,17 +1266,19 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * the content update.
      */
     private void updateVirtualChildNodeIds() {
+        List<Element> contentChildren = getElement().getChildren()
+                .filter(this::isContentChild).collect(Collectors.toList());
+
         // Add detach listeners (child may be removed with removeFromParent())
-        getElement().getChildren().filter(this::isContentChild)
-                .forEach(child -> {
-                    if (!childDetachListenerMap.containsKey(child)) {
-                        childDetachListenerMap.put(child,
-                                child.addDetachListener(childDetachListener));
-                    }
-                });
+        contentChildren.forEach(child -> {
+            if (!childDetachListenerMap.containsKey(child)) {
+                childDetachListenerMap.put(child,
+                        child.addDetachListener(childDetachListener));
+            }
+        });
 
         this.getElement().setPropertyList("virtualChildNodeIds",
-                getElement().getChildren().filter(this::isContentChild)
+                contentChildren.stream()
                         .map(element -> element.getNode().getId())
                         .collect(Collectors.toList()));
 
@@ -1300,16 +1286,14 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Checks whether the given child element holds main dialog content, as
-     * opposed to the header/footer wrapper elements which are slotted into the
-     * dialog's {@code header-content} / {@code footer} slots. Only content
-     * children are relayed through the {@code virtualChildNodeIds} renderer;
-     * the slotted wrappers must be excluded so they are not moved into the
-     * content renderer root.
+     * Checks whether the given element holds main dialog content, as opposed to
+     * the header/footer wrappers which carry a {@code slot} attribute. Only
+     * content children are relayed through the {@code virtualChildNodeIds}
+     * renderer; the slotted wrappers must be excluded so they are not moved
+     * into the content renderer root.
      */
-    private boolean isContentChild(Element child) {
-        return (dialogHeader == null || !child.equals(dialogHeader.root))
-                && (dialogFooter == null || !child.equals(dialogFooter.root));
+    private boolean isContentChild(Element element) {
+        return !element.hasAttribute("slot");
     }
 
     @Override

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -203,7 +203,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * `resize` event is sent when the user finishes resizing the dialog.
-     * 
+     *
      * @since 3.1
      */
     @DomEvent("resize")
@@ -267,7 +267,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * `dragged` event is sent when the user finishes dragging the dialog.
-     * 
+     *
      * @since 24.6
      */
     @DomEvent("dragged")
@@ -309,7 +309,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * which, when closing the dialog, is before the closing animation has
      * finished. To wait for the animation to finish, listen for the
      * {@link ClosedEvent} event.
-     * 
+     *
      * @since 23.3
      */
     public static class OpenedChangeEvent extends ComponentEvent<Dialog> {
@@ -328,7 +328,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
     /**
      * Event that is fired after the dialog's closing animation has finished.
      * Can be used to remove a dialog from the UI afterward.
-     * 
+     *
      * @since 25.0
      */
     @DomEvent("closed")
@@ -622,17 +622,20 @@ public class Dialog extends Component implements HasComponents, HasSize,
         updateVirtualChildNodeIds();
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Only the main content components are returned. Components added to the
-     * header or footer via {@link #getHeader()} / {@link #getFooter()} live in
-     * separate slotted wrapper elements and are excluded.
-     */
+    private boolean isHeaderFooterWrapper(Element element) {
+        return (dialogHeader != null && dialogHeader.root.equals(element))
+                || (dialogFooter != null && dialogFooter.root.equals(element));
+    }
+
     @Override
     public Stream<Component> getChildren() {
-        return super.getChildren().filter(
-                child -> isContentChild(child.getElement().getParent()));
+        // Collect into a list so the returned stream is a snapshot, matching
+        // Component.getChildren() and staying safe when callers such as
+        // removeAll() remove children while iterating.
+        return getElement().getChildren()
+                .filter(element -> !isHeaderFooterWrapper(element))
+                .flatMap(element -> element.getComponent().stream()).toList()
+                .stream();
     }
 
     @Override
@@ -964,7 +967,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * Class for adding and removing components to the header part of a dialog.
-     * 
+     *
      * @since 23.1
      */
     final public static class DialogHeader extends DialogHeaderFooter {
@@ -975,7 +978,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     /**
      * Class for adding and removing components to the footer part of a dialog.
-     * 
+     *
      * @since 23.1
      */
     final public static class DialogFooter extends DialogHeaderFooter {
@@ -1267,7 +1270,8 @@ public class Dialog extends Component implements HasComponents, HasSize,
      */
     private void updateVirtualChildNodeIds() {
         List<Element> contentChildren = getElement().getChildren()
-                .filter(this::isContentChild).collect(Collectors.toList());
+                .filter(element -> !isHeaderFooterWrapper(element))
+                .collect(Collectors.toList());
 
         // Add detach listeners (child may be removed with removeFromParent())
         contentChildren.forEach(child -> {
@@ -1283,17 +1287,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
                         .collect(Collectors.toList()));
 
         this.getElement().callJsFunction("requestContentUpdate");
-    }
-
-    /**
-     * Checks whether the given element holds main dialog content, as opposed to
-     * the header/footer wrappers which carry a {@code slot} attribute. Only
-     * content children are relayed through the {@code virtualChildNodeIds}
-     * renderer; the slotted wrappers must be excluded so they are not moved
-     * into the content renderer root.
-     */
-    private boolean isContentChild(Element element) {
-        return !element.hasAttribute("slot");
     }
 
     @Override

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
@@ -168,7 +168,6 @@ class DialogChildrenTest {
         dialog.getHeader().add(new Div());
         dialog.getFooter().add(new Div());
 
-        // The header/footer wrappers are real, slotted children of the dialog
         Assertions.assertEquals(2, dialog.getElement().getChildCount());
         Assertions.assertEquals(dialog.getElement(),
                 dialog.getHeader().root.getParent());

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
@@ -164,15 +164,88 @@ class DialogChildrenTest {
     }
 
     @Test
-    void headerAndFooterAddedAsVirtualChildren() {
+    void headerAndFooterAddedAsSlottedChildren() {
         dialog.getHeader().add(new Div());
         dialog.getFooter().add(new Div());
 
-        Assertions.assertEquals(0, dialog.getElement().getChildCount());
+        // The header/footer wrappers are real, slotted children of the dialog
+        Assertions.assertEquals(2, dialog.getElement().getChildCount());
         Assertions.assertEquals(dialog.getElement(),
                 dialog.getHeader().root.getParent());
         Assertions.assertEquals(dialog.getElement(),
                 dialog.getFooter().root.getParent());
+        Assertions.assertEquals("header-content",
+                dialog.getHeader().root.getAttribute("slot"));
+        Assertions.assertEquals("footer",
+                dialog.getFooter().root.getAttribute("slot"));
+    }
+
+    @Test
+    void headerAndFooter_notIncludedInVirtualChildNodeIds() {
+        var content = new Div();
+        dialog.add(content);
+        dialog.getHeader().add(new Div());
+        dialog.getFooter().add(new Div());
+
+        // Only the main content child is relayed through virtualChildNodeIds;
+        // the slotted header/footer wrappers must be excluded
+        assertVirtualChildren(content);
+    }
+
+    @Test
+    void emptyHeader_wrapperDetached() {
+        var child = new Div();
+        dialog.getHeader().add(child);
+        Assertions.assertEquals(dialog.getElement(),
+                dialog.getHeader().root.getParent());
+
+        dialog.getHeader().remove(child);
+        Assertions.assertNull(dialog.getHeader().root.getParent());
+
+        // Re-adding content re-attaches the wrapper to the dialog
+        dialog.getHeader().add(new Div());
+        Assertions.assertEquals(dialog.getElement(),
+                dialog.getHeader().root.getParent());
+    }
+
+    @Test
+    void headerPresent_getChildrenExcludesHeaderFooterContent() {
+        var content = new Div();
+        dialog.add(content);
+        dialog.getHeader().add(new Div());
+        dialog.getFooter().add(new Div());
+
+        Assertions.assertEquals(List.of(content),
+                dialog.getChildren().collect(Collectors.toList()));
+        Assertions.assertEquals(1, dialog.getComponentCount());
+    }
+
+    @Test
+    void headerPresent_addComponentAtIndex_contentOrderPreserved() {
+        // Header content added first, so its wrapper precedes main content in
+        // the element child list
+        dialog.getHeader().add(new Div());
+
+        var a = new Div();
+        var b = new Div();
+        var c = new Div();
+        dialog.add(a);
+        dialog.add(b);
+        dialog.addComponentAtIndex(1, c);
+
+        Assertions.assertEquals(List.of(a, c, b),
+                dialog.getChildren().collect(Collectors.toList()));
+        // virtualChildNodeIds must follow the same content order
+        assertVirtualChildren(a, c, b);
+    }
+
+    @Test
+    void headerPresent_addComponentAtIndexOutOfRange_throws() {
+        dialog.getHeader().add(new Div());
+        dialog.add(new Div());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> dialog.addComponentAtIndex(2, new Div()));
     }
 
     @Test


### PR DESCRIPTION
The `vaadin-dialog` web component gained native `header-content` and `footer` slots in https://github.com/vaadin/web-components/pull/10624. This moves the Flow `DialogHeader`/`DialogFooter` off the `headerRenderer`/`footerRenderer` renderer functions and onto those slots, matching the earlier Popover cleanup (#7791).

The old approach set the renderer via `executeJs`, tracked renderer state (`rendererCreated`), added the wrapper as a virtual child, and re-created the renderer on every attach. All of that is removed: the header/footer wrapper is now a real slotted child, so its content is preserved across reattach (including `@PreserveOnRefresh`) without any re-init code.

## Changes

- `DialogHeaderFooter` sets `slot="header-content"` / `slot="footer"` on its wrapper and attaches it as a real child; the wrapper is removed from the DOM when it has no content, so the web component does not keep the empty header/footer visible.
- The main dialog content still renders through the existing `renderer`. The slotted wrappers are excluded from `virtualChildNodeIds` (via an identity check) so they are not relocated into the content renderer root.
- Because the wrappers are now real children, `getChildren()` is overridden to return only the main content, and `addComponentAtIndex` maps the content index to the element index that skips the wrappers. Otherwise `removeAll()` and index-based inserts would see the slotted wrappers.
- Added unit tests (slotting, `virtualChildNodeIds` exclusion, empty-wrapper detach, `getChildren`/index behavior) and integration tests asserting the `has-header`/`has-footer` state attributes toggle on add and remove.

Part of #9384

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)