### PR TITLE
feat: add setAutofocus to dialog, deprecate setFocusTrap

### DIFF
--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -683,8 +683,10 @@ public class Dialog extends Component implements HasComponents, HasSize,
      *
      * @return {@code true} if focus trap is enabled (default), {@code false}
      *         otherwise
+     * @deprecated use {@link #isAutofocus()} instead
      * @since 25.1
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     public boolean isFocusTrap() {
         return !getElement().getProperty("noFocusTrap", false);
     }
@@ -698,10 +700,42 @@ public class Dialog extends Component implements HasComponents, HasSize,
      *
      * @param focusTrap
      *            {@code true} to enable focus trap, {@code false} to disable it
+     * @deprecated use {@link #setAutofocus(boolean)} instead
      * @since 25.1
      */
+    @Deprecated(since = "25.3", forRemoval = true)
     public void setFocusTrap(boolean focusTrap) {
         getElement().setProperty("noFocusTrap", !focusTrap);
+    }
+
+    /**
+     * Gets whether focus moves into the dialog when opened.
+     * <p>
+     * This setting only works for non-modal dialogs and is ignored for modal
+     * ones, where focus must always stay inside. Autofocus is enabled by
+     * default.
+     *
+     * @return {@code true} if autofocus is enabled (default), {@code false}
+     *         otherwise
+     * @since 25.3
+     */
+    public boolean isAutofocus() {
+        return !getElement().getProperty("noAutofocus", false);
+    }
+
+    /**
+     * Sets whether focus should move into the dialog when opened.
+     * <p>
+     * This setting only works for non-modal dialogs and is ignored for modal
+     * ones, where focus must always stay inside. Autofocus is enabled by
+     * default.
+     *
+     * @param autofocus
+     *            {@code true} to enable autofocus, {@code false} to disable it
+     * @since 25.3
+     */
+    public void setAutofocus(boolean autofocus) {
+        getElement().setProperty("noAutofocus", !autofocus);
     }
 
     /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -192,6 +192,7 @@ class DialogTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void isFocusTrap_trueByDefault() {
         Dialog dialog = new Dialog();
         Assertions.assertTrue(dialog.isFocusTrap(),
@@ -202,6 +203,7 @@ class DialogTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void setFocusTrap_dialogFocusTrapCanBeDisabled() {
         Dialog dialog = new Dialog();
         dialog.setFocusTrap(false);
@@ -213,6 +215,7 @@ class DialogTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void setFocusTrap_dialogFocusTrapCanBeReEnabled() {
         Dialog dialog = new Dialog();
         dialog.setFocusTrap(false);

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -225,6 +225,24 @@ class DialogTest {
     }
 
     @Test
+    void setAutofocus_isAutofocus() {
+        Dialog dialog = new Dialog();
+        Assertions.assertTrue(dialog.isAutofocus());
+        Assertions.assertFalse(
+                dialog.getElement().getProperty("noAutofocus", false));
+
+        dialog.setAutofocus(false);
+        Assertions.assertFalse(dialog.isAutofocus());
+        Assertions.assertTrue(
+                dialog.getElement().getProperty("noAutofocus", false));
+
+        dialog.setAutofocus(true);
+        Assertions.assertTrue(dialog.isAutofocus());
+        Assertions.assertFalse(
+                dialog.getElement().getProperty("noAutofocus", false));
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     void getRole_defaultDialog() {
         Dialog dialog = new Dialog();


### PR DESCRIPTION
This PR adds a `setAutofocus` method to Dialog that controls whether focus should automatically move into the dialog's overlay on open, and deprecates `setFocusTrap` in its favor. The setting only works for non-modal dialogs and is ignored for modal ones, where focus must always stay inside.

Fixes https://github.com/vaadin/web-components/issues/11971