### PR TITLE
fix: preserve scrollToIndex preload range on initial render

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -1246,7 +1246,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
-     * 
+     *
      * @since 24.2
      */
     public <C> void setDataProvider(DataProvider<TItem, C> dataProvider,
@@ -1426,7 +1426,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
-     * 
+     *
      * @since 23.2.12
      */
     protected void validate() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -1246,7 +1246,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
-     *
+     * 
      * @since 24.2
      */
     public <C> void setDataProvider(DataProvider<TItem, C> dataProvider,
@@ -1426,7 +1426,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
-     *
+     * 
      * @since 23.2.12
      */
     protected void validate() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3529,6 +3529,17 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         });
     }
 
+    private void runWhenComponentAttached(SerializableRunnable action) {
+        if (isAttached()) {
+            action.run();
+        } else {
+            addAttachListener((event) -> {
+                event.unregisterListener();
+                action.run();
+            });
+        }
+    }
+
     /**
      * Adds a selection listener to the current selection model.
      * <p>
@@ -5235,7 +5246,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @since 4.1
      */
     public void scrollToIndex(int rowIndex) {
-        getElement().getNode().runWhenAttached((ui) -> {
+        // getNode().runWhenAttached can't be used here: it would run before
+        // onAttach, whose viewport range reset would overwrite the preloaded
+        // range.
+        runWhenComponentAttached(() -> {
             setViewportRangeByIndex(rowIndex);
 
             scheduleScrollExecution(() -> getElement()
@@ -5298,7 +5312,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 .orElseThrow(() -> new NoSuchElementException(
                         "Item to scroll to cannot be found: " + item));
 
-        getElement().getNode().runWhenAttached((ui) -> {
+        // getNode().runWhenAttached can't be used here: it would run before
+        // onAttach, whose viewport range reset would overwrite the preloaded
+        // range.
+        runWhenComponentAttached(() -> {
             setViewportRangeByIndex(itemIndex);
 
             scheduleScrollExecution(() -> getElement().callJsFunction(

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3529,17 +3529,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         });
     }
 
-    private void runWhenComponentAttached(SerializableRunnable action) {
-        if (isAttached()) {
-            action.run();
-        } else {
-            addAttachListener((event) -> {
-                event.unregisterListener();
-                action.run();
-            });
-        }
-    }
-
     /**
      * Adds a selection listener to the current selection model.
      * <p>
@@ -5246,15 +5235,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @since 4.1
      */
     public void scrollToIndex(int rowIndex) {
-        // getNode().runWhenAttached can't be used here: it would run before
-        // onAttach, whose viewport range reset would overwrite the preloaded
-        // range.
-        runWhenComponentAttached(() -> {
-            setViewportRangeByIndex(rowIndex);
+        setViewportRangeByIndex(rowIndex);
 
-            scheduleScrollExecution(() -> getElement()
-                    .callJsFunction("scrollToIndex", rowIndex));
-        });
+        scheduleScrollExecution(() -> getElement()
+                .callJsFunction("scrollToIndex", rowIndex));
     }
 
     private void setViewportRangeByIndex(int rowIndex) {
@@ -5312,15 +5296,10 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 .orElseThrow(() -> new NoSuchElementException(
                         "Item to scroll to cannot be found: " + item));
 
-        // getNode().runWhenAttached can't be used here: it would run before
-        // onAttach, whose viewport range reset would overwrite the preloaded
-        // range.
-        runWhenComponentAttached(() -> {
-            setViewportRangeByIndex(itemIndex);
+        setViewportRangeByIndex(itemIndex);
 
-            scheduleScrollExecution(() -> getElement().callJsFunction(
-                    "$connector.scrollToItem", itemKey, itemIndex));
-        });
+        scheduleScrollExecution(() -> getElement().callJsFunction(
+                "$connector.scrollToItem", itemKey, itemIndex));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4113,6 +4113,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
+        setViewportRange(0, getPageSize());
         if (dataProviderChangeRegistration != null) {
             dataProviderChangeRegistration.remove();
             dataProviderChangeRegistration = null;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1466,7 +1466,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         @Override
         public void initialize() {
-            setViewportRange(0, getPageSize());
+            // NO-OP
         }
     }
 
@@ -4101,6 +4101,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         initConnector();
         updateClientSorterDirections();
         updateClientSelectionMode();
+        if (pendingScrollRegistration == null) {
+            setViewportRange(0, getPageSize());
+        }
         if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4101,7 +4101,6 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         initConnector();
         updateClientSorterDirections();
         updateClientSelectionMode();
-        setViewportRange(0, getPageSize());
         if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }
@@ -5237,8 +5236,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public void scrollToIndex(int rowIndex) {
         setViewportRangeByIndex(rowIndex);
 
-        scheduleScrollExecution(() -> getElement()
-                .callJsFunction("scrollToIndex", rowIndex));
+        scheduleScrollExecution(
+                () -> getElement().callJsFunction("scrollToIndex", rowIndex));
     }
 
     private void setViewportRangeByIndex(int rowIndex) {
@@ -5298,8 +5297,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         setViewportRangeByIndex(itemIndex);
 
-        scheduleScrollExecution(() -> getElement().callJsFunction(
-                "$connector.scrollToItem", itemKey, itemIndex));
+        scheduleScrollExecution(() -> getElement()
+                .callJsFunction("$connector.scrollToItem", itemKey, itemIndex));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -4101,9 +4101,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         initConnector();
         updateClientSorterDirections();
         updateClientSelectionMode();
-        if (pendingScrollRegistration == null) {
-            setViewportRange(0, getPageSize());
-        }
+        setViewportRange(0, getPageSize());
         if (getDataProvider() != null) {
             handleDataProviderChange(getDataProvider());
         }
@@ -5237,10 +5235,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @since 4.1
      */
     public void scrollToIndex(int rowIndex) {
-        setViewportRangeByIndex(rowIndex);
+        getElement().getNode().runWhenAttached((ui) -> {
+            setViewportRangeByIndex(rowIndex);
 
-        scheduleScrollExecution(
-                () -> getElement().callJsFunction("scrollToIndex", rowIndex));
+            scheduleScrollExecution(() -> getElement()
+                    .callJsFunction("scrollToIndex", rowIndex));
+        });
     }
 
     private void setViewportRangeByIndex(int rowIndex) {
@@ -5298,10 +5298,12 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
                 .orElseThrow(() -> new NoSuchElementException(
                         "Item to scroll to cannot be found: " + item));
 
-        setViewportRangeByIndex(itemIndex);
+        getElement().getNode().runWhenAttached((ui) -> {
+            setViewportRangeByIndex(itemIndex);
 
-        scheduleScrollExecution(() -> getElement()
-                .callJsFunction("$connector.scrollToItem", itemKey, itemIndex));
+            scheduleScrollExecution(() -> getElement().callJsFunction(
+                    "$connector.scrollToItem", itemKey, itemIndex));
+        });
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToIndexTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToIndexTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.grid;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -131,6 +132,26 @@ class GridScrollToIndexTest {
         ui.add(grid);
         ui.fakeClientCommunication();
         assertSingleJavaScriptScrollInvocation("scrollToIndex(this._flatSize)");
+    }
+
+    @Test
+    void scrollToIndex_afterAttach_viewportRangePreloaded() {
+        grid.setItems(
+                IntStream.range(0, 1000).mapToObj(i -> "Item " + i).toList());
+        ui.add(grid);
+        grid.scrollToIndex(500);
+        ui.fakeClientCommunication();
+        Assertions.assertEquals("500-550", getViewportRange(grid));
+    }
+
+    @Test
+    void scrollToIndex_beforeAttach_thenAttach_viewportRangePreloaded() {
+        grid.setItems(
+                IntStream.range(0, 1000).mapToObj(i -> "Item " + i).toList());
+        grid.scrollToIndex(500);
+        ui.add(grid);
+        ui.fakeClientCommunication();
+        Assertions.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToIndexTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToIndexTest.java
@@ -47,6 +47,7 @@ class GridScrollToIndexTest {
     void scrollToStart_preloadOnePage() {
         ui.add(grid);
         grid.scrollToIndex(0);
+        ui.fakeClientCommunication();
         Assertions.assertEquals("0-50", getViewportRange(grid));
     }
 
@@ -54,6 +55,7 @@ class GridScrollToIndexTest {
     void scrollToEnd_preloadOnePage() {
         ui.add(grid);
         grid.scrollToIndex(950);
+        ui.fakeClientCommunication();
         Assertions.assertEquals("950-1000", getViewportRange(grid));
     }
 
@@ -61,6 +63,7 @@ class GridScrollToIndexTest {
     void scrollToStartOfPage_preloadOnePage() {
         ui.add(grid);
         grid.scrollToIndex(500);
+        ui.fakeClientCommunication();
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }
 
@@ -68,6 +71,7 @@ class GridScrollToIndexTest {
     void scrollToSecondIndexOfPage_preloadOnePage() {
         ui.add(grid);
         grid.scrollToIndex(501);
+        ui.fakeClientCommunication();
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }
 
@@ -75,6 +79,7 @@ class GridScrollToIndexTest {
     void scrollToSecondLastIndexOfPage_preloadTwoPages() {
         ui.add(grid);
         grid.scrollToIndex(499);
+        ui.fakeClientCommunication();
         Assertions.assertEquals("450-550", getViewportRange(grid));
     }
 
@@ -83,6 +88,7 @@ class GridScrollToIndexTest {
         grid.setPageSize(5);
         ui.add(grid);
         grid.scrollToIndex(499);
+        ui.fakeClientCommunication();
         Assertions.assertEquals("495-540", getViewportRange(grid));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToIndexTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToIndexTest.java
@@ -45,30 +45,35 @@ class GridScrollToIndexTest {
 
     @Test
     void scrollToStart_preloadOnePage() {
+        ui.add(grid);
         grid.scrollToIndex(0);
         Assertions.assertEquals("0-50", getViewportRange(grid));
     }
 
     @Test
     void scrollToEnd_preloadOnePage() {
+        ui.add(grid);
         grid.scrollToIndex(950);
         Assertions.assertEquals("950-1000", getViewportRange(grid));
     }
 
     @Test
     void scrollToStartOfPage_preloadOnePage() {
+        ui.add(grid);
         grid.scrollToIndex(500);
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test
     void scrollToSecondIndexOfPage_preloadOnePage() {
+        ui.add(grid);
         grid.scrollToIndex(501);
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }
 
     @Test
     void scrollToSecondLastIndexOfPage_preloadTwoPages() {
+        ui.add(grid);
         grid.scrollToIndex(499);
         Assertions.assertEquals("450-550", getViewportRange(grid));
     }
@@ -76,6 +81,7 @@ class GridScrollToIndexTest {
     @Test
     void smallPageSize_scrollToIndex_preloadMultiplePages() {
         grid.setPageSize(5);
+        ui.add(grid);
         grid.scrollToIndex(499);
         Assertions.assertEquals("495-540", getViewportRange(grid));
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToItemTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToItemTest.java
@@ -51,6 +51,7 @@ class GridScrollToItemTest {
 
         grid.setItems(items);
 
+        ui.add(grid);
         grid.scrollToItem(items.get(500));
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }
@@ -75,6 +76,7 @@ class GridScrollToItemTest {
                 q -> items.stream().skip(q.getOffset()).limit(q.getLimit()))
                 .setItemIndexProvider((item, query) -> items.indexOf(item));
 
+        ui.add(grid);
         grid.scrollToItem(items.get(500));
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToItemTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToItemTest.java
@@ -53,6 +53,7 @@ class GridScrollToItemTest {
 
         ui.add(grid);
         grid.scrollToItem(items.get(500));
+        ui.fakeClientCommunication();
         Assertions.assertEquals("500-550", getViewportRange(grid));
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToItemTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridScrollToItemTest.java
@@ -111,6 +111,30 @@ class GridScrollToItemTest {
     }
 
     @Test
+    void scrollToItem_afterAttach_viewportRangePreloaded() {
+        List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
+                .toList();
+        grid.setItems(items);
+
+        ui.add(grid);
+        grid.scrollToItem(items.get(500));
+        ui.fakeClientCommunication();
+        Assertions.assertEquals("500-550", getViewportRange(grid));
+    }
+
+    @Test
+    void scrollToItem_beforeAttach_thenAttach_viewportRangePreloaded() {
+        List<String> items = IntStream.range(0, 1000).mapToObj(String::valueOf)
+                .toList();
+        grid.setItems(items);
+
+        grid.scrollToItem(items.get(500));
+        ui.add(grid);
+        ui.fakeClientCommunication();
+        Assertions.assertEquals("500-550", getViewportRange(grid));
+    }
+
+    @Test
     void scrollToIndex_scrollToItem_onlyScrollToItemExecuted() {
         grid.setItems("Item 0", "Item 1");
         ui.add(grid);


### PR DESCRIPTION
When `scrollToIndex` or `scrollToItem` was called in the same roundtrip that attached the grid (for example, in a view constructor), the preloaded viewport range was overwritten back to the first page by `GridArrayUpdater.initialize()` during the first data flush. The client then had to fetch the target rows in an extra request, briefly showing empty rows.

```java
add(grid); // grid with 1000 items
grid.scrollToIndex(500);
```

The PR removes the viewport range reset from `GridArrayUpdater.initialize()`, both to fix this issue and because it was redundant: the Grid constructor already ensures the initial viewport range during the `setPageSize` call