### PR TITLE
refactor: init VirtualList connector in onAttach

### DIFF
--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -150,7 +150,7 @@ public class VirtualList<T> extends Component
         getUI().orElseThrow(() -> new IllegalStateException(
                 "Connector can only be initialized for an attached VirtualList"))
                 .getPage().executeJs(
-                        "window.Vaadin.Flow.virtualListConnector.initLazy($0)",
+                        "if ($0) window.Vaadin.Flow.virtualListConnector.initLazy($0)",
                         getElement());
     }
 

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/java/com/vaadin/flow/component/virtuallist/VirtualList.java
@@ -117,7 +117,7 @@ public class VirtualList<T> extends Component
 
         @Override
         public void initialize() {
-            initConnector();
+            // NO-OP
         }
     };
 
@@ -144,6 +144,9 @@ public class VirtualList<T> extends Component
     }
 
     private void initConnector() {
+        // Using Page.executeJs to ensure this runs before any other
+        // executeJs calls scheduled on the component that require the
+        // connector.
         getUI().orElseThrow(() -> new IllegalStateException(
                 "Connector can only be initialized for an attached VirtualList"))
                 .getPage().executeJs(
@@ -378,6 +381,8 @@ public class VirtualList<T> extends Component
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
+
+        initConnector();
 
         // When the component is detached and reattached in the same roundtrip,
         // data communicator will clear all data generators, which will also


### PR DESCRIPTION
VirtualList initializes its connector in `ArrayUpdater.initialize()`, which only runs when the data communicator flushes data for an uninitialized client. Other components like Grid and ComboBox initialize their connectors directly in `onAttach`. This change makes VirtualList follow the same pattern.

As a side benefit, the connector init is now added to the response at attach time instead of flush time, so it runs before any `executeJs` calls that application code schedules on the component in the same roundtrip.