### PR TITLE
fix: reuse custom editors on user-driven cell updates

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SheetWidget.java
@@ -3555,6 +3555,23 @@ public class SheetWidget extends Panel {
                 && customWidgetMap.containsKey(getSelectedCellKey());
     }
 
+    /**
+     * Returns whether the given cell renders a custom editor inside the cell
+     * itself, in which case the cell contents must not be overwritten.
+     *
+     * @param cellKey
+     *            the key of the cell to check
+     * @return {@code true} if the cell renders a custom editor
+     */
+    private boolean hasCustomEditorInCell(String cellKey) {
+        if (isShowCustomEditorOnFocus()) {
+            return false;
+        }
+        SpreadsheetCustomEditorFactory factory = getSheetHandler()
+                .getCustomEditorFactory();
+        return factory != null && factory.hasCustomEditor(cellKey);
+    }
+
     public void showCustomWidgets(HashMap<String, Widget> newWidgetMap) {
         if (customWidgetMap != null) {
             for (Widget w : customWidgetMap.values()) {
@@ -4464,7 +4481,7 @@ public class SheetWidget extends Panel {
                         }
                     }
 
-                    if (!(hasCustomEditor && !isShowCustomEditorOnFocus())) {
+                    if (!hasCustomEditor || isShowCustomEditorOnFocus()) {
                         cell.setValue(cd.value, cd.cellStyle, cd.textColor,
                                 cd.needsMeasure);
                         cell.markAsOverflowDirty();
@@ -5507,7 +5524,12 @@ public class SheetWidget extends Panel {
 
     public void updateSelectedCellValue(String value) {
         Cell selectedCell = getSelectedCell();
-        if (isSelectedCellRendered() && selectedCell != null) {
+        // Writing a value replaces the cell contents, removing any custom
+        // editor in it. The commit is deferred (see
+        // SpreadsheetWidget.doDeferredCellValueCommit) and resolves its target
+        // from the selection, which by then may have moved onto an editor cell.
+        if (isSelectedCellRendered() && selectedCell != null
+                && !hasCustomEditorInCell(getSelectedCellKey())) {
             selectedCell.setValue(value);
         }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/CustomEditorReloadPage.java
@@ -27,6 +27,9 @@ public class CustomEditorReloadPage extends VerticalLayout {
 
     static final String[] FRUITS = { "Apple", "Banana", "Cherry" };
 
+    /** Value {@code onCustomEditorDisplayed} writes into the editor. */
+    public static final String CALLBACK_VALUE = "Banana";
+
     private int callbackCount;
     private final Span callbackCounter = new Span("0");
     private final Spreadsheet spreadsheet = new Spreadsheet();
@@ -68,6 +71,18 @@ public class CustomEditorReloadPage extends VerticalLayout {
                 ComboBox<String> comboBox = new ComboBox<>();
                 comboBox.setItems(FRUITS);
                 comboBox.setWidthFull();
+                // Mirrors the reproducer in issue #9180: write the picked value
+                // into the cell and refresh it. Client-side changes only, so
+                // the callback's own setValue below does not trigger a refresh
+                // and the callback count stays deterministic.
+                comboBox.addValueChangeListener(event -> {
+                    if (!event.isFromClient()) {
+                        return;
+                    }
+                    Cell editedCell = spreadsheet.createCell(rowIndex,
+                            columnIndex, event.getValue());
+                    spreadsheet.refreshCells(editedCell);
+                });
                 return comboBox;
             }
             return null;
@@ -82,7 +97,7 @@ public class CustomEditorReloadPage extends VerticalLayout {
             if (customEditor instanceof ComboBox<?> comboBox) {
                 @SuppressWarnings("unchecked")
                 ComboBox<String> typed = (ComboBox<String>) comboBox;
-                typed.setValue(FRUITS[columnIndex % FRUITS.length]);
+                typed.setValue(CALLBACK_VALUE);
             }
         }
     }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/CustomEditorDelayedCallbackFixture.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/CustomEditorDelayedCallbackFixture.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.tests.fixtures;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Sheet;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
+
+/**
+ * Ports the reproducer from issues #9180 and #9036, so tests exercise the same
+ * combination it uses:
+ * <ul>
+ * <li>four adjacent editors in B2:E2, a new instance on every factory
+ * call,</li>
+ * <li>a value-change listener that writes the cell and calls
+ * {@code refreshCells}, <b>without</b> an {@code isFromClient} guard,</li>
+ * <li>{@code autoselect} enabled through the DOM attribute, which is the only
+ * way to enable it,</li>
+ * <li>a slow {@code onCustomEditorDisplayed} that sets a value which is
+ * <b>not</b> in the item set and then calls {@code inputElement.select()}.</li>
+ * </ul>
+ * <p>
+ * Kept separate from {@link CustomEditorSelectFixture}, which backs the
+ * infinite-loop regression tests from #9113 and must keep its current shape.
+ */
+public class CustomEditorDelayedCallbackFixture implements SpreadsheetFixture {
+
+    private static final String[] FRUITS = { "Apple", "Banana", "Cherry" };
+
+    /** Prefix of the value {@code onCustomEditorDisplayed} sets. */
+    public static final String CALLBACK_VALUE_PREFIX = "Value Reset ";
+
+    /**
+     * Makes the callback slow enough for the selection to move on before it
+     * completes. Shorter than the reproducer's one second, which is not needed.
+     */
+    private static final long CALLBACK_DELAY_MILLIS = 200;
+
+    @Override
+    public void loadFixture(Spreadsheet spreadsheet) {
+        for (int column = 1; column <= 4; column++) {
+            spreadsheet.setColumnWidth(column, 150);
+        }
+        spreadsheet.setSpreadsheetComponentFactory(
+                new DelayedCallbackEditorFactory());
+    }
+
+    private static class DelayedCallbackEditorFactory
+            implements SpreadsheetComponentFactory {
+
+        private int callbackCount;
+        private Span counterLabel;
+
+        /**
+         * Exposes the callback count in cell A1 so tests can check that the
+         * un-guarded {@code refreshCells} above does not keep re-firing
+         * {@code onCustomEditorDisplayed}.
+         */
+        @Override
+        public Component getCustomComponentForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            if (rowIndex != 0 || columnIndex != 0) {
+                return null;
+            }
+            if (counterLabel == null) {
+                counterLabel = new Span("0");
+                counterLabel.setId("callbackCount");
+            }
+            return counterLabel;
+        }
+
+        @Override
+        public Component getCustomEditorForCell(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet) {
+            if (rowIndex != 1 || columnIndex < 1 || columnIndex > 4) {
+                return null;
+            }
+            ComboBox<String> comboBox = new ComboBox<>();
+            comboBox.setItems(FRUITS);
+            comboBox.setWidthFull();
+
+            if (cell != null && cell.getCellType() == CellType.STRING) {
+                comboBox.setValue(cell.getStringCellValue());
+            }
+
+            // No isFromClient guard, matching the reported code: the callback's
+            // own setValue also reaches this listener.
+            comboBox.addValueChangeListener(event -> {
+                if (cell != null) {
+                    cell.setCellValue(event.getValue());
+                    spreadsheet.refreshCells(cell);
+                }
+            });
+
+            comboBox.getElement().setAttribute("autoselect", true);
+            return comboBox;
+        }
+
+        @Override
+        public void onCustomEditorDisplayed(Cell cell, int rowIndex,
+                int columnIndex, Spreadsheet spreadsheet, Sheet sheet,
+                Component customEditor) {
+            if (!(customEditor instanceof ComboBox<?> comboBox)) {
+                return;
+            }
+            callbackCount++;
+            if (counterLabel != null) {
+                counterLabel.setText(String.valueOf(callbackCount));
+            }
+            try {
+                Thread.sleep(CALLBACK_DELAY_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            @SuppressWarnings("unchecked")
+            ComboBox<String> typed = (ComboBox<String>) comboBox;
+            typed.setValue(CALLBACK_VALUE_PREFIX + columnIndex);
+            // autoselect only fires on focus, which has already happened, so
+            // the new text has to be selected explicitly.
+            customEditor.getElement().executeJs("this.inputElement.select();");
+        }
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/TestFixtures.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/main/java/com/vaadin/flow/component/spreadsheet/tests/fixtures/TestFixtures.java
@@ -41,6 +41,7 @@ public enum TestFixtures {
     CustomEditorShared(CustomEditorSharedFixture.class),
     CustomEditorRow(CustomEditorRowFixture.class),
     CustomEditorSelect(CustomEditorSelectFixture.class),
+    CustomEditorDelayedCallback(CustomEditorDelayedCallbackFixture.class),
     Styles(StylesFixture.class),
     LockCell(LockCellFixture.class),
     LockSheet(LockSheetFixture.class),

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -369,6 +369,44 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
                         .getInputElementValue());
     }
 
+    /**
+     * Returns the name of the slot the given cell's editor is assigned to. A
+     * cell knows only this name, not the editor itself, so editor lookups start
+     * here.
+     *
+     * @param cellAddress
+     *            address of the cell, e.g. "B2"
+     * @return the slot name, or {@code null} if the cell renders no editor
+     */
+    protected String getEditorSlotName(String cellAddress) {
+        var slots = getSpreadsheet().getCellAt(cellAddress)
+                .findElements(By.tagName("slot"));
+        return slots.isEmpty() ? null : slots.get(0).getDomAttribute("name");
+    }
+
+    /**
+     * Returns the custom editor rendered in the given cell, or {@code null} if
+     * the cell renders none.
+     *
+     * @param <T>
+     *            element type of the editor
+     * @param cellAddress
+     *            address of the cell, e.g. "B2"
+     * @param editorType
+     *            e.g. {@code ComboBoxElement.class}
+     * @return the editor element, or {@code null} if there is none
+     */
+    protected <T extends TestBenchElement> T getCellEditor(String cellAddress,
+            Class<T> editorType) {
+        String slotName = getEditorSlotName(cellAddress);
+        if (slotName == null) {
+            return null;
+        }
+        var editors = getSpreadsheet().$(editorType).attribute("slot", slotName)
+                .all();
+        return editors.isEmpty() ? null : editors.get(0);
+    }
+
     public void assertNoErrorIndicatorDetected() {
         Assert.assertTrue("Error indicator detected when there should be none.",
                 findElements(By.className("v-errorindicator")).isEmpty());

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.spreadsheet.test;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
@@ -370,6 +371,33 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     }
 
     /**
+     * State of the input element inside the custom editor rendered in a cell.
+     *
+     * @param value
+     *            the text shown in the input
+     * @param selectionStart
+     *            start of the text selection
+     * @param selectionEnd
+     *            end of the text selection
+     * @param focused
+     *            whether the input holds the focus
+     */
+    public record EditorInputState(String value, int selectionStart,
+            int selectionEnd, boolean focused) {
+
+        /**
+         * Returns whether the whole text is selected, which is what
+         * {@code inputElement.select()} produces.
+         *
+         * @return {@code true} if the text is non-empty and fully selected
+         */
+        public boolean isFullySelected() {
+            return !value.isEmpty() && selectionStart == 0
+                    && selectionEnd == value.length();
+        }
+    }
+
+    /**
      * Returns the name of the slot the given cell's editor is assigned to. A
      * cell knows only this name, not the editor itself, so editor lookups start
      * here.
@@ -378,7 +406,7 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
      *            address of the cell, e.g. "B2"
      * @return the slot name, or {@code null} if the cell renders no editor
      */
-    protected String getEditorSlotName(String cellAddress) {
+    private String getEditorSlotName(String cellAddress) {
         var slots = getSpreadsheet().getCellAt(cellAddress)
                 .findElements(By.tagName("slot"));
         return slots.isEmpty() ? null : slots.get(0).getDomAttribute("name");
@@ -405,6 +433,48 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
         var editors = getSpreadsheet().$(editorType).attribute("slot", slotName)
                 .all();
         return editors.isEmpty() ? null : editors.get(0);
+    }
+
+    /**
+     * Returns the input state of the custom editor rendered in the given cell,
+     * or {@code null} if the cell renders no editor.
+     *
+     * @param cellAddress
+     *            address of the cell, e.g. "B2"
+     * @return the editor's input state, or {@code null} if there is none
+     */
+    @SuppressWarnings("unchecked")
+    public EditorInputState getEditorInputState(String cellAddress) {
+        String slotName = getEditorSlotName(cellAddress);
+        if (slotName == null) {
+            return null;
+        }
+        Object raw = executeScript("""
+                const editor = arguments[0].querySelector(
+                        '[slot="' + arguments[1] + '"]');
+                if (!editor || !editor.inputElement) return null;
+                const i = editor.inputElement;
+                // document.activeElement stops at a shadow host, so descend.
+                let active = document.activeElement;
+                while (active && active.shadowRoot
+                        && active.shadowRoot.activeElement) {
+                  active = active.shadowRoot.activeElement;
+                }
+                return {
+                  value: i.value == null ? '' : i.value,
+                  selectionStart: i.selectionStart,
+                  selectionEnd: i.selectionEnd,
+                  focused: active === i
+                };
+                """, getSpreadsheet(), slotName);
+        if (raw == null) {
+            return null;
+        }
+        Map<String, Object> state = (Map<String, Object>) raw;
+        return new EditorInputState(String.valueOf(state.get("value")),
+                ((Number) state.get("selectionStart")).intValue(),
+                ((Number) state.get("selectionEnd")).intValue(),
+                Boolean.TRUE.equals(state.get("focused")));
     }
 
     public void assertNoErrorIndicatorDetected() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorReloadIT.java
@@ -11,12 +11,12 @@ package com.vaadin.flow.component.spreadsheet.test;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.interactions.Actions;
 
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.component.spreadsheet.testbench.SpreadsheetElement;
+import com.vaadin.flow.component.spreadsheet.tests.CustomEditorReloadPage;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -33,78 +33,134 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
     @Test
     public void editorSelected_scrolledAwayAndBack_callbackNotRefiredAndValuePreserved() {
         selectEditorCellB2();
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
 
         getSpreadsheet().scroll(5000);
         getCommandExecutor().waitForVaadin();
         getSpreadsheet().scroll(0);
         getCommandExecutor().waitForVaadin();
-        waitUntil(driver -> !getSpreadsheet()
-                .findElements(By.tagName("vaadin-combo-box")).isEmpty());
+        waitUntil(driver -> getEditorElementCount() > 0);
 
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
     }
 
     @Test
     public void editorSelected_columnSelected_callbackNotRefiredAndValuePreserved() {
         selectEditorCellB2();
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
 
         selectColumn("B");
         getCommandExecutor().waitForVaadin();
 
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
     }
 
     @Test
     public void editorSelected_rangeSelected_callbackNotRefiredAndValuePreserved() {
         selectEditorCellB2();
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
 
         selectCell("B5", false, true);
         getCommandExecutor().waitForVaadin();
 
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
     }
 
     @Test
     public void editorSelected_rowResized_callbackNotRefiredAndValuePreserved() {
         selectEditorCellB2();
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
 
         resizeRow(2);
 
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
     }
 
     @Test
     public void editorSelected_columnResized_callbackNotRefiredAndValuePreserved() {
         selectEditorCellB2();
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
 
         resizeColumn("B");
 
-        Assert.assertEquals("1", getCallbackCount());
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
+    }
+
+    @Test
+    public void editorSelected_otherCellValueCommitted_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        assertEditorIntact();
+        int initialEditorCount = getEditorElementCount();
+
+        // Committing a plain cell runs the internal updateMarkedCells refresh,
+        // which must reuse the cached editors instead of wiping them.
+        setCellValue("A4", "committed");
+        getCommandExecutor().waitForVaadin();
+
+        assertEditorIntact();
+        Assert.assertEquals(initialEditorCount, getEditorElementCount());
+    }
+
+    @Test
+    public void editorValueSet_applicationRefreshedEditedCell_callbackNotRefiredAndValuePreserved() {
+        selectEditorCellB2();
+        assertEditorIntact();
+
+        // Picking a value makes the page call refreshCells, as in issue #9180.
+        // That refresh must not recreate the editor, or the picked value is
+        // replaced by whatever onCustomEditorDisplayed sets.
+        getEditor("B2").selectByText("Cherry");
+        getCommandExecutor().waitForVaadin();
+
+        assertEditorIntact("Cherry");
+    }
+
+    @Test
+    public void plainCellEditorOpened_editorCellSelected_editorStillShown() {
+        // Open the built-in inline editor on a plain cell, then select a cell
+        // that has a custom editor. That editor must still be rendered.
+        getInlineEditor("B5");
+        getCommandExecutor().waitForVaadin();
+
+        clickCell("B2");
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertNotNull("Custom editor disappeared from B2",
+                getEditor("B2"));
+        // Not enough that it exists: the reported symptom was wiped text.
+        assertEditorIntact();
     }
 
     @Test
     public void editorSelected_visibleContentsReloaded_editorRecreated() {
         selectEditorCellB2();
-        Assert.assertEquals("Banana", getComboBoxValue("B2"));
+        assertEditorIntact();
 
         clickReload();
         getCommandExecutor().waitForVaadin();
-        Assert.assertEquals("", getComboBoxValue("B2"));
+        // The explicit reload recreates the editors from the factory without
+        // re-firing onCustomEditorDisplayed, so the fresh editor is empty.
+        assertEditorIntact("");
+    }
+
+    /**
+     * Asserts B2 still holds the value onCustomEditorDisplayed wrote, i.e. the
+     * editor was reused rather than replaced.
+     */
+    private void assertEditorIntact() {
+        assertEditorIntact(CustomEditorReloadPage.CALLBACK_VALUE);
+    }
+
+    /**
+     * Asserts that B2 shows the given editor value and that
+     * onCustomEditorDisplayed has fired exactly once, i.e. only for the initial
+     * selection of B2.
+     */
+    private void assertEditorIntact(String expectedValue) {
+        Assert.assertEquals("Unexpected editor value in B2", expectedValue,
+                getComboBoxValue("B2"));
+        Assert.assertEquals("Unexpected onCustomEditorDisplayed call count",
+                "1", getCallbackCount());
     }
 
     private void selectEditorCellB2() {
@@ -135,21 +191,20 @@ public class CustomEditorReloadIT extends AbstractSpreadsheetIT {
         return $(TestBenchElement.class).id("callbackCount").getText();
     }
 
+    private int getEditorElementCount() {
+        return getSpreadsheet().$(ComboBoxElement.class).all().size();
+    }
+
     private void clickReload() {
         $("vaadin-button").id("reloadBtn").click();
     }
 
+    private ComboBoxElement getEditor(String cellAddress) {
+        return getCellEditor(cellAddress, ComboBoxElement.class);
+    }
+
     private String getComboBoxValue(String cellAddress) {
-        var cell = getSpreadsheet().getCellAt(cellAddress);
-        try {
-            var slotName = cell.findElement(By.tagName("slot"))
-                    .getDomAttribute("name");
-            return getSpreadsheet()
-                    .findElement(By.cssSelector("[slot='" + slotName + "']"))
-                    .findElement(By.cssSelector("input"))
-                    .getDomProperty("value");
-        } catch (NoSuchElementException e) {
-            return null;
-        }
+        var editor = getEditor(cellAddress);
+        return editor == null ? null : editor.getInputElementValue();
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorSelectionIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorSelectionIT.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.spreadsheet.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.spreadsheet.tests.fixtures.CustomEditorDelayedCallbackFixture;
+import com.vaadin.flow.component.spreadsheet.tests.fixtures.TestFixtures;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+/**
+ * Covers the text-selection half of issues #9180 and #9036: the value set by
+ * {@code onCustomEditorDisplayed} must end up selected, and stay selected.
+ * <p>
+ * Note that {@code autoselect} is not what selects the text — it fires on
+ * focus, before the delayed callback sets its value. The fixture's explicit
+ * {@code inputElement.select()} is.
+ */
+@TestPath("vaadin-spreadsheet")
+public class CustomEditorSelectionIT extends AbstractSpreadsheetIT {
+
+    @Before
+    public void init() {
+        open();
+        createNewSpreadsheet();
+        loadTestFixture(TestFixtures.CustomEditorDelayedCallback);
+    }
+
+    @Test
+    public void editorDisplayed_callbackSelectsInput_textIsSelected() {
+        clickCell("B2");
+
+        assertEditorTextSelected("B2");
+    }
+
+    @Test
+    public void editorDisplayed_callbackSetsSameValueAgain_textIsSelected() {
+        clickCell("B2");
+        assertEditorTextSelected("B2");
+
+        // Leave and come back. The callback sets the same text again, so there
+        // is no value change for the client to react to — the case reported as
+        // the selection no longer working.
+        clickCell("A4");
+        getCommandExecutor().waitForVaadin();
+        clickCell("B2");
+
+        assertEditorTextSelected("B2");
+    }
+
+    @Test
+    public void editorDisplayed_callbackRefreshedCellWithoutGuard_callbackNotRefired() {
+        clickCell("B2");
+        assertEditorTextSelected("B2");
+
+        // The fixture's value-change listener has no isFromClient guard, so the
+        // value the callback sets reaches it and calls refreshCells. That
+        // refresh has to reuse the editor, or the callback fires again on the
+        // same cell and keeps going.
+        Assert.assertEquals(
+                "onCustomEditorDisplayed re-fired after the un-guarded refreshCells",
+                "1", getCallbackCount());
+    }
+
+    /**
+     * Waits until the callback has set its value in the given cell's editor,
+     * then asserts that the whole text is selected and that the editor still
+     * holds the focus. The focus check covers the other half of #9036: focus
+     * must not move off the editor while the delayed callback runs.
+     *
+     * @param cellAddress
+     *            address of the cell holding the editor, e.g. "B2"
+     */
+    private void assertEditorTextSelected(String cellAddress) {
+        String expectedValue = CustomEditorDelayedCallbackFixture.CALLBACK_VALUE_PREFIX
+                + columnIndexOf(cellAddress);
+        EditorInputState state = waitUntil(driver -> {
+            var current = getEditorInputState(cellAddress);
+            return current != null && expectedValue.equals(current.value())
+                    ? current
+                    : null;
+        });
+        Assert.assertTrue(
+                "Text in " + cellAddress + " not fully selected: " + state,
+                state.isFullySelected());
+        Assert.assertTrue("Editor in " + cellAddress + " lost focus: " + state,
+                state.focused());
+    }
+
+    private String getCallbackCount() {
+        return $(TestBenchElement.class).id("callbackCount").getText();
+    }
+
+    private int columnIndexOf(String cellAddress) {
+        return cellAddress.charAt(0) - 'A';
+    }
+}

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -2484,10 +2484,29 @@ public class Spreadsheet extends Component
      * Updates the content of the cells that have been marked for update with
      * {@link #markCellAsUpdated(Cell, boolean)}.
      * <p>
-     * Does NOT update custom components (editors / always visible) for the
-     * cells. For that, use {@link #reloadVisibleCellContents()}
+     * Also reloads custom components, reusing the editors already shown so
+     * their state survives the update. Use
+     * {@link #updateMarkedCellsRecreatingEditors()} when the cells behind the
+     * editors move.
      */
     void updateMarkedCells() {
+        updateMarkedCells(false);
+    }
+
+    /**
+     * Updates the content of the cells that have been marked for update, like
+     * {@link #updateMarkedCells()}, but discards the custom editors currently
+     * shown and asks {@link SpreadsheetComponentFactory} for new ones.
+     * <p>
+     * Only for updates that move cells, such as inserting or deleting rows:
+     * editors are cached per cell, so one left in place would end up on the
+     * wrong cell.
+     */
+    void updateMarkedCellsRecreatingEditors() {
+        updateMarkedCells(true);
+    }
+
+    private void updateMarkedCells(boolean recreateEditors) {
         // update conditional formatting in case styling has changed. New values
         // are fetched in ValueManager (below).
         conditionalFormatter.createConditionalFormatterRules();
@@ -2502,7 +2521,7 @@ public class Spreadsheet extends Component
         loadCellComments();
 
         // update custom components, editors
-        reloadVisibleCellContents();
+        reloadVisibleCellContents(recreateEditors);
     }
 
     /**
@@ -2916,7 +2935,8 @@ public class Spreadsheet extends Component
         }
         styler.loadCustomBorderStylesToState();
 
-        updateMarkedCells(); // deleted and formula cells and style selectors
+        // deleted and formula cells and style selectors
+        updateMarkedCellsRecreatingEditors();
         updateRowAndColumnRangeCellData(firstRow, firstColumn, lastRow,
                 lastColumn); // shifted area values
         updateMergedRegions();
@@ -3142,7 +3162,7 @@ public class Spreadsheet extends Component
         if (hasSheetOverlays()) {
             reloadImageSizesFromPOI = true;
         }
-        updateMarkedCells();
+        updateMarkedCellsRecreatingEditors();
         CellReference selectedCellReference = getSelectedCellReference();
         if (selectedCellReference.getRow() >= startRow
                 && selectedCellReference.getRow() <= endRow) {
@@ -3625,9 +3645,23 @@ public class Spreadsheet extends Component
      * contents. This forces reload of all: custom components (always visible
      * and editors) from {@link SpreadsheetComponentFactory}, hyperlinks, cells'
      * comments and cells' contents. Also updates styles for the visible area.
+     * <p>
+     * Any state entered into a custom editor is lost, as the editors are
+     * replaced with new instances from the factory.
      */
     public void reloadVisibleCellContents() {
-        loadCustomComponents(true);
+        reloadVisibleCellContents(true);
+    }
+
+    /**
+     * Reloads the currently viewed cell contents.
+     *
+     * @param recreateEditors
+     *            {@code true} to ask the factory for new editors, {@code false}
+     *            to keep the existing ones so their state survives
+     */
+    private void reloadVisibleCellContents(boolean recreateEditors) {
+        loadCustomComponents(recreateEditors);
         updateRowAndColumnRangeCellData(firstRow, firstColumn, lastRow,
                 lastColumn);
     }
@@ -3797,10 +3831,9 @@ public class Spreadsheet extends Component
      * cell.
      */
     protected void loadCustomEditorOnSelectedCell() {
-        // Guard against reentrancy: if user code in onCustomEditorDisplayed
-        // calls refreshCells() -> updateMarkedCells() ->
-        // reloadVisibleCellContents() -> loadCells() ->
-        // loadCustomEditorOnSelectedCell(), skip the recursive call.
+        // Guard against reentrancy: onCustomEditorDisplayed that changes the
+        // selection or the component factory ends up back here, so skip the
+        // nested call instead of firing the callback again.
         if (insideCustomEditorCallback) {
             return;
         }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetComponentFactory.java
@@ -109,6 +109,13 @@ public interface SpreadsheetComponentFactory extends Serializable {
      * <p>
      * For merged regions, this method is only called for the first cell of the
      * merged region.
+     * <p>
+     * The returned editor is kept for that cell, so this method is not called
+     * again while the cell keeps showing it. That preserves what the user has
+     * entered into the editor when the cell is updated. An editor chosen from
+     * the cell's value is therefore not replaced when the value changes; call
+     * {@link Spreadsheet#reloadVisibleCellContents()} to have the editors asked
+     * for again.
      *
      * @param cell
      *            Cell that should display the custom editor or


### PR DESCRIPTION
Custom editors from a `SpreadsheetComponentFactory` were replaced with new instances on every user interaction that commits a cell value, so whatever the user had entered was lost. #9493 fixed the cases that re-render the same cells (scrolling, selection, resize), but the paths through `updateMarkedCells()` still recreated them. #9493 even describes `refreshCells()` as reusing editors, while in code it recreated them, and that is the case the reproducer in #9180 hits.

## Reproduction

```java
ComboBox<String> comboBox = new ComboBox<>();
comboBox.setItems("Apple", "Banana", "Cherry");
comboBox.addValueChangeListener(event -> {
    spreadsheet.createCell(rowIndex, columnIndex, event.getValue());
    spreadsheet.refreshCells(spreadsheet.getCell(rowIndex, columnIndex));
});
```

Pick a value in the editor cell: it is replaced by whatever `onCustomEditorDisplayed` sets. The same happens on Delete, paste, fill-drag, merging cells and collapsing a group.

A second case: double-click a plain cell to open the built-in editor, then click a cell that has a custom editor. That editor disappears until the cell is selected again.

## Changes

Reuse is now the default in `updateMarkedCells()`. Only `shiftRows()` and `deleteRows()` opt out, through `updateMarkedCellsRecreatingEditors()`, because they move cells and editors are cached per cell.

Reused editors keep their client node ids, so `cellKeysToEditorIdMap` stops changing, and the client re-attaches editors only when it does. That revealed an older bug behind the second case: the deferred commit of an inline edit takes its target from the selection, which may have moved onto an editor cell by then, and writing a value into a cell removes the editor in it. `SheetWidget.updateSelectedCellValue` now skips that write, using the check `cellValuesUpdated` already applies. The late target resolution itself is left alone, and the cell value is not affected, because `doCommitIfEditing` commits it before the deferred call runs.

Since the factory is now asked for an editor only once per cell, an editor picked from the cell's value is no longer replaced when that value changes. `getCustomEditorForCell` says so now, and names `reloadVisibleCellContents()` as the way to force a re-ask. Factories that decide by position, which is the common case, are unaffected.

`reloadVisibleCellContents()`, `shiftRows()` and `deleteRows()` still leave a recreated editor empty with no callback to fill it. That is long-standing behaviour, reported as #9812.

`CustomEditorSelectionIT` covers the text selection asked for in #9036, which no test asserted before.

Part of #9180, Follow-up to #9493, Related to #9036, Related to #9812

---

🤖 Generated with Claude Code
