### PR TITLE
feat: add headingLevel API to Accordion

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/main/java/com/vaadin/flow/component/accordion/Accordion.java
@@ -56,6 +56,7 @@ public class Accordion extends Component implements HasSize, HasStyle {
 
     private static final String OPENED_PROPERTY = "opened";
     private static final String OPENED_CHANGED_DOM_EVENT = "opened-changed";
+    private static final String HEADING_LEVEL_PROPERTY = "headingLevel";
 
     /**
      * Initializes a new Accordion component.
@@ -215,6 +216,40 @@ public class Accordion extends Component implements HasSize, HasStyle {
                 ? Optional.empty()
                 : accordion.getElement().getChild(index).getComponent()
                         .map(AccordionPanel.class::cast);
+    }
+
+    /**
+     * Gets the ARIA heading level applied to the panel headings.
+     *
+     * @return the heading level, or {@code null} if none is set
+     * @since 25.3
+     */
+    public Integer getHeadingLevel() {
+        if (getElement().getPropertyRaw(HEADING_LEVEL_PROPERTY) == null) {
+            return null;
+        }
+        return (int) getElement().getProperty(HEADING_LEVEL_PROPERTY, 0.0);
+    }
+
+    /**
+     * Sets the ARIA heading level for the panel headings, exposing them at the
+     * level that matches the surrounding page structure. This sets the
+     * {@code aria-level} attribute on each panel heading.
+     * <p>
+     * By default no heading level is set and screen readers announce the
+     * headings using their default level. Set to {@code null} to restore the
+     * default.
+     *
+     * @param headingLevel
+     *            the heading level, or {@code null} to remove it
+     * @since 25.3
+     */
+    public void setHeadingLevel(Integer headingLevel) {
+        if (headingLevel == null) {
+            getElement().removeProperty(HEADING_LEVEL_PROPERTY);
+        } else {
+            getElement().setProperty(HEADING_LEVEL_PROPERTY, headingLevel);
+        }
     }
 
     /**

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/test/java/com/vaadin/flow/component/accordion/AccordionTest.java
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/src/test/java/com/vaadin/flow/component/accordion/AccordionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.accordion;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AccordionTest {
+
+    @Test
+    void headingLevel() {
+        Accordion accordion = new Accordion();
+
+        Assertions.assertNull(accordion.getHeadingLevel());
+        Assertions.assertNull(
+                accordion.getElement().getPropertyRaw("headingLevel"));
+
+        accordion.setHeadingLevel(3);
+
+        Assertions.assertEquals(3, accordion.getHeadingLevel());
+        Assertions.assertEquals(3.0,
+                accordion.getElement().getProperty("headingLevel", 0.0));
+
+        accordion.setHeadingLevel(null);
+
+        Assertions.assertNull(accordion.getHeadingLevel());
+        Assertions.assertNull(
+                accordion.getElement().getPropertyRaw("headingLevel"));
+    }
+}


### PR DESCRIPTION
Accordion headings expose only a `role="heading"` with no `aria-level`, so screen readers announce them at a default level that may not match the surrounding page structure. The web component gained a `headingLevel` property ([vaadin/web-components#12133](https://github.com/vaadin/web-components/pull/12133)) to set `aria-level` on each panel heading; this exposes it in Flow.

`Accordion.setHeadingLevel(Integer)` / `getHeadingLevel()` map to the web component's `headingLevel` property. It is a nullable `Integer`: `null` (the default) leaves no `aria-level` set, and passing `null` clears a previously set value.

The API lives on `Accordion` only. The web component's per-panel property is internal and re-propagated from the accordion on every change, so there is no public per-panel counterpart.

Part of https://github.com/vaadin/web-components/issues/6900

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)