### PR TITLE
chore: use vaadin-parent as parent for flow-components-bom

### DIFF
--- a/flow-components-bom/pom.xml
+++ b/flow-components-bom/pom.xml
@@ -3,13 +3,20 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <artifactId>vaadin-parent</artifactId>
+        <version>3.0.3</version>
     </parent>
     <artifactId>flow-components-bom</artifactId>
+    <version>25.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Flow Components Bill of Materials</name>
     <description>Flow Components Bill of Materials</description>
+    <url>https://vaadin.com/components</url>
+    <scm>
+        <connection>scm:https:https://github.com/vaadin/flow-components.git</connection>
+        <developerConnection>scm:git:git@github.com:vaadin/flow-components.git</developerConnection>
+        <url>https://github.com/vaadin/flow-components</url>
+    </scm>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -519,4 +526,16 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,14 @@
 
         <!-- Additional Surefire argLine - set to -javaagent:${org.mockito:mockito-core:jar} in modules using Mockito -->
         <surefire.argLine/>
+
+        <!--
+          Ensures modules that do not declare this POM as parent
+          (like flow-bom) are updated as well when using versions:set
+          to change the project version
+        -->
+        <processAllModules>true</processAllModules>
+
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Inheriting from vaadin-flow-components causes the BOM to pull in internal dependencies (e.g. JUnit jupiter), which prevents it from being consumed independently by downstream projects.

A similar change has been applied in Flow
https://github.com/vaadin/flow/pull/23507.
