### PR TITLE
refactor: deprecate Grid.UpdateQueue to make it private in Vaadin 26

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -255,7 +255,14 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     /**
      * @since 1.1
+     * @deprecated To customize array updates, override
+     *             {@link #createDefaultArrayUpdater()} and return a
+     *             {@link GridArrayUpdater} whose
+     *             {@link GridArrayUpdater#startUpdate(int) startUpdate} method
+     *             returns a custom {@link Update} implementation. This class
+     *             will be made private in Vaadin 26.
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     protected static class UpdateQueue implements Update {
         private final ArrayList<SerializableRunnable> queue = new ArrayList<>();
         private final Element element;


### PR DESCRIPTION
`Grid.UpdateQueue` is protected, but there is no need for subclasses to extend it: subclasses that need to customize array updates can override `createDefaultArrayUpdater()` and return a `GridArrayUpdater` whose `startUpdate` method returns a custom `Update` implementation. This PR deprecates the class so it can be made private in Vaadin 26.