### PR TITLE
feat: support left and right in grid ColumnTextAlign

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnTextAlign.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnTextAlign.java
@@ -53,21 +53,11 @@ public enum ColumnTextAlign {
 
     /**
      * Aligns the content to the right side of the cell in both left-to-right
-     * and right-to-left layout direction. Use this instead of
-     * {@link ColumnTextAlign#END} for content that should stay right-aligned in
-     * right-to-left layout direction, such as numbers.
+     * and right-to-left layout direction.
      *
      * @since 25.3
      */
-    RIGHT("right"),
-
-    /**
-     * Stretches the content lines of the cell so that they fill the width of
-     * the cell, except for the last line.
-     *
-     * @since 25.3
-     */
-    JUSTIFY("justify");
+    RIGHT("right");
 
     private final String propertyValue;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnTextAlign.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnTextAlign.java
@@ -26,7 +26,48 @@ package com.vaadin.flow.component.grid;
  */
 public enum ColumnTextAlign {
 
-    START("start"), CENTER("center"), END("end");
+    /**
+     * Aligns the content to the start of the cell, which is the left side in
+     * left-to-right and the right side in right-to-left layout direction.
+     */
+    START("start"),
+
+    /**
+     * Aligns the content to the center of the cell.
+     */
+    CENTER("center"),
+
+    /**
+     * Aligns the content to the end of the cell, which is the right side in
+     * left-to-right and the left side in right-to-left layout direction.
+     */
+    END("end"),
+
+    /**
+     * Aligns the content to the left side of the cell in both left-to-right and
+     * right-to-left layout direction.
+     *
+     * @since 25.3
+     */
+    LEFT("left"),
+
+    /**
+     * Aligns the content to the right side of the cell in both left-to-right
+     * and right-to-left layout direction. Use this instead of
+     * {@link ColumnTextAlign#END} for content that should stay right-aligned in
+     * right-to-left layout direction, such as numbers.
+     *
+     * @since 25.3
+     */
+    RIGHT("right"),
+
+    /**
+     * Stretches the content lines of the cell so that they fill the width of
+     * the cell, except for the last line.
+     *
+     * @since 25.3
+     */
+    JUSTIFY("justify");
 
     private final String propertyValue;
 
@@ -45,17 +86,12 @@ public enum ColumnTextAlign {
      *         <code>null</code>
      */
     public static ColumnTextAlign fromPropertyValue(String propertyValue) {
-        if (propertyValue == null) {
-            return START;
+        for (ColumnTextAlign textAlign : values()) {
+            if (textAlign.getPropertyValue().equals(propertyValue)) {
+                return textAlign;
+            }
         }
-        switch (propertyValue) {
-        case "center":
-            return CENTER;
-        case "end":
-            return END;
-        default:
-            return START;
-        }
+        return START;
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -216,6 +216,19 @@ class GridColumnTest {
     }
 
     @Test
+    void setTextAlign_textAlignPropertyUpdated() {
+        Grid<Person> grid = new Grid<>();
+        Column<Person> nameColumn = grid.addColumn(Person::getName);
+
+        for (ColumnTextAlign textAlign : ColumnTextAlign.values()) {
+            nameColumn.setTextAlign(textAlign);
+            Assertions.assertEquals(textAlign.getPropertyValue(),
+                    nameColumn.getElement().getProperty("textAlign"));
+            Assertions.assertEquals(textAlign, nameColumn.getTextAlign());
+        }
+    }
+
+    @Test
     void setTextAlignToNull_defaultTextAlign() {
         Grid<Person> grid = new Grid<>();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -207,43 +207,21 @@ class GridColumnTest {
     }
 
     @Test
-    void addColumn_defaultTextAlign() {
-        Grid<Person> grid = new Grid<>();
-
-        Column<Person> nameColumn = grid.addColumn(Person::getName);
-        Assertions.assertEquals(ColumnTextAlign.START,
-                nameColumn.getTextAlign());
-    }
-
-    @Test
     void setTextAlign_textAlignPropertyUpdated() {
         Grid<Person> grid = new Grid<>();
-        Column<Person> nameColumn = grid.addColumn(Person::getName);
 
-        for (ColumnTextAlign textAlign : ColumnTextAlign.values()) {
-            nameColumn.setTextAlign(textAlign);
-            Assertions.assertEquals(textAlign.getPropertyValue(),
-                    nameColumn.getElement().getProperty("textAlign"));
-            Assertions.assertEquals(textAlign, nameColumn.getTextAlign());
-        }
-    }
+        Column<Person> column = grid.addColumn(Person::getName);
+        Assertions.assertEquals(ColumnTextAlign.START, column.getTextAlign());
+        Assertions.assertNull(column.getElement().getProperty("textAlign"));
 
-    @Test
-    void setTextAlignToNull_defaultTextAlign() {
-        Grid<Person> grid = new Grid<>();
+        column.setTextAlign(ColumnTextAlign.END);
+        Assertions.assertEquals(ColumnTextAlign.END, column.getTextAlign());
+        Assertions.assertEquals("end",
+                column.getElement().getProperty("textAlign"));
 
-        Column<Person> nameColumn = grid.addColumn(Person::getName)
-                .setTextAlign(null);
-        Assertions.assertEquals(ColumnTextAlign.START,
-                nameColumn.getTextAlign());
-
-        nameColumn.setTextAlign(ColumnTextAlign.CENTER);
-        Assertions.assertEquals(ColumnTextAlign.CENTER,
-                nameColumn.getTextAlign());
-
-        nameColumn.setTextAlign(null);
-        Assertions.assertEquals(ColumnTextAlign.START,
-                nameColumn.getTextAlign());
+        column.setTextAlign(null);
+        Assertions.assertEquals(ColumnTextAlign.START, column.getTextAlign());
+        Assertions.assertNull(column.getElement().getProperty("textAlign"));
     }
 
     @Test


### PR DESCRIPTION
`ColumnTextAlign` only had the logical values `START`, `CENTER` and `END`, which flip with the layout direction. The web component now also accepts the physical `left` and `right` values (vaadin/web-components#12233), so this PR adds them to the enum:

```java
grid.addColumn(Person::getAge).setTextAlign(ColumnTextAlign.RIGHT);
```

Fixes #2879
