### PR TITLE
test: wait for loaded items count in LazyLoadingIT page-size tests

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -60,6 +61,28 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
             ComboBoxElement comboBox) {
         Assert.assertEquals(message, expectedCount,
                 getLoadedItems(comboBox).size());
+    }
+
+    /**
+     * Waits until the number of loaded items matches the expected count. Items
+     * are loaded asynchronously after opening the overlay or changing the page
+     * size, so asserting the count without waiting is prone to timing issues.
+     */
+    protected void waitForLoadedItemsCount(String message, int expectedCount,
+            ComboBoxElement comboBox) {
+        waitForLoadedItemsCount(message, count -> count == expectedCount,
+                comboBox);
+    }
+
+    protected void waitForLoadedItemsCount(String message,
+            IntPredicate expectedCount, ComboBoxElement comboBox) {
+        try {
+            waitUntil(driver -> expectedCount
+                    .test(getLoadedItems(comboBox).size()));
+        } catch (TimeoutException e) {
+            Assert.fail(message + " Loaded items count: "
+                    + getLoadedItems(comboBox).size());
+        }
     }
 
     // Gets all the loaded json items, but they are not necessarily rendered

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
@@ -117,7 +117,7 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
                 "Expected size = 2 after applying programmatic filter", 2);
 
         firstComboBox.openPopup();
