### PR TITLE
refactor: slot Dialog content instead of using a renderer

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogContentView.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogContentView.java
@@ -46,7 +46,15 @@ public class DialogContentView extends HorizontalLayout {
         });
         openButton.setId("open-button");
 
+        // Detaches and re-attaches the dialog, mimicking a UI transfer. Slotted
+        // content must survive this without any renderer re-initialization.
+        var reattachButton = new Button("Reattach dialog", e -> {
+            remove(dialog);
+            add(dialog);
+        });
+        reattachButton.setId("reattach-button");
+
         // It's crucial that the dialog itself is added to the UI for this test
-        add(dialog, addContentButton, openButton);
+        add(dialog, addContentButton, openButton, reattachButton);
     }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogContentIT.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogContentIT.java
@@ -46,4 +46,16 @@ public class DialogContentIT extends AbstractComponentIT {
         // Expect the content to be present inside the dialog overlay
         waitForElementPresent(By.cssSelector("vaadin-dialog #close-button"));
     }
+
+    @Test
+    public void addContentReattachDialogAndOpen_contentPresent() {
+        // Add dialog content, then detach and re-attach the dialog before
+        // opening it. Slotted content must survive the reattach.
+        clickElementWithJs("add-content-button");
+        clickElementWithJs("reattach-button");
+        clickElementWithJs("open-button");
+
+        // Expect the content to be present inside the dialog overlay
+        waitForElementPresent(By.cssSelector("vaadin-dialog #close-button"));
+    }
 }

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -16,11 +16,8 @@
 package com.vaadin.flow.component.dialog;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AttachEvent;
@@ -46,8 +43,6 @@ import com.vaadin.flow.component.shared.internal.ModalRoot;
 import com.vaadin.flow.component.shared.internal.OverlayAutoAddController;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
-import com.vaadin.flow.dom.ElementDetachEvent;
-import com.vaadin.flow.dom.ElementDetachListener;
 import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.function.SerializableFunction;
@@ -85,7 +80,6 @@ import com.vaadin.flow.signals.Signal;
 @Tag("vaadin-dialog")
 @NpmPackage(value = "@vaadin/dialog", version = "25.3.0-alpha4")
 @JsModule("@vaadin/dialog/src/vaadin-dialog.js")
