### PR TITLE
chore: add repro skill for triaging Flow component issues

### DIFF
--- a/.claude/skills/repro/SKILL.md
+++ b/.claude/skills/repro/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: repro
+description: Reproduce a Vaadin Flow component bug from a GitHub issue in vaadin/flow-components or a component-specific issue in vaadin/flow. Builds a minimal integration-test View, confirms the bug in a running browser with playwright-cli, points at the likely root cause, pushes a shareable repro/<issue> branch, and (after confirmation) posts a verification-pending summary comment on the issue.
+argument-hint: <issue-url>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(gh:*), Bash(mvn:*), Bash(playwright-cli:*), Bash(npx:*), Bash(git:*), Bash(curl:*), Bash(lsof:*), Bash(kill:*)
+---
+
+<!-- In-repo Flow-only port of the ds-tools `repro` skill (v1.4.0). -->
+
+You are a tester reproducing a Vaadin Flow component bug. Input `$0` is a GitHub issue URL in `vaadin/flow-components` or `vaadin/flow`. Work the phases in order. **Never claim a bug is reproduced until you have seen it in a running browser.**
+
+Detailed instructions live in references — read each one the **first time** a phase needs it. They stay in context: on later runs in the same session, do not re-read them.
+
+| Reference | Covers |
+| --- | --- |
+| [`references/issue-analysis.md`](references/issue-analysis.md) | Phase 1 in full |
+| [`references/reproduce.md`](references/reproduce.md) | Phases 2–3: View scaffold, running the server, maintenance branches |
+| [`references/verify.md`](references/verify.md) | browser-observation discipline |
+| [`references/share.md`](references/share.md) | Phases 4–6 and cleanup |
+
+## Phase 0 — Setup (once per session)
+
+- Resolve `<ROOT>` = `git rev-parse --show-toplevel` (this flow-components checkout). Prefix every later command with absolute paths (`git -C <ROOT> …`) — env vars don't persist between shell calls.
+- `<FLOW_CORE>` = `<dirname of ROOT>/flow`, optional — only for root-cause search on `vaadin/flow` issues. If absent, note it and continue.
+- Preflight: `playwright-cli --version 2>/dev/null || npx --no-install playwright-cli --version 2>/dev/null` (if neither prints a version, stop and ask the user to run `npm install -g @playwright/cli@latest && playwright-cli install --skills`, resume once confirmed) and `gh auth status`.
+- Record the starting branch and `git status --porcelain` as the **baseline** — cleanup compares against it, not against an empty tree.
+
+Skip all of this when already done earlier in this session.
+
+## Phase 1 — Understand the bug
+
+Follow issue-analysis.md: fetch issue + comments in one `gh` call, note the affected version, **classify the regression** (`worked in <ver> / broke in <ver>` | `not a regression` | `unknown`), resolve every named component to its real source, run **fix archaeology** on old issues, write the hypothesis line — **"The bug is X, triggered by Y, observable as Z"** — and search for duplicates.
+
+## Phase 2 — Build the reproduction
+
+The smallest View that exercises the hypothesis, starting from the reporter's example, named after the issue (never overwrite an existing file): `Repro<issue>View.java` with `@Route("repro-<issue>")` per reproduce.md. **Design for iteration** (ids on assertion targets, control buttons, parallel variants, query-parameter switches) so Java-edit restarts stay rare. Prefer a **minimal pair**: the failing case plus a control that isolates the trigger.
+
+## Phase 3 — Run and reproduce
+
+1. Start the server in the background and wait for real readiness per reproduce.md — Jetty does not hot-reload Java.
+2. Drive the browser per verify.md. Look for the exact signal Z; the verdict comes from what you **saw** — snapshot, console, screenshot — not the issue text. **Guard:** a client `TypeError` from `jar-resources/*Connector.*` is a stale dev bundle, never the bug — regenerate per reproduce.md before trusting the result.
+3. **Iterate before concluding "not reproduced"** — the trigger is often precise (gesture, attach/detach cycle, property combination, timing). Record every attempted variation.
+4. Minimize, re-verify after each removal, and capture the demo artifact: screenshot for static failures, short video for motion (recipes in verify.md).
+
+## Phase 4 — Report
+
+Fill `assets/summary-template.md` → `<ROOT>/repro-<issue>-summary.md` with **every** field. Chat reply = verdict + regression + branch + 3–5 essential bullets + pointer to the file; do **not** restate the full summary. Details in share.md.
+
+## Phase 5 — Locate the root cause
+
+Point at the suspected cause as a **permalink pinned to a commit SHA** (format in share.md), searching the layer the evidence implicates — component module, connector JS, or Flow core (`<FLOW_CORE>`). If the evidence implicates the underlying web component itself, say so and point at `vaadin/web-components` source — reproducing there is out of scope. Don't fix the bug unless asked.
+
+## Phase 6 — Decide the disposition (always ask)
+
+**End every run with an `AskUserQuestion` — never a prose "want me to…?".** Options per verdict are in share.md. Never close an issue yourself.
+
+## Cleanup
+
+Follow share.md. Not reproduced → no branch: archive the scaffold to your scratchpad, delete it from the repo, revert any pom edit.

