### PR TITLE
refactor: allow grid header and footer renderers to run multiple times

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -97,6 +97,13 @@ public class GridHeaderFooterRowPage extends Div {
         button.setId("set-components-for-headers");
         add(button);
 
+        button = new NativeButton("Set components for footers",
+                event -> grid.getFooterRows().stream()
+                        .flatMap(row -> row.getCells().stream())
+                        .forEach(cell -> cell.setComponent(new Span("foo"))));
+        button.setId("set-components-for-footers");
+        add(button);
+
         button = new NativeButton("Set text for headers",
                 event -> grid.getHeaderRows().stream()
                         .flatMap(row -> row.getCells().stream())

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -117,6 +117,42 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setHeaderComponent_appendHeader_componentIsPreserved() {
+        clickButton("append-header");
+        clickButton("set-components-for-headers");
+        clickButton("append-header");
+
+        List<WebElement> headerCells = getHeaderCells();
+        Assert.assertEquals("Unexpected amount of header cells", 2,
+                headerCells.size());
+        Assert.assertEquals(
+                "The first header row should contain the moved component",
+                "<span>foo</span>",
+                headerCells.get(0).getDomProperty("innerHTML"));
+        Assert.assertEquals(
+                "The appended header row should contain only its own text", "1",
+                headerCells.get(1).getDomProperty("innerHTML"));
+    }
+
+    @Test
+    public void setFooterComponent_prependFooter_componentIsPreserved() {
+        clickButton("append-footer");
+        clickButton("set-components-for-footers");
+        clickButton("prepend-footer");
+
+        List<WebElement> footerCells = getFooterCells();
+        Assert.assertEquals("Unexpected amount of footer cells", 2,
+                footerCells.size());
+        Assert.assertEquals(
+                "The prepended footer row should contain only its own text",
+                "1", footerCells.get(0).getDomProperty("innerHTML"));
+        Assert.assertEquals(
+                "The last footer row should contain the moved component",
+                "<span>foo</span>",
+                footerCells.get(1).getDomProperty("innerHTML"));
+    }
+
+    @Test
     public void appendHeaderAfterGridIsRendered_lastHeaderIsEmpty() {
         clickButton("append-header");
         clickButton("append-header-without-content");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { init, setRootItems, getHeaderCellContent, getFooterCellContent } from './shared.js';
 import type { FlowGrid } from './shared.js';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 
-class FlowElement extends HTMLElement {
+class TestElement extends HTMLElement {
   connectSpy = sinon.spy();
   disconnectSpy = sinon.spy();
 
@@ -18,7 +18,7 @@ class FlowElement extends HTMLElement {
   }
 }
 
-customElements.define('flow-element', FlowElement);
+customElements.define('test-element', TestElement);
 
 describe('grid connector - header and footer renderers', () => {
   let grid: FlowGrid;
@@ -82,7 +82,7 @@ describe('grid connector - header and footer renderers', () => {
     });
 
     it('should not detach node content when renderer runs again', async () => {
-      const content = document.createElement('flow-element') as FlowElement;
+      const content = document.createElement('test-element') as TestElement;
       grid.$connector.setHeaderRenderer(column, { content });
       await nextFrame();
 
@@ -187,7 +187,7 @@ describe('grid connector - header and footer renderers', () => {
     });
 
     it('should not detach node content when renderer runs again', async () => {
-      const content = document.createElement('flow-element') as FlowElement;
+      const content = document.createElement('test-element') as TestElement;
       grid.$connector.setFooterRenderer(column, { content });
       await nextFrame();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
@@ -66,13 +66,42 @@ describe('grid connector - header and footer renderers', () => {
     });
 
     describe('sorter', () => {
-      it('should render content inside the sorter', async () => {
+      it('should render sorter', async () => {
         grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
         await nextFrame();
 
         const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
         expect(sorter).to.exist;
+        expect(sorter.path).to.equal('name');
+      });
+
+      it('should render text content inside sorter', async () => {
+        grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
+        await nextFrame();
+
+        const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
         expect(sorter.textContent).to.equal('Name');
+      });
+
+      it('should render node content inside sorter', async () => {
+        const span = document.createElement('span');
+        span.textContent = 'Name';
+        grid.$connector.setHeaderRenderer(column, { content: span, showSorter: true, sorterPath: 'name' });
+        await nextFrame();
+
+        const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+        expect(sorter.contains(span)).to.be.true;
+      });
+
+      it('should reuse sorter element when renderer runs again', async () => {
+        grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
+        await nextFrame();
+
+        const oldSorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+        grid.requestContentUpdate();
+        const newSorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+
+        expect(newSorter).to.equal(oldSorter);
       });
     });
   });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-header-footer.test.ts
@@ -1,8 +1,24 @@
 import { expect } from 'chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { init, setRootItems, getHeaderCellContent, getFooterCellContent } from './shared.js';
 import type { FlowGrid } from './shared.js';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
+
+class FlowElement extends HTMLElement {
+  connectSpy = sinon.spy();
+  disconnectSpy = sinon.spy();
+
+  connectedCallback() {
+    this.connectSpy();
+  }
+
+  disconnectedCallback() {
+    this.disconnectSpy();
+  }
+}
+
+customElements.define('flow-element', FlowElement);
 
 describe('grid connector - header and footer renderers', () => {
   let grid: FlowGrid;
@@ -65,6 +81,19 @@ describe('grid connector - header and footer renderers', () => {
       expect(column.headerRenderer).to.be.null;
     });
 
+    it('should not detach node content when renderer runs again', async () => {
+      const content = document.createElement('flow-element') as FlowElement;
+      grid.$connector.setHeaderRenderer(column, { content });
+      await nextFrame();
+
+      grid.requestContentUpdate();
+      await nextFrame();
+
+      expect(getHeaderCellContent(column).contains(content)).to.be.true;
+      expect(content.connectSpy).to.be.calledOnce;
+      expect(content.disconnectSpy).to.not.be.called;
+    });
+
     describe('sorter', () => {
       it('should render sorter', async () => {
         grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
@@ -93,15 +122,26 @@ describe('grid connector - header and footer renderers', () => {
         expect(sorter.contains(span)).to.be.true;
       });
 
-      it('should reuse sorter element when renderer runs again', async () => {
+      it('should reuse sorter element when renderer runs with different root', async () => {
+        grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
+        await nextFrame();
+        const sorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+
+        const div = document.createElement('div');
+        column.headerRenderer!(div, column);
+        expect(div.querySelector('vaadin-grid-sorter')!).to.equal(sorter);
+      });
+
+      it('should not detach sorter when renderer runs again', async () => {
         grid.$connector.setHeaderRenderer(column, { content: 'Name', showSorter: true, sorterPath: 'name' });
         await nextFrame();
 
-        const oldSorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
-        grid.requestContentUpdate();
-        const newSorter = getHeaderCellContent(column).querySelector('vaadin-grid-sorter')!;
+        const mutationSpy = sinon.spy();
+        new MutationObserver(mutationSpy).observe(getHeaderCellContent(column), { childList: true });
 
-        expect(newSorter).to.equal(oldSorter);
+        grid.requestContentUpdate();
+        await nextFrame();
+        expect(mutationSpy).to.not.be.called;
       });
     });
   });
@@ -144,6 +184,19 @@ describe('grid connector - header and footer renderers', () => {
 
       expect(getFooterCellContent(column).textContent).to.equal('');
       expect(column.footerRenderer).to.be.null;
+    });
+
+    it('should not detach node content when renderer runs again', async () => {
+      const content = document.createElement('flow-element') as FlowElement;
+      grid.$connector.setFooterRenderer(column, { content });
+      await nextFrame();
+
+      grid.requestContentUpdate();
+      await nextFrame();
+
+      expect(getFooterCellContent(column).contains(content)).to.be.true;
+      expect(content.connectSpy).to.be.calledOnce;
+      expect(content.disconnectSpy).to.not.be.called;
     });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -10,7 +10,11 @@ function isRangeEqual(range1, range2) {
 
 function renderContent(root, content) {
   if (content instanceof Node) {
-    root.appendChild(content);
+    // Skip if the content is already in place: re-appending would detach
+    // and reattach it, making header components lose state such as focus.
+    if (content.parentNode !== root) {
+      root.appendChild(content);
+    }
   } else {
     root.textContent = content;
   }
@@ -431,7 +435,9 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       if (showSorter) {
         sorter ??= document.createElement('vaadin-grid-sorter');
         sorter.setAttribute('path', sorterPath);
-        root.appendChild(sorter);
+        if (sorter.parentNode !== root) {
+          root.appendChild(sorter);
+        }
 
         // Use sorter as content root
         contentRoot = sorter;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -10,8 +10,6 @@ function isRangeEqual(range1, range2) {
 
 function renderContent(root, content) {
   if (content instanceof Node) {
-    // Skip if the content is already in place: re-appending would detach
-    // and reattach it, making header components lose state such as focus.
     if (content.parentNode !== root) {
       root.appendChild(content);
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -8,15 +8,6 @@ function isRangeEqual(range1, range2) {
   return range1?.[0] === range2?.[0] && range1?.[1] === range2?.[1];
 }
 
-function singleTimeRenderer(renderer) {
-  return (root) => {
-    if (renderer) {
-      renderer(root);
-      renderer = null;
-    }
-  };
-}
-
 function renderContent(root, content) {
   if (content instanceof Node) {
     root.appendChild(content);
@@ -430,11 +421,15 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       return;
     }
 
-    column.headerRenderer = singleTimeRenderer((root) => {
-      // Render sorter
+    // The renderer can run multiple times, e.g. when the grid re-creates
+    // header cells. The sorter is cached between runs: re-creating it would
+    // reset its direction and fire a sorters-changed round-trip to the server.
+    let sorter;
+
+    column.headerRenderer = (root) => {
       let contentRoot = root;
       if (showSorter) {
-        const sorter = document.createElement('vaadin-grid-sorter');
+        sorter ??= document.createElement('vaadin-grid-sorter');
         sorter.setAttribute('path', sorterPath);
         root.appendChild(sorter);
 
@@ -443,7 +438,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       }
 
       renderContent(contentRoot, content);
-    });
+    };
   };
 
   // This method is overridden to prevent the grid web component from
@@ -488,7 +483,7 @@ window.Vaadin.Flow.gridConnector.initLazy = (grid) => {
       return;
     }
 
-    column.footerRenderer = singleTimeRenderer((root) => renderContent(root, content));
+    column.footerRenderer = (root) => renderContent(root, content);
   };
 
   grid.addEventListener('vaadin-context-menu-before-open', function (e) {


### PR DESCRIPTION
The grid web component is moving to rendering its header and footer declaratively with Lit (vaadin/web-components#12134). With that change, header and footer cells can be re-created, which re-runs the column renderers. The connector wrapped these renderers in `singleTimeRenderer`, so a re-created cell would stay empty.

The sorter element is now cached between renderer runs: re-creating it on every run would reset the sort direction and send a needless `sorters-changed` event to the server.

Part of vaadin/web-components#10789