-@JsModule("./flow-component-renderer.js")
 @ModalRoot
 public class Dialog extends Component implements HasComponents, HasSize,
         HasStyle, HasThemeVariant<DialogVariant>, HasAriaRole {
@@ -111,11 +105,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
      * Creates an empty dialog.
      */
     public Dialog() {
-        // Needs to be updated on each
-        // attach, as element depends on node id which is subject to change if
-        // the dialog is transferred to another UI, e.g. due to
-        // @PreserveOnRefresh
-        getElement().getNode().addAttachListener(this::attachComponentRenderer);
+        // Dimensions are applied via executeJs, which does not persist across
+        // reattach (e.g. when the dialog is transferred to another UI due to
+        // @PreserveOnRefresh), so they must be re-applied on each attach.
+        getElement().getNode().addAttachListener(this::reapplyDimensions);
 
         // Workaround for: https://github.com/vaadin/flow/issues/3496
         getElement().setProperty("opened", false);
@@ -571,20 +564,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
     }
 
     /**
-     * Adds the given components into this dialog.
-     *
-     * @param components
-     *            the components to add
-     * @since 24.0
-     */
-    @Override
-    public void add(Collection<Component> components) {
-        HasComponents.super.add(components);
-
-        updateVirtualChildNodeIds();
-    }
-
-    /**
      * Adds the given component into this dialog at the given index.
      *
      * @param index
@@ -618,8 +597,6 @@ public class Dialog extends Component implements HasComponents, HasSize,
                     getElement().indexOfChild(children.get(index).getElement()),
                     component.getElement());
         }
-
-        updateVirtualChildNodeIds();
     }
 
     private boolean isHeaderFooterWrapper(Element element) {
@@ -640,11 +617,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
 
     @Override
     public void removeAll() {
-        // HasComponents.removeAll triggers a special RPC call that clears the
-        // innerHTML of the dialog element. This results in removing the content
-        // elements created by the web component for slotting contents into its
-        // overlay. To avoid this, we manually remove all children instead.
-        // getChildren() excludes header/footer content, so those are preserved.
+        // HasComponents.removeAll would clear all children of the dialog
+        // element, including the slotted header/footer wrappers. getChildren()
+        // returns only the main content, so removing those preserves the
+        // header/footer.
         getChildren().forEach(this::remove);
     }
 
@@ -1237,63 +1213,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
         return super.addDetachListener(listener);
     }
 
-    private Map<Element, Registration> childDetachListenerMap = new HashMap<>();
-    // Must not use lambda here as that would break serialization. See
-    // https://github.com/vaadin/flow-components/issues/5597
-    private ElementDetachListener childDetachListener = new ElementDetachListener() {
-        @Override
-        public void onDetach(ElementDetachEvent e) {
-            var child = e.getSource();
-            var childDetachedFromContainer = !getElement().getChildren()
-                    .anyMatch(containerChild -> Objects.equals(child,
-                            containerChild));
-
-            if (childDetachedFromContainer) {
-                // The child was removed from the dialog
-
-                // Remove the registration for the child detach listener
-                childDetachListenerMap.get(child).remove();
-                childDetachListenerMap.remove(child);
-
-                updateVirtualChildNodeIds();
-            }
-        }
-    };
-
-    /**
-     * Updates the virtualChildNodeIds property of the dialog element.
-     * <p>
-     * This method is called whenever the dialog's child components change.
-     * <p>
-     * Also calls {@code requestContentUpdate} on the dialog element to trigger
-     * the content update.
-     */
-    private void updateVirtualChildNodeIds() {
-        List<Element> contentChildren = getElement().getChildren()
-                .filter(element -> !isHeaderFooterWrapper(element))
-                .collect(Collectors.toList());
-
-        // Add detach listeners (child may be removed with removeFromParent())
-        contentChildren.forEach(child -> {
-            if (!childDetachListenerMap.containsKey(child)) {
-                childDetachListenerMap.put(child,
-                        child.addDetachListener(childDetachListener));
-            }
-        });
-
-        this.getElement().setPropertyList("virtualChildNodeIds",
-                contentChildren.stream()
-                        .map(element -> element.getNode().getId())
-                        .collect(Collectors.toList()));
-
-        this.getElement().callJsFunction("requestContentUpdate");
-    }
-
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
 
-        updateVirtualChildNodeIds();
         registerClientCloseHandler();
         applyModality();
     }
@@ -1390,16 +1313,7 @@ public class Dialog extends Component implements HasComponents, HasSize,
                 dimension, value);
     }
 