--- a/.claude/skills/repro/SKILL.md
+++ b/.claude/skills/repro/SKILL.md
@@ -2,10 +2,9 @@
 name: repro
 description: Reproduce a Vaadin Flow component bug from a GitHub issue in vaadin/flow-components or a component-specific issue in vaadin/flow. Builds a minimal integration-test View, confirms the bug in a running browser with playwright-cli, points at the likely root cause, pushes a shareable repro/<issue> branch, and (after confirmation) posts a verification-pending summary comment on the issue.
 argument-hint: <issue-url>
+disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(gh:*), Bash(mvn:*), Bash(playwright-cli:*), Bash(npx:*), Bash(git:*), Bash(curl:*), Bash(lsof:*), Bash(kill:*)
 ---
-
-<!-- In-repo Flow-only port of the ds-tools `repro` skill (v1.4.0). -->
 
 You are a tester reproducing a Vaadin Flow component bug. Input `$0` is a GitHub issue URL in `vaadin/flow-components` or `vaadin/flow`. Work the phases in order. **Never claim a bug is reproduced until you have seen it in a running browser.**
 
@@ -21,7 +20,7 @@ Detailed instructions live in references — read each one the **first time** a 
 ## Phase 0 — Setup (once per session)
 
 - Resolve `<ROOT>` = `git rev-parse --show-toplevel` (this flow-components checkout). Prefix every later command with absolute paths (`git -C <ROOT> …`) — env vars don't persist between shell calls.
-- `<FLOW_CORE>` = `<dirname of ROOT>/flow`, optional — only for root-cause search on `vaadin/flow` issues. If absent, note it and continue.
+- Optional sibling checkouts, used only for root-cause search: `<FLOW_CORE>` = `<dirname of ROOT>/flow` (Flow core, for `vaadin/flow` issues) and `<WC_ROOT>` = `<dirname of ROOT>/web-components` (the underlying web components). When one is absent, note it and read that source on GitHub instead (`gh api` / permalinks).
 - Preflight: `playwright-cli --version 2>/dev/null || npx --no-install playwright-cli --version 2>/dev/null` (if neither prints a version, stop and ask the user to run `npm install -g @playwright/cli@latest && playwright-cli install --skills`, resume once confirmed) and `gh auth status`.
 - Record the starting branch and `git status --porcelain` as the **baseline** — cleanup compares against it, not against an empty tree.
 
@@ -48,7 +47,7 @@ Fill `assets/summary-template.md` → `<ROOT>/repro-<issue>-summary.md` with **e
 
 ## Phase 5 — Locate the root cause
 
-Point at the suspected cause as a **permalink pinned to a commit SHA** (format in share.md), searching the layer the evidence implicates — component module, connector JS, or Flow core (`<FLOW_CORE>`). If the evidence implicates the underlying web component itself, say so and point at `vaadin/web-components` source — reproducing there is out of scope. Don't fix the bug unless asked.
+Point at the suspected cause as a **permalink pinned to a commit SHA** (format in share.md), searching the layer the evidence implicates — component module, connector JS, or Flow core (`<FLOW_CORE>`). If the evidence implicates the underlying web component itself, say so and point at `vaadin/web-components` source (read it at `<WC_ROOT>` when present, otherwise on GitHub) — reproducing there is out of scope. Don't fix the bug unless asked.
 
 ## Phase 6 — Decide the disposition (always ask)
 

--- a/.claude/skills/repro/assets/summary-template.md
+++ b/.claude/skills/repro/assets/summary-template.md
@@ -4,14 +4,16 @@
 > **Automated reproduction — produced by the Claude Code `repro` skill. Needs human verification.**
 > The steps, verdict, and root-cause pointer below were generated automatically and must be confirmed by a human before being treated as authoritative.
 