-        assertLoadedItemsCount("Should be 2 persons after filtering", 2,
+        waitForLoadedItemsCount("Should be 2 persons after filtering", 2,
                 firstComboBox);
 
         // Verify that the second combo box has not been impacted by filtering

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
@@ -140,7 +140,7 @@ public class CustomValueIT extends AbstractComboBoxIT {
         assertCustomValueChanges("bar", "foobaz");
         assertValueChanges("bar", "foo", "foobaz");
         combo.openPopup();
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "Expected 3 items to be loaded after adding the custom value",
                 3, combo);
         assertItemSelected(combo, "foobaz");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -58,7 +58,7 @@ public class DetachReattachIT extends AbstractComboBoxIT {
         clickButton("attach");
         combo = $(ComboBoxElement.class).first();
         combo.openPopup();
-        assertLoadedItemsCount("Expected 2 items to be loaded", 2, combo);
+        waitForLoadedItemsCount("Expected 2 items to be loaded", 2, combo);
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -192,17 +192,19 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         clickButton("change-pagesize");
         pagesizeBox.openPopup();
-        waitUntilTextInContent(pagesizeBox, "Item");
-        assertLoadedItemsCount(
-                "After opening the ComboBox, the first 'pageSize' amount "
-                        + "of items should be loaded (with updated pageSize: 100).",
-                100, pagesizeBox);
+        // The connector fetches the visible range plus a prefetch buffer, so
+        // opening the overlay may load one or two pages of the new size.
+        waitForLoadedItemsCount(
+                "After opening the ComboBox, items should be loaded in "
+                        + "full pages of the updated pageSize: 100.",
+                count -> count > 0 && count % 100 == 0, pagesizeBox);
 
         scrollToItem(pagesizeBox, 100);
 
-        assertLoadedItemsCount(
-                "Expected two pages to be loaded (with updated pageSize 100).",
-                200, pagesizeBox);
+        waitForLoadedItemsCount(
+                "After scrolling, at least two full pages should be loaded "
+                        + "(with updated pageSize: 100).",
+                count -> count >= 200 && count % 100 == 0, pagesizeBox);
         assertRendered(pagesizeBox, "Item 100");
     }
 
@@ -486,19 +488,20 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     @Test
     public void disabledLazyLoading_reducePageSize_enablesLazyLoading() {
         disabledLazyLoadingBox.openPopup();
-        assertLoadedItemsCount("Initially all 100 items should be loaded", 100,
+        waitForLoadedItemsCount("Initially all 100 items should be loaded", 100,
                 disabledLazyLoadingBox);
         disabledLazyLoadingBox.closePopup();
 
         clickButton("enable-lazy-loading");
         disabledLazyLoadingBox.openPopup();
-        assertLoadedItemsCount(
-                "After reducing page size, 50 items should be loaded", 50,
-                disabledLazyLoadingBox);
+        // The connector fetches the visible range plus a prefetch buffer, so
+        // opening the overlay may load one or two pages of the new size.
+        waitForLoadedItemsCount(
+                "After reducing page size, items should be loaded in "
+                        + "full pages of the updated pageSize: 50.",
+                count -> count > 0 && count % 50 == 0, disabledLazyLoadingBox);
 
         scrollToItem(disabledLazyLoadingBox, 100);
-        assertLoadedItemsCount("Scrolling down should load further pages", 50,
-                disabledLazyLoadingBox);
         assertRendered(disabledLazyLoadingBox, "99");
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -77,7 +77,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     @Test
     public void openPopup_firstPageLoaded() {
         stringBox.openPopup();
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, stringBox);
         assertRendered(stringBox, "Item 10");
@@ -172,7 +172,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     @Test
     public void customPageSize_correctAmountOfItemsRequested() {
         pagesizeBox.openPopup();
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "After opening the ComboBox, the first 'pageSize' amount "
                         + "of items should be loaded.",
                 180, pagesizeBox);
@@ -346,7 +346,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         Assert.assertEquals("0", lazySizeRequestCountSpan.getText());
 
         callbackBox.openPopup();
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, callbackBox);
         assertRendered(callbackBox, "Item 0");
@@ -357,7 +357,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         callbackBox.openPopup();
         scrollToItem(callbackBox, 60);
 
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "There should be 100 items after loading two pages", 100,
                 callbackBox);
         assertRendered(callbackBox, "Item 60");
@@ -367,7 +367,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     public void comboBoxInATemplate_worksWithLazyLoading() {
         templateBox.openPopup();
 
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, templateBox);
         assertRendered(templateBox, "Item 8");
@@ -378,7 +378,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         templateBox.openPopup();
         scrollToItem(templateBox, 50);
 
-        assertLoadedItemsCount(
+        waitForLoadedItemsCount(
                 "There should be 100 items after loading two pages", 100,
                 templateBox);
         assertRendered(templateBox, "Item 50");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountUnknownComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/dataview/ItemCountUnknownComboBoxIT.java
@@ -148,7 +148,7 @@ public class ItemCountUnknownComboBoxIT extends AbstractItemCountComboBoxIT {
 
         comboBoxElement.openPopup();
 
-        assertLoadedItemsCount("Should be 50 items before filtering", 50,
+        waitForLoadedItemsCount("Should be 50 items before filtering", 50,
                 comboBoxElement);
 
         // Apply text filter


### PR DESCRIPTION
Two LazyLoadingIT tests fail randomly on CI and locally: `loadItems_changePageSize` and `disabledLazyLoading_reducePageSize_enablesLazyLoading`. Both assert an exact loaded-items count right after reopening the overlay following a page-size change. The count is updated asynchronously, and the connector fetches the visible range plus a prefetch buffer, so one or two full pages may load on open. Depending on timing, the same assertion sees 0, 100 or 200 items.

Observed failures for the same assertion across runs:

```
expected:<100> but was:<0>
expected:<100> but was:<200>
expected:<50> but was:<100>
```

The tests now wait until the loaded count settles on a non-zero multiple of the new page size instead of asserting an exact count immediately. A new `waitForLoadedItemsCount` helper in `AbstractComboBoxIT` supports both exact counts and predicates. The exact-count assertion after scrolling in `disabledLazyLoading_reducePageSize_enablesLazyLoading` is removed because the count depends on when items outside the active range are dropped; the existing `assertRendered` check already verifies that lazy loading works.

With this change the suite passed twice in a row locally (31/31); before, every run had 1-3 failures.

Follow-up to #9238

---

🤖 Generated with Claude Code