-    private void attachComponentRenderer() {
-        this.getElement().executeJs(
-                "Vaadin.FlowComponentHost.patchVirtualContainer(this)");
-
-        String appId = UI.getCurrentOrThrow().getInternals().getAppId();
-
-        getElement().executeJs(
-                "this.renderer = (root) => Vaadin.FlowComponentHost.setChildNodes($0, this.virtualChildNodeIds, root)",
-                appId);
-
+    private void reapplyDimensions() {
         setDimension(ElementConstants.STYLE_MIN_WIDTH, minWidth);
         setDimension(ElementConstants.STYLE_MAX_WIDTH, maxWidth);
         setDimension(ElementConstants.STYLE_MIN_HEIGHT, minHeight);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.dialog;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,11 +26,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
-
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.node.ArrayNode;
 
 class DialogChildrenTest {
     @RegisterExtension
@@ -46,121 +41,100 @@ class DialogChildrenTest {
     }
 
     @Test
-    void add_virtualNodeIdsInSync() {
+    void add_slottedAsContent() {
         var child = new Div();
         dialog.add(child);
-        assertVirtualChildren(child);
+        assertContent(child);
     }
 
     @Test
-    void addMany_virtualNodeIdsInSync() {
+    void addMany_slottedInOrder() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(child);
         dialog.add(child2);
-        assertVirtualChildren(child, child2);
+        assertContent(child, child2);
     }
 
     @Test
-    void addCollection_virtualNodeIdsInSync() {
+    void addCollection_slottedInOrder() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(List.of(child, child2));
-        assertVirtualChildren(child, child2);
+        assertContent(child, child2);
     }
 
     @Test
-    void addComponentAsFirst_virtualNodeIdsInSync() {
+    void addComponentAsFirst_slottedInOrder() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(child);
         dialog.addComponentAsFirst(child2);
-        assertVirtualChildren(child2, child);
+        assertContent(child2, child);
     }
 
     @Test
-    void remove_virtualNodeIdsInSync() {
+    void remove_removedFromContent() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(child, child2);
         dialog.remove(child2);
-        assertVirtualChildren(child);
+        assertContent(child);
     }
 
     @Test
-    void removeAll_virtualNodeIdsInSync() {
+    void removeAll_contentEmpty() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(child, child2);
         dialog.removeAll();
-        assertVirtualChildren();
+        assertContent();
     }
 
     @Test
-    void addComponentAtIndex_virtualNodeIdsInSync() {
+    void addComponentAtIndex_slottedInOrder() {
         var child = new Div();
         var child2 = new Div();
         var child3 = new Div();
         dialog.add(child, child2);
         dialog.addComponentAtIndex(1, child3);
-        assertVirtualChildren(child, child3, child2);
+        assertContent(child, child3, child2);
     }
 
     @Test
-    void addTextNodes_virtualNodeIdsInSync() {
+    void addTextNodes_slottedInOrder() {
         var child = new Text("text");
         var child2 = new Text("text2");
         dialog.add(child, child2);
-        assertVirtualChildren(child, child2);
+        assertContent(child, child2);
     }
 
     @Test
-    void addBeforeAttaching_validNodeIds() {
+    void addBeforeAttaching_contentSlotted() {
         dialog = new Dialog();
         var child = new Div();
         dialog.add(child);
         ui.add(dialog);
-        Assertions.assertNotEquals("[-1]",
-                dialog.getElement().getProperty("virtualChildNodeIds"));
+        assertContent(child);
     }
 
     @Test
-    void selfRemoveChild_virtualNodeIdsInSync() {
+    void selfRemoveChild_removedFromContent() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(child, child2);
         child.removeFromParent();
-        assertVirtualChildren(child2);
+        assertContent(child2);
     }
 
     @Test
-    void addSeparately_selfRemoveChild_doesNotThrow() {
+    void addSeparately_selfRemoveChild_removedFromContent() {
         var child = new Div();
         var child2 = new Div();
         dialog.add(child);
         dialog.add(child2);
         child.removeFromParent();
-        assertVirtualChildren(child2);
-    }
-
-    @Test
-    void relocateChild_detachListenerRemoved() {
-        var child = new Div();
-        dialog.add(child);
-
-        // Move the child to a new parent
-        var newParent = new Div();
-        ui.add(newParent);
-        newParent.add(child);
-
-        // Should be empty of virtual children
-        assertVirtualChildren();
-        // Manually modify the virtualChildNodeIds property
-        dialog.getElement().setProperty("virtualChildNodeIds", "[-1]");
-
-        newParent.remove(child);
-        Assertions.assertEquals("[-1]",
-                dialog.getElement().getProperty("virtualChildNodeIds"));
+        assertContent(child2);
     }
 
     @Test
@@ -180,15 +154,15 @@ class DialogChildrenTest {
     }
 
     @Test
-    void headerAndFooter_notIncludedInVirtualChildNodeIds() {
+    void headerAndFooter_excludedFromContent() {
         var content = new Div();
         dialog.add(content);
         dialog.getHeader().add(new Div());
         dialog.getFooter().add(new Div());
 
-        // Only the main content child is relayed through virtualChildNodeIds;
-        // the slotted header/footer wrappers must be excluded
-        assertVirtualChildren(content);
+        // Only the main content is returned; the slotted header/footer wrappers
+        // are excluded
+        assertContent(content);
     }
 
     @Test
@@ -208,14 +182,11 @@ class DialogChildrenTest {
     }
 
     @Test
-    void headerPresent_getChildrenExcludesHeaderFooterContent() {
-        var content = new Div();
-        dialog.add(content);
+    void headerPresent_getComponentCountExcludesHeaderFooter() {
+        dialog.add(new Div());
         dialog.getHeader().add(new Div());
         dialog.getFooter().add(new Div());
 
-        Assertions.assertEquals(List.of(content),
-                dialog.getChildren().collect(Collectors.toList()));
         Assertions.assertEquals(1, dialog.getComponentCount());
     }
 
@@ -232,10 +203,7 @@ class DialogChildrenTest {
         dialog.add(b);
         dialog.addComponentAtIndex(1, c);
 
-        Assertions.assertEquals(List.of(a, c, b),
-                dialog.getChildren().collect(Collectors.toList()));
-        // virtualChildNodeIds must follow the same content order
-        assertVirtualChildren(a, c, b);
+        assertContent(a, c, b);
     }
 
     @Test
@@ -260,20 +228,20 @@ class DialogChildrenTest {
                 dialog.getFooter().root.getParent());
     }
 
-    private void assertVirtualChildren(Component... components) {
-        // Get a List of the node ids
-        var childIds = Arrays.stream(components)
-                .map(component -> component.getElement().getNode().getId())
-                .collect(Collectors.toList());
-
-        // Get the virtualChildNodeIds property from the dialog as a JsonArray
-        var jsonArrayOfIds = (ArrayNode) JacksonUtils.getMapper().readTree(
-                dialog.getElement().getProperty("virtualChildNodeIds"));
-
-        var virtualChildNodeIds = JacksonUtils.stream(jsonArrayOfIds)
-                .mapToInt(JsonNode::asInt).boxed().collect(Collectors.toList());
-
-        Assertions.assertEquals(childIds, virtualChildNodeIds);
+    /**
+     * Asserts that the given components are the dialog's main content, in
+     * order: returned by {@link Dialog#getChildren()} and slotted as direct
+     * light-DOM children of the dialog element (default slot, i.e. without a
+     * {@code slot} attribute).
+     */
+    private void assertContent(Component... expected) {
+        Assertions.assertEquals(List.of(expected),
+                dialog.getChildren().collect(Collectors.toList()));
+        for (Component component : expected) {
+            Assertions.assertEquals(dialog.getElement(),
+                    component.getElement().getParent());
+            Assertions.assertFalse(component.getElement().hasAttribute("slot"));
+        }
     }
 
 }


### PR DESCRIPTION
## Description

Depends on #9743

Updated to add content directly instead of using `renderer` function and `virtualChildNodeIds` logic.

- Add main content as plain light-DOM children of `<vaadin-dialog>`, which the web component projects into the content slot. No renderer is set.
- Remove the `virtualChildNodeIds` machinery: the `executeJs` renderer, the `virtualChildNodeIds` property, `updateVirtualChildNodeIds`, and the child detach listener. Content now survives reattach (for example `@PreserveOnRefresh`) without any re-initialization.
- Reduce the attach handler to re-applying the dialog dimensions, which are set via `executeJs` and do not persist across reattach.
- Keep the `getChildren`, `addComponentAtIndex` and `removeAll` overrides: the header/footer wrappers are still slotted children that must be excluded from the main content.
- Rewrote `DialogChildrenTest` to assert content is slotted as real children (returned by `getChildren()`, parented to the dialog element, no `slot` attribute) instead of checking the removed `virtualChildNodeIds` property.
- Added an integration test that detaches and re-attaches the dialog before opening it, verifying slotted content survives the reattach.

Part of #9384

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)