### PR TITLE
refactor: deprecate setPrimaryStyle and setSecondaryStyle in SplitLayout

### DIFF
--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitLayoutView.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/src/main/java/com/vaadin/flow/component/splitlayout/test/SplitLayoutView.java
@@ -97,9 +97,8 @@ public class SplitLayoutView extends Div {
         layout.addToPrimary(new Span("First content component"));
         layout.addToSecondary(new Span("Second content component"));
 
-        layout.setPrimaryStyle("minWidth", "100px");
-        layout.setPrimaryStyle("maxWidth", "150px");
-        layout.setPrimaryStyle("background", "salmon");
+        layout.getPrimaryComponent().getStyle().set("minWidth", "100px")
+                .set("maxWidth", "150px").set("background", "salmon");
 
         layout.getPrimaryComponent().setId("min-max-first-component");
         setMinHeightForLayout(layout);

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -86,10 +86,11 @@ public class SplitLayout extends Component
             splitterPosition = calcNewSplitterPosition(
                     e.primaryComponentFlexBasis, e.secondaryComponentFlexBasis);
 
-            setPrimaryStyle("flex",
-                    String.format("1 1 %s", e.primaryComponentFlexBasis));
-            setSecondaryStyle("flex",
-                    String.format("1 1 %s", e.secondaryComponentFlexBasis));
+            setInnerComponentStyle("flex",
+                    String.format("1 1 %s", e.primaryComponentFlexBasis), true);
+            setInnerComponentStyle("flex",
+                    String.format("1 1 %s", e.secondaryComponentFlexBasis),
+                    false);
         });
     }
 
@@ -263,8 +264,10 @@ public class SplitLayout extends Component
         }
         double primary = Math.min(Math.max(this.splitterPosition, 0), 100);
         double secondary = 100 - primary;
-        setPrimaryStyle("flex", String.format("1 1 %s%%", primary));
-        setSecondaryStyle("flex", String.format("1 1 %s%%", secondary));
+        setInnerComponentStyle("flex", String.format("1 1 %s%%", primary),
+                true);
+        setInnerComponentStyle("flex", String.format("1 1 %s%%", secondary),
+                false);
     }
 
     /**
@@ -274,7 +277,10 @@ public class SplitLayout extends Component
      *            name of the style to set
      * @param value
      *            the value to set
+     * @deprecated since 25.3, use {@link #getPrimaryComponent()} and set styles
+     *             on the primary component directly instead.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     public void setPrimaryStyle(String styleName, String value) {
         setInnerComponentStyle(styleName, value, true);
     }
@@ -286,7 +292,10 @@ public class SplitLayout extends Component
      *            name of the style to set
      * @param value
      *            the value to set
+     * @deprecated since 25.3, use {@link #getSecondaryComponent()} and set
+     *             styles on the secondary component directly instead.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     public void setSecondaryStyle(String styleName, String value) {
         setInnerComponentStyle(styleName, value, false);
     }


### PR DESCRIPTION
## Description

Suggest getPrimaryComponent()/getSecondaryComponent() with getStyle() to style the split contents directly. Internal callers now use the private setInnerComponentStyle helper instead of the deprecated methods.

Part of #6486

## Type of change

- Refactor / deprecation