### PR TITLE
fix: pin playwright to a version supporting Debian 11

### DIFF
--- a/scripts/wtr.js
+++ b/scripts/wtr.js
@@ -25,6 +25,9 @@ async function computeModules() {
 
 const wtrTestsFolderName = 'test';
 
+// Playwright 1.62 dropped Chromium builds for Debian 11, which the CI agents still run
+const playwrightVersion = '1.61.0';
+
 function runTests() {
   for (const module of modules) {
     const id = module.replace('-parent', '');
@@ -51,6 +54,12 @@ function runTests() {
         cwd: itFolder,
         stdio: 'inherit'
       });
+
+      // Pin Playwright. Written after the Flow build, which rewrites
+      // package.json and can drop the overrides section.
+      const json = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+      json.overrides = { ...json.overrides, playwright: playwrightVersion, 'playwright-core': playwrightVersion };
+      fs.writeFileSync(packageJson, JSON.stringify(json, null, 2));
 
       // Install dependencies required to run the web-test-runner tests
       execSync(`npm install @open-wc/testing @web/dev-server-esbuild @web/test-runner @web/test-runner-playwright @types/mocha sinon @vaadin/testing-helpers --save-dev --legacy-peer-deps`, {


### PR DESCRIPTION
Snapshot builds for 25.1 and 24.10 fail in the "Run test" step. `scripts/wtr.js` installs its test tooling with no version pins and these branches have no lockfile, so each build resolves the newest Playwright. Playwright 1.62.0, released 2026-07-24, removed the Chromium download entry for `debian11-x64`, which is what the build agents run.

```
You are running Node.js 18.17.0.
Playwright requires Node.js 20 or higher.
```

After the agents were upgraded to Node 22, the next error appeared:

```
Failed to install browsers
Error: ERROR: Playwright does not support chromium on debian11-x64
    at runTests (/opt/agent/work/.../scripts/wtr.js:62:7)
```

1.61.0 is the newest release that still provides `debian11-x64` builds for both `chromium` and `chromium-headless-shell`.

The pin uses npm `overrides` rather than a version on the `npm install` line, so it applies no matter what range `@web/test-runner-playwright` declares. It is written after the Flow build, because `flow:build-frontend` rewrites package.json and can remove the overrides section.

main and 25.2 are unaffected only because their package-lock.json pins Playwright 1.60.0. The lasting fix is moving the agents to Debian 12, and this pin should be removed then.

> [!NOTE]
> PR checks do not cover this change. The WTR step runs only in the Bender snapshot build, so verification needs a custom `FlowComponents_Snapshot` run against this branch.

---

🤖 Generated with Claude Code
