### PR TITLE
feat: add HasAriaDescription to field components

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Checkbox.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
@@ -85,8 +86,9 @@ import com.vaadin.flow.signals.Signal;
 @NpmPackage(value = "@vaadin/checkbox", version = "25.3.0-alpha8")
 @JsModule("@vaadin/checkbox/src/vaadin-checkbox.js")
 public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
-        implements ClickNotifier<Checkbox>, Focusable<Checkbox>, HasAriaLabel,
-        HasValidationProperties, HasValidator<Boolean>,
+        implements ClickNotifier<Checkbox>, Focusable<Checkbox>,
+        HasAriaDescription, HasAriaLabel, HasValidationProperties,
+        HasValidator<Boolean>,
         InputField<AbstractField.ComponentValueChangeEvent<Checkbox, Boolean>, Boolean>,
         HasThemeVariant<CheckboxVariant> {
 
@@ -320,6 +322,23 @@ public class Checkbox extends AbstractSinglePropertyField<Checkbox, Boolean>
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Tag;
@@ -116,8 +117,8 @@ import tools.jackson.databind.node.ArrayNode;
 @JsModule("@vaadin/checkbox-group/src/vaadin-checkbox-group.js")
 public class CheckboxGroup<T>
         extends AbstractSinglePropertyField<CheckboxGroup<T>, Set<T>>
-        implements HasAriaLabel, HasDataView<T, Void, CheckboxGroupDataView<T>>,
-        HasItemComponents<T>,
+        implements HasAriaDescription, HasAriaLabel,
+        HasDataView<T, Void, CheckboxGroupDataView<T>>, HasItemComponents<T>,
         InputField<AbstractField.ComponentValueChangeEvent<CheckboxGroup<T>, Set<T>>, Set<T>>,
         HasListDataView<T, CheckboxGroupListDataView<T>>,
         HasThemeVariant<CheckboxGroupVariant>, HasValidationProperties,
@@ -661,6 +662,23 @@ public class CheckboxGroup<T>
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/Switch.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -83,8 +84,8 @@ import com.vaadin.flow.data.binder.Validator;
 @NpmPackage(value = "@vaadin/switch", version = "25.3.0-alpha8")
 @JsModule("@vaadin/switch/src/vaadin-switch.js")
 public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
-        implements ClickNotifier<Switch>, Focusable<Switch>, HasAriaLabel,
-        HasValidationProperties, HasValidator<Boolean>,
+        implements ClickNotifier<Switch>, Focusable<Switch>, HasAriaDescription,
+        HasAriaLabel, HasValidationProperties, HasValidator<Boolean>,
         InputField<AbstractField.ComponentValueChangeEvent<Switch, Boolean>, Boolean>,
         HasThemeVariant<SwitchVariant> {
 
@@ -318,6 +319,23 @@ public class Switch extends AbstractSinglePropertyField<Switch, Boolean>
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
@@ -626,6 +627,28 @@ class CheckboxGroupTest {
 
         group.setAriaLabelledBy((String) null);
         Assertions.assertTrue(group.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        Assertions.assertTrue(
+                HasAriaDescription.class.isAssignableFrom(CheckboxGroup.class));
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        CheckboxGroup<String> group = new CheckboxGroup<>();
+        group.setAriaDescribedBy("description-id");
+
+        Assertions.assertEquals("description-id",
+                group.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                group.getAriaDescribedBy().get());
+
+        group.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                group.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(group.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxUnitTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -145,6 +146,28 @@ class CheckboxUnitTest {
 
         checkbox.setAriaLabelledBy((String) null);
         Assertions.assertTrue(checkbox.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        Checkbox checkbox = new Checkbox();
+        Assertions.assertTrue(checkbox instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        Checkbox checkbox = new Checkbox();
+        checkbox.setAriaDescribedBy("description-id");
+
+        Assertions.assertEquals("description-id",
+                checkbox.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                checkbox.getAriaDescribedBy().get());
+
+        checkbox.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                checkbox.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(checkbox.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/SwitchTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.checkbox.Switch;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.tests.MockUIExtension;
@@ -72,5 +73,27 @@ class SwitchTest {
     void implementsHasThemeVariant() {
         Assertions.assertTrue(
                 HasThemeVariant.class.isAssignableFrom(Switch.class));
+    }
+
+    @Test
+    void implementsHasAriaDescription() {
+        Assertions.assertTrue(
+                HasAriaDescription.class.isAssignableFrom(Switch.class));
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        Switch field = new Switch();
+        field.setAriaDescribedBy("description-id");
+
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasPlaceholder;
 import com.vaadin.flow.component.HasTheme;
@@ -91,9 +92,10 @@ import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
  * @since 23.2
  */
 public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, TItem, TValue>, TItem, TValue>
-        extends AbstractSinglePropertyField<TComponent, TValue> implements
-        Focusable<TComponent>, HasAllowedCharPattern, HasAriaLabel, HasAutoOpen,
-        HasClearButton, HasDataView<TItem, String, ComboBoxDataView<TItem>>,
+        extends AbstractSinglePropertyField<TComponent, TValue>
+        implements Focusable<TComponent>, HasAllowedCharPattern,
+        HasAriaDescription, HasAriaLabel, HasAutoOpen, HasClearButton,
+        HasDataView<TItem, String, ComboBoxDataView<TItem>>,
         InputField<AbstractField.ComponentValueChangeEvent<TComponent, TValue>, TValue>,
         HasLazyDataView<TItem, String, ComboBoxLazyDataView<TItem>>,
         HasListDataView<TItem, ComboBoxListDataView<TItem>>, HasTheme,
@@ -459,6 +461,23 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasPlaceholder;
@@ -75,6 +76,14 @@ abstract class ComboBoxBaseTest {
                 HasAriaLabel.class.isAssignableFrom(
                         createComboBox(String.class).getClass()),
                 "ComboBox should support setting aria-label and aria-labelledby");
+    }
+
+    @Test
+    void implementsHasAriaDescription() {
+        Assertions.assertTrue(
+                HasAriaDescription.class.isAssignableFrom(
+                        createComboBox(String.class).getClass()),
+                "ComboBox should support setting aria-describedby");
     }
 
     @Test
@@ -374,5 +383,21 @@ abstract class ComboBoxBaseTest {
 
         comboBox.setAriaLabelledBy((String) null);
         Assertions.assertTrue(comboBox.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
+
+        comboBox.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                comboBox.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                comboBox.getAriaDescribedBy().get());
+
+        comboBox.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                comboBox.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(comboBox.getAriaDescribedBy().isEmpty());
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasPlaceholder;
 import com.vaadin.flow.component.HasValue;
@@ -135,8 +136,8 @@ import tools.jackson.databind.node.ObjectNode;
 @NpmPackage(value = "date-fns", version = "4.1.0")
 public class DatePicker
         extends AbstractSinglePropertyField<DatePicker, LocalDate>
-        implements Focusable<DatePicker>, HasAllowedCharPattern, HasAriaLabel,
-        HasAutoOpen, HasClearButton,
+        implements Focusable<DatePicker>, HasAllowedCharPattern,
+        HasAriaDescription, HasAriaLabel, HasAutoOpen, HasClearButton,
         InputField<AbstractField.ComponentValueChangeEvent<DatePicker, LocalDate>, LocalDate>,
         HasPrefix, HasThemeVariant<DatePickerVariant>, HasValidationProperties,
         HasValidator<LocalDate>, HasPlaceholder {
@@ -571,6 +572,23 @@ public class DatePicker
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     @Override

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
@@ -320,6 +321,29 @@ class DatePickerTest {
 
         datePicker.setAriaLabelledBy((String) null);
         Assertions.assertTrue(datePicker.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        Assertions.assertTrue(
+                HasAriaDescription.class.isAssignableFrom(DatePicker.class),
+                "Date picker should support aria-describedby");
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        DatePicker datePicker = new DatePicker();
+
+        datePicker.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id", datePicker.getElement()
+                .getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                datePicker.getAriaDescribedBy().get());
+
+        datePicker.setAriaDescribedBy((String) null);
+        Assertions.assertNull(datePicker.getElement()
+                .getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(datePicker.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.SignalPropertySupport;
@@ -107,8 +108,9 @@ import com.vaadin.flow.signals.Signal;
 @NpmPackage(value = "@vaadin/radio-group", version = "25.3.0-alpha8")
 @JsModule("@vaadin/radio-group/src/vaadin-radio-group.js")
 public class RadioButtonGroup<T>
-        extends AbstractSinglePropertyField<RadioButtonGroup<T>, T> implements
-        HasAriaLabel, HasDataView<T, Void, RadioButtonGroupDataView<T>>,
+        extends AbstractSinglePropertyField<RadioButtonGroup<T>, T>
+        implements HasAriaDescription, HasAriaLabel,
+        HasDataView<T, Void, RadioButtonGroupDataView<T>>,
         HasListDataView<T, RadioButtonGroupListDataView<T>>,
         InputField<AbstractField.ComponentValueChangeEvent<RadioButtonGroup<T>, T>, T>,
         HasThemeVariant<RadioGroupVariant>, HasValidationProperties,
@@ -674,6 +676,23 @@ public class RadioButtonGroup<T>
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     @SuppressWarnings("unchecked")

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
@@ -495,6 +496,28 @@ class RadioButtonGroupTest {
 
         group.setAriaLabelledBy((String) null);
         Assertions.assertTrue(group.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        Assertions.assertTrue(HasAriaDescription.class
+                .isAssignableFrom(RadioButtonGroup.class));
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setAriaDescribedBy("description-id");
+
+        Assertions.assertEquals("description-id",
+                group.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                group.getAriaDescribedBy().get());
+
+        group.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                group.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(group.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasPlaceholder;
@@ -112,7 +113,7 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@vaadin/select", version = "25.3.0-alpha8")
 @JsModule("@vaadin/select/src/vaadin-select.js")
 public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
-        implements Focusable<Select<T>>, HasAriaLabel,
+        implements Focusable<Select<T>>, HasAriaDescription, HasAriaLabel,
         HasDataView<T, Void, SelectDataView<T>>, HasItemComponents<T>,
         InputField<AbstractField.ComponentValueChangeEvent<Select<T>, T>, T>,
         HasListDataView<T, SelectListDataView<T>>, HasPrefix,
@@ -576,6 +577,23 @@ public class Select<T> extends AbstractSinglePropertyField<Select<T>, T>
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Unit;
@@ -863,6 +864,29 @@ class SelectTest {
 
         select.setAriaLabelledBy((String) null);
         Assertions.assertTrue(select.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        Assertions.assertTrue(
+                HasAriaDescription.class.isAssignableFrom(Select.class),
+                "Select should support aria-describedby");
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        Select<String> select = new Select<>();
+
+        select.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                select.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                select.getAriaDescribedBy().get());
+
+        select.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                select.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(select.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/main/java/com/vaadin/flow/component/slider/NumberSlider.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.slider;
 
 import java.util.Optional;
 
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.function.SerializableFunction;
 
@@ -32,7 +33,7 @@ import com.vaadin.flow.function.SerializableFunction;
  */
 abstract class NumberSlider<TComponent extends NumberSlider<TComponent, TValue>, TValue extends Number>
         extends SliderBase<TComponent, TValue, TValue, Double>
-        implements HasAriaLabel {
+        implements HasAriaDescription, HasAriaLabel {
 
     /**
      * Constructs a NumberSlider with the given min and max values, and
@@ -104,6 +105,35 @@ abstract class NumberSlider<TComponent extends NumberSlider<TComponent, TValue>,
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * Sets the id of an element to be used as the accessible description for
+     * the range input element of the slider.
+     * <p>
+     * The referenced element is announced in addition to the helper text and
+     * the error message.
+     *
+     * @param ariaDescribedBy
+     *            the id of the element to be used as the description, or
+     *            {@code null} to remove it
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    /**
+     * Gets the id of the element used as the accessible description for the
+     * range input element of the slider.
+     *
+     * @return an optional id of the element used as the description, or an
+     *         empty optional if none has been set
+     */
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/AbstractSliderTest.java
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/src/test/java/com/vaadin/flow/component/slider/AbstractSliderTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -60,6 +61,26 @@ abstract class AbstractSliderTest<TComponent extends NumberSlider<TComponent, TV
 
         slider.setAriaLabelledBy((String) null);
         Assertions.assertTrue(slider.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementsHasAriaDescription() {
+        Assertions.assertTrue(slider instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        slider.setAriaDescribedBy("description-id");
+
+        Assertions.assertEquals("description-id",
+                slider.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                slider.getAriaDescribedBy().get());
+
+        slider.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                slider.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(slider.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldBase.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.CompositionNotifier;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasPlaceholder;
 import com.vaadin.flow.component.InputNotifier;
@@ -50,10 +51,11 @@ import com.vaadin.flow.function.SerializableFunction;
  */
 public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent, TValue>, TValue>
         extends AbstractSinglePropertyField<TComponent, TValue>
-        implements CompositionNotifier, Focusable<TComponent>, HasAriaLabel,
-        HasAutocapitalize, HasAutocomplete, HasAutocorrect, HasClearButton,
-        HasValidationProperties, HasValidator<TValue>, HasValueChangeMode,
-        HasPlaceholder, HasPrefix, HasSuffix, InputNotifier, KeyNotifier,
+        implements CompositionNotifier, Focusable<TComponent>,
+        HasAriaDescription, HasAriaLabel, HasAutocapitalize, HasAutocomplete,
+        HasAutocorrect, HasClearButton, HasValidationProperties,
+        HasValidator<TValue>, HasValueChangeMode, HasPlaceholder, HasPrefix,
+        HasSuffix, InputNotifier, KeyNotifier,
         InputField<AbstractField.ComponentValueChangeEvent<TComponent, TValue>, TValue> {
 
     private ValueChangeMode currentMode;
@@ -232,6 +234,23 @@ public abstract class TextFieldBase<TComponent extends TextFieldBase<TComponent,
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     /**

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
@@ -190,6 +191,28 @@ class BigDecimalFieldTest extends TextFieldTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        BigDecimalField field = new BigDecimalField();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        BigDecimalField field = new BigDecimalField();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/EmailFieldTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasTooltip;
@@ -160,6 +161,28 @@ class EmailFieldTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        EmailField field = new EmailField();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        EmailField field = new EmailField();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/IntegerFieldTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.component.shared.InputField;
@@ -249,6 +250,28 @@ class IntegerFieldTest extends TextFieldTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        IntegerField field = new IntegerField();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        IntegerField field = new IntegerField();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/NumberFieldTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasTooltip;
@@ -299,6 +300,28 @@ class NumberFieldTest extends TextFieldTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        NumberField field = new NumberField();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        NumberField field = new NumberField();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.InputField;
@@ -186,6 +187,28 @@ class PasswordFieldTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        PasswordField field = new PasswordField();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        PasswordField field = new PasswordField();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -202,6 +203,28 @@ class TextAreaTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        TextArea field = new TextArea();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        TextArea field = new TextArea();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.InputMode;
 import com.vaadin.flow.component.shared.HasAllowedCharPattern;
@@ -214,6 +215,28 @@ class TextFieldTest {
 
         field.setAriaLabelledBy((String) null);
         Assertions.assertTrue(field.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        TextField field = new TextField();
+        Assertions.assertTrue(field instanceof HasAriaDescription);
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        TextField field = new TextField();
+
+        field.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id",
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                field.getAriaDescribedBy().get());
+
+        field.setAriaDescribedBy((String) null);
+        Assertions.assertNull(
+                field.getElement().getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(field.getAriaDescribedBy().isEmpty());
     }
 
     @Test

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasPlaceholder;
 import com.vaadin.flow.component.HasValue;
@@ -117,8 +118,8 @@ import com.vaadin.flow.signals.Signal;
 @JsModule("./vaadin-time-picker/timepickerConnector.js")
 public class TimePicker
         extends AbstractSinglePropertyField<TimePicker, LocalTime>
-        implements Focusable<TimePicker>, HasAllowedCharPattern, HasAriaLabel,
-        HasAutoOpen, HasClearButton,
+        implements Focusable<TimePicker>, HasAllowedCharPattern,
+        HasAriaDescription, HasAriaLabel, HasAutoOpen, HasClearButton,
         InputField<AbstractField.ComponentValueChangeEvent<TimePicker, LocalTime>, LocalTime>,
         HasPrefix, HasThemeVariant<TimePickerVariant>, HasValidationProperties,
         HasValidator<LocalTime>, HasPlaceholder {
@@ -451,6 +452,23 @@ public class TimePicker
     public Optional<String> getAriaLabelledBy() {
         return Optional
                 .ofNullable(getElement().getProperty("accessibleNameRef"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The referenced elements are announced in addition to the helper text and
+     * the error message.
+     */
+    @Override
+    public void setAriaDescribedBy(String ariaDescribedBy) {
+        getElement().setProperty("accessibleDescriptionRef", ariaDescribedBy);
+    }
+
+    @Override
+    public Optional<String> getAriaDescribedBy() {
+        return Optional.ofNullable(
+                getElement().getProperty("accessibleDescriptionRef"));
     }
 
     @Override

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaDescription;
 import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
@@ -325,6 +326,29 @@ class TimePickerTest {
 
         timePicker.setAriaLabelledBy((String) null);
         Assertions.assertTrue(timePicker.getAriaLabelledBy().isEmpty());
+    }
+
+    @Test
+    void implementHasAriaDescription() {
+        Assertions.assertTrue(
+                HasAriaDescription.class.isAssignableFrom(TimePicker.class),
+                "Time picker should support aria-describedby");
+    }
+
+    @Test
+    void setAriaDescribedBy() {
+        TimePicker timePicker = new TimePicker();
+
+        timePicker.setAriaDescribedBy("description-id");
+        Assertions.assertEquals("description-id", timePicker.getElement()
+                .getProperty("accessibleDescriptionRef"));
+        Assertions.assertEquals("description-id",
+                timePicker.getAriaDescribedBy().get());
+
+        timePicker.setAriaDescribedBy((String) null);
+        Assertions.assertNull(timePicker.getElement()
+                .getProperty("accessibleDescriptionRef"));
+        Assertions.assertTrue(timePicker.getAriaDescribedBy().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
This PR adds the `HasAriaDescription` mixin interface to all field components that implement `HasAriaLabel`, overriding `setAriaDescribedBy` / `getAriaDescribedBy` to map to the `accessibleDescriptionRef` property, which propagates the reference to the input element (the default implementation sets attributes on the host element instead). This follows the same pattern as `accessibleName` / `accessibleNameRef`.

DateTimePicker is left out because it doesn't implement `HasAriaLabel`, `HasPrefix` or `HasSuffix`.

Part of vaadin/web-components#11975