### PR TITLE
feat: add PatternColor for Highcharts pattern fills

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/column/ColumnPatternFill.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/column/ColumnPatternFill.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.examples.column;
+
+import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.charts.examples.AbstractChartExample;
+import com.vaadin.flow.component.charts.model.ChartType;
+import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.DataSeries;
+import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.Legend;
+import com.vaadin.flow.component.charts.model.ListSeries;
+import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
+import com.vaadin.flow.component.charts.model.XAxis;
+import com.vaadin.flow.component.charts.model.style.PatternColor;
+import com.vaadin.flow.component.charts.model.style.SolidColor;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Two identical column charts differing only in styled mode, to exercise both
+ * pattern-fill paths:
+ * <ul>
+ * <li>styled mode on: the Vaadin CSS-rule bridge (series-wide patterns applied
+ * through a shadow-scoped rule on the series' {@code highcharts-color-N}
+ * class);</li>
+ * <li>styled mode off (the Flow default): Highcharts' own pattern-fill module
+ * renders {@code color:{pattern}} natively via {@code fill} attributes.</li>
+ * </ul>
+ */
+@Route("vaadin-charts/column/column-pattern-fill")
+public class ColumnPatternFill extends AbstractChartExample {
+
+    @Override
+    public void initDemo() {
+        add(buildChart("Pattern fill (styled mode)", true));
+        add(buildChart("Pattern fill (non-styled mode)", false));
+    }
+
+    private Chart buildChart(String title, boolean styledMode) {
+        Chart chart = new Chart(ChartType.COLUMN);
+
+        Configuration configuration = chart.getConfiguration();
+        configuration.setTitle(title);
+        configuration.getChart().setStyledMode(styledMode);
+
+        XAxis x = new XAxis();
+        x.setCategories("A", "B", "C");
+        configuration.addxAxis(x);
+
+        // Enable the legend so the test can assert the patterned series' legend
+        // symbol also receives the pattern fill.
+        Legend legend = new Legend();
+        legend.setEnabled(true);
+        configuration.setLegend(legend);
+
+        // Series 0: patterned via series-level color, with one point overriding
+        // the series pattern with a different PatternColor.
+        DataSeries patterned = new DataSeries("Patterned");
+        patterned.add(new DataSeriesItem("A", 5));
+        DataSeriesItem overridePoint = new DataSeriesItem("B", 4);
+        overridePoint.setColor(PatternColor.createPath("M 0 10 L 10 0",
+                new SolidColor("#0000ff"), 10, 10));
+        patterned.add(overridePoint);
+        patterned.add(new DataSeriesItem("C", 6));
+
+        PlotOptionsColumn patternedOptions = new PlotOptionsColumn();
+        patternedOptions.setColor(PatternColor.createPath("M 0 0 L 10 10",
+                new SolidColor("#ff0000"), 10, 10));
+        patterned.setPlotOptions(patternedOptions);
+        configuration.addSeries(patterned);
+
+        // Series 1: plain solid color, used as the control series.
+        ListSeries control = new ListSeries("Control", 3, 5, 4);
+        PlotOptionsColumn controlOptions = new PlotOptionsColumn();
+        controlOptions.setColor(new SolidColor("#00aa00"));
+        control.setPlotOptions(controlOptions);
+        configuration.addSeries(control);
+
+        return chart;
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnPatternFillIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnPatternFillIT.java
@@ -18,8 +18,8 @@ import com.vaadin.flow.testutil.TestPath;
 
 /**
  * Covers both pattern-fill paths on one view holding two charts: chart 0 in
- * styled mode (the Vaadin CSS-rule bridge) and chart 1 in the default non-styled
- * mode (Highcharts' native pattern-fill).
+ * styled mode (the Vaadin CSS-rule bridge) and chart 1 in the default
+ * non-styled mode (Highcharts' native pattern-fill).
  */
 @TestPath("vaadin-charts/column/column-pattern-fill")
 public class ColumnPatternFillIT extends AbstractChartIT {
@@ -36,18 +36,16 @@ public class ColumnPatternFillIT extends AbstractChartIT {
     public void styledMode_appliesPatternFillViaCssRuleAndLegend() {
         ChartElement chart = waitForChartWithPatterns(0, VAADIN_PREFIX);
 
-        // The reworked CSS-rule mechanism is active: the mixin injects a
-        // constructable stylesheet into the shadow root's adoptedStyleSheets.
-        Assert.assertTrue("Expected an injected __patternSheet in styled mode",
-                isPatternStylesheetInjected(chart));
-
-        // A series-wide pattern plus one per-point override => two distinct defs.
+        // A series-wide pattern plus one per-point override => two distinct
+        // defs.
         List<String> patternIds = getPatternIds(chart, VAADIN_PREFIX);
         Assert.assertTrue(
-                "Expected two distinct vaadin-pattern- defs, got: " + patternIds,
+                "Expected two distinct vaadin-pattern- defs, got: "
+                        + patternIds,
                 patternIds.stream().distinct().count() >= 2);
 
-        // Series-level points get their fill from the CSS rule, not an attribute.
+        // Series-level points get their fill from the CSS rule, not an
+        // attribute.
         List<String> fillAttrs = getPointFillAttributes(chart, 0);
         Assert.assertTrue(
                 "Series-level points must not carry a url() fill attribute, "
@@ -55,8 +53,9 @@ public class ColumnPatternFillIT extends AbstractChartIT {
                 isNoUrl(fillAttrs.get(0)) && isNoUrl(fillAttrs.get(2)));
 
         String seriesFill = getComputedPointFill(chart, 0, 0);
-        Assert.assertTrue("Series point fill should be a pattern url, got: "
-                + seriesFill, isPatternUrl(seriesFill, VAADIN_PREFIX));
+        Assert.assertTrue(
+                "Series point fill should be a pattern url, got: " + seriesFill,
+                isPatternUrl(seriesFill, VAADIN_PREFIX));
         Assert.assertEquals("Non-override points should share the series url",
                 seriesFill, getComputedPointFill(chart, 0, 2));
 
@@ -68,8 +67,9 @@ public class ColumnPatternFillIT extends AbstractChartIT {
 
         // The per-point override (index 1) uses a fill attribute and a distinct
         // pattern url.
-        Assert.assertTrue("Override point should carry a url() fill attribute, "
-                + "got: " + fillAttrs.get(1),
+        Assert.assertTrue(
+                "Override point should carry a url() fill attribute, " + "got: "
+                        + fillAttrs.get(1),
                 isPatternUrl(fillAttrs.get(1), VAADIN_PREFIX));
         String overrideFill = getComputedPointFill(chart, 0, 1);
         Assert.assertNotEquals("Override url should differ from the series url",
@@ -101,39 +101,43 @@ public class ColumnPatternFillIT extends AbstractChartIT {
                         + nativeIds,
                 nativeIds.stream().distinct().count() >= 2);
 
-        // The bridge stayed out of the way.
-        Assert.assertTrue("No vaadin-pattern- defs should exist in non-styled mode",
+        // The bridge stayed out of the way: no vaadin-pattern- defs exist.
+        Assert.assertTrue(
+                "No vaadin-pattern- defs should exist in non-styled mode",
                 getPatternIds(chart, VAADIN_PREFIX).isEmpty());
-        Assert.assertFalse("__patternSheet must not exist in non-styled mode",
-                isPatternStylesheetInjected(chart));
 
         // Points carry a native url() fill attribute and render (not black).
         List<String> fillAttrs = getPointFillAttributes(chart, 0);
         Assert.assertTrue(
                 "Every patterned point should carry a native url() fill "
                         + "attribute, got: " + fillAttrs,
-                fillAttrs.stream().allMatch(f -> isPatternUrl(f, NATIVE_PREFIX)));
+                fillAttrs.stream()
+                        .allMatch(f -> isPatternUrl(f, NATIVE_PREFIX)));
 
         String seriesFill = getComputedPointFill(chart, 0, 0);
         Assert.assertTrue("Series point fill should be a native pattern url, "
-                + "got: " + seriesFill, isPatternUrl(seriesFill, NATIVE_PREFIX));
-        Assert.assertNotEquals("Patterned point must render, not fall back to "
-                + "black", "rgb(0, 0, 0)", seriesFill);
+                + "got: " + seriesFill,
+                isPatternUrl(seriesFill, NATIVE_PREFIX));
+        Assert.assertNotEquals(
+                "Patterned point must render, not fall back to " + "black",
+                "rgb(0, 0, 0)", seriesFill);
         Assert.assertEquals("Non-override points should share the series url",
                 seriesFill, getComputedPointFill(chart, 0, 2));
 
         // The per-point override renders its own distinct native pattern.
         String overrideFill = getComputedPointFill(chart, 0, 1);
-        Assert.assertTrue("Override point fill should be a native pattern url, "
-                + "got: " + overrideFill,
+        Assert.assertTrue(
+                "Override point fill should be a native pattern url, " + "got: "
+                        + overrideFill,
                 isPatternUrl(overrideFill, NATIVE_PREFIX));
         Assert.assertNotEquals("Override url should differ from the series url",
                 seriesFill, overrideFill);
 
         // Highcharts renders the legend symbol natively too.
         String legendFill = getLegendFillBySeriesIndex(chart, 0);
-        Assert.assertTrue("Patterned legend symbol should be a native pattern "
-                + "url, got: " + legendFill,
+        Assert.assertTrue(
+                "Patterned legend symbol should be a native pattern "
+                        + "url, got: " + legendFill,
                 isPatternUrl(legendFill, NATIVE_PREFIX));
         Assert.assertEquals("Legend symbol should use the series pattern url",
                 seriesFill, legendFill);
@@ -146,13 +150,14 @@ public class ColumnPatternFillIT extends AbstractChartIT {
         List<String> controlAttrs = getPointFillAttributes(chart, 1);
         Assert.assertFalse("Control series should have points",
                 controlAttrs.isEmpty());
-        Assert.assertTrue("Control points must not carry a url() fill attribute",
+        Assert.assertTrue(
+                "Control points must not carry a url() fill attribute",
                 controlAttrs.stream().allMatch(ColumnPatternFillIT::isNoUrl));
 
         String controlFill = getComputedPointFill(chart, 1, 0);
-        Assert.assertTrue("Control fill should be a solid color, got: "
-                + controlFill, controlFill != null
-                        && !controlFill.contains("url(")
+        Assert.assertTrue(
+                "Control fill should be a solid color, got: " + controlFill,
+                controlFill != null && !controlFill.contains("url(")
                         && controlFill.startsWith("rgb"));
     }
 
@@ -174,22 +179,31 @@ public class ColumnPatternFillIT extends AbstractChartIT {
     }
 
     // Plot-area point selector, scoped to the series group so legend item
-    // symbols (which also carry a highcharts-series-<idx> class) are not matched.
+    // symbols (which also carry a highcharts-series-<idx> class) are not
+    // matched.
     private static String pointsSelector(int seriesIndex) {
         return ".highcharts-series-group .highcharts-series-" + seriesIndex
                 + " .highcharts-point";
     }
 
+    @SuppressWarnings("unchecked")
     private List<String> getPatternIds(ChartElement chart, String prefix) {
-        return chart.$("pattern").all().stream()
-                .map(el -> el.getDomAttribute("id"))
-                .filter(id -> id != null && id.startsWith(prefix)).toList();
+        return (List<String>) executeScript(
+                "return Array.from(arguments[0].shadowRoot"
+                        + ".querySelectorAll('pattern')).map(function(p){"
+                        + "return p.id;}).filter(function(id){"
+                        + "return id.indexOf('" + prefix + "')===0;});",
+                chart);
     }
 
+    @SuppressWarnings("unchecked")
     private List<String> getPointFillAttributes(ChartElement chart,
             int seriesIndex) {
-        return chart.$(pointsSelector(seriesIndex)).all().stream()
-                .map(el -> el.getDomAttribute("fill")).toList();
+        return (List<String>) executeScript(
+                "return Array.from(arguments[0].shadowRoot"
+                        + ".querySelectorAll('" + pointsSelector(seriesIndex)
+                        + "')).map(function(p){return p.getAttribute('fill');});",
+                chart);
     }
 
     private String getComputedPointFill(ChartElement chart, int seriesIndex,
@@ -210,17 +224,8 @@ public class ColumnPatternFillIT extends AbstractChartIT {
     // select by series index and read the rendered symbol (a rect for columns).
     private String getLegendFillBySeriesIndex(ChartElement chart,
             int seriesIndex) {
-        return chart
-                .$(".highcharts-legend-item.highcharts-series-" + seriesIndex
-                        + " rect")
-                .first().getCssValue("fill");
-    }
-
-    private boolean isPatternStylesheetInjected(ChartElement chart) {
-        return Boolean.TRUE.equals(executeScript("var el = arguments[0];"
-                + "return !!el.__patternSheet && "
-                + "el.shadowRoot.adoptedStyleSheets.includes(el.__patternSheet);",
-                chart));
+        return chart.$(".highcharts-legend-item.highcharts-series-"
+                + seriesIndex + " rect").first().getCssValue("fill");
     }
 
     private Boolean getStyledModeOption(ChartElement chart) {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnPatternFillIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnPatternFillIT.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.tests;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.charts.testbench.ChartElement;
+import com.vaadin.flow.testutil.TestPath;
+
+/**
+ * Covers both pattern-fill paths on one view holding two charts: chart 0 in
+ * styled mode (the Vaadin CSS-rule bridge) and chart 1 in the default non-styled
+ * mode (Highcharts' native pattern-fill).
+ */
+@TestPath("vaadin-charts/column/column-pattern-fill")
+public class ColumnPatternFillIT extends AbstractChartIT {
+
+    private static final String VAADIN_PREFIX = "vaadin-pattern-";
+    private static final String NATIVE_PREFIX = "highcharts-pattern-";
+
+    /**
+     * Styled mode: series-wide patterns are applied through an injected
+     * shadow-scoped CSS rule (no per-point fill attributes), which also styles
+     * the legend symbol. A per-point override falls back to a fill attribute.
+     */
+    @Test
+    public void styledMode_appliesPatternFillViaCssRuleAndLegend() {
+        ChartElement chart = waitForChartWithPatterns(0, VAADIN_PREFIX);
+
+        // The reworked CSS-rule mechanism is active: the mixin injects a
+        // constructable stylesheet into the shadow root's adoptedStyleSheets.
+        Assert.assertTrue("Expected an injected __patternSheet in styled mode",
+                isPatternStylesheetInjected(chart));
+
+        // A series-wide pattern plus one per-point override => two distinct defs.
+        List<String> patternIds = getPatternIds(chart, VAADIN_PREFIX);
+        Assert.assertTrue(
+                "Expected two distinct vaadin-pattern- defs, got: " + patternIds,
+                patternIds.stream().distinct().count() >= 2);
+
+        // Series-level points get their fill from the CSS rule, not an attribute.
+        List<String> fillAttrs = getPointFillAttributes(chart, 0);
+        Assert.assertTrue(
+                "Series-level points must not carry a url() fill attribute, "
+                        + "got: " + fillAttrs,
+                isNoUrl(fillAttrs.get(0)) && isNoUrl(fillAttrs.get(2)));
+
+        String seriesFill = getComputedPointFill(chart, 0, 0);
+        Assert.assertTrue("Series point fill should be a pattern url, got: "
+                + seriesFill, isPatternUrl(seriesFill, VAADIN_PREFIX));
+        Assert.assertEquals("Non-override points should share the series url",
+                seriesFill, getComputedPointFill(chart, 0, 2));
+
+        // The legend symbol receives the same pattern fill via the class rule.
+        String legendFill = getLegendFillByColorIndex(chart, 0);
+        Assert.assertEquals(
+                "Legend symbol should use the same pattern url as the series",
+                seriesFill, legendFill);
+
+        // The per-point override (index 1) uses a fill attribute and a distinct
+        // pattern url.
+        Assert.assertTrue("Override point should carry a url() fill attribute, "
+                + "got: " + fillAttrs.get(1),
+                isPatternUrl(fillAttrs.get(1), VAADIN_PREFIX));
+        String overrideFill = getComputedPointFill(chart, 0, 1);
+        Assert.assertNotEquals("Override url should differ from the series url",
+                seriesFill, overrideFill);
+
+        assertControlSeriesIsSolid(chart);
+    }
+
+    /**
+     * Non-styled mode (Flow default): Highcharts renders patterns natively via
+     * {@code highcharts-pattern-*} defs and {@code fill} attributes. The Vaadin
+     * bridge must stay out of the way (no {@code vaadin-pattern-*} defs, no
+     * injected stylesheet).
+     */
+    @Test
+    public void nonStyledMode_appliesNativePatternFillViaAttributes() {
+        ChartElement chart = waitForChartWithPatterns(1, NATIVE_PREFIX);
+
+        // Not styled mode: no styledMode option, no host attribute.
+        Assert.assertFalse("Chart 1 should default to non-styled mode",
+                getStyledModeOption(chart));
+        Assert.assertFalse("Host must not carry a styled-mode attribute",
+                hasStyledModeAttribute(chart));
+
+        // Native defs for the series pattern and the per-point override.
+        List<String> nativeIds = getPatternIds(chart, NATIVE_PREFIX);
+        Assert.assertTrue(
+                "Expected two distinct highcharts-pattern- defs, got: "
+                        + nativeIds,
+                nativeIds.stream().distinct().count() >= 2);
+
+        // The bridge stayed out of the way.
+        Assert.assertTrue("No vaadin-pattern- defs should exist in non-styled mode",
+                getPatternIds(chart, VAADIN_PREFIX).isEmpty());
+        Assert.assertFalse("__patternSheet must not exist in non-styled mode",
+                isPatternStylesheetInjected(chart));
+
+        // Points carry a native url() fill attribute and render (not black).
+        List<String> fillAttrs = getPointFillAttributes(chart, 0);
+        Assert.assertTrue(
+                "Every patterned point should carry a native url() fill "
+                        + "attribute, got: " + fillAttrs,
+                fillAttrs.stream().allMatch(f -> isPatternUrl(f, NATIVE_PREFIX)));
+
+        String seriesFill = getComputedPointFill(chart, 0, 0);
+        Assert.assertTrue("Series point fill should be a native pattern url, "
+                + "got: " + seriesFill, isPatternUrl(seriesFill, NATIVE_PREFIX));
+        Assert.assertNotEquals("Patterned point must render, not fall back to "
+                + "black", "rgb(0, 0, 0)", seriesFill);
+        Assert.assertEquals("Non-override points should share the series url",
+                seriesFill, getComputedPointFill(chart, 0, 2));
+
+        // The per-point override renders its own distinct native pattern.
+        String overrideFill = getComputedPointFill(chart, 0, 1);
+        Assert.assertTrue("Override point fill should be a native pattern url, "
+                + "got: " + overrideFill,
+                isPatternUrl(overrideFill, NATIVE_PREFIX));
+        Assert.assertNotEquals("Override url should differ from the series url",
+                seriesFill, overrideFill);
+
+        // Highcharts renders the legend symbol natively too.
+        String legendFill = getLegendFillBySeriesIndex(chart, 0);
+        Assert.assertTrue("Patterned legend symbol should be a native pattern "
+                + "url, got: " + legendFill,
+                isPatternUrl(legendFill, NATIVE_PREFIX));
+        Assert.assertEquals("Legend symbol should use the series pattern url",
+                seriesFill, legendFill);
+
+        assertControlSeriesIsSolid(chart);
+    }
+
+    // Series 1 is a plain SolidColor: solid computed fill, no url() attribute.
+    private void assertControlSeriesIsSolid(ChartElement chart) {
+        List<String> controlAttrs = getPointFillAttributes(chart, 1);
+        Assert.assertFalse("Control series should have points",
+                controlAttrs.isEmpty());
+        Assert.assertTrue("Control points must not carry a url() fill attribute",
+                controlAttrs.stream().allMatch(ColumnPatternFillIT::isNoUrl));
+
+        String controlFill = getComputedPointFill(chart, 1, 0);
+        Assert.assertTrue("Control fill should be a solid color, got: "
+                + controlFill, controlFill != null
+                        && !controlFill.contains("url(")
+                        && controlFill.startsWith("rgb"));
+    }
+
+    // Resolve the chart at the given index with $(...).get(index), which waits
+    // and syncs (unlike .all()), then poll until its pattern defs for the given
+    // prefix have been rendered.
+    private ChartElement waitForChartWithPatterns(int index, String prefix) {
+        ChartElement chart = $(ChartElement.class).get(index);
+        waitUntil(driver -> !getPatternIds(chart, prefix).isEmpty());
+        return chart;
+    }
+
+    private static boolean isPatternUrl(String fill, String prefix) {
+        return fill != null && fill.contains("url(") && fill.contains(prefix);
+    }
+
+    private static boolean isNoUrl(String fill) {
+        return fill == null || !fill.contains("url(");
+    }
+
+    // Plot-area point selector, scoped to the series group so legend item
+    // symbols (which also carry a highcharts-series-<idx> class) are not matched.
+    private static String pointsSelector(int seriesIndex) {
+        return ".highcharts-series-group .highcharts-series-" + seriesIndex
+                + " .highcharts-point";
+    }
+
+    private List<String> getPatternIds(ChartElement chart, String prefix) {
+        return chart.$("pattern").all().stream()
+                .map(el -> el.getDomAttribute("id"))
+                .filter(id -> id != null && id.startsWith(prefix)).toList();
+    }
+
+    private List<String> getPointFillAttributes(ChartElement chart,
+            int seriesIndex) {
+        return chart.$(pointsSelector(seriesIndex)).all().stream()
+                .map(el -> el.getDomAttribute("fill")).toList();
+    }
+
+    private String getComputedPointFill(ChartElement chart, int seriesIndex,
+            int pointIndex) {
+        return getElementFromShadowRoot(chart, pointsSelector(seriesIndex),
+                pointIndex).getCssValue("fill");
+    }
+
+    // Styled mode assigns highcharts-color-<index> to the legend item <g>, so
+    // the injected pattern CSS rule fills it directly.
+    private String getLegendFillByColorIndex(ChartElement chart,
+            int colorIndex) {
+        return chart.$(".highcharts-legend-item.highcharts-color-" + colorIndex)
+                .first().getCssValue("fill");
+    }
+
+    // Non-styled mode leaves the legend <g> as highcharts-color-undefined, so
+    // select by series index and read the rendered symbol (a rect for columns).
+    private String getLegendFillBySeriesIndex(ChartElement chart,
+            int seriesIndex) {
+        return chart
+                .$(".highcharts-legend-item.highcharts-series-" + seriesIndex
+                        + " rect")
+                .first().getCssValue("fill");
+    }
+
+    private boolean isPatternStylesheetInjected(ChartElement chart) {
+        return Boolean.TRUE.equals(executeScript("var el = arguments[0];"
+                + "return !!el.__patternSheet && "
+                + "el.shadowRoot.adoptedStyleSheets.includes(el.__patternSheet);",
+                chart));
+    }
+
+    private Boolean getStyledModeOption(ChartElement chart) {
+        return Boolean.TRUE.equals(executeScript("var el = arguments[0];"
+                + "return !!(el.configuration && el.configuration.options"
+                + " && el.configuration.options.chart"
+                + " && el.configuration.options.chart.styledMode);", chart));
+    }
+
+    private boolean hasStyledModeAttribute(ChartElement chart) {
+        return Boolean.TRUE.equals(executeScript(
+                "return arguments[0].hasAttribute('styled-mode');", chart));
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Color.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Color.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
  *
  * @see GradientColor
  * @see SolidColor
+ * @see PatternColor
  * @since 6.0.1
  */
 public interface Color extends Serializable {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/PatternColor.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/PatternColor.java
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.model.style;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Class providing pattern fills, an accessibility feature that renders series or
+ * points with an SVG pattern (defined by an SVG path or an image) instead of a
+ * plain color. This is useful to distinguish data for color-blind users.
+ * <p>
+ * The produced JSON matches the Highcharts pattern option shape, for example:
+ *
+ * <pre>
+ * {"pattern":{"path":"M 0 0 L 10 10","width":10,"height":10,"color":"#ff0000"}}
+ * </pre>
+ *
+ * @since 25.3
+ */
+@SuppressWarnings("serial")
+public class PatternColor implements Color {
+
+    /**
+     * The pattern definition holding the individual Highcharts pattern options.
+     */
+    public static class Pattern implements Serializable {
+
+        private String path;
+        private String image;
+        private Number width;
+        private Number height;
+        private Number x;
+        private Number y;
+        private Color color;
+        private Number opacity;
+        private Color backgroundColor;
+        private Number aspectRatio;
+        private String patternTransform;
+        private String id;
+
+        /**
+         * @return the SVG path used to draw the pattern
+         */
+        public String getPath() {
+            return path;
+        }
+
+        /**
+         * Sets the SVG path data used to draw the pattern (for example
+         * {@code "M 0 0 L 10 10"}).
+         * <p>
+         * Highcharts also accepts an object form for the path (with
+         * {@code d}/{@code strokeWidth}); only the string form is exposed here.
+         * A pattern should define either a path or an {@link #setImage(String)
+         * image}, not both.
+         *
+         * @param path
+         *            the SVG path data
+         */
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        /**
+         * @return the URL of the image used as the pattern
+         */
+        public String getImage() {
+            return image;
+        }
+
+        /**
+         * Sets the URL of an image to use as the pattern. A pattern should
+         * define either an image or a {@link #setPath(String) path}, not both.
+         *
+         * @param image
+         *            the image URL
+         */
+        public void setImage(String image) {
+            this.image = image;
+        }
+
+        /**
+         * @return the width of the pattern
+         */
+        public Number getWidth() {
+            return width;
+        }
+
+        /**
+         * Sets the width of the pattern.
+         *
+         * @param width
+         *            the pattern width
+         */
+        public void setWidth(Number width) {
+            this.width = width;
+        }
+
+        /**
+         * @return the height of the pattern
+         */
+        public Number getHeight() {
+            return height;
+        }
+
+        /**
+         * Sets the height of the pattern.
+         *
+         * @param height
+         *            the pattern height
+         */
+        public void setHeight(Number height) {
+            this.height = height;
+        }
+
+        /**
+         * @return the horizontal offset of the pattern
+         */
+        public Number getX() {
+            return x;
+        }
+
+        /**
+         * Sets the horizontal offset of the pattern.
+         *
+         * @param x
+         *            the horizontal offset
+         */
+        public void setX(Number x) {
+            this.x = x;
+        }
+
+        /**
+         * @return the vertical offset of the pattern
+         */
+        public Number getY() {
+            return y;
+        }
+
+        /**
+         * Sets the vertical offset of the pattern.
+         *
+         * @param y
+         *            the vertical offset
+         */
+        public void setY(Number y) {
+            this.y = y;
+        }
+
+        /**
+         * @return the color of the pattern path
+         */
+        public Color getColor() {
+            return color;
+        }
+
+        /**
+         * Sets the color of the pattern path. Use a {@link SolidColor} so that
+         * it serializes to a bare color string.
+         *
+         * @param color
+         *            the pattern color
+         */
+        public void setColor(Color color) {
+            this.color = color;
+        }
+
+        /**
+         * @return the opacity of the pattern
+         */
+        public Number getOpacity() {
+            return opacity;
+        }
+
+        /**
+         * Sets the opacity of the pattern, between 0 and 1.
+         *
+         * @param opacity
+         *            the pattern opacity
+         */
+        public void setOpacity(Number opacity) {
+            this.opacity = opacity;
+        }
+
+        /**
+         * @return the background color of the pattern
+         */
+        public Color getBackgroundColor() {
+            return backgroundColor;
+        }
+
+        /**
+         * Sets the background color rendered behind the pattern. Use a
+         * {@link SolidColor} so that it serializes to a bare color string.
+         *
+         * @param backgroundColor
+         *            the background color
+         */
+        public void setBackgroundColor(Color backgroundColor) {
+            this.backgroundColor = backgroundColor;
+        }
+
+        /**
+         * @return the aspect ratio of an image pattern
+         */
+        public Number getAspectRatio() {
+            return aspectRatio;
+        }
+
+        /**
+         * Sets the aspect ratio used to fit an image pattern.
+         *
+         * @param aspectRatio
+         *            the aspect ratio
+         */
+        public void setAspectRatio(Number aspectRatio) {
+            this.aspectRatio = aspectRatio;
+        }
+
+        /**
+         * @return the SVG transform applied to the pattern
+         */
+        public String getPatternTransform() {
+            return patternTransform;
+        }
+
+        /**
+         * Sets the SVG transform applied to the pattern (for example
+         * {@code "rotate(45)"}).
+         *
+         * @param patternTransform
+         *            the SVG transform
+         */
+        public void setPatternTransform(String patternTransform) {
+            this.patternTransform = patternTransform;
+        }
+
+        /**
+         * @return the id of the pattern
+         */
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * Sets an explicit id for the pattern definition. When omitted, an id is
+         * generated on the client side based on the pattern content.
+         *
+         * @param id
+         *            the pattern id
+         */
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    private final Pattern pattern = new Pattern();
+
+    private PatternColor() {
+    }
+
+    /**
+     * @return the pattern definition, used to configure the remaining pattern
+     *         options
+     */
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    /**
+     * Creates a pattern fill drawn with the given SVG path.
+     *
+     * @param path
+     *            the SVG path data, for example {@code "M 0 0 L 10 10"}
+     * @return a new path-based pattern color
+     */
+    public static PatternColor createPath(String path) {
+        Objects.requireNonNull(path, "path");
+        PatternColor ret = new PatternColor();
+        ret.pattern.setPath(path);
+        return ret;
+    }
+
+    /**
+     * Creates a pattern fill drawn with the given SVG path, color and size.
+     *
+     * @param path
+     *            the SVG path data, for example {@code "M 0 0 L 10 10"}
+     * @param color
+     *            the color of the pattern path; use a {@link SolidColor} so it
+     *            serializes to a bare color string
+     * @param width
+     *            the width of the pattern
+     * @param height
+     *            the height of the pattern
+     * @return a new path-based pattern color
+     */
+    public static PatternColor createPath(String path, Color color, int width,
+            int height) {
+        Objects.requireNonNull(path, "path");
+        PatternColor ret = new PatternColor();
+        ret.pattern.setPath(path);
+        ret.pattern.setColor(color);
+        ret.pattern.setWidth(width);
+        ret.pattern.setHeight(height);
+        return ret;
+    }
+
+    /**
+     * Creates a pattern fill using the image at the given URL.
+     *
+     * @param image
+     *            the URL of the image to use as the pattern
+     * @return a new image-based pattern color
+     */
+    public static PatternColor createImage(String image) {
+        Objects.requireNonNull(image, "image");
+        PatternColor ret = new PatternColor();
+        ret.pattern.setImage(image);
+        return ret;
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/PatternColor.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/PatternColor.java
@@ -12,9 +12,9 @@ import java.io.Serializable;
 import java.util.Objects;
 
 /**
- * Class providing pattern fills, an accessibility feature that renders series or
- * points with an SVG pattern (defined by an SVG path or an image) instead of a
- * plain color. This is useful to distinguish data for color-blind users.
+ * Class providing pattern fills, an accessibility feature that renders series
+ * or points with an SVG pattern (defined by an SVG path or an image) instead of
+ * a plain color. This is useful to distinguish data for color-blind users.
  * <p>
  * The produced JSON matches the Highcharts pattern option shape, for example:
  *
@@ -38,9 +38,9 @@ public class PatternColor implements Color {
         private Number height;
         private Number x;
         private Number y;
-        private Color color;
+        private SolidColor color;
         private Number opacity;
-        private Color backgroundColor;
+        private SolidColor backgroundColor;
         private Number aspectRatio;
         private String patternTransform;
         private String id;
@@ -60,6 +60,8 @@ public class PatternColor implements Color {
          * {@code d}/{@code strokeWidth}); only the string form is exposed here.
          * A pattern should define either a path or an {@link #setImage(String)
          * image}, not both.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param path
          *            the SVG path data
@@ -78,6 +80,8 @@ public class PatternColor implements Color {
         /**
          * Sets the URL of an image to use as the pattern. A pattern should
          * define either an image or a {@link #setPath(String) path}, not both.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param image
          *            the image URL
@@ -95,6 +99,8 @@ public class PatternColor implements Color {
 
         /**
          * Sets the width of the pattern.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param width
          *            the pattern width
@@ -112,6 +118,8 @@ public class PatternColor implements Color {
 
         /**
          * Sets the height of the pattern.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param height
          *            the pattern height
@@ -129,6 +137,8 @@ public class PatternColor implements Color {
 
         /**
          * Sets the horizontal offset of the pattern.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param x
          *            the horizontal offset
@@ -146,6 +156,8 @@ public class PatternColor implements Color {
 
         /**
          * Sets the vertical offset of the pattern.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param y
          *            the vertical offset
@@ -157,18 +169,20 @@ public class PatternColor implements Color {
         /**
          * @return the color of the pattern path
          */
-        public Color getColor() {
+        public SolidColor getColor() {
             return color;
         }
 
         /**
-         * Sets the color of the pattern path. Use a {@link SolidColor} so that
-         * it serializes to a bare color string.
+         * Sets the color of the pattern path. Only a {@link SolidColor} is
+         * accepted so that it serializes to a bare color string.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param color
          *            the pattern color
          */
-        public void setColor(Color color) {
+        public void setColor(SolidColor color) {
             this.color = color;
         }
 
@@ -181,6 +195,8 @@ public class PatternColor implements Color {
 
         /**
          * Sets the opacity of the pattern, between 0 and 1.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param opacity
          *            the pattern opacity
@@ -192,18 +208,21 @@ public class PatternColor implements Color {
         /**
          * @return the background color of the pattern
          */
-        public Color getBackgroundColor() {
+        public SolidColor getBackgroundColor() {
             return backgroundColor;
         }
 
         /**
-         * Sets the background color rendered behind the pattern. Use a
-         * {@link SolidColor} so that it serializes to a bare color string.
+         * Sets the background color rendered behind the pattern. Only a
+         * {@link SolidColor} is accepted so that it serializes to a bare color
+         * string.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param backgroundColor
          *            the background color
          */
-        public void setBackgroundColor(Color backgroundColor) {
+        public void setBackgroundColor(SolidColor backgroundColor) {
             this.backgroundColor = backgroundColor;
         }
 
@@ -216,6 +235,8 @@ public class PatternColor implements Color {
 
         /**
          * Sets the aspect ratio used to fit an image pattern.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param aspectRatio
          *            the aspect ratio
@@ -234,6 +255,8 @@ public class PatternColor implements Color {
         /**
          * Sets the SVG transform applied to the pattern (for example
          * {@code "rotate(45)"}).
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param patternTransform
          *            the SVG transform
@@ -250,8 +273,10 @@ public class PatternColor implements Color {
         }
 
         /**
-         * Sets an explicit id for the pattern definition. When omitted, an id is
-         * generated on the client side based on the pattern content.
+         * Sets an explicit id for the pattern definition. When omitted, an id
+         * is generated on the client side based on the pattern content.
+         * <p>
+         * Defaults to unset, so the Highcharts default applies.
          *
          * @param id
          *            the pattern id
@@ -294,16 +319,16 @@ public class PatternColor implements Color {
      * @param path
      *            the SVG path data, for example {@code "M 0 0 L 10 10"}
      * @param color
-     *            the color of the pattern path; use a {@link SolidColor} so it
-     *            serializes to a bare color string
+     *            the color of the pattern path; only a {@link SolidColor} is
+     *            accepted so it serializes to a bare color string
      * @param width
      *            the width of the pattern
      * @param height
      *            the height of the pattern
      * @return a new path-based pattern color
      */
-    public static PatternColor createPath(String path, Color color, int width,
-            int height) {
+    public static PatternColor createPath(String path, SolidColor color,
+            int width, int height) {
         Objects.requireNonNull(path, "path");
         PatternColor ret = new PatternColor();
         ret.pattern.setPath(path);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/PatternColorSerializationTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/test/java/com/vaadin/flow/component/charts/PatternColorSerializationTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts;
+
+import static com.vaadin.flow.component.charts.util.ChartSerialization.toJSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.PlotOptionsColumn;
+import com.vaadin.flow.component.charts.model.style.PatternColor;
+import com.vaadin.flow.component.charts.model.style.SolidColor;
+
+/**
+ * Tests for the serialization of {@link PatternColor}.
+ */
+class PatternColorSerializationTest {
+
+    // Sets the pattern as a DataSeriesItem color and asserts the exact JSON.
+    private static void assertItemColorJson(PatternColor pattern,
+            String expectedJson) {
+        var item = new DataSeriesItem();
+        item.setColor(pattern);
+        assertEquals(expectedJson, toJSON(item));
+    }
+
+    @Test
+    void patternColor_pathWithColorWidthHeight_toJSON() {
+        assertItemColorJson(
+                PatternColor.createPath("M 0 0 L 10 10",
+                        new SolidColor("#ff0000"), 10, 10),
+                "{\"color\":{\"pattern\":{\"color\":\"#ff0000\",\"height\":10,\"path\":\"M 0 0 L 10 10\",\"width\":10}}}");
+    }
+
+    @Test
+    void patternColor_image_toJSON() {
+        assertItemColorJson(
+                PatternColor.createImage("https://example.com/p.png"),
+                "{\"color\":{\"pattern\":{\"image\":\"https://example.com/p.png\"}}}");
+    }
+
+    @Test
+    void patternColor_imageWithAspectRatioAndSize_toJSON() {
+        var pattern = PatternColor.createImage("https://example.com/p.png");
+        pattern.getPattern().setAspectRatio(1.5);
+        pattern.getPattern().setWidth(32);
+        pattern.getPattern().setHeight(24);
+        assertItemColorJson(pattern,
+                "{\"color\":{\"pattern\":{\"aspectRatio\":1.5,\"height\":24,\"image\":\"https://example.com/p.png\",\"width\":32}}}");
+    }
+
+    @Test
+    void patternColor_extrasSet_toJSON() {
+        var pattern = PatternColor.createPath("M 0 0 L 10 10");
+        pattern.getPattern().setWidth(8);
+        pattern.getPattern().setHeight(8);
+        pattern.getPattern().setX(1);
+        pattern.getPattern().setY(2);
+        pattern.getPattern().setColor(new SolidColor("#00ff00"));
+        pattern.getPattern().setOpacity(0.5);
+        pattern.getPattern().setBackgroundColor(new SolidColor("#ffffff"));
+        pattern.getPattern().setAspectRatio(1.5);
+        pattern.getPattern().setPatternTransform("rotate(45)");
+        pattern.getPattern().setId("my-pattern");
+        assertItemColorJson(pattern,
+                "{\"color\":{\"pattern\":{\"aspectRatio\":1.5,\"backgroundColor\":\"#ffffff\",\"color\":\"#00ff00\",\"height\":8,\"id\":\"my-pattern\",\"opacity\":0.5,\"path\":\"M 0 0 L 10 10\",\"patternTransform\":\"rotate(45)\",\"width\":8,\"x\":1,\"y\":2}}}");
+    }
+
+    @Test
+    void patternColor_unsetFieldsAbsent_toJSON() {
+        // Only the path is present; no null fields are serialized.
+        assertItemColorJson(PatternColor.createPath("M 0 0 L 10 10"),
+                "{\"color\":{\"pattern\":{\"path\":\"M 0 0 L 10 10\"}}}");
+    }
+
+    @Test
+    void patternColor_onPlotOptions_toJSON() {
+        var plotOptions = new PlotOptionsColumn();
+        plotOptions.setColor(PatternColor.createPath("M 0 0 L 10 10",
+                new SolidColor("#ff0000"), 10, 10));
+        assertEquals(
+                "{\"color\":{\"pattern\":{\"color\":\"#ff0000\",\"height\":10,\"path\":\"M 0 0 L 10 10\",\"width\":10}}}",
+                toJSON(plotOptions));
+    }
+}


### PR DESCRIPTION
Adds the Java API for chart pattern fills (an accessibility aid for color-blind users, see #9990). Charts had `SolidColor` and `GradientColor` but no way to set a pattern fill from Flow.

- New `PatternColor` (implements `Color`, mirrors `GradientColor`), with `createPath(...)` and `createImage(...)` factories and a nested `Pattern` bean exposing the Highcharts pattern options (path/image, width, height, color, opacity, etc.). It serializes to `{"pattern":{...}}`.
- Add `PatternColor` to the `Color` javadoc.
- Unit tests for the serialization plus an integration test covering both styled mode (the web component's CSS-rule bridge) and the default non-styled mode (Highcharts' native rendering).

Depends on vaadin/web-components#12204

Part of #9990

🤖 Generated with Claude Code
