### PR TITLE
feat: add headingLevel API to Login

### DIFF
--- a/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java
@@ -70,6 +70,7 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
     private static final String PROP_DISABLED = "disabled";
     private static final String PROP_ERROR = "error";
     private static final String PROP_NO_FORGOT_PASSWORD = "noForgotPassword";
+    private static final String PROP_HEADING_LEVEL = "headingLevel";
 
     private static final PropertyChangeListener NO_OP = event -> {
     };
@@ -227,6 +228,36 @@ public abstract class AbstractLogin extends Component implements HasEnabled {
      */
     public boolean isForgotPasswordButtonVisible() {
         return !getElement().getProperty(PROP_NO_FORGOT_PASSWORD, false);
+    }
+
+    /**
+     * Gets the root heading level ({@code aria-level}) of the heading
+     * hierarchy.
+     *
+     * @return the heading level
+     * @see #setHeadingLevel(int)
+     * @since 25.3
+     */
+    public int getHeadingLevel() {
+        return getElement().getProperty(PROP_HEADING_LEVEL, 1);
+    }
+
+    /**
+     * Sets the root heading level ({@code aria-level}) for the heading
+     * hierarchy, exposing the headings at the level that matches the
+     * surrounding page structure. Child headings automatically increment from
+     * this base level: a standalone login form renders its title at the given
+     * level, whereas the form inside the overlay uses the next level down, as
+     * the base level is used by the overlay's own title.
+     * <p>
+     * The default heading level is {@code 1}.
+     *
+     * @param headingLevel
+     *            the heading level
+     * @since 25.3
+     */
+    public void setHeadingLevel(int headingLevel) {
+        getElement().setProperty(PROP_HEADING_LEVEL, headingLevel);
     }
 
     /**

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginFormTest.java
@@ -201,4 +201,17 @@ class LoginFormTest {
 
         Assertions.assertEquals("javascript:alert(1)", form.getAction());
     }
+
+    @Test
+    void headingLevel() {
+        final LoginForm form = new LoginForm();
+
+        Assertions.assertEquals(1, form.getHeadingLevel());
+
+        form.setHeadingLevel(3);
+
+        Assertions.assertEquals(3, form.getHeadingLevel());
+        Assertions.assertEquals(3.0,
+                form.getElement().getProperty("headingLevel", 0.0));
+    }
 }

--- a/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
+++ b/vaadin-login-flow-parent/vaadin-login-flow/src/test/java/com/vaadin/flow/component/login/LoginOverlayTest.java
@@ -143,4 +143,17 @@ class LoginOverlayTest {
         Assertions.assertFalse(overlay.isError(),
                 "Expected error status being reset by default listener");
     }
+
+    @Test
+    void headingLevel() {
+        final LoginOverlay overlay = new LoginOverlay();
+
+        Assertions.assertEquals(1, overlay.getHeadingLevel());
+
+        overlay.setHeadingLevel(3);
+
+        Assertions.assertEquals(3, overlay.getHeadingLevel());
+        Assertions.assertEquals(3.0,
+                overlay.getElement().getProperty("headingLevel", 0.0));
+    }
 }


### PR DESCRIPTION
Added missing API for `headingLevel`.

Based on https://github.com/vaadin/web-components/pull/8445

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)