-- **Verdict:** reproduced | not reproduced (fixed by #PR | addressed | obsolete API | unknown) | partially reproduced | works as designed (likely misuse) | duplicate of #N
+- **Verdict:** reproduced | not reproduced (fixed | addressed | obsolete API | unknown) | partially reproduced | works as designed (likely misuse) | duplicate of #N
 - **Hypothesis tested:** The bug is <X>, triggered by <Y>, observable as <Z>.
 - **Regression?:** worked in <ver> / broke in <ver> | not a regression (broken since introduction) | unknown
+- **Fixed by:** <repo>#PR (<one-line mechanism>) | broad rework (no single PR) | n/a
+- **Duplicate of:** <repo>#N (<open/closed; the issue the fixing PR closed, if any>) | none found
 - **Branch:** `repro/<issue>` — pushed to `vaadin/<repo>`
 - **Reproduced on:** <repo> @ <version or branch>
 - **Present on main?:** yes (still broken) | no (fixed in <line>) | n/a
 - **Theme / Browser:** <theme> / <browser>
-- **Screenshot** (static bug): `![<caption>](https://raw.githubusercontent.com/vaadin/<repo>/<commit-sha>/repro-<issue>.png)` — embeds inline.
+- **Screenshot** (static bug): ![<caption>](https://raw.githubusercontent.com/vaadin/<repo>/<commit-sha>/repro-<issue>.png) — embeds inline.
 - **Demo video** (motion bug): `repro-<issue>-<symptom>.webm` (on the branch; drag into the comment for inline playback)
 
 ## Observed behavior
@@ -47,8 +49,8 @@ https://github.com/vaadin/<repo>/blob/<sha>/<path>#L<start>-L<end>
 
 ## Duplicate
 
-<!-- Include only if this duplicates another issue; otherwise delete this section. -->
-Same bug as **#N** (<open/closed; fixed in … if known>): identical stack trace, root cause, and trigger. <One line on why they match.> Recommend closing this issue as a duplicate of #N.
+<!-- Include when this issue duplicates another one — including an already-fixed issue discovered via the fixing PR; otherwise delete this section. -->
+Same bug as **<repo>#N** (<open/closed; fixed by #PR if known>): identical root cause and trigger. <One line on why they match.> Recommend closing this issue as a duplicate of #N, citing the fixing PR when known.
 
 ## Notes
 

--- a/.claude/skills/repro/assets/summary-template.md
+++ b/.claude/skills/repro/assets/summary-template.md
@@ -1,0 +1,55 @@
+<!-- Edit any field. This file is committed on the `repro/<issue>` branch and posted as the issue comment. -->
+
+> [!WARNING]
+> **Automated reproduction — produced by the Claude Code `repro` skill. Needs human verification.**
+> The steps, verdict, and root-cause pointer below were generated automatically and must be confirmed by a human before being treated as authoritative.
+
+- **Verdict:** reproduced | not reproduced (fixed by #PR | addressed | obsolete API | unknown) | partially reproduced | works as designed (likely misuse) | duplicate of #N
+- **Hypothesis tested:** The bug is <X>, triggered by <Y>, observable as <Z>.
+- **Regression?:** worked in <ver> / broke in <ver> | not a regression (broken since introduction) | unknown
+- **Branch:** `repro/<issue>` — pushed to `vaadin/<repo>`
+- **Reproduced on:** <repo> @ <version or branch>
+- **Present on main?:** yes (still broken) | no (fixed in <line>) | n/a
+- **Theme / Browser:** <theme> / <browser>
+- **Screenshot** (static bug): `![<caption>](https://raw.githubusercontent.com/vaadin/<repo>/<commit-sha>/repro-<issue>.png)` — embeds inline.
+- **Demo video** (motion bug): `repro-<issue>-<symptom>.webm` (on the branch; drag into the comment for inline playback)
+
+## Observed behavior
+
+<What actually happened — cite the DOM snapshot, console output, or screenshot.>
+
+## Expected behavior
+
+<From the issue or the bug description.>
+
+## Steps to reproduce
+
+1. <step>
+2. <step>
+3. <step>
+
+## Reproduction
+
+How to run: start the server (`mvn … jetty:run`) and open the route below.
+
+- **Route / page:** `http://localhost:8080/repro-<issue>`
+- **Scaffold:** `<path to the View committed on this branch>`
+
+```
+<key View source — the minimal reproduction>
+```
+
+## Root cause (suspected)
+
+<short explanation of the problematic area>:
+
+https://github.com/vaadin/<repo>/blob/<sha>/<path>#L<start>-L<end>
+
+## Duplicate
+
+<!-- Include only if this duplicates another issue; otherwise delete this section. -->
+Same bug as **#N** (<open/closed; fixed in … if known>): identical stack trace, root cause, and trigger. <One line on why they match.> Recommend closing this issue as a duplicate of #N.
+
+## Notes
+
+<Anything else: version-specific findings, dependencies added to an IT pom, dead ends, related issues.>

--- a/.claude/skills/repro/references/issue-analysis.md
+++ b/.claude/skills/repro/references/issue-analysis.md
@@ -31,10 +31,11 @@ Old issues are often already fixed, the fix never linked back. Before scaffoldin
 
 1. Grep the component's IT module for an existing regression view/test matching the symptom.
 2. `git log --oneline -S "<distinctive symbol or error string>" -- <suspect paths>` to find the fixing commit/PR; record `fixing PR: <#N | none found>` for the summary. Many fixes are broad reworks with no single greppable PR — "none found" is a normal answer.
-3. Check the reported API still exists (e.g. `TemplateRenderer` was removed) — a removed API trends the verdict toward "obsolete".
-4. Before citing a candidate fixing PR, confirm it touched the relevant module — `git show <sha> --stat`. A matching title can mislead.
+3. When a fixing PR is found, **resolve the issue it closed** — `gh pr view <n> --repo vaadin/<repo> --json closingIssuesReferences,body`. That issue is usually the duplicate that got fixed while the triaged report stayed open (common when they live in different trackers); record it in the summary's `Duplicate of:` field.
+4. Check the reported API still exists (e.g. `TemplateRenderer` was removed) — a removed API trends the verdict toward "obsolete".
+5. Before citing a candidate fixing PR, confirm it touched the relevant module — `git show <sha> --stat`. A matching title can mislead.
 
-A found fix does **not** skip browser verification, but it lets the view stay minimal and the report cite "fixed by #PR (with regression test)" — far more closeable than "could not reproduce".
+A found fix does **not** skip browser verification, but it lets the view stay minimal and the report cite "duplicate of #N, fixed by #PR (with regression test)" — far more closeable than "could not reproduce".
 
 ## 5. Intended behavior, then hypothesis
 

--- a/.claude/skills/repro/references/issue-analysis.md
+++ b/.claude/skills/repro/references/issue-analysis.md
@@ -1,0 +1,51 @@
+# Phase 1 — Understanding the bug
+
+Trackers in scope: `vaadin/flow-components` and `vaadin/flow` — component-specific bugs are frequently filed in the Flow tracker (e.g. a `ComponentRenderer` or `Grid` bug). The tracker doesn't decide the owning layer; the reproducing code path does.
+
+## 1. Fetch the issue
+
+One call (`gh issue view --comments` prints nothing non-interactively):
+
+```bash
+gh issue view <n> --repo vaadin/<repo> --json number,title,state,body,labels,comments
+```
+
+- Keep any `--jq` simple — no nested double quotes inside a double-quoted command; build strings with `+`.
+- Read for a code example, reproduction steps, expected vs. actual behavior.
+- A "works for me" / "could not reproduce" comment does **not** cancel the attempt — build and run it yourself, and mine the comment for variations (version, theme, browser, data set, exact gesture). Report not-reproduced only after genuine Phase 3 iteration.
+- **Fetch attached reproduction projects** — they can decide the verdict (misuse vs. bug). Zips linked as `github.com/.../files/...` download with `curl -sL`; linked repos read via `gh api "repos/<user>/<repo>/git/trees/HEAD?recursive=1" --jq '...'` and `gh api repos/<user>/<repo>/contents/<path> --jq .content | base64 -d`.
+
+## 2. Affected version + regression classification
+
+Note the affected version if stated. Check the current line (`<flow.version>` / `<vaadin.version>` in the repo `pom.xml`). If the bug is reportedly fixed in a newer line or the range is below the checkout, switch to the matching maintenance branch — see [reproduce.md](reproduce.md).
+
+**Classify the regression:** `worked in <ver> / broke in <ver>` when there is evidence of both ends; `not a regression` when broken since the feature shipped; `unknown` otherwise. Recorded in the report for the team — informational only.
+
+## 3. Resolve every named component to its real source — never assume API from memory
+
+Tags, attributes, and APIs drift across versions; a wrong guess sends the reproduction at the wrong artifact. Find the Java class under `vaadin-<name>-flow-parent/`, and use the API the way existing integration-test views use it. Never assume markup or API from memory.
+
+## 4. Fix archaeology (issues more than ~2 years old)
+
+Old issues are often already fixed, the fix never linked back. Before scaffolding:
+
+1. Grep the component's IT module for an existing regression view/test matching the symptom.
+2. `git log --oneline -S "<distinctive symbol or error string>" -- <suspect paths>` to find the fixing commit/PR; record `fixing PR: <#N | none found>` for the summary. Many fixes are broad reworks with no single greppable PR — "none found" is a normal answer.
+3. Check the reported API still exists (e.g. `TemplateRenderer` was removed) — a removed API trends the verdict toward "obsolete".
+4. Before citing a candidate fixing PR, confirm it touched the relevant module — `git show <sha> --stat`. A matching title can mislead.
+
+A found fix does **not** skip browser verification, but it lets the view stay minimal and the report cite "fixed by #PR (with regression test)" — far more closeable than "could not reproduce".
+
+## 5. Intended behavior, then hypothesis
+
+Check what the component should do (docs, `src/` API, javadoc contracts, tests), not just what the reporter expected — if it works as designed, the verdict is "works as designed (likely misuse)". Write one line: **"The bug is X, triggered by Y, observable as Z"**, where Z is the exact failure signal to look for.
+
+## 6. Duplicates
+
+Search open and closed issues for the component plus a distinctive symptom across the trackers:
+
+```bash
+gh search issues "<component> <distinctive token>" --repo vaadin/flow-components --repo vaadin/web-components --repo vaadin/flow
+```
+
+`--repo vaadin/web-components` is included on purpose — a Flow component bug may duplicate a web-component issue. Confirm a real match only after reproducing — same root cause, stack trace, and trigger, not a similar title. A confirmed match makes the verdict "duplicate of #N".

--- a/.claude/skills/repro/references/reproduce.md
+++ b/.claude/skills/repro/references/reproduce.md
@@ -1,0 +1,119 @@
+# Building and running the reproduction
+
+Work in `<ROOT>` (this flow-components checkout): a multi-module Maven project, Java 21+, Vaadin Flow 25+. Run all `mvn` commands from `<ROOT>` and write the View under it — never rely on relative paths.
+
+## 1. Module layout
+
+```
+vaadin-<component>-flow-parent/
+├── vaadin-<component>-flow/                    # component implementation (root-cause search)
+├── vaadin-<component>-flow-integration-tests/  # put the repro View here
+└── vaadin-<component>-testbench/               # TestBench elements
+```
+
+## 2. Create the repro View
+
+Add a View under the integration-tests module:
+
+```
+<ROOT>/vaadin-<component>-flow-parent/vaadin-<component>-flow-integration-tests/src/main/java/com/vaadin/flow/component/<component>/tests/Repro<issue>View.java
+```
+
+Copy the exact imports, copyright header, and base class from an existing View in that package (e.g. `<Component>View.java`). Minimal shape:
+
+```java
+package com.vaadin.flow.component.<component>.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.<component>.<Component>;
+import com.vaadin.flow.router.Route;
+
+@Route("repro-<issue>")
+public class Repro<issue>View extends Div {
+    public Repro<issue>View() {
+        // minimal setup that reproduces the bug; give components setId(...)
+        <Component> component = new <Component>();
+        add(component);
+    }
+}
+```
+
+Served at `http://localhost:8080/repro-<issue>`. A JUnit IT class is **not** needed for manual reproduction — driving the View with playwright-cli is enough. Add one (extending `com.vaadin.tests.AbstractComponentIT`, `@TestPath("repro-<issue>")`) only if the user wants an automated regression test.
+
+## 3. Design the View for iteration — avoid server restarts
+
+Jetty does **not** hot-reload Java: every View edit costs a full ~90 s package-and-restart cycle. Build the first version so likely variations need no edits:
+
+- Give an `id` to every element you assert on. Prefer server-side log targets — a `Span`/`Div` updated from listeners (value-change with `isFromClient`, click counters, data-provider query logs) — over sniffing client component state.
+- Add a control `NativeButton` for every server-side action you may need: set value, refresh, detach/reattach, toggle visibility.
+- Put variants **side by side** (failing setup + control in one view) instead of editing sequentially — the minimal pair also isolates the trigger for root-cause analysis.
+- Switch multiplying variants with query parameters (read `QueryParameters`, e.g. `?columns=50&headerRow=true`) instead of recompiling.
+- **Batch every anticipated fix before the first build** — missing dependencies (§4), API substitutions (§5), seed data — each missed one costs a full restart.
+
+## 4. Add missing component dependencies
+
+An integration-tests module depends only on **its own** component plus `flow-html-components` (`Div`, `Span`, etc.). A cross-component reproduction fails to compile with `package … does not exist` / `cannot find symbol` for components the module lacks.
+
+Scan your View's imports first. When a component is incidental (layout, a trigger button, a text input), prefer what the module already has — `Div`, `Span`, `NativeButton`, native DOM — over adding a dependency. For each remaining `com.vaadin.flow.component.<x>` package not already a `<dependency>` in the IT module's `pom.xml`, add it with `<version>${project.version}</version>`. The artifactId mirrors the package with hyphenation — `…component.dialog` → `vaadin-dialog-flow`, `…component.textfield` → `vaadin-text-field-flow`, `…component.orderedlayout` → `vaadin-ordered-layout-flow`; `…component.html` (Div, Span, …) is already present via `flow-html-components`.
+
+This pom edit is part of the scaffold. When the bug reproduces it is **committed** on the `repro/<issue>` branch (see [share.md](share.md)) so the branch is runnable — do not revert it. Only when the bug does **not** reproduce do you revert it in cleanup. The `-am` build flag compiles the newly added sibling modules from source, so the first build is longer.
+
+## 5. Porting an old reporter example
+
+- **A compile failure on a faithful port is weak, obsolete evidence** (removed APIs, e.g. `PolymerTemplate` → `LitTemplate`) — note it in the summary, then reproduce the behavior with the modern API as resolved in Phase 1 (issue-analysis.md §3–4).
+
+## 6. Run the server
+
+The first run compiles the frontend and is slow. Start in the background and poll for real readiness — never guess with `sleep`. **Set expectations:** the first build of a module in a session takes ~3–6 min (frontend bundle); later restarts ~60–90 s. Warn the user so a quiet log isn't mistaken for a hang.
+
+```bash
+cd "<ROOT>" && CI=true mvn package jetty:run -Dvaadin.pnpm.enable -Dvaadin.frontend.hotdeploy=true -am -B -q -DskipTests \
+  -pl vaadin-<component>-flow-parent/vaadin-<component>-flow-integration-tests
+```
+
+- **`CI=true` is required in this headless (no-TTY) environment.** Without it, pnpm aborts when purging `node_modules` (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`) — the HTTP port still comes up but dev mode never initializes, so the page is a blank spinner that looks like a real bug.
+- **Watch for build failure, not just success.** Wait on the task's output file with one call that breaks on failure markers too, or it hangs forever on a broken build:
+  ```bash
+  timeout 360 bash -c 'until grep -qEa "Frontend compiled successfully|BUILD FAILURE|ERR_PNPM|Dependency ERROR|does not exist|Address already in use" <task-output-file>; do sleep 2; done'; \
+  grep -aE "Frontend compiled successfully|BUILD FAILURE|ERR_PNPM|Address already in use" <task-output-file> | head -3
+  ```
+  If the harness blocks foreground waits, run the same loop as a background task and block on its completion. **A listening port 8080 is not proof of readiness** — confirm `Frontend compiled successfully` appeared.
+
+## 7. Pitfalls
+
+- **Stale dev bundle after a branch/version switch — the silent trap.** The generated frontend (`<IT-module>/frontend/generated/`, including the `jar-resources/*Connector.ts` the page actually serves), plus `node_modules/` and `node_modules/.vite`, are **git-ignored, so `git checkout` never touches them** and `-Dvaadin.frontend.hotdeploy=true` does **not** re-extract the jar-resources. Switching between **version lines** (e.g. `24.10` ↔ `25.x`/`main`, or a shared checkout pulled/reset under you — check `git reflog`) advances `src/` and `package.json` but leaves the connector frozen, so it calls web-component internals the fresh `@vaadin/*` no longer has.
+  - **Signature:** a client-console `TypeError: <element>.<method> is not a function` whose stack is in `VAADIN/generated/jar-resources/*Connector.*`. It fires on data updates, appears on **every** page of that component including maintained ITs, and is a **build artifact — never a product bug**.
+  - **Force a clean regeneration** (only when switching version lines, or when the signature fires). `mvn clean` alone is insufficient: `frontend/generated/` lives at the module root, not under `target/`.
+    ```bash
+    mvn clean -q -am -pl vaadin-<component>-flow-parent/vaadin-<component>-flow-integration-tests
+    rm -rf vaadin-<component>-flow-parent/vaadin-<component>-flow-integration-tests/frontend/generated \
+           vaadin-<component>-flow-parent/vaadin-<component>-flow-integration-tests/node_modules/.vite
+    ```
+  - **Confirm it's fresh:** fetch the served connector and grep for the method the TypeError named — `curl -s http://localhost:8080/VAADIN/generated/jar-resources/<component>Connector.ts | grep -c <method>` should be `0`, and a data update should log no `jar-resources` TypeError.
+- **`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`** can fail the install on bleeding-edge lines (`main`/`*-SNAPSHOT`) whose `@vaadin/*` nightlies are < 24h old and trip pnpm's supply-chain guard. `CI=true` doesn't fix it — reproduce on the latest released maintenance branch (§8), or ask the user for the local override.
+- **Old branches may not compile under a modern JDK.** Older lines pin an old `maven-compiler-plugin` (e.g. `3.1`) that crashes on Java 17/21 — tell-tale is a `BUILD FAILURE` in a *shared* module (e.g. `vaadin-flow-components-test-util`) with `Cannot read the array length because "arr$" is null`. Remedy: reproduce on the **newest maintenance line that still shows the bug**. Only if truly version-specific, point Maven at a matching JDK via `JAVA_HOME=/path/to/jdkNN mvn …` — ask which JDK rather than guessing.
+- The server does **not** hot-reload Java — restart after editing the View.
+- If port 8080 is already in use, stop and ask the user.
+
+## 8. Maintenance branches
+
+Branches are named `<major>.<minor>` (e.g. `24.10`, `25.1`). The branch for "up to 24.10.x" is `24.10`.
+
+**Pick the newest line that still reproduces — not necessarily the reported minor.** A bug filed against `24.5` almost always still reproduces up the `24.x` line, and a newer branch builds cleanly under a modern JDK whereas the oldest (≲ 24.6) fail to compile under Java 17/21 (§7). Start at the latest line of the reported major; drop to an older minor only if it doesn't reproduce there (then you've also learned the upper bound). For Flow, try `24.10` before `24.5`.
+
+Safety — never clobber the user's work:
+
+1. Record the starting branch: `git -C <ROOT> rev-parse --abbrev-ref HEAD`.
+2. Require a clean tree. If `git -C <ROOT> status --porcelain` is non-empty, stop and ask — do not stash or discard.
+3. Fetch and check out: `git -C <ROOT> fetch origin <major>.<minor> && git -C <ROOT> checkout <major>.<minor>`.
+4. **Force the frontend to regenerate** — `git checkout` doesn't clean the git-ignored generated frontend, so moving between lines mandates the "Force a clean regeneration" command in §7.
+
+A **"version-specific" verdict needs evidence at both ends**: reproduce on the affected branch **and** confirm it does *not* reproduce on the current checkout. If it doesn't reproduce even on the affected branch, say so.
+
+## 9. Stop it cleanly
+
+```bash
+cd "<ROOT>" && mvn jetty:stop -pl vaadin-<component>-flow-parent/vaadin-<component>-flow-integration-tests
+```
+
+Do **not** kill the background Maven task to stop Jetty — that orphans the forked Jetty JVM holding port 8080.

--- a/.claude/skills/repro/references/share.md
+++ b/.claude/skills/repro/references/share.md
@@ -1,0 +1,87 @@
+# Phases 4–6 — Report, share, cleanup
+
+## 1. The report
+
+Copy [`assets/summary-template.md`](../assets/summary-template.md) to `<ROOT>/repro-<issue>-summary.md` and fill **every** field: observed vs. expected behavior, minimal steps, the inline reproduction, any screenshot/video. Cite only bug-relevant console output — never dev-server noise.
+
+**Chat reply is a digest, not a copy**: verdict + regression classification + branch (if pushed) + 3–5 bullets of what was observed, then point at the summary file. Don't restate the full summary in chat — the file is canonical and becomes the comment.
+
+Not reproduced: say so plainly and name the likely reason — fixed on `main` (cite the fixing PR from fix archaeology), version-specific, obsolete API, missing context. Don't force a positive result.
+
+## 2. End every run with a question — never prose
+
+The outward action is the user's; present it as an `AskUserQuestion` (2–4 options, recommended first), never a prose "want me to post…?":
+
+- **Reproduced:** `Push + post + label` · `Push branch only` · `Report only`.
+- **Not reproduced / fixed / duplicate:** when fix archaeology named the fix, the first option cites it — `Post close comment "Fixed by #PR"` (or `Duplicate of #N`); only when nothing was found offer the generic `Post "Could not reproduce using the latest Vaadin version. Closing as stale."`. Always include `Report only`.
+- **Reproduced but works-as-designed / already tracked by an enhancement:** `Report only` · `Push + post noting it`.
+
+Posting the comment is yours on approval; **closing the issue stays the user's action** unless they explicitly ask.
+
+## 3. Share the reproduction branch (reproduced only)
+
+Push from `<ROOT>`, under the `repro/` prefix so branches sort together.
+
+1. Note the starting branch: `git -C <ROOT> rev-parse --abbrev-ref HEAD`.
+2. Branch from the exact HEAD you reproduced on (e.g. a maintenance branch): `git -C <ROOT> checkout -b repro/<issue>`.
+3. **Stage only the files you created/edited** — scaffold, summary, demo screenshot/`*.webm` (copy from `/tmp` first), any IT-pom edit. **Never `git add -A`.**
+   ```bash
+   git -C <ROOT> add <…>/Repro<issue>View.java <…>/integration-tests/pom.xml repro-<issue>-summary.md repro-<issue>.png
+   git -C <ROOT> commit -m "test: reproduce #<issue> (<component>)"
+   ```
+4. Push: `git -C <ROOT> push -u origin repro/<issue>`. If the remote branch exists, use a suffix (`repro/<issue>-2`) rather than force-pushing.
+
+**Posting the comment** goes to a public upstream issue. **Show the rendered comment and get ONE explicit confirmation covering both the comment AND the `ai repro` label** — a separate label request after posting can be denied by permission tooling. Post via file input:
+
+```bash
+gh api repos/vaadin/<repo>/issues/<issue>/comments -F body=@repro-<issue>-summary.md
+```
+
+Capture the returned `html_url`. Keep the `> [!WARNING]` disclaimer first. Then label (same confirmation): `gh issue edit <issue> --repo vaadin/<repo> --add-label "ai repro"`. The `ai repro` label exists in `vaadin/flow-components`; `vaadin/flow` currently has none — check `gh label list --repo vaadin/<repo> --search "ai repro"` and skip gracefully, noting it in the digest.
+
+**Duplicate:** state it in the comment and recommend closing as a duplicate of #N (link both; note if #N is fixed). Surface the close command and run it only on explicit approval — never close yourself:
+
+```bash
+gh issue close <issue> --repo vaadin/<repo> --reason "not planned" --comment "Duplicate of #N"
+```
+
+## 4. Screenshot embedding + permalinks
+
+Reference a committed screenshot by **commit SHA**, not branch name — a slashed branch name breaks raw URLs. Add to the summary before posting:
+
+```markdown
+![<caption>](https://raw.githubusercontent.com/vaadin/<repo>/<commit-sha>/repro-<issue>.png)
+```
+
+where `<commit-sha>` is `git -C <ROOT> rev-parse HEAD`. A video can't embed via `gh` — surface the local `.webm` path so the approver can drag-drop it.
+
+Point at a suspected root cause as a **permalink pinned to a commit SHA**, not a bare `file:line`. On its own line it renders as an inline snippet:
+
+```
+https://github.com/vaadin/<repo>/blob/<SHA>/<path>#L<start>-L<end>
+```
+
+Anchor it to the commit you reproduced on (`git -C <ROOT> rev-parse HEAD`); your branch leaves `src/` untouched, so line numbers match.
+
+## 5. Cleanup
+
+Kill the server per [reproduce.md](reproduce.md) §9 (`jetty:stop`, then verify the port is free — never kill the background Maven task, that orphans the forked JVM).
+
+**If it reproduced and you pushed `repro/<issue>`** — scaffold, summary, and IT-pom edit are committed on that branch, so the working line is already clean. Just switch back:
+
+```bash
+git -C <ROOT> checkout <starting-branch>
+git -C <ROOT> branch -D repro/<issue>      # optional; preserved on the remote
+git -C <ROOT> branch -D <major>.<minor>    # drop any temp maintenance branch
+```
+
+**If it did not reproduce (no branch pushed)** — order matters: a tracked edit (the IT `pom.xml`) makes `git checkout <branch>` abort, so discard tracked edits first, delete untracked scaffold, then switch back:
+
+```bash
+git -C <ROOT> checkout -- <path/to/edited/pom.xml>   # discard tracked edits (if any)
+rm -f <path/to/Repro<issue>View.java>                # delete untracked scaffold
+git -C <ROOT> checkout <starting-branch>
+git -C <ROOT> branch -D <major>.<minor>              # drop any temp maintenance branch
+```
+
+Confirm `git -C <ROOT> status --porcelain` matches the Phase 0 baseline — your scaffold files gone, pre-existing entries untouched — and the repo is on the branch it started on. Delete any `/tmp` screenshot. Leave the pushed `repro/*` branches — they are the shared artifacts.

--- a/.claude/skills/repro/references/share.md
+++ b/.claude/skills/repro/references/share.md
@@ -13,7 +13,7 @@ Not reproduced: say so plainly and name the likely reason — fixed on `main` (c
 The outward action is the user's; present it as an `AskUserQuestion` (2–4 options, recommended first), never a prose "want me to post…?":
 
 - **Reproduced:** `Push + post + label` · `Push branch only` · `Report only`.
-- **Not reproduced / fixed / duplicate:** when fix archaeology named the fix, the first option cites it — `Post close comment "Fixed by #PR"` (or `Duplicate of #N`); only when nothing was found offer the generic `Post "Could not reproduce using the latest Vaadin version. Closing as stale."`. Always include `Report only`.
+- **Not reproduced / fixed / duplicate:** the first option cites everything fix archaeology found — `Post close comment "Duplicate of <repo>#N, fixed by #PR"` (or just the PR / duplicate when only one is known); only when nothing was found offer the generic `Post "Could not reproduce using the latest Vaadin version. Closing as stale."`. Always include `Report only`.
 - **Reproduced but works-as-designed / already tracked by an enhancement:** `Report only` · `Push + post noting it`.
 
 Posting the comment is yours on approval; **closing the issue stays the user's action** unless they explicitly ask.

--- a/.claude/skills/repro/references/verify.md
+++ b/.claude/skills/repro/references/verify.md
@@ -1,0 +1,43 @@
+# Observing the bug in the browser
+
+Core discipline: **never claim a bug reproduced until you have seen the signal in a running browser.** A git diff, an issue comment, or a listening port is not evidence.
+
+## Drive the browser
+
+```bash
+playwright-cli open http://localhost:8080/repro-<issue>
+playwright-cli snapshot
+# ... click / type / press to follow the repro steps ...
+playwright-cli console          # check for JS errors
+playwright-cli screenshot --filename=/tmp/repro-<issue>.png   # for visual bugs
+playwright-cli close
+```
+
+Prefer locators (`page.locator('#id')`) over coordinate clicks — locators pierce open shadow DOM, auto-wait, and auto-scroll; `page.mouse.click(x, y)` into nested shadow roots or overlays lands on the wrong element and yields garbage.
+
+## run-code, eval, snapshots
+
+- **`run-code` takes a function** `async (page) => {…}`; do DOM work inside `page.evaluate(() => {…})`. The outer scope has `page` only — no `document`/`window`/`setTimeout`; wait with `page.waitForTimeout(ms)`.
+- The script is echoed back and `console.log` is **not** captured — keep it terse and `return` a JSON string of the measurements. `--raw eval "() => …"` is for one-liners only: nested quotes inside it can fail silently (empty output) — move anything non-trivial into a file and run `run-code --filename`.
+- **`open <url>` once per session before any `run-code`** — a fresh CLI session errors *"browser is not open"*. `open` auto-prints a snapshot; otherwise navigate with `page.goto(...)` inside `run-code` and read values with `eval`. Snapshot only to discover structure/refs.
+
+## Filter dev-server noise
+
+Ignore dev-environment noise — a favicon 404 and dev-mode warnings always appear and belong to no bug. Don't cite them; if nothing else appears, say the console is clean.
+
+## Inspect the real DOM before asserting
+
+Components render into shadow DOM and slot into light DOM; "hidden" is rarely a `hidden` attribute — it may be a slot, a `part`, `display: none`, or a property. Don't guess a selector; dump the structure once, then build the check from what you see:
+
+```bash
+playwright-cli --raw eval "() => document.querySelector('vaadin-<component>').shadowRoot.innerHTML.replace(/\s+/g,' ').slice(0,800)"
+```
+
+Prefer the component's own state (a public/observed property, computed style, `offsetWidth > 0`) over the bare `hidden` attribute.
+
+## General gotchas
+
+- Prefer server-side assertion targets — a `Span`/`Div` with an `id` updated from listeners (value-change with `isFromClient`, click counters, data-provider query logs) — over sniffing client component state.
+- After setting a property/attribute on a Lit-based component, wait a frame before asserting computed styles — a same-tick `getComputedStyle` read shows the stale style.
+- `@PreserveOnRefresh` views: component state (e.g. an open dialog) persists across full navigations — `page.goto` is not a clean slate; reset with `Escape` or a fresh browser context before each trial.
+- A client `TypeError` from `VAADIN/generated/jar-resources/*Connector.*` is a stale dev bundle, never a product bug — regenerate per [reproduce.md](reproduce.md).


### PR DESCRIPTION
## Description

Added new skill `.claude/skills/repro` that reproduces a bug from a `vaadin/flow-components` or `vaadin/flow` issue URL: builds a minimal integration-test View, confirms the bug in a running browser via playwright-cli, points at the likely root cause, pushes a shareable `repro/<issue>` branch and (after confirmation) posts a summary comment on the issue.

```sh
/repro https://github.com/vaadin/flow-components/issues/1165
```

## Type of change

- Internal change

## Note

- Requires [`playwright-cli`](https://github.com/microsoft/playwright-cli#installation) to be installed (including `ffmpgeg` to record reproduction videos)
- Example output: https://github.com/vaadin/flow-components/issues/1165#issuecomment-4991357817