### PR TITLE
fix!: return empty string from SelectElement.getSelectedText() if no item selected

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
@@ -164,15 +164,16 @@ public abstract class AbstractSelectIT extends AbstractComponentIT {
         }
 
         void noItemSelected() {
-            try {
-                SelectElement.ItemElement selectedItem = selectElement
-                        .getSelectedItem();
-                Assert.fail(
-                        "Expected nothing to be selected, but selection was: "
-                                + selectedItem.getText());
-            } catch (NoSuchElementException nsee) {
-                // expected
-            }
+            SelectElement.ItemElement selectedItem = selectElement
+                    .getSelectedItem();
+            Assert.assertNull(
+                    "Expected nothing to be selected, but selection was: "
+                            + (selectedItem == null ? null
+                                    : selectedItem.getText()),
+                    selectedItem);
+            Assert.assertEquals(
+                    "Expected empty selected text when nothing is selected", "",
+                    selectElement.getSelectedText());
         }
 
         void emptySelectionItemSelected() {

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/SelectionIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/SelectionIT.java
@@ -26,6 +26,11 @@ import com.vaadin.flow.testutil.TestPath;
 public class SelectionIT extends AbstractSelectIT {
 
     @Test
+    public void testSelection_nothingSelected_getSelectedTextReturnsEmptyString() {
+        verify.noItemSelected();
+    }
+
+    @Test
     public void testSelection_userSelection_firesValueChangeEvent() {
         for (int i = 0; i < getInitialNumberOfItems(); i++) {
             selectElement.selectItemByIndex(i);

--- a/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
@@ -99,7 +99,8 @@ public class SelectElement extends TestBenchElement implements HasSelectByText,
 
     @Override
     public String getSelectedText() {
-        return getSelectedItem().getText();
+        ItemElement selectedItem = getSelectedItem();
+        return selectedItem == null ? "" : selectedItem.getText();
     }
 
     public ItemElement getSelectedOptionItem() {
@@ -109,8 +110,15 @@ public class SelectElement extends TestBenchElement implements HasSelectByText,
                         "No item selected from popup"));
     }
 
+    /**
+     * Gets the currently selected item shown in the value button, or
+     * {@code null} if nothing is selected.
+     *
+     * @return the selected item, or {@code null} if nothing is selected
+     */
     public ItemElement getSelectedItem() {
         TestBenchElement valueElement = $("vaadin-select-value-button").first();
-        return valueElement.$(ItemElement.class).first();
+        return valueElement.$(ItemElement.class).all().stream().findFirst()
+                .orElse(null);
     }
 }


### PR DESCRIPTION
Fixes #1056.

`SelectElement.getSelectedText()` threw `NoSuchElementException` when nothing was selected in a vaadin-select. It now returns an empty string.

`getSelectedItem()` now returns `null` instead of throwing when the value button has no item.

Generated with [Claude Code](https://claude.ai/code)