### PR TITLE
refactor: use optional chaining for connector checks in executeJs

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -249,10 +249,9 @@ class ComboBoxDataController<TItem>
             dataCommunicator.reset();
         }
         comboBox.runBeforeClientResponse(ui -> ui.getPage().executeJs(
-                // If-statement is needed because on the first attach this
+                // Optional chaining is needed because on the first attach this
                 // JavaScript is called before initializing the connector.
-                "if($0.$connector) $0.$connector.reset();",
-                comboBox.getElement()));
+                "$0.$connector?.reset()", comboBox.getElement()));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3176,8 +3176,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                             + pageSize);
         }
         getElement().setProperty("pageSize", pageSize);
-        getElement()
-                .executeJs("if (this.$connector) { this.$connector.reset() }");
+        getElement().executeJs("this.$connector?.reset()");
         getDataCommunicator().setPageSize(pageSize);
         setViewportRange(0, pageSize);
         getDataCommunicator().reset();
@@ -3228,8 +3227,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     }
 
     protected void updateSelectionModeOnClient() {
-        getElement().executeJs(
-                "if (this.$connector) { this.$connector.setSelectionMode($0) }",
+        getElement().executeJs("this.$connector?.setSelectionMode($0)",
                 selectionMode.name());
     }
 
@@ -4201,8 +4199,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         if (getElement().getNode().isAttached()) {
             this.pendingSorterUpdate = getElement().executeJs(
-                    "if (this.$connector) { this.$connector.setSorterDirections($0) }",
-                    directions);
+                    "this.$connector?.setSorterDirections($0)", directions);
         }
     }
 


### PR DESCRIPTION
Several inline JavaScript snippets wrapped connector calls in `if (this.$connector) { ... }` to handle the case where the connector is not initialized yet. Optional chaining does the same check with less code.
