### PR TITLE
chore: skip web-components setup for unit tests in validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -199,7 +199,7 @@ jobs:
           node-version: '24'
 
       - name: Checkout web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
+        if: matrix.type != 'unit' && (github.event_name == 'schedule' || inputs.local-wc-validation)
         uses: actions/checkout@v6
         with:
           repository: vaadin/web-components
@@ -207,12 +207,12 @@ jobs:
           path: web-components
 
       - name: Install web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
+        if: matrix.type != 'unit' && (github.event_name == 'schedule' || inputs.local-wc-validation)
         run: yarn install --ignore-engines --ignore-scripts
         working-directory: web-components
 
       - name: Configure local web-components
-        if: matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation
+        if: matrix.type != 'unit' && (github.event_name == 'schedule' || inputs.local-wc-validation)
         run: echo "LOCAL_WEB_COMPONENTS_PATH=web-components" > .env
 
       - name: npm install


### PR DESCRIPTION
In GitHub expressions `&&` binds tighter than `||`, so the condition `matrix.type != 'unit' && github.event_name == 'schedule' || inputs.local-wc-validation` evaluates as `(A && B) || C`. As a result, when `local-wc-validation` is enabled, the web-components checkout, install and configuration steps also run in the unit tests shard, where they are not used and only waste time. This adds parentheses so these steps never run for unit tests.