### PR TITLE
refactor: move shared upload logic to UploadHelper

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/Upload.java
@@ -45,9 +45,7 @@ import com.vaadin.flow.internal.streams.UploadStartEvent;
 import com.vaadin.flow.server.NoInputStreamException;
 import com.vaadin.flow.server.NoOutputStreamException;
 import com.vaadin.flow.server.StreamReceiver;
-import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.StreamVariable;
-import com.vaadin.flow.server.streams.UploadEvent;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.flow.shared.Registration;
 
@@ -132,7 +130,7 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
         getElement().addEventListener("upload-abort",
                 event -> interruptUpload());
 
-        setUploadHandler(new FailFastUploadHandler());
+        setUploadHandler(new UploadHelper.FailFastUploadHandler());
 
         final String filesUploading = "element.files.some(file => file.uploading)";
         DomEventListener allFinishedListener = e -> {
@@ -380,22 +378,7 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
             checkNoReceiverSet("setAcceptedMimeTypes");
             checkNoDeprecatedFileTypes("setAcceptedMimeTypes");
         }
-        if (mimeTypes == null || mimeTypes.length == 0) {
-            acceptedMimeTypes = List.of();
-        } else {
-            for (var mimeType : mimeTypes) {
-                if (mimeType == null || mimeType.isBlank()) {
-                    throw new IllegalArgumentException(
-                            "MIME types cannot contain null or blank values");
-                }
-                if (!mimeType.contains("/")) {
-                    throw new IllegalArgumentException(
-                            "MIME type must contain a ‘/’ character: "
-                                    + mimeType);
-                }
-            }
-            acceptedMimeTypes = List.of(mimeTypes);
-        }
+        acceptedMimeTypes = UploadHelper.validateMimeTypes(mimeTypes);
         updateAcceptProperty();
     }
 
@@ -449,21 +432,8 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
             checkNoReceiverSet("setAcceptedFileExtensions");
             checkNoDeprecatedFileTypes("setAcceptedFileExtensions");
         }
-        if (extensions == null || extensions.length == 0) {
-            acceptedFileExtensions = List.of();
-        } else {
-            for (var ext : extensions) {
-                if (ext == null || ext.isBlank()) {
-                    throw new IllegalArgumentException(
-                            "File extensions cannot contain null or blank values");
-                }
-                if (!ext.startsWith(".")) {
-                    throw new IllegalArgumentException(
-                            "File extension must start with ‘.’: " + ext);
-                }
-            }
-            acceptedFileExtensions = List.of(extensions);
-        }
+        acceptedFileExtensions = UploadHelper
+                .validateFileExtensions(extensions);
         updateAcceptProperty();
     }
 
