### PR TITLE
feat: add solid gauge and tooltip options for activity gauge

### DIFF
--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/other/SolidGaugeMultipleKPI.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/other/SolidGaugeMultipleKPI.java
@@ -47,7 +47,6 @@ public class SolidGaugeMultipleKPI extends AbstractChartExample {
         chart.setHeight("500px");
 
         Configuration configuration = chart.getConfiguration();
-        configuration.getChart().setHeight("110%");
         configuration.setTitle("Multiple KPI gauge");
 
         // Full-circle pane with three concentric tracks

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/other/SolidGaugeMultipleKPI.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/main/java/com/vaadin/flow/component/charts/examples/other/SolidGaugeMultipleKPI.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.charts.examples.other;
+
+import com.vaadin.flow.component.charts.Chart;
+import com.vaadin.flow.component.charts.examples.AbstractChartExample;
+import com.vaadin.flow.component.charts.model.Background;
+import com.vaadin.flow.component.charts.model.ChartType;
+import com.vaadin.flow.component.charts.model.Configuration;
+import com.vaadin.flow.component.charts.model.DataSeries;
+import com.vaadin.flow.component.charts.model.DataSeriesItem;
+import com.vaadin.flow.component.charts.model.HorizontalAlign;
+import com.vaadin.flow.component.charts.model.Pane;
+import com.vaadin.flow.component.charts.model.PlotOptionsSolidgauge;
+import com.vaadin.flow.component.charts.model.Position;
+import com.vaadin.flow.component.charts.model.TextAlign;
+import com.vaadin.flow.component.charts.model.Tooltip;
+import com.vaadin.flow.component.charts.model.VerticalAlign;
+import com.vaadin.flow.component.charts.model.YAxis;
+import com.vaadin.flow.component.charts.model.style.SolidColor;
+import com.vaadin.flow.component.charts.model.style.Style;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Reproduces the Highcharts "Multiple KPI gauge" demo
+ * (https://www.highcharts.com/demo/highcharts/gauge-multiple-kpi) using the
+ * Flow API.
+ * <p>
+ * The FontAwesome icons from the original demo are omitted: they are drawn in a
+ * {@code chart.events.render} callback via the SVG renderer, which Flow does
+ * not expose.
+ */
+@Route("vaadin-charts/other/solid-gauge-multiple-kpi")
+public class SolidGaugeMultipleKPI extends AbstractChartExample {
+
+    @Override
+    public void initDemo() {
+        Chart chart = new Chart(ChartType.SOLIDGAUGE);
+        // Fixed size so the gauge does not grow with the viewport width
+        chart.setWidth("500px");
+        chart.setHeight("500px");
+
+        Configuration configuration = chart.getConfiguration();
+        configuration.getChart().setHeight("110%");
+        configuration.setTitle("Multiple KPI gauge");
+
+        // Full-circle pane with three concentric tracks
+        Pane pane = configuration.getPane();
+        pane.setStartAngle(0);
+        pane.setEndAngle(360);
+
+        pane.setBackground(
+                track("100%", "78%", new SolidColor(124, 181, 236, 0.3)),
+                track("77%", "56%", new SolidColor(67, 67, 72, 0.3)),
+                track("55%", "34%", new SolidColor(144, 237, 125, 0.3)));
+
+        YAxis yAxis = configuration.getyAxis();
+        yAxis.setMin(0);
+        yAxis.setMax(100);
+        yAxis.setLineWidth(0);
+        yAxis.setTickPositions(new Number[0]);
+
+        PlotOptionsSolidgauge plotOptions = new PlotOptionsSolidgauge();
+        plotOptions.getDataLabels().setEnabled(false);
+        plotOptions.setLinecap("round");
+        plotOptions.setStickyTracking(false);
+        plotOptions.setRounded(true);
+        configuration.setPlotOptions(plotOptions);
+
+        Tooltip tooltip = new Tooltip();
+        tooltip.setValueSuffix("%");
+        tooltip.setBackgroundColor(new SolidColor("none"));
+        tooltip.setBorderWidth(0);
+        tooltip.setShadow(false);
+        tooltip.setFixed(true);
+
+        Position position = new Position();
+        position.setHorizontalAlign(HorizontalAlign.CENTER);
+        position.setVerticalAlign(VerticalAlign.MIDDLE);
+        tooltip.setPosition(position);
+
+        tooltip.setPointFormat("{series.name}<br>"
+                + "<span style=\"font-size:2em; color:{point.color}; font-weight:bold\">{point.y}</span>");
+
+        Style style = new Style();
+        style.setFontSize("16px");
+        style.setTextAlign(TextAlign.CENTER);
+        tooltip.setStyle(style);
+
+        configuration.setTooltip(tooltip);
+
+        configuration.addSeries(kpiSeries("Conversion", 80, "100%", "78%",
+                new SolidColor(124, 181, 236)));
+        configuration.addSeries(kpiSeries("Engagement", 65, "77%", "56%",
+                new SolidColor(67, 67, 72)));
+        configuration.addSeries(kpiSeries("Feedback", 50, "55%", "34%",
+                new SolidColor(144, 237, 125)));
+
+        add(chart);
+    }
+
+    private static Background track(String outerRadius, String innerRadius,
+            SolidColor color) {
+        Background background = new Background();
+        background.setOuterRadius(outerRadius);
+        background.setInnerRadius(innerRadius);
+        background.setBackgroundColor(color);
+        background.setBorderWidth(0);
+        return background;
+    }
+
+    private static DataSeries kpiSeries(String name, Number value,
+            String radius, String innerRadius, SolidColor color) {
+        DataSeriesItem item = new DataSeriesItem();
+        item.setY(value);
+        item.setColor(color);
+
+        // Ring placement now comes from per-series PlotOptionsSolidgauge
+        PlotOptionsSolidgauge seriesOptions = new PlotOptionsSolidgauge();
+        seriesOptions.setRadius(radius);
+        seriesOptions.setInnerRadius(innerRadius);
+
+        DataSeries series = new DataSeries(name);
+        series.setPlotOptions(seriesOptions);
+        series.add(item);
+        return series;
+    }
+}

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
@@ -42,6 +42,8 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
     private Number overshoot;
     private Number opacity;
     private String _fn_pointDescriptionFormatter;
+    private String radius;
+    private String innerRadius;
     private Boolean rounded;
     private Boolean selected;
     private Boolean showCheckbox;
@@ -114,6 +116,46 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
      */
     public void setBorderRadius(String borderRadius) {
         this.borderRadius = borderRadius;
+    }
+
+    /**
+     * @see #setRadius(String)
+     * @since 25.3
+     */
+    public String getRadius() {
+        return radius;
+    }
+
+    /**
+     * The outer radius for points in the solid gauge. Can be given as a number
+     * (pixels) or a percentage string, like for example 100%, relative to the
+     * pane size.
+     *
+     * @param radius
+     * @since 25.3
+     */
+    public void setRadius(String radius) {
+        this.radius = radius;
+    }
+
+    /**
+     * @see #setInnerRadius(String)
+     * @since 25.3
+     */
+    public String getInnerRadius() {
+        return innerRadius;
+    }
+
+    /**
+     * The inner radius for points in the solid gauge. Can be given as a number
+     * (pixels) or a percentage string, like for example 60%, relative to the
+     * pane size.
+     *
+     * @param innerRadius
+     * @since 25.3
+     */
+    public void setInnerRadius(String innerRadius) {
+        this.innerRadius = innerRadius;
     }
 
     /**

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
@@ -130,6 +130,8 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
      * The outer radius for points in the solid gauge. Can be given as a number
      * (pixels) or a percentage string, like for example 100%, relative to the
      * pane size.
+     * <p>
+     * Defaults to: 100%
      *
      * @param radius
      * @since 25.3
@@ -150,6 +152,8 @@ public class PlotOptionsSolidgauge extends GaugeOptions {
      * The inner radius for points in the solid gauge. Can be given as a number
      * (pixels) or a percentage string, like for example 60%, relative to the
      * pane size.
+     * <p>
+     * Defaults to: 60%
      *
      * @param innerRadius
      * @since 25.3

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Tooltip.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Tooltip.java
@@ -663,6 +663,8 @@ public class Tooltip extends AbstractConfigurationObject {
      * {@link #setPosition(Position)} instead of following the mouse or the
      * hovered point. Useful for charts like solid gauges where the tooltip
      * should stay in a fixed spot.
+     * <p>
+     * Defaults to: false
      *
      * @param fixed
      * @since 25.3
@@ -682,6 +684,8 @@ public class Tooltip extends AbstractConfigurationObject {
     /**
      * The position of the tooltip when {@link #setFixed(Boolean)} is true.
      * Supports {@code align}, {@code verticalAlign}, {@code x} and {@code y}.
+     * <p>
+     * Defaults to: undefined
      *
      * @param position
      * @since 25.3

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Tooltip.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Tooltip.java
@@ -49,6 +49,8 @@ public class Tooltip extends AbstractConfigurationObject {
     private String xDateFormat;
     private Number changeDecimals;
     private Boolean outside;
+    private Boolean fixed;
+    private Position position;
 
     public Tooltip() {
     }
@@ -646,5 +648,45 @@ public class Tooltip extends AbstractConfigurationObject {
      */
     public void setOutside(Boolean outside) {
         this.outside = outside;
+    }
+
+    /**
+     * @see #setFixed(Boolean)
+     * @since 25.3
+     */
+    public Boolean getFixed() {
+        return fixed;
+    }
+
+    /**
+     * When true, the tooltip is fixed to a position given by
+     * {@link #setPosition(Position)} instead of following the mouse or the
+     * hovered point. Useful for charts like solid gauges where the tooltip
+     * should stay in a fixed spot.
+     *
+     * @param fixed
+     * @since 25.3
+     */
+    public void setFixed(Boolean fixed) {
+        this.fixed = fixed;
+    }
+
+    /**
+     * @see #setPosition(Position)
+     * @since 25.3
+     */
+    public Position getPosition() {
+        return position;
+    }
+
+    /**
+     * The position of the tooltip when {@link #setFixed(Boolean)} is true.
+     * Supports {@code align}, {@code verticalAlign}, {@code x} and {@code y}.
+     *
+     * @param position
+     * @since 25.3
+     */
+    public void setPosition(Position position) {
+        this.position = position;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Style.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Style.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.charts.model.style;
 
 import com.vaadin.flow.component.charts.model.AbstractConfigurationObject;
+import com.vaadin.flow.component.charts.model.TextAlign;
 
 /**
  * Style options for CSS styling
@@ -26,6 +27,7 @@ public class Style extends AbstractConfigurationObject {
     private StylePosition position;
     private String lineHeight;
     private String textShadow;
+    private TextAlign textAlign;
 
     /**
      * @see #setColor(Color)
@@ -167,5 +169,24 @@ public class Style extends AbstractConfigurationObject {
      */
     public void setTextShadow(String textShadow) {
         this.textShadow = textShadow;
+    }
+
+    /**
+     * @see #setTextAlign(TextAlign)
+     * @since 25.3
+     */
+    public TextAlign getTextAlign() {
+        return textAlign;
+    }
+
+    /**
+     * Sets how the text is aligned, one of {@link TextAlign#LEFT},
+     * {@link TextAlign#CENTER} or {@link TextAlign#RIGHT}.
+     *
+     * @param textAlign
+     * @since 25.3
+     */
+    public void setTextAlign(TextAlign textAlign) {
+        this.textAlign = textAlign;
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Style.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/style/Style.java
@@ -182,6 +182,8 @@ public class Style extends AbstractConfigurationObject {
     /**
      * Sets how the text is aligned, one of {@link TextAlign#LEFT},
      * {@link TextAlign#CENTER} or {@link TextAlign#RIGHT}.
+     * <p>
+     * Defaults to: undefined
      *
      * @param textAlign
      * @since 25.3


### PR DESCRIPTION
The Charts API could not reproduce the Highcharts multiple-KPI /
activity gauge, because a few standard Highcharts options were missing
from the typed model.

This adds them:
- `PlotOptionsSolidgauge`: `radius`, `innerRadius` — place each series'
  arc in its own concentric ring (the defining feature of the chart)
- `Tooltip`: `fixed`, `position` — pin the tooltip to a fixed spot
- `Style`: `textAlign` — align tooltip text

A new demo page (`SolidGaugeMultipleKPI`) reproduces the Highcharts
multiple-KPI gauge using only the typed API. The FontAwesome ring icons
from the original demo are omitted: they require a chart render event /
SVG renderer, which Flow does not expose.

Part of vaadin/web-components#1768

---

🤖 Generated with Claude Code
