### PR TITLE
chore: add web-components ref input to validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -20,6 +20,10 @@ on:
         required: false
         default: false
         type: boolean
+      local-wc-ref:
+        description: 'Branch or ref of web-components to use with local-wc-validation, empty for main'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
@@ -203,7 +207,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: vaadin/web-components
-          ref: main
+          ref: ${{ inputs.local-wc-ref || 'main' }}
           path: web-components
 
       - name: Install web-components


### PR DESCRIPTION
The validation workflow can already run against a local web-components checkout, but it always uses the `main` branch. This adds a `local-wc-ref` input to the manual dispatch so validation can run against a specific web-components branch, for example to test a web-components change before it is merged. When the input is empty, scheduled and manual runs keep using `main` as before.