@@ -559,11 +529,8 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
      * configured MIME types and file extensions.
      */
     private void updateAcceptProperty() {
-        var accept = Stream
-                .concat(acceptedMimeTypes.stream(),
-                        acceptedFileExtensions.stream())
-                .collect(Collectors.joining(","));
-        getElement().setProperty("accept", accept);
+        getElement().setProperty("accept", UploadHelper
+                .formatAcceptValue(acceptedMimeTypes, acceptedFileExtensions));
     }
 
     /**
@@ -985,28 +952,16 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
      * @since 25.0
      */
     public void setUploadHandler(UploadHandler handler, String targetName) {
-        Objects.requireNonNull(handler, "UploadHandler cannot be null");
-        Objects.requireNonNull(targetName, "The target name cannot be null");
-        if (targetName.isBlank()) {
-            throw new IllegalArgumentException(
-                    "The target name cannot be blank");
-        }
-        if (!(handler instanceof FailFastUploadHandler)) {
+        var elementStreamResource = UploadHelper.createTargetResource(handler,
+                getElement(), targetName, () -> acceptedMimeTypes,
+                () -> acceptedFileExtensions);
+        var failFast = handler instanceof UploadHelper.FailFastUploadHandler;
+        if (!failFast) {
             handlerExplicitlyConfigured = true;
         }
-        var validatingHandler = UploadHelper.wrapHandlerWithFileTypeValidation(
-                handler, () -> acceptedMimeTypes, () -> acceptedFileExtensions);
-        StreamResourceRegistry.ElementStreamResource elementStreamResource = new StreamResourceRegistry.ElementStreamResource(
-                validatingHandler, this.getElement()) {
-            @Override
-            public String getName() {
-                return targetName;
-            }
-        };
         runBeforeClientResponse(ui -> getElement().setAttribute("target",
                 elementStreamResource));
-        if (!hasListener(UploadStartEvent.class)
-                && !(handler instanceof FailFastUploadHandler)) {
+        if (!hasListener(UploadStartEvent.class) && !failFast) {
             addListener(UploadStartEvent.class, event -> startUpload());
             addListener(UploadCompleteEvent.class, event -> endUpload());
         }
@@ -1171,17 +1126,4 @@ public class Upload extends Component implements HasEnabled, HasSize, HasStyle,
         return handlerExplicitlyConfigured;
     }
 
-    /**
-     * An internal implementation of the UploadHandler interface that just
-     * reminds the developer that UploadHandler must be set to Upload. Upload
-     * event listeners are not registered for this handler.
-     */
-    private static final class FailFastUploadHandler implements UploadHandler {
-        @Override
-        public void handleUploadRequest(UploadEvent event) {
-            throw new IllegalStateException(
-                    "Upload cannot be performed without a upload handler set. "
-                            + "Please firstly set the upload handler implementation with upload.setUploadHandler()");
-        }
-    }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadHelper.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadHelper.java
@@ -19,9 +19,14 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.dom.DisabledUpdateMode;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.streams.UploadEvent;
 import com.vaadin.flow.server.streams.UploadHandler;
 
@@ -58,6 +63,137 @@ public class UploadHelper implements Serializable {
      */
     public static boolean hasUploadHandler(Upload upload) {
         return upload.isHandlerExplicitlyConfigured();
+    }
+
+    /**
+     * Validates the given MIME types and returns them as an immutable list.
+     * Each value must be non-null, non-blank and contain a {@code /} character.
+     *
+     * @param mimeTypes
+     *            the MIME types to validate, may be {@code null} or empty
+     * @return an immutable list of the given MIME types, or an empty list when
+     *         the input is {@code null} or empty
+     * @throws IllegalArgumentException
+     *             if any value is null, blank, or does not contain a {@code /}
+     *             character
+     */
+    static List<String> validateMimeTypes(String... mimeTypes) {
+        if (mimeTypes == null || mimeTypes.length == 0) {
+            return List.of();
+        }
+        for (var mimeType : mimeTypes) {
+            if (mimeType == null || mimeType.isBlank()) {
+                throw new IllegalArgumentException(
+                        "MIME types cannot contain null or blank values");
+            }
+            if (!mimeType.contains("/")) {
+                throw new IllegalArgumentException(
+                        "MIME type must contain a '/' character: " + mimeType);
+            }
+        }
+        return List.of(mimeTypes);
+    }
+
+    /**
+     * Validates the given file extensions and returns them as an immutable
+     * list. Each value must be non-null, non-blank and start with a dot.
+     *
+     * @param extensions
+     *            the file extensions to validate, may be {@code null} or empty
+     * @return an immutable list of the given file extensions, or an empty list
+     *         when the input is {@code null} or empty
+     * @throws IllegalArgumentException
+     *             if any value is null, blank, or does not start with a dot
+     */
+    static List<String> validateFileExtensions(String... extensions) {
+        if (extensions == null || extensions.length == 0) {
+            return List.of();
+        }
+        for (var ext : extensions) {
+            if (ext == null || ext.isBlank()) {
+                throw new IllegalArgumentException(
+                        "File extensions cannot contain null or blank values");
+            }
+            if (!ext.startsWith(".")) {
+                throw new IllegalArgumentException(
+                        "File extension must start with '.': " + ext);
+            }
+        }
+        return List.of(extensions);
+    }
+
+    /**
+     * Formats the client-side {@code accept} property value from the given MIME
+     * types and file extensions.
+     *
+     * @param mimeTypes
+     *            the accepted MIME types, not {@code null}
+     * @param extensions
+     *            the accepted file extensions, not {@code null}
+     * @return a comma-separated string of all values, empty when both lists are
+     *         empty
+     */
+    static String formatAcceptValue(List<String> mimeTypes,
+            List<String> extensions) {
+        return Stream.concat(mimeTypes.stream(), extensions.stream())
+                .collect(Collectors.joining(","));
+    }
+
+    /**
+     * Creates the stream resource to set as the upload {@code target}
+     * attribute. Validates the handler and target name, wraps the handler with
+     * file type validation (see
+     * {@link #wrapHandlerWithFileTypeValidation(UploadHandler, SerializableSupplier, SerializableSupplier)})
+     * and uses the given target name as the last path segment of the generated
+     * upload URL.
+     *
+     * @param handler
+     *            the upload handler, not {@code null}
+     * @param ownerElement
+     *            the element owning the stream resource, not {@code null}
+     * @param targetName
+     *            the endpoint name (single path segment); must not be blank
+     * @param mimeTypesSupplier
+     *            supplier for the current list of accepted MIME type patterns,
+     *            not {@code null}
+     * @param extensionsSupplier
+     *            supplier for the current list of accepted file extensions, not
+     *            {@code null}
+     * @return the stream resource to set as the {@code target} attribute
+     */
+    static StreamResourceRegistry.ElementStreamResource createTargetResource(
+            UploadHandler handler, Element ownerElement, String targetName,
+            SerializableSupplier<List<String>> mimeTypesSupplier,
+            SerializableSupplier<List<String>> extensionsSupplier) {
+        Objects.requireNonNull(handler, "UploadHandler cannot be null");
+        Objects.requireNonNull(targetName, "The target name cannot be null");
+        if (targetName.isBlank()) {
+            throw new IllegalArgumentException(
+                    "The target name cannot be blank");
+        }
+        var validatingHandler = wrapHandlerWithFileTypeValidation(handler,
+                mimeTypesSupplier, extensionsSupplier);
+        return new StreamResourceRegistry.ElementStreamResource(
+                validatingHandler, ownerElement) {
+            @Override
+            public String getName() {
+                return targetName;
+            }
+        };
+    }
+
+    /**
+     * An internal implementation of the UploadHandler interface that reminds
+     * the developer that an upload handler must be set. Upload event listeners
+     * are not registered for this handler.
+     */
+    static final class FailFastUploadHandler implements UploadHandler {
+        @Override
+        public void handleUploadRequest(UploadEvent event) {
+            throw new IllegalStateException(
+                    "Upload cannot be performed without an upload handler set. "
+                            + "Please first set the upload handler with setUploadHandler()");
+        }
     }
 
     /**

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadManager.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/UploadManager.java
@@ -21,8 +21,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -33,8 +31,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.internal.streams.UploadCompleteEvent;
 import com.vaadin.flow.internal.streams.UploadStartEvent;
-import com.vaadin.flow.server.StreamResourceRegistry;
-import com.vaadin.flow.server.streams.UploadEvent;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.flow.shared.Registration;
 
@@ -121,8 +117,8 @@ public class UploadManager implements Serializable {
         owner.getElement().appendVirtualChild(connector.getElement());
 
         // Set up default fail-fast handler
-        setUploadHandler(
-                handler != null ? handler : new FailFastUploadHandler());
+        setUploadHandler(handler != null ? handler
+                : new UploadHelper.FailFastUploadHandler());
 
         // Listen for file-remove and file-reject events from client.
         // We manually listen to DOM events and fire ComponentEvents with the
@@ -196,25 +192,12 @@ public class UploadManager implements Serializable {
      *            blank
      */
     public void setUploadHandler(UploadHandler handler, String targetName) {
-        Objects.requireNonNull(handler, "UploadHandler cannot be null");
-        Objects.requireNonNull(targetName, "The target name cannot be null");
-        if (targetName.isBlank()) {
-            throw new IllegalArgumentException(
-                    "The target name cannot be blank");
-        }
-        if (!(handler instanceof FailFastUploadHandler)) {
+        var elementStreamResource = UploadHelper.createTargetResource(handler,
+                connector.getElement(), targetName, () -> acceptedMimeTypes,
+                () -> acceptedFileExtensions);
+        if (!(handler instanceof UploadHelper.FailFastUploadHandler)) {
             handlerExplicitlyConfigured.set(true);
         }
-        var validatingHandler = UploadHelper.wrapHandlerWithFileTypeValidation(
-                handler, () -> acceptedMimeTypes, () -> acceptedFileExtensions);
-        // Wrap handler with ElementStreamResource to use custom target name
-        StreamResourceRegistry.ElementStreamResource elementStreamResource = new StreamResourceRegistry.ElementStreamResource(
-                validatingHandler, connector.getElement()) {
-            @Override
-            public String getName() {
-                return targetName;
-            }
-        };
         connector.getElement().setAttribute("target", elementStreamResource);
     }
 
@@ -288,22 +271,7 @@ public class UploadManager implements Serializable {
      *             character
      */
     public void setAcceptedMimeTypes(String... mimeTypes) {
-        if (mimeTypes == null || mimeTypes.length == 0) {
-            acceptedMimeTypes = List.of();
-        } else {
-            for (String mimeType : mimeTypes) {
-                if (mimeType == null || mimeType.isBlank()) {
-                    throw new IllegalArgumentException(
-                            "MIME types cannot contain null or blank values");
-                }
-                if (!mimeType.contains("/")) {
-                    throw new IllegalArgumentException(
-                            "MIME type must contain a '/' character: "
-                                    + mimeType);
-                }
-            }
-            acceptedMimeTypes = List.of(mimeTypes);
-        }
+        acceptedMimeTypes = UploadHelper.validateMimeTypes(mimeTypes);
         updateAcceptProperty();
     }
 
@@ -334,21 +302,8 @@ public class UploadManager implements Serializable {
      *             if any value is null, blank, or does not start with a dot
      */
     public void setAcceptedFileExtensions(String... extensions) {
-        if (extensions == null || extensions.length == 0) {
-            acceptedFileExtensions = List.of();
-        } else {
-            for (String ext : extensions) {
-                if (ext == null || ext.isBlank()) {
-                    throw new IllegalArgumentException(
-                            "File extensions cannot contain null or blank values");
-                }
-                if (!ext.startsWith(".")) {
-                    throw new IllegalArgumentException(
-                            "File extension must start with '.': " + ext);
-                }
-            }
-            acceptedFileExtensions = List.of(extensions);
-        }
+        acceptedFileExtensions = UploadHelper
+                .validateFileExtensions(extensions);
         updateAcceptProperty();
     }
 
@@ -366,11 +321,8 @@ public class UploadManager implements Serializable {
      * configured MIME types and file extensions.
      */
     private void updateAcceptProperty() {
-        String accept = Stream
-                .concat(acceptedMimeTypes.stream(),
-                        acceptedFileExtensions.stream())
-                .collect(Collectors.joining(","));
-        connector.getElement().setProperty("accept", accept);
+        connector.getElement().setProperty("accept", UploadHelper
+                .formatAcceptValue(acceptedMimeTypes, acceptedFileExtensions));
     }
 
     /**
@@ -542,20 +494,6 @@ public class UploadManager implements Serializable {
      */
     boolean isHandlerExplicitlyConfigured() {
         return handlerExplicitlyConfigured.get();
-    }
-
-    /**
-     * An internal implementation of the UploadHandler interface that reminds
-     * the developer that UploadHandler must be set. Upload event listeners are
-     * not registered for this handler.
-     */
-    private static final class FailFastUploadHandler implements UploadHandler {
-        @Override
-        public void handleUploadRequest(UploadEvent event) {
-            throw new IllegalStateException(
-                    "Upload cannot be performed without an upload handler set. "
-                            + "Please first set the upload handler with setUploadHandler()");
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Upload and UploadManager had ~100 lines of copy-pasted logic (handler target resource creation, MIME type / file extension validation, accept property formatting, and the fail-fast placeholder handler) that had already started to drift, e.g. different quote characters and grammar in error messages.
- Moves that logic into package-private helpers in the existing UploadHelper class so both classes use one implementation and can't drift again.
- No behavior changes; only the previously drifted error message wording is now unified.

Related to https://github.com/vaadin/web-components/issues/10939

🤖 Generated with [Claude Code](https://claude.com/claude-code)