### PR TITLE
test: re-enable undefined-size grid scroll regression checks

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
@@ -56,12 +56,8 @@ public abstract class AbstractItemCountGridIT extends AbstractComponentIT {
     protected void doScroll(int rowToScroll, int expectedRows, int fetchIndex,
             int start, int end) {
         grid.scrollToRow(rowToScroll);
-        // Note: the per-scroll fetch-range assertion
-        // (verifyFetchForUndefinedSizeCallback) is intentionally not used here.
-        // The grid fetches page by page, so a single scroll may trigger several
-        // fetches, which the one-range-per-scroll fetchIndex model cannot
-        // express. The fetchIndex/start/end parameters are kept for readability
-        // of the intended range. Only the resulting row count is asserted.
+        // A single scroll may fetch several pages, so only the resulting row
+        // count is asserted here. fetchIndex/start/end document the range.
         verifyRows(expectedRows);
     }
 
@@ -104,6 +100,16 @@ public abstract class AbstractItemCountGridIT extends AbstractComponentIT {
 
     protected int getFetchQueryCount() {
         return findElements(By.cssSelector("[id^='log-']")).size();
+    }
+
+    /**
+     * Returns the start offset of the fetch query logged at the given index.
+     * Log entries are formatted as {@code "<index>:Range [<start>..<end>]"}.
+     */
+    protected int getFetchedOffset(int index) {
+        String text = findElement(By.id("log-" + index)).getText();
+        return Integer.parseInt(
+                text.substring(text.indexOf('[') + 1, text.indexOf("..")));
     }
 
     protected void verifyFetchForUndefinedSizeCallback(int index, Range range) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
@@ -56,10 +56,12 @@ public abstract class AbstractItemCountGridIT extends AbstractComponentIT {
     protected void doScroll(int rowToScroll, int expectedRows, int fetchIndex,
             int start, int end) {
         grid.scrollToRow(rowToScroll);
-        // FIXME when grid reduces size, it does currently some extra fetches
-        // -> not checking the requested items until this is fixed
-        // verifyFetchForUndefinedSizeCallback(fetchIndex,
-        // Range.between(start, end));
+        // Note: the per-scroll fetch-range assertion
+        // (verifyFetchForUndefinedSizeCallback) is intentionally not used here.
+        // The grid fetches page by page, so a single scroll may trigger several
+        // fetches, which the one-range-per-scroll fetchIndex model cannot
+        // express. The fetchIndex/start/end parameters are kept for readability
+        // of the intended range. Only the resulting row count is asserted.
         verifyRows(expectedRows);
     }
 
@@ -98,6 +100,10 @@ public abstract class AbstractItemCountGridIT extends AbstractComponentIT {
     protected void verifyRows(int size) {
         Assert.assertEquals("Item count doesn't match", size,
                 grid.getRowCount());
+    }
+
+    protected int getFetchQueryCount() {
+        return findElements(By.cssSelector("[id^='log-']")).size();
     }
 
     protected void verifyFetchForUndefinedSizeCallback(int index, Range range) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
@@ -49,21 +49,19 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
         doScroll(500, 500, 5, 450, 500);
         Assert.assertEquals(499, grid.getLastVisibleRowIndex());
 
-        // After the size was adjusted down from the estimate, scrolling back
-        // and forth must keep the adjusted size and must not make the grid
-        // fetch extra earlier ranges (regression test for #1038 / flow #9166).
-        int fetchCountAfterEnd = getFetchQueryCount();
+        // After the size is adjusted down, scrolling back and forth keeps the
+        // size and only fetches the visited viewports (near the top and near
+        // row 450) - never the ranges in between.
+        int fetchesBefore = getFetchQueryCount();
         doScroll(0, 500, 6, 0, 100);
         doScroll(450, 500, 7, 400, 500);
-        // Scrolling within the already-known size fetches at most the two
-        // visited viewports (top and around row 450), never a storm of
-        // earlier-range refetches. Observed delta is 4; a small margin guards
-        // against viewport/row-height variance while still catching the
-        // pre-fix behavior, which refetched many earlier ranges.
-        Assert.assertTrue(
-                "Scrolling after the size was adjusted must not trigger "
-                        + "unnecessary fetches for earlier ranges",
-                getFetchQueryCount() - fetchCountAfterEnd <= 6);
+        for (int i = fetchesBefore; i < getFetchQueryCount(); i++) {
+            int offset = getFetchedOffset(i);
+            Assert.assertTrue(
+                    "Refetched an off-viewport range at offset " + offset
+                            + " after the size was adjusted",
+                    offset < 150 || offset >= 350);
+        }
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
@@ -48,10 +48,22 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
         // scroll to actual end, no more items returned and size is adjusted
         doScroll(500, 500, 5, 450, 500);
         Assert.assertEquals(499, grid.getLastVisibleRowIndex());
-        // TODO #1038 test further after grid is note fetching extra stuff when
-        // size has been adjusted to less than what it is
-        // doScroll(0, 500, 6, 0, 100);
-        // doScroll(450, 500, 7, 400, 500);
+
+        // After the size was adjusted down from the estimate, scrolling back
+        // and forth must keep the adjusted size and must not make the grid
+        // fetch extra earlier ranges (regression test for #1038 / flow #9166).
+        int fetchCountAfterEnd = getFetchQueryCount();
+        doScroll(0, 500, 6, 0, 100);
+        doScroll(450, 500, 7, 400, 500);
+        // Scrolling within the already-known size fetches at most the two
+        // visited viewports (top and around row 450), never a storm of
+        // earlier-range refetches. Observed delta is 4; a small margin guards
+        // against viewport/row-height variance while still catching the
+        // pre-fix behavior, which refetched many earlier ranges.
+        Assert.assertTrue(
+                "Scrolling after the size was adjusted must not trigger "
+                        + "unnecessary fetches for earlier ranges",
+                getFetchQueryCount() - fetchCountAfterEnd <= 6);
     }
 
     @Test


### PR DESCRIPTION
## Description

Re-enable the disabled steps in the ItemCountUnknownGridIT scroll-to-end test and drop the stale FIXME. The grid no longer fetches extra earlier ranges after the item count shrinks from an estimate to the real size, so assert that scrolling around after the size is adjusted keeps the size and does not trigger unnecessary fetches.

Related to https://github.com/vaadin/flow/issues/9166

## Type of change

- Test