### PR TITLE
refactor: replace collect(Collectors.toList()) with toList()

### DIFF
--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +48,7 @@ class AppLayoutTest {
         systemUnderTest.setContent(content);
 
         List<Element> children = systemUnderTest.getElement().getChildren()
-                .collect(Collectors.toList());
+                .toList();
         assertTrue(children.contains(content.getElement()));
     }
 
@@ -63,7 +62,7 @@ class AppLayoutTest {
         systemUnderTest.setContent(null);
 
         List<Element> children = systemUnderTest.getElement().getChildren()
-                .collect(Collectors.toList());
+                .toList();
         assertFalse(children.contains(content.getElement()));
         assertNull(systemUnderTest.getContent());
     }

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/src/main/java/com/vaadin/flow/component/avatar/AvatarGroup.java
@@ -660,7 +660,7 @@ public class AvatarGroup extends Component
      */
     public void add(AvatarGroupItem... items) {
         setItems(Stream.concat(this.items.stream(), Arrays.stream(items))
-                .collect(Collectors.toList()));
+                .toList());
     }
 
     /**
@@ -673,8 +673,7 @@ public class AvatarGroup extends Component
         List<AvatarGroupItem> itemsToRemove = Arrays.asList(items);
 
         setItems(this.items.stream()
-                .filter(item -> !itemsToRemove.contains(item))
-                .collect(Collectors.toList()));
+                .filter(item -> !itemsToRemove.contains(item)).toList());
     }
 
     /**
@@ -714,8 +713,8 @@ public class AvatarGroup extends Component
     public <S extends Signal<AvatarGroupItem>> SignalBinding<Collection<AvatarGroupItem>> bindItems(
             Signal<List<S>> itemsSignal) {
         Objects.requireNonNull(itemsSignal, "Signal cannot be null");
-        return itemsSupport.bind(() -> itemsSignal.get().stream()
-                .map(Signal::get).collect(Collectors.toList()));
+        return itemsSupport.bind(
+                () -> itemsSignal.get().stream().map(Signal::get).toList());
     }
 
     /**

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/internal/FunctionCallerTest.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/internal/FunctionCallerTest.java
@@ -10,7 +10,6 @@ package com.vaadin.flow.component.board.internal;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -88,8 +87,7 @@ public class FunctionCallerTest {
         method.setAccessible(true);
         Stream<PendingJavaScriptInvocation> pendingJS = (Stream<PendingJavaScriptInvocation>) method
                 .invoke(internals);
-        List<PendingJavaScriptInvocation> invocations = pendingJS
-                .collect(Collectors.toList());
+        List<PendingJavaScriptInvocation> invocations = pendingJS.toList();
         Assertions.assertEquals(1, invocations.size());
         Assertions.assertEquals(expectedJS,
                 invocations.get(0).getInvocation().getExpression());

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ColumnWithLazyMultiLevelDrilldownCallbackTestsIT.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.charts.tests;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -106,6 +105,6 @@ public class ColumnWithLazyMultiLevelDrilldownCallbackTestsIT
 
     private List<String> getLogMessages() {
         return findElements(By.tagName("li")).stream().map(e -> e.getText())
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/GlobalOptionsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/GlobalOptionsIT.java
@@ -12,7 +12,6 @@ import java.text.DateFormatSymbols;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -62,7 +61,7 @@ public class GlobalOptionsIT extends AbstractChartIT {
         List<WebElement> axisLabels = container.findElements(
                 By.cssSelector(".highcharts-xaxis-labels > text"));
         List<String> actual = axisLabels.stream().map(WebElement::getText)
-                .collect(Collectors.toList());
+                .toList();
         List<String> expected = Arrays
                 .asList(new DateFormatSymbols(locale).getShortWeekdays());
         Assert.assertTrue(expected.containsAll(actual));

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/src/test/java/com/vaadin/flow/component/charts/tests/ServerSideEventsIT.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.charts.tests;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -299,7 +298,7 @@ public class ServerSideEventsIT extends AbstractChartIT {
             String eventDetailsJson = eventDetailsSpan.getText();
 
             return new HistoryEvent(eventType, eventDetailsJson);
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     private static class HistoryEvent {

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/SVGGeneratorTest.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/src/test/java/com/vaadin/flow/component/charts/export/SVGGeneratorTest.java
@@ -21,7 +21,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -206,8 +205,8 @@ class SVGGeneratorTest {
     @Test
     void exportWithLargeSeries() throws IOException, InterruptedException {
         Configuration configuration = new Configuration();
-        List<Number> data = IntStream.range(0, 100000).boxed()
-                .collect(Collectors.toList());
+        List<Number> data = IntStream.range(0, 100000)
+                .<Number> mapToObj(Integer::valueOf).toList();
         ListSeries series = new ListSeries(data);
         configuration.addSeries(series);
         svgGenerator.generate(configuration);

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/Chart.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.AttachEvent;
@@ -664,9 +663,8 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * @since 23.1
      */
     public void addThemeVariants(ChartVariant... variants) {
-        getThemeNames()
-                .addAll(Stream.of(variants).map(ChartVariant::getVariantName)
-                        .collect(Collectors.toList()));
+        getThemeNames().addAll(
+                Stream.of(variants).map(ChartVariant::getVariantName).toList());
     }
 
     /**
@@ -677,9 +675,8 @@ public class Chart extends Component implements HasStyle, HasSize, HasTheme {
      * @since 23.1
      */
     public void removeThemeVariants(ChartVariant... variants) {
-        getThemeNames()
-                .removeAll(Stream.of(variants).map(ChartVariant::getVariantName)
-                        .collect(Collectors.toList()));
+        getThemeNames().removeAll(
+                Stream.of(variants).map(ChartVariant::getVariantName).toList());
     }
 
     /*

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataProviderSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataProviderSeries.java
@@ -8,7 +8,6 @@
  */
 package com.vaadin.flow.component.charts.model;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.HashMap;
@@ -234,7 +233,7 @@ public class DataProviderSeries<T> extends AbstractSeries {
                                         ? Optional.ofNullable(
                                                 entry.getValue().apply(item))
                                         : Optional.empty())))
-                .collect(toList());
+                .toList();
     }
 
     /**

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDemoPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupDemoPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.checkbox.tests;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
@@ -210,12 +209,12 @@ public class CheckboxGroupDemoPage extends Div {
     }
 
     private String toString(Set<String> value) {
-        return value.stream().sorted().collect(Collectors.toList()).toString();
+        return value.stream().sorted().toList().toString();
     }
 
     private String getNames(Set<Person> persons) {
-        return persons.stream().map(Person::getName).sorted()
-                .collect(Collectors.toList()).toString();
+        return persons.stream().map(Person::getName).sorted().toList()
+                .toString();
     }
 
     private void addCard(String title, Component... components) {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DetachReattachIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/DetachReattachIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.checkbox.tests;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,7 +57,7 @@ public class DetachReattachIT extends AbstractComponentIT {
     private List<Boolean> getCheckboxesCheckedState() {
         TestBenchElement group = $("vaadin-checkbox-group").first();
         return group.$(CheckboxElement.class).all().stream()
-                .map(CheckboxElement::isChecked).collect(Collectors.toList());
+                .map(CheckboxElement::isChecked).toList();
     }
 
     private void clickButton(String id) {

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -134,8 +133,7 @@ class CheckboxGroupTest {
         group.addValueChangeListener(events::add);
 
         List<String> keys = group.getChildren().map(Component::getElement)
-                .map(element -> element.getProperty("value"))
-                .collect(Collectors.toList());
+                .map(element -> element.getProperty("value")).toList();
         String enabledKey = keys.get(0);
         String disabledKey = keys.get(1);
 
@@ -216,7 +214,7 @@ class CheckboxGroupTest {
         checkboxGroup.setItems("Foo", "Bar");
 
         List<Checkbox> checkboxes = checkboxGroup.getChildren()
-                .map(Checkbox.class::cast).collect(Collectors.toList());
+                .map(Checkbox.class::cast).toList();
 
         checkboxGroup.select("Foo");
         Assertions.assertTrue(checkboxes.get(0).getValue());
@@ -588,8 +586,7 @@ class CheckboxGroupTest {
 
     private void assertCheckboxLabels(CheckboxGroup<Wrapper> checkboxGroup,
             String firstLabel, String secondLabel) {
-        List<Component> components = checkboxGroup.getChildren()
-                .collect(Collectors.toList());
+        List<Component> components = checkboxGroup.getChildren().toList();
         Assertions.assertEquals(2, components.size());
         Assertions.assertEquals(firstLabel,
                 ((Checkbox) components.get(0)).getLabel());

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/CheckboxGroupElement.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/src/main/java/com/vaadin/flow/component/checkbox/testbench/CheckboxGroupElement.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.checkbox.testbench;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.testbench.HasHelper;
@@ -36,8 +35,7 @@ public class CheckboxGroupElement extends TestBenchElement
      * @return a list of the labels
      */
     public List<String> getOptions() {
-        return getCheckboxes().stream().map(CheckboxElement::getLabel)
-                .collect(Collectors.toList());
+        return getCheckboxes().stream().map(CheckboxElement::getLabel).toList();
     }
 
     /**
@@ -94,8 +92,7 @@ public class CheckboxGroupElement extends TestBenchElement
      */
     public List<String> getSelectedTexts() {
         Stream<CheckboxElement> button = getSelectedCheckboxes();
-        return button.map(CheckboxElement::getLabel)
-                .collect(Collectors.toList());
+        return button.map(CheckboxElement::getLabel).toList();
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ClientSideFilterPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ClientSideFilterPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -80,8 +79,7 @@ public class ClientSideFilterPage extends Div {
         inMemoryComboBox.setId(IN_MEMORY_COMBO_BOX);
         ComboBoxListDataView<String> listDataView = inMemoryComboBox
                 .setItems(IntStream.range(0, inMemoryComboBox.getPageSize() * 2)
-                        .mapToObj(i -> "Item " + i)
-                        .collect(Collectors.toList()));
+                        .mapToObj(i -> "Item " + i).toList());
         Span itemCountSpan = new Span("0");
         itemCountSpan.setId(IN_MEMORY_COMBO_BOX_ITEM_COUNT_SPAN_ID);
         this.add(itemCountSpan);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxDemoPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxDemoPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.github.javafaker.Faker;
@@ -389,7 +388,7 @@ public class ComboBoxDemoPage extends VerticalLayout {
     private List<String> getNames(int count) {
         Faker faker = Faker.instance();
         return IntStream.range(0, count).mapToObj(i -> faker.name().fullName())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<Song> createListOfSongs() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -34,7 +33,7 @@ public class ComboBoxFocusSelectedItemPage extends Div {
 
     private static final int ITEM_COUNT = 10000;
     private static final List<String> ALL_ITEMS = IntStream.range(0, ITEM_COUNT)
-            .mapToObj(i -> "Item " + i).collect(Collectors.toList());
+            .mapToObj(i -> "Item " + i).toList();
 
     private static final String LAZY_WITH_PROVIDER = "lazy-with-provider";
     private static final String IN_MEMORY = "in-memory";

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -165,6 +166,6 @@ public class ComboBoxListDataViewPage extends Div {
                 .mapToObj(index -> new Person(index, "Person " + index,
                         "lastName", index % 100, new Person.Address(),
                         "1234567890"))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxLitRendererPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxLitRendererPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Component;
@@ -31,8 +30,7 @@ public class ComboBoxLitRendererPage extends Div {
 
     public ComboBoxLitRendererPage() {
         ComboBox<Integer> combo = new ComboBox<>();
-        combo.setItems(
-                IntStream.range(0, 1000).boxed().collect(Collectors.toList()));
+        combo.setItems(IntStream.range(0, 1000).boxed().toList());
         setLitRenderer(combo);
         add(combo);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComponentRendererPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComponentRendererPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -115,7 +114,7 @@ public class ComponentRendererPage extends Div {
         List<ComboBoxDemoPage.Song> longListOfSongs = IntStream.range(0, 1000)
                 .mapToObj(i -> new ComboBoxDemoPage.Song("Song " + i,
                         "Artist " + i, "Album " + i))
-                .collect(Collectors.toList());
+                .toList();
         comboBox.setItems(longListOfSongs);
 
         comboBox.getStyle().set(ElementConstants.STYLE_WIDTH, "250px");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -303,7 +303,8 @@ public class LazyLoadingPage extends Div {
 
     public static List<String> generateStrings(int count) {
         List<String> items = IntStream.range(0, count)
-                .mapToObj(i -> "Item " + i).toList();
+                .mapToObj(i -> "Item " + i)
+                .collect(Collectors.toCollection(ArrayList::new));
         return items;
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -134,7 +135,7 @@ public class LazyLoadingPage extends Div {
 
         List<Person> people = IntStream.range(0, 987)
                 .mapToObj(i -> new Person("Person " + i, i))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
         ListDataProvider<Person> personDataProvider = new ListDataProvider<>(
                 people);
 
@@ -156,8 +157,7 @@ public class LazyLoadingPage extends Div {
         itemLabelGeneratorButton.setId("item-label-generator");
 
         List<Person> altPeople = IntStream.range(0, 220)
-                .mapToObj(i -> new Person("Changed " + i, 2000 + i))
-                .collect(Collectors.toList());
+                .mapToObj(i -> new Person("Changed " + i, 2000 + i)).toList();
         ListDataProvider<Person> altPersonDataProvider = new ListDataProvider<>(
                 altPeople);
         NativeButton dataProviderButton = new NativeButton(
@@ -188,8 +188,7 @@ public class LazyLoadingPage extends Div {
         comboBox.setId("custom-filter");
 
         List<Person> people = IntStream.range(0, 500)
-                .mapToObj(i -> new Person("Person", i))
-                .collect(Collectors.toList());
+                .mapToObj(i -> new Person("Person", i)).toList();
         ListDataProvider<Person> personDataProvider = new ListDataProvider<>(
                 people);
 
@@ -279,8 +278,7 @@ public class LazyLoadingPage extends Div {
         comboBox.setId("disabled-lazy-loading");
         // Having a number of items less than or equal than the page size will
         // disable lazy-loading
-        List<Integer> items = IntStream.range(0, 100).boxed()
-                .collect(Collectors.toList());
+        List<Integer> items = IntStream.range(0, 100).boxed().toList();
         comboBox.setItems(items);
 
         NativeButton enableLazyLoading = new NativeButton("Enable lazy loading",
@@ -305,7 +303,7 @@ public class LazyLoadingPage extends Div {
 
     public static List<String> generateStrings(int count) {
         List<String> items = IntStream.range(0, count)
-                .mapToObj(i -> "Item " + i).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + i).toList();
         return items;
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxAutoExpandPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxAutoExpandPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -31,7 +30,7 @@ public class MultiSelectComboBoxAutoExpandPage extends Div {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
 
         NativeButton expandHorizontal = new NativeButton("Expand horizontal",

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxClientSideFilteringPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -31,7 +30,7 @@ public class MultiSelectComboBoxClientSideFilteringPage extends Div {
         // By generating less items than the default page size of 50 we
         // automatically enable client-side filtering
         List<String> items = IntStream.range(0, 10)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
 
         add(comboBox);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDetachReattachPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxDetachReattachPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -30,7 +29,7 @@ public class MultiSelectComboBoxDetachReattachPage extends Div {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
 
         NativeButton detach = new NativeButton("detach", e -> remove(comboBox));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxKeepFilterPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxKeepFilterPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -30,7 +29,7 @@ public class MultiSelectComboBoxKeepFilterPage extends Div {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
 
         Checkbox keepFilter = new Checkbox("Keep filter");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitRendererPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitRendererPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -33,8 +32,7 @@ public class MultiSelectComboBoxLitRendererPage extends Div {
     private void addReadOnlyUseCase() {
         MultiSelectComboBox<Integer> multiSelect = new MultiSelectComboBox<>();
         multiSelect.setId("read-only-multi-select-combo-box");
-        multiSelect.setItems(
-                IntStream.range(0, 1000).boxed().collect(Collectors.toList()));
+        multiSelect.setItems(IntStream.range(0, 1000).boxed().toList());
         multiSelect.select(0, 1);
         multiSelect.setRenderer(createLitRenderer());
         multiSelect.setReadOnly(true);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitWrapperPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxLitWrapperPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Tag;
@@ -41,8 +40,7 @@ public class MultiSelectComboBoxLitWrapperPage extends Div {
 
         public MultiSelectComboBoxLitWrapper() {
             List<String> items = IntStream.range(0, 100)
-                    .mapToObj(i -> "Item " + (i + 1))
-                    .collect(Collectors.toList());
+                    .mapToObj(i -> "Item " + (i + 1)).toList();
             comboBox.setItems(items);
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxMultiSelectPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxMultiSelectPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -31,7 +30,7 @@ public class MultiSelectComboBoxMultiSelectPage extends Div {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
         // Make component wider, so that we can fit multiple chips
         comboBox.setWidth("500px");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPolymerWrapperPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxPolymerWrapperPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Tag;
@@ -43,8 +42,7 @@ public class MultiSelectComboBoxPolymerWrapperPage extends Div {
 
         public MultiSelectComboBoxPolymerWrapper() {
             List<String> items = IntStream.range(0, 100)
-                    .mapToObj(i -> "Item " + (i + 1))
-                    .collect(Collectors.toList());
+                    .mapToObj(i -> "Item " + (i + 1)).toList();
             comboBox.setItems(items);
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxRefreshValuePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxRefreshValuePage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -30,8 +29,7 @@ public class MultiSelectComboBoxRefreshValuePage extends Div {
         MultiSelectComboBox<TestBean> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<TestBean> items = IntStream.range(0, 100)
-                .mapToObj(i -> new TestBean("Item " + (i + 1)))
-                .collect(Collectors.toList());
+                .mapToObj(i -> new TestBean("Item " + (i + 1))).toList();
         comboBox.setItems(items);
         comboBox.setItemLabelGenerator(TestBean::getName);
         // Make component wider, so that we can fit multiple chips

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxSelectedItemsOnTopPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxSelectedItemsOnTopPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -33,7 +32,7 @@ public class MultiSelectComboBoxSelectedItemsOnTopPage extends Div {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
 
         NativeButton setSelectedOnTop = new NativeButton("Set selected on top",

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxServerSideFilteringPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -31,7 +30,7 @@ public class MultiSelectComboBoxServerSideFilteringPage extends Div {
         // By generating more items than the default page size of 50 we
         // automatically enable server-side filtering
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
 
         add(comboBox);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/MultiSelectComboBoxValueChangePage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
@@ -32,7 +31,7 @@ public class MultiSelectComboBoxValueChangePage extends Div {
         MultiSelectComboBox<String> comboBox = new MultiSelectComboBox<>(
                 "Items");
         List<String> items = IntStream.range(0, 100)
-                .mapToObj(i -> "Item " + (i + 1)).collect(Collectors.toList());
+                .mapToObj(i -> "Item " + (i + 1)).toList();
         comboBox.setItems(items);
         // Make component wider, so that we can fit multiple chips
         comboBox.setWidth("500px");

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/PreSelectedValuePage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/PreSelectedValuePage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -30,8 +29,8 @@ public class PreSelectedValuePage extends Div {
 
     public PreSelectedValuePage() {
         ComboBox<String> comboBox = new ComboBox<>();
-        comboBox.setItems(IntStream.range(0, 20).mapToObj(i -> "Item " + i)
-                .collect(Collectors.toList()));
+        comboBox.setItems(
+                IntStream.range(0, 20).mapToObj(i -> "Item " + i).toList());
         comboBox.setValue(PRE_SELECTED_VALUE);
         comboBox.setId("combo");
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -134,14 +133,13 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
     // There's more items loaded though.
     protected List<String> getOverlayContents(ComboBoxElement comboBox) {
         return getItemElements(comboBox).stream().map(this::getItemLabel)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     protected List<String> getNonEmptyOverlayContents(
             ComboBoxElement comboBox) {
         return getOverlayContents(comboBox).stream()
-                .filter(rendered -> !rendered.isEmpty())
-                .collect(Collectors.toList());
+                .filter(rendered -> !rendered.isEmpty()).toList();
     }
 
     protected String getItemLabel(TestBenchElement itemElement) {
@@ -151,8 +149,7 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
 
     protected List<TestBenchElement> getItemElements(ComboBoxElement comboBox) {
         return getScroller(comboBox).$("vaadin-combo-box-item").all().stream()
-                .filter(element -> !element.hasAttribute("hidden"))
-                .collect(Collectors.toList());
+                .filter(element -> !element.hasAttribute("hidden")).toList();
     }
 
     protected void scrollToItem(ComboBoxElement comboBox, int index) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.combobox.test;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -285,6 +284,6 @@ public class ComboBoxIT extends AbstractComboBoxIT {
     private List<String> getRenderedItems(ComboBoxElement comboBox) {
         return getItemElements(comboBox).stream()
                 .map(element -> element.getPropertyString("innerHTML"))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/StringItemsWithTextRendererIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/StringItemsWithTextRendererIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,7 +37,7 @@ public class StringItemsWithTextRendererIT extends AbstractComponentIT {
         comboBox.sendKeys(Keys.ARROW_DOWN);
 
         List<String> items = comboBox.$("vaadin-combo-box-item").all().stream()
-                .map(WebElement::getText).collect(Collectors.toList());
+                .map(WebElement::getText).toList();
         Assert.assertEquals(
                 "Unexpected items size. The rendered items size must be 2", 2,
                 items.size());

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -262,18 +261,17 @@ class MultiSelectComboBoxTest extends ComboBoxBaseTest {
         comboBox.select("Two");
         comboBox.select("Four");
         value = comboBox.getValue();
-        valueAsList = value.stream().collect(Collectors.toList());
+        valueAsList = value.stream().toList();
         Assertions.assertEquals("Eight", valueAsList.get(0));
         Assertions.assertEquals("Two", valueAsList.get(1));
         Assertions.assertEquals("Four", valueAsList.get(2));
         comboBox.clear();
 
         Set<String> linkedHashSetValue = new LinkedHashSet<>(
-                Arrays.asList("Eight", "Two", "Four").stream()
-                        .collect(Collectors.toList()));
+                Arrays.asList("Eight", "Two", "Four").stream().toList());
         comboBox.setValue(linkedHashSetValue);
         value = comboBox.getValue();
-        valueAsList = value.stream().collect(Collectors.toList());
+        valueAsList = value.stream().toList();
         Assertions.assertEquals("Eight", valueAsList.get(0));
         Assertions.assertEquals("Two", valueAsList.get(1));
         Assertions.assertEquals("Four", valueAsList.get(2));
@@ -281,7 +279,7 @@ class MultiSelectComboBoxTest extends ComboBoxBaseTest {
 
         comboBox.select("Eight", "Two", "Four");
         value = comboBox.getValue();
-        valueAsList = value.stream().collect(Collectors.toList());
+        valueAsList = value.stream().toList();
         Assertions.assertEquals("Eight", valueAsList.get(0));
         Assertions.assertEquals("Two", valueAsList.get(1));
         Assertions.assertEquals("Four", valueAsList.get(2));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.combobox.dataview;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -241,7 +240,7 @@ class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
 
         List<String> filteredItems = genericDataProvider
                 .fetch(new Query<>(0, Integer.MAX_VALUE, null, null, "ba"))
-                .collect(Collectors.toList());
+                .toList();
 
         // The result should contain an intersection of two filters (text and
         // predicate), so the result should start with 'ba' and contain 6 chars.

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuManager.java
@@ -19,7 +19,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.ClickEvent;
@@ -336,7 +335,7 @@ public class MenuManager<C extends Component, I extends MenuItemBase<?, I, S>, S
      */
     public List<I> getItems() {
         return getChildren().filter(itemType::isInstance).map(itemType::cast)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -49,32 +48,31 @@ class ContextMenuTest {
 
         contextMenu.addComponent(span1, span2);
 
-        List<Component> children = contextMenu.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = contextMenu.getChildren().toList();
         Assertions.assertEquals(2, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span2));
 
         contextMenu.addComponent(span3);
-        children = contextMenu.getChildren().collect(Collectors.toList());
+        children = contextMenu.getChildren().toList();
         Assertions.assertEquals(3, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span2));
         Assertions.assertTrue(children.contains(span3));
 
         contextMenu.remove(span2);
-        children = contextMenu.getChildren().collect(Collectors.toList());
+        children = contextMenu.getChildren().toList();
         Assertions.assertEquals(2, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span3));
 
         contextMenu.remove(span1);
-        children = contextMenu.getChildren().collect(Collectors.toList());
+        children = contextMenu.getChildren().toList();
         Assertions.assertEquals(1, children.size());
         Assertions.assertTrue(children.contains(span3));
 
         contextMenu.removeAll();
-        children = contextMenu.getChildren().collect(Collectors.toList());
+        children = contextMenu.getChildren().toList();
         Assertions.assertEquals(0, children.size());
     }
 
@@ -100,8 +98,7 @@ class ContextMenuTest {
         ContextMenu contextMenu = new ContextMenu();
         contextMenu.addItem("foo",
                 (ComponentEventListener<ClickEvent<MenuItem>>) null);
-        List<Component> children = contextMenu.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = contextMenu.getChildren().toList();
         Assertions.assertEquals(1, children.size());
         assertComponentIsMenuItem(children.get(0), "foo");
     }
@@ -142,8 +139,7 @@ class ContextMenuTest {
         Span span2 = new Span("bar");
         contextMenu.addComponent(span2);
 
-        List<Component> children = contextMenu.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = contextMenu.getChildren().toList();
         Assertions.assertEquals(4, children.size());
 
         Assertions.assertEquals(item1, children.get(0));

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuManagerTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.contextmenu;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -168,8 +167,7 @@ class MenuManagerTest {
 
         manager.addComponent(component1, component2);
 
-        List<Component> children = manager.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = manager.getChildren().toList();
 
         Assertions.assertEquals(2, children.size());
         Assertions.assertEquals(component1, children.get(0));
@@ -200,8 +198,7 @@ class MenuManagerTest {
 
         manager.remove(component1, component2);
 
-        List<Component> children = manager.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = manager.getChildren().toList();
 
         Assertions.assertTrue(children.isEmpty());
 
@@ -232,8 +229,7 @@ class MenuManagerTest {
 
         manager.removeAll();
 
-        List<Component> children = manager.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = manager.getChildren().toList();
 
         Assertions.assertTrue(children.isEmpty());
 
@@ -253,8 +249,7 @@ class MenuManagerTest {
         manager.addComponent(component1, component2);
         manager.addComponentAtIndex(1, component3);
 
-        List<Component> children = manager.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = manager.getChildren().toList();
 
         Assertions.assertEquals(3, children.size());
         Assertions.assertEquals(component1, children.get(0));

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/SubMenuTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.contextmenu;
 
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -219,8 +218,7 @@ class SubMenuTest {
 
     private void verifyChildren(SubMenu subMenu,
             Component... expectedChildren) {
-        List<Component> children = subMenu.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = subMenu.getChildren().toList();
         Assertions.assertArrayEquals(expectedChildren,
                 children.toArray(new Component[children.size()]));
     }

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/tests/PersonCrudDataProvider.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/main/java/com/vaadin/flow/component/crud/tests/PersonCrudDataProvider.java
@@ -39,7 +39,7 @@ class PersonCrudDataProvider
                 .of(new Person(1, "Sayo", "Sayo"),
                         new Person(2, "Manolo", "Otto"),
                         new Person(3, "Guille", "Guille"))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private Consumer<Long> sizeChangeListener;

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -13,7 +13,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
@@ -655,7 +654,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme, HasStyle {
 
     private static List<String> variantNames(CrudVariant... variants) {
         return Arrays.stream(variants).map(CrudVariant::getVariantName)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
@@ -10,7 +10,6 @@ package com.vaadin.flow.component.crud.testbench;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
 
@@ -87,7 +86,7 @@ public class CrudElement extends TestBenchElement {
                     .map(column -> editedRow.getCell(column))
                     .filter(cell -> cell.getInnerHTML()
                             .contains("vaadin-crud-edit"))
-                    .collect(Collectors.toList()).get(0);
+                    .toList().get(0);
             editCell.$("vaadin-crud-edit").get(0).click();
         }
     }

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/src/main/java/com/vaadin/flow/component/customfield/CustomField.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.customfield;
 
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
@@ -217,9 +216,8 @@ public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
      * @since 23.1
      */
     public void addThemeVariants(CustomFieldVariant... variants) {
-        getThemeNames().addAll(
-                Stream.of(variants).map(CustomFieldVariant::getVariantName)
-                        .collect(Collectors.toList()));
+        getThemeNames().addAll(Stream.of(variants)
+                .map(CustomFieldVariant::getVariantName).toList());
     }
 
     /**
@@ -230,8 +228,7 @@ public abstract class CustomField<T> extends AbstractField<CustomField<T>, T>
      * @since 23.1
      */
     public void removeThemeVariants(CustomFieldVariant... variants) {
-        getThemeNames().removeAll(
-                Stream.of(variants).map(CustomFieldVariant::getVariantName)
-                        .collect(Collectors.toList()));
+        getThemeNames().removeAll(Stream.of(variants)
+                .map(CustomFieldVariant::getVariantName).toList());
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerInAGridHeaderPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerInAGridHeaderPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -35,8 +34,8 @@ public class DatePickerInAGridHeaderPage extends Div {
         header.setId("date-picker");
 
         grid.addColumn(ValueProvider.identity()).setHeader(header);
-        grid.setItems(IntStream.range(0, 100).mapToObj(i -> "Item " + i)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.range(0, 100).mapToObj(i -> "Item " + i).toList());
 
         add(grid);
     }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -326,7 +325,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                 .filter(log -> !log.getMessage().contains("Lit is in dev mode"))
                 .filter(log -> !log.getMessage()
                         .contains("React Router Future Flag Warning"))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private void assertNoWarnings() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
@@ -1379,7 +1378,7 @@ public class DatePicker
                 this.dateFormats = new ArrayList<>();
                 this.dateFormats.add(primaryFormat);
                 this.dateFormats.addAll(Stream.of(additionalParsingFormats)
-                        .filter(Objects::nonNull).collect(Collectors.toList()));
+                        .filter(Objects::nonNull).toList());
             }
 
             return this;

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.datepicker.testbench;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -48,8 +47,7 @@ public class DatePickerElement extends TestBenchElement
          */
         public List<MonthCalendarElement> getVisibleMonthCalendars() {
             return this.$("vaadin-month-calendar").all().stream()
-                    .map(el -> el.wrap(MonthCalendarElement.class))
-                    .collect(Collectors.toList());
+                    .map(el -> el.wrap(MonthCalendarElement.class)).toList();
         }
 
         /**

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogChildrenTest.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.dialog;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -236,7 +235,7 @@ class DialogChildrenTest {
      */
     private void assertContent(Component... expected) {
         Assertions.assertEquals(List.of(expected),
-                dialog.getChildren().collect(Collectors.toList()));
+                dialog.getChildren().toList());
         for (Component component : expected) {
             Assertions.assertEquals(dialog.getElement(),
                     component.getElement().getParent());

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.dialog;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -54,32 +53,31 @@ class DialogTest {
         dialog.setWidth("200px");
         dialog.setHeight("100px");
 
-        List<Component> children = dialog.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = dialog.getChildren().toList();
         Assertions.assertEquals(2, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span2));
 
         dialog.add(span3);
-        children = dialog.getChildren().collect(Collectors.toList());
+        children = dialog.getChildren().toList();
         Assertions.assertEquals(3, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span2));
         Assertions.assertTrue(children.contains(span3));
 
         dialog.remove(span2);
-        children = dialog.getChildren().collect(Collectors.toList());
+        children = dialog.getChildren().toList();
         Assertions.assertEquals(2, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span3));
 
         span1.getElement().removeFromParent();
-        children = dialog.getChildren().collect(Collectors.toList());
+        children = dialog.getChildren().toList();
         Assertions.assertEquals(1, children.size());
         Assertions.assertTrue(children.contains(span3));
 
         dialog.removeAll();
-        children = dialog.getChildren().collect(Collectors.toList());
+        children = dialog.getChildren().toList();
         Assertions.assertEquals(0, children.size());
 
         Assertions.assertEquals("200px", dialog.getWidth());

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/AbstractComponentIT.java
@@ -383,7 +383,7 @@ public abstract class AbstractComponentIT extends TestBenchTestCase {
                         .intValue())
                 .filter(logEntry -> !logEntry.getMessage()
                         .contains("favicon.ico"))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static final String WEB_SOCKET_CONNECTION_ERROR_PREFIX = "WebSocket connection to ";

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/DataProviderListenersTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/dataprovider/DataProviderListenersTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.tests.dataprovider;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -119,7 +120,8 @@ public final class DataProviderListenersTest {
             super(Collections.emptyList());
             final int maxListenerNumberExpected = 4;
             listenerRemoved = Stream.of(new Boolean[maxListenerNumberExpected])
-                    .map(item -> Boolean.FALSE).collect(Collectors.toList());
+                    .map(item -> Boolean.FALSE)
+                    .collect(Collectors.toCollection(ArrayList::new));
         }
 
         @Override

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -50,8 +49,7 @@ public class ContextMenuGridPage extends Div {
         grid.addColumn(Person::getFirstName).setHeader("Name").setId("Name-Id");
         grid.addColumn(Person::getAge).setHeader("Born").setId("Born-Id");
         grid.setItems(IntStream.range(0, 77)
-                .mapToObj(i -> new Person("Person " + i, 1900 + i))
-                .collect(Collectors.toList()));
+                .mapToObj(i -> new Person("Person " + i, 1900 + i)).toList());
 
         GridContextMenu<Person> contextMenu = grid.addContextMenu();
         addItems(contextMenu);
@@ -94,8 +92,8 @@ public class ContextMenuGridPage extends Div {
         GridInATemplate template = new GridInATemplate();
         Grid<String> gridInATemplate = template.getGrid();
         gridInATemplate.addColumn(s -> s).setHeader("Item");
-        gridInATemplate.setItems(IntStream.range(0, 26)
-                .mapToObj(i -> "Item " + i).collect(Collectors.toList()));
+        gridInATemplate.setItems(
+                IntStream.range(0, 26).mapToObj(i -> "Item " + i).toList());
 
         GridContextMenu<String> contextMenu = gridInATemplate.addContextMenu();
         contextMenu.addItem("Show name of context menu target item",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -36,8 +35,7 @@ public class DynamicContextMenuGridPage extends Div {
         grid.addColumn(Person::getAge).setHeader("Born").setId("Born-Id");
 
         grid.setItems(IntStream.range(0, 50)
-                .mapToObj(i -> new Person("Person " + i, i))
-                .collect(Collectors.toList()));
+                .mapToObj(i -> new Person("Person " + i, i)).toList());
 
         GridContextMenu<Person> contextMenu = grid.addContextMenu();
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ChangingDataSizePage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ChangingDataSizePage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -40,7 +41,7 @@ public class ChangingDataSizePage extends Div {
         grid.addColumn(s -> s);
 
         items = IntStream.range(0, 133).mapToObj(idx -> "Item " + idx)
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
 
         removeItems = new NativeButton("Remove 10 items from the DataProvider",
                 event -> {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridGenericPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridGenericPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +38,8 @@ import com.vaadin.flow.router.Route;
 public class DragAndDropGridGenericPage extends Div {
 
     private List<String> items = IntStream.range(0, 10)
-            .mapToObj(String::valueOf).collect(Collectors.toList());
+            .mapToObj(String::valueOf)
+            .collect(Collectors.toCollection(ArrayList::new));
     private Grid<String> grid = new Grid<>();
     private String draggedCard;
     private final Div dropbox;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridPage.java
@@ -36,7 +36,7 @@ import com.vaadin.flow.router.Route;
 public class DragAndDropGridPage extends Div {
 
     private List<String> items = IntStream.range(0, 5).mapToObj(String::valueOf)
-            .collect(Collectors.toList());
+            .toList();
     private Grid<String> grid = new Grid<>();
 
     public DragAndDropGridPage() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDragSelectPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDragSelectPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -30,8 +29,8 @@ import com.vaadin.flow.router.Route;
 public class GridDragSelectPage extends VerticalLayout {
     public GridDragSelectPage() {
         Grid<String> grid = new Grid<>();
-        grid.setItems(IntStream.range(0, 100).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.range(0, 100).mapToObj(Integer::toString).toList());
         grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length())).setHeader("length");
         grid.setSelectionMode(Grid.SelectionMode.MULTI);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -119,7 +118,7 @@ public class GridFilteringPage extends Div {
         grid.addColumn(ValueProvider.identity()).setHeader("Items");
 
         final List<String> items = IntStream.range(0, 1000)
-                .mapToObj(item -> "Item " + item).collect(Collectors.toList());
+                .mapToObj(item -> "Item " + item).toList();
 
         TextField filterField = new TextField("Search Item");
         filterField.setId(GRID_FILTER_ID);
@@ -141,7 +140,7 @@ public class GridFilteringPage extends Div {
 
     private Collection<String> findAnyMatching(Optional<String> filter) {
         if (filter.isPresent()) {
-            return filter(filter).collect(Collectors.toList());
+            return filter(filter).toList();
         }
         return Collections.emptyList();
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -173,7 +172,7 @@ public class GridItemRefreshPage extends Div {
     private List<Bean> createItems(int numberOfItems) {
         return IntStream.range(0, numberOfItems).mapToObj(
                 intValue -> new Bean(String.valueOf(intValue), intValue))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private void updateBean(Bean bean) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridListDataViewPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridListDataViewPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -179,7 +180,7 @@ public class GridListDataViewPage extends Div {
                 .mapToObj(i -> new Person("Person " + i, "lastName",
                         "person" + i + "@test.com", (i % 90) + 15,
                         Gender.UNKNOWN, new Address()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLitRendererPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLitRendererPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Component;
@@ -39,8 +38,7 @@ public class GridLitRendererPage extends Div {
 
     public GridLitRendererPage() {
         Grid<Integer> grid = new Grid<>();
-        grid.setItems(
-                IntStream.range(0, 1000).boxed().collect(Collectors.toList()));
+        grid.setItems(IntStream.range(0, 1000).boxed().toList());
         grid.addColumn(LitRenderer
                 .<Integer> of(
                         "<span id=\"item-${index}\">Lit: ${item.name}</span>")

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.grid.it;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -95,7 +94,7 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createInMemoryGrid() {
         Grid<String> grid = new Grid<>();
         grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+                .toList());
         setUp(grid);
         grid.setId(IN_MEMORY_GRID_ID);
         add(new H2("In-memory grid"), grid);
@@ -143,7 +142,7 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createBasicGridFromSingleToMultiBeforeAttached() {
         Grid<String> grid = new Grid<>();
         grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+                .toList());
         setUp(grid);
         grid.setId("in-testing-multi-selection-mode-grid");
         add(new H2("in-testing-multi-selection-mode-grid"), grid);
@@ -156,7 +155,7 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createBasicGridFromMultiToSingleBeforeAttached() {
         Grid<String> grid = new Grid<>();
         grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+                .toList());
         setUp(grid);
         grid.setId("in-testing-multi-selection-mode-grid-single");
         add(new H2("in-testing-multi-selection-mode-grid-single"), grid);
@@ -169,7 +168,7 @@ public class GridMultiSelectionColumnPage extends Div {
     private void setAutoWidthIsTrueOfSelectionColumn() {
         Grid<String> grid = new Grid<>();
         grid.setItems(IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+                .toList());
         setUp(grid);
         grid.setId("set-auto-width-true");
         add(new H2("In-set-auto-width-true"), grid);
@@ -181,8 +180,8 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createBasicGridMultiAllRowsSelected() {
         Grid<String> grid = new Grid<>();
         grid.setId(MULTI_SELECT_GRID_ALL_SELECTED_GRID_ID);
-        grid.setItems(IntStream.range(0, 2).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.range(0, 2).mapToObj(Integer::toString).toList());
         grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length())).setHeader("length");
         grid.setSelectionMode(Grid.SelectionMode.MULTI);
@@ -203,8 +202,8 @@ public class GridMultiSelectionColumnPage extends Div {
     private void createBasicGridMultiOneRowDeSelected() {
         Grid<String> grid = new Grid<>();
         grid.setId(MULTI_SELECT_GRID_ONE_NOT_SELECTED_GRID_ID);
-        grid.setItems(IntStream.range(0, 2).mapToObj(Integer::toString)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.range(0, 2).mapToObj(Integer::toString).toList());
         grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length())).setHeader("length");
         grid.setSelectionMode(Grid.SelectionMode.MULTI);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridScrollToPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -31,7 +32,8 @@ public class GridScrollToPage extends Div {
         grid.setId("data-grid");
 
         List<String> items = IntStream.rangeClosed(0, 1000)
-                .mapToObj(String::valueOf).collect(Collectors.toList());
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toCollection(ArrayList::new));
         grid.setItems(items);
 
         grid.addColumn(item -> item).setHeader("Data");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionDeselectAllowedPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.button.Button;
@@ -66,8 +65,8 @@ public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
         Grid<String> grid = new Grid<>();
         grid.addColumn(string -> String.valueOf(Math.random())) // NOSONAR
                 .setHeader("column 1");
-        grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.rangeClosed(1, 3).mapToObj(String::valueOf).toList());
         grid.setAllRowsVisible(true);
         if (!deselectAllowed) {
             ((GridSingleSelectionModel) grid.getSelectionModel())
@@ -81,8 +80,8 @@ public class GridSingleSelectionDeselectAllowedPage extends VerticalLayout {
     private Grid<String> setItemsGrid(Grid grid, String id) {
         grid.addColumn(string -> String.valueOf(Math.random())) // NOSONAR
                 .setHeader("column 1");
-        grid.setItems(IntStream.rangeClosed(1, 3).mapToObj(String::valueOf)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.rangeClosed(1, 3).mapToObj(String::valueOf).toList());
         grid.setAllRowsVisible(true);
         grid.setId(id);
         return grid;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSingleSelectionPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -30,8 +29,7 @@ import com.vaadin.flow.router.Route;
 public class GridSingleSelectionPage extends Div {
 
     public GridSingleSelectionPage() {
-        List<Integer> items = IntStream.range(0, 500).boxed()
-                .collect(Collectors.toList());
+        List<Integer> items = IntStream.range(0, 500).boxed().toList();
         Grid<Integer> grid = new Grid<>();
         grid.setItems(items);
         grid.addColumn(ValueProvider.identity()).setHeader("Item");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -32,7 +31,7 @@ public class GridStylingPage extends Div {
         Grid<String> grid = new Grid<>();
 
         List<String> items = IntStream.range(0, 20).mapToObj(String::valueOf)
-                .collect(Collectors.toList());
+                .toList();
         grid.setItems(items);
 
         Grid.Column<String> col0 = grid.addColumn(i -> i).setHeader("text");

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
@@ -133,8 +133,8 @@ public class GridTestPage extends Div {
                 "Set reorder listener", evt -> {
                     grid.addColumnReorderListener(e -> {
                         if (e.isFromClient()) {
-                            List<Column<Item>> columnList = e.getColumns()
-                                    .stream().collect(Collectors.toList());
+                            List<Column<Item>> columnList = new ArrayList<>(
+                                    e.getColumns());
                             // Reorder columns in the list
                             Collections.swap(columnList, 1, 2);
                             grid.setColumnOrder(columnList);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestScrollingOver100kLines.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestScrollingOver100kLines.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.time.LocalDate;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -48,7 +47,7 @@ public class GridTestScrollingOver100kLines extends Div {
         grid.setHeight("300px");
 
         grid.setItems(IntStream.rangeClosed(1, 100500).mapToObj(String::valueOf)
-                .collect(Collectors.toList()));
+                .toList());
         add(grid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewBasicFeaturesPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewBasicFeaturesPage.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.ColumnTextAlign;
@@ -66,14 +65,14 @@ public class GridViewBasicFeaturesPage extends LegacyTestView {
         HeaderRow topHeader = grid.prependHeaderRow();
 
         IntStream.range(baseYear, baseYear + numberOfYears).forEach(year -> {
-            BigDecimal firstHalfSum = list.fetch(new Query<>())
-                    .collect(Collectors.toList()).stream()
+            BigDecimal firstHalfSum = list.fetch(new Query<>()).toList()
+                    .stream()
                     .map(budgetHistory -> budgetHistory
                             .getFirstHalfOfYear(year))
                     .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-            BigDecimal secondHalfSum = list.fetch(new Query<>())
-                    .collect(Collectors.toList()).stream()
+            BigDecimal secondHalfSum = list.fetch(new Query<>()).toList()
+                    .stream()
                     .map(budgetHistory -> budgetHistory
                             .getSecondHalfOfYear(year))
                     .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSelectionPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridViewSelectionPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
@@ -49,11 +48,9 @@ public class GridViewSelectionPage extends LegacyTestView {
 
         grid.asMultiSelect().addSelectionListener(event -> {
             List<Person> previousSelectionSorted = event.getOldValue().stream()
-                    .sorted(Comparator.comparingLong(Person::getId))
-                    .collect(Collectors.toList());
+                    .sorted(Comparator.comparingLong(Person::getId)).toList();
             List<Person> newSelectionSorted = event.getValue().stream()
-                    .sorted(Comparator.comparingLong(Person::getId))
-                    .collect(Collectors.toList());
+                    .sorted(Comparator.comparingLong(Person::getId)).toList();
 
             messageDiv.setText(String.format(
                     "Selection changed from %s to %s, selection is from client: %s",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/HiddenEditorButtonsPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/HiddenEditorButtonsPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Component;
@@ -42,8 +41,8 @@ public class HiddenEditorButtonsPage extends Div {
 
         grid.setSelectionMode(SelectionMode.NONE);
         grid.setId("editor-grid");
-        grid.setItems(IntStream.range(1, 1001).mapToObj(this::createPerson)
-                .collect(Collectors.toList()));
+        grid.setItems(
+                IntStream.range(1, 1001).mapToObj(this::createPerson).toList());
 
         Binder<Person> binder = new Binder<>(Person.class);
         TextField editorComponent = new TextField();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/LegacyTestView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/LegacyTestView.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
@@ -55,7 +57,8 @@ public class LegacyTestView extends Div {
     }
 
     protected List<Person> getItems() {
-        return items.stream().map(Person::clone).toList();
+        return items.stream().map(Person::clone)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     protected List<PersonWithLevel> getRootItems() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/LegacyTestView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/LegacyTestView.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
@@ -56,7 +55,7 @@ public class LegacyTestView extends Div {
     }
 
     protected List<Person> getItems() {
-        return items.stream().map(Person::clone).collect(Collectors.toList());
+        return items.stream().map(Person::clone).toList();
     }
 
     protected List<PersonWithLevel> getRootItems() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -36,12 +35,12 @@ public class ToggleVisibilityPage extends Div {
     public ToggleVisibilityPage() {
         Grid<String> grid1 = new Grid<>();
         grid1.setItems(IntStream.range(0, 100).mapToObj(i -> "Grid1 Item " + i)
-                .collect(Collectors.toList()));
+                .toList());
         grid1.addColumn(ValueProvider.identity());
 
         Grid<String> grid2 = new Grid<>();
         grid2.setItems(IntStream.range(0, 100).mapToObj(i -> "Grid2 Item " + i)
-                .collect(Collectors.toList()));
+                .toList());
         grid2.addColumn(ValueProvider.identity());
 
         Div parent1 = new Div(grid1);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridRefreshAllPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridRefreshAllPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.treegrid.it;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.button.Button;
@@ -63,7 +62,7 @@ public class TreeGridRefreshAllPage extends Div {
 
         TreeData<String> treeData = new TreeData<>();
         List<String> rootItems = IntStream.iterate(1, i -> i + 1).limit(11)
-                .mapToObj(String::valueOf).collect(Collectors.toList());
+                .mapToObj(String::valueOf).toList();
         treeData.addRootItems(rootItems);
         rootItems.forEach(
                 rootItem -> treeData.addItem(rootItem, "item: " + rootItem));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridStringDataBuilder.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridStringDataBuilder.java
@@ -20,7 +20,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
@@ -55,14 +54,13 @@ public class TreeGridStringDataBuilder {
         }
         return parentItems.stream()
                 .map(parent -> addItemsToParent(name, numberOfItems, parent))
-                .flatMap(List::stream).collect(Collectors.toList());
+                .flatMap(List::stream).toList();
     }
 
     private List<String> addItemsToParent(String name, int numberOfItems,
             String parent) {
         return IntStream.range(0, numberOfItems)
-                .mapToObj(index -> createItem(name, parent, index))
-                .collect(Collectors.toList());
+                .mapToObj(index -> createItem(name, parent, index)).toList();
     }
 
     private String createItem(String name, String parent, int index) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/data/bean/ItemGenerator.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/data/bean/ItemGenerator.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.data.bean;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -33,7 +34,7 @@ public class ItemGenerator extends BeanGenerator {
         LocalDate baseDate = LocalDate.of(2018, 1, 10);
         return IntStream.range(0, amount)
                 .mapToObj(index -> createItem(index + 1, baseDate))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private Item createItem(int index, LocalDate baseDate) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/data/bean/PeopleGenerator.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/data/bean/PeopleGenerator.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.data.bean;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,14 +36,14 @@ public class PeopleGenerator extends BeanGenerator {
     public List<Person> generatePeople(int amount) {
         return IntStream.range(0, amount)
                 .mapToObj(index -> createPerson(index + 1))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     public List<PersonWithLevel> generatePeopleWithLevels(int amount,
             int level) {
         return IntStream.range(0, amount)
                 .mapToObj(index -> createPersonWithLevel(index + 1, level))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private PersonWithLevel createPersonWithLevel(int index, int level) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/data/performance/AbstractBeansMemoryTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/data/performance/AbstractBeansMemoryTest.java
@@ -19,7 +19,6 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -90,8 +89,7 @@ public abstract class AbstractBeansMemoryTest<T extends Component> extends Div
     protected abstract T createComponent();
 
     protected List<Person> createBeans(int size) {
-        return IntStream.range(0, size).mapToObj(this::createPerson)
-                .collect(Collectors.toList());
+        return IntStream.range(0, size).mapToObj(this::createPerson).toList();
     }
 
     protected Person createPerson(int index) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridLoadsItemsIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridLoadsItemsIT.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.grid.contextmenu;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -92,7 +91,7 @@ public class GridLoadsItemsIT extends AbstractComponentIT {
 
     private List<String> getMessages() {
         return findElements(By.cssSelector("#messages > span")).stream()
-                .map(WebElement::getText).collect(Collectors.toList());
+                .map(WebElement::getText).toList();
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
@@ -429,24 +428,23 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         List<WebElement> headers = thead.findElements(By.tagName("tr")).stream()
                 .filter(tr -> tr.getDomAttribute("hidden") == null)
                 .flatMap(tr -> tr.findElements(By.tagName("th")).stream())
-                .collect(Collectors.toList());
+                .toList();
 
         List<String> cellNames = headers.stream().map(header -> header
                 .findElement(By.tagName("slot")).getDomAttribute("name"))
-                .collect(Collectors.toList());
+                .toList();
 
         List<WebElement> headerCells = cellNames.stream()
-                .map(name -> grid.findElement(By.cssSelector(
+                .<WebElement> map(name -> grid.findElement(By.cssSelector(
                         "vaadin-grid-cell-content[slot='" + name + "']")))
-                .collect(Collectors.toList());
+                .toList();
 
         return headerCells;
     }
 
     private List<String> getHeaderContents() {
         return getHeaderCells().stream()
-                .map(cell -> cell.getDomProperty("innerHTML"))
-                .collect(Collectors.toList());
+                .map(cell -> cell.getDomProperty("innerHTML")).toList();
     }
 
     private void assertFooterOrder(int... numbers) {
@@ -466,16 +464,16 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         List<WebElement> footers = tfoot.findElements(By.tagName("tr")).stream()
                 .filter(tr -> tr.getDomAttribute("hidden") == null)
                 .flatMap(tr -> tr.findElements(By.tagName("td")).stream())
-                .collect(Collectors.toList());
+                .toList();
 
         List<String> cellNames = footers.stream().map(footer -> footer
                 .findElement(By.tagName("slot")).getDomAttribute("name"))
-                .collect(Collectors.toList());
+                .toList();
 
         List<WebElement> footerCells = cellNames.stream()
-                .map(name -> grid.findElement(By.cssSelector(
+                .<WebElement> map(name -> grid.findElement(By.cssSelector(
                         "vaadin-grid-cell-content[slot='" + name + "']")))
-                .collect(Collectors.toList());
+                .toList();
 
         return footerCells;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderIT.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -111,7 +110,7 @@ public class GridUpdateDataProviderIT extends AbstractComponentIT {
         data.add("fooba");
         data.add("foobar");
         Collection<String> lengths = data.stream().map(String::length)
-                .map(Object::toString).collect(Collectors.toList());
+                .map(Object::toString).toList();
         data.addAll(lengths);
         findElements(By.tagName("vaadin-grid-cell-content"))
                 .forEach(cell -> data.remove(cell.getText()));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewSelectionIT.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.grid.it;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
@@ -152,11 +151,9 @@ public class GridViewSelectionIT extends AbstractComponentIT {
     private static String getSelectionMessage(List<Person> previousSelection,
             List<Person> newSelection, boolean isFromClient) {
         List<Person> previousSelectionSorted = previousSelection.stream()
-                .sorted(Comparator.comparingLong(Person::getId))
-                .collect(Collectors.toList());
+                .sorted(Comparator.comparingLong(Person::getId)).toList();
         List<Person> newSelectionSorted = newSelection.stream()
-                .sorted(Comparator.comparingLong(Person::getId))
-                .collect(Collectors.toList());
+                .sorted(Comparator.comparingLong(Person::getId)).toList();
 
         return String.format(
                 "Selection changed from %s to %s, selection is from client: %s",

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.grid;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -326,13 +327,14 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
     protected List<Column<?>> getBottomChildColumns() {
         List<Column<?>> columnChildren = getChildren()
                 .filter(child -> child instanceof Column<?>)
-                .map(child -> (Column<?>) child).collect(Collectors.toList());
+                .map(child -> (Column<?>) child)
+                .collect(Collectors.toCollection(ArrayList::new));
 
         columnChildren.addAll(
                 getChildren().filter(child -> child instanceof ColumnGroup)
                         .flatMap(child -> ((ColumnGroup) child)
                                 .getBottomChildColumns().stream())
-                        .collect(Collectors.toList()));
+                        .toList());
         return columnChildren;
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -478,8 +478,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
             return Stream.empty();
         }
         List<T> children = dataProvider
-                .fetchChildren(new HierarchicalQuery<>(null, parent))
-                .collect(Collectors.toList());
+                .fetchChildren(new HierarchicalQuery<>(null, parent)).toList();
         if (children.isEmpty()) {
             return Stream.empty();
         }
@@ -503,7 +502,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
         Map<Object, T> addedItemsMap = mapItemsById(addedItems);
         Map<Object, T> removedItemsMap = mapItemsById(removedItems);
         addedItemsMap.keySet().stream().filter(removedItemsMap::containsKey)
-                .collect(Collectors.toList()).forEach(key -> {
+                .toList().forEach(key -> {
                     addedItemsMap.remove(key);
                     removedItemsMap.remove(key);
                 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractRow.java
@@ -126,7 +126,7 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
         this.layer = layer;
         this.cellCtor = cellCtor;
         cells = layer.getColumns().stream().map(cellCtor)
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**
@@ -227,8 +227,7 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
      *             if it's not possible to join the given cells
      */
     public CELL join(Column<?>... columns) {
-        return join(Arrays.stream(columns).map(this::getCell)
-                .collect(Collectors.toList()));
+        return join(Arrays.stream(columns).map(this::getCell).toList());
     }
 
     /**
@@ -297,7 +296,7 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
 
         List<CELL> sortedCells = cells.stream().sorted((c1, c2) -> Integer
                 .compare(this.cells.indexOf(c1), this.cells.indexOf(c2)))
-                .collect(Collectors.toList());
+                .toList();
 
         int cellInsertIndex = this.cells.indexOf(sortedCells.get(0));
         IntStream.range(0, sortedCells.size()).forEach(i -> {
@@ -308,11 +307,10 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
         });
 
         List<AbstractColumn<?>> columnsToJoin = sortedCells.stream()
-                .map(CELL::getColumn).collect(Collectors.toList());
+                .<AbstractColumn<?>> map(CELL::getColumn).toList();
 
         List<Column<?>> bottomColumnsToJoin = columnsToJoin.stream()
-                .flatMap(col -> col.getBottomChildColumns().stream())
-                .collect(Collectors.toList());
+                .flatMap(col -> col.getBottomChildColumns().stream()).toList();
 
         List<ColumnLayer> layers = grid.getColumnLayers();
 
@@ -354,7 +352,7 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
             List<AbstractColumn<?>> joinedColumns = possibleParentLayer
                     .getColumns().stream().filter(col -> ((ColumnGroup) col)
                             .getChildColumns().size() > 1)
-                    .collect(Collectors.toList());
+                    .toList();
             boolean otherColumnsJoined = joinedColumns.stream()
                     .flatMap(col -> col.getBottomChildColumns().stream())
                     .anyMatch(col -> !bottomColumnsToJoin.contains(col));
@@ -386,8 +384,8 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
 
         layer.getColumns().removeAll(columnsToJoin);
         CELL keeper = this.cells.get(elementInsertIndex);
-        this.cells.removeAll(cellsToJoin.stream().filter(cell -> cell != keeper)
-                .collect(Collectors.toList()));
+        this.cells.removeAll(
+                cellsToJoin.stream().filter(cell -> cell != keeper).toList());
 
         return this.cells.get(cellInsertIndex);
     }
@@ -403,7 +401,7 @@ abstract class AbstractRow<CELL extends AbstractCell> implements Serializable {
         List<AbstractColumn<?>> childColumns = lowerLayer.getColumns().stream()
                 .filter(col -> bottomColumnsToJoin
                         .containsAll(col.getBottomChildColumns()))
-                .collect(Collectors.toList());
+                .toList();
 
         List<AbstractColumn<?>> newColumns = new ArrayList<AbstractColumn<?>>();
         Iterator<AbstractColumn<?>> leftColumns = layer.getColumns().stream()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.grid;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -71,9 +70,9 @@ class ColumnGroup extends AbstractColumn<ColumnGroup> {
         return getElement().getChildren()
                 .filter(element -> element.getComponent().isPresent() && element
                         .getComponent().get() instanceof AbstractColumn)
-                .map(element -> (AbstractColumn<?>) element.getComponent()
-                        .get())
-                .collect(Collectors.toList());
+                .<AbstractColumn<?>> map(element -> (AbstractColumn<?>) element
+                        .getComponent().get())
+                .toList();
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroupHelpers.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnGroupHelpers.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,7 +44,7 @@ class ColumnGroupHelpers {
     public static List<AbstractColumn<?>> wrapInSeparateColumnGroups(
             Collection<AbstractColumn<?>> cols, Grid<?> grid) {
         return cols.stream().map(col -> wrapSingleColumn(col, grid))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2691,7 +2691,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     public List<HeaderRow> getHeaderRows() {
         List<HeaderRow> rows = columnLayers.stream()
                 .filter(ColumnLayer::isHeaderRow).map(ColumnLayer::asHeaderRow)
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
         Collections.reverse(rows);
         return rows;
     }
@@ -2703,7 +2703,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      */
     public List<FooterRow> getFooterRows() {
         return columnLayers.stream().filter(ColumnLayer::isFooterRow)
-                .map(ColumnLayer::asFooterRow).collect(Collectors.toList());
+                .map(ColumnLayer::asFooterRow).toList();
     }
 
     /**
@@ -2714,8 +2714,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @since 2.0
      */
     public void addThemeVariants(GridVariant... variants) {
-        getThemeNames().addAll(Stream.of(variants)
-                .map(GridVariant::getVariantName).collect(Collectors.toList()));
+        getThemeNames().addAll(
+                Stream.of(variants).map(GridVariant::getVariantName).toList());
     }
 
     /**
@@ -2726,8 +2726,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * @since 2.0
      */
     public void removeThemeVariants(GridVariant... variants) {
-        getThemeNames().removeAll(Stream.of(variants)
-                .map(GridVariant::getVariantName).collect(Collectors.toList()));
+        getThemeNames().removeAll(
+                Stream.of(variants).map(GridVariant::getVariantName).toList());
     }
 
     /**
@@ -3605,8 +3605,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         return getElement().getChildren().map(element -> element.getComponent())
                 .filter(component -> component.isPresent()
                         && component.get() instanceof ColumnBase<?>)
-                .map(component -> (ColumnBase<?>) component.get())
-                .collect(Collectors.toList());
+                .<ColumnBase<?>> map(
+                        component -> (ColumnBase<?>) component.get())
+                .toList();
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -76,7 +76,7 @@ class GridColumnOrderHelper<T> {
 
         // sanity test passed. Reorder the columns.
         final List<String> newOrderIDs = columns.stream()
-                .map(Grid.Column::getInternalId).collect(Collectors.toList());
+                .map(Grid.Column::getInternalId).toList();
         final GraphNodeLeafCache nodeLeafCache = new GraphNodeLeafCache();
         // first run a dry run, to check whether the column ordering is possible
         // without actually performing the DOM reorder.

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.ClientCallable;
@@ -619,8 +618,7 @@ public class TreeGrid<T> extends Grid<T>
     public Column<T> setHierarchyColumn(String propertyName,
             ValueProvider<T, ?> valueProvider) {
         List<String> currentPropertyList = getColumns().stream()
-                .map(Column::getKey).filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .map(Column::getKey).filter(Objects::nonNull).toList();
         resetColumns(propertyName, valueProvider, currentPropertyList);
         return getColumnByKey(propertyName);
     }
@@ -923,7 +921,7 @@ public class TreeGrid<T> extends Grid<T>
                             getItemsWithChildrenRecursively(getDataProvider()
                                     .fetchChildren(
                                             new HierarchicalQuery<>(null, item))
-                                    .collect(Collectors.toList()), depth - 1));
+                                    .toList(), depth - 1));
                 });
         return itemsWithChildren;
     }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSortingTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridSortingTest.java
@@ -408,7 +408,7 @@ class GridSortingTest {
         Random random = new Random(0);
         return IntStream.range(1, 500)
                 .mapToObj(index -> createPerson(index, random))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private static Person createPerson(int index, Random random) {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -1388,8 +1388,7 @@ class HeaderFooterTest {
 
     private void assertRowWrapsLayer(AbstractRow<?> row, List<Element> layer) {
         List<Element> cellWrappedElements = row.getCells().stream()
-                .map(cell -> cell.getColumn().getElement())
-                .collect(Collectors.toList());
+                .map(cell -> cell.getColumn().getElement()).toList();
 
         Assertions.assertEquals(layer.size(), cellWrappedElements.size(),
                 "The row contains unexpected amount of column elements");
@@ -1423,8 +1422,7 @@ class HeaderFooterTest {
      */
     private List<List<Element>> getColumnLayers() {
         List<List<Element>> layers = new ArrayList<List<Element>>();
-        List<Element> children = grid.getElement().getChildren()
-                .collect(Collectors.toList());
+        List<Element> children = grid.getElement().getChildren().toList();
         while (children.stream().anyMatch(isColumnGroup)) {
             if (!children.stream().allMatch(isColumnGroup)) {
                 throw new IllegalStateException(
@@ -1437,8 +1435,7 @@ class HeaderFooterTest {
             }
             layers.add(children);
             children = children.stream()
-                    .flatMap(element -> element.getChildren())
-                    .collect(Collectors.toList());
+                    .flatMap(element -> element.getChildren()).toList();
         }
         if (children.stream().anyMatch(isColumn)) {
             if (!children.stream().allMatch(isColumn)) {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/src/main/java/com/vaadin/flow/component/gridpro/tests/MainView.java
@@ -174,7 +174,7 @@ public class MainView extends VerticalLayout {
         Random random = new Random(0); // NOSONAR
         return IntStream.range(1, 500)
                 .mapToObj(index -> createPerson(index, random))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private static Person createPerson(int index, Random random) {
@@ -197,7 +197,7 @@ public class MainView extends VerticalLayout {
 
     private static List<City> createCityItems() {
         return IntStream.range(1, 500).mapToObj(index -> createCity(index))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static City createCity(int index) {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -11,7 +11,6 @@ package com.vaadin.flow.component.gridpro;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
@@ -794,9 +793,8 @@ public class GridPro<E> extends Grid<E> {
      * @since 23.1
      */
     public void addThemeVariants(GridProVariant... variants) {
-        getThemeNames()
-                .addAll(Stream.of(variants).map(GridProVariant::getVariantName)
-                        .collect(Collectors.toList()));
+        getThemeNames().addAll(Stream.of(variants)
+                .map(GridProVariant::getVariantName).toList());
     }
 
     /**
@@ -807,8 +805,7 @@ public class GridPro<E> extends Grid<E> {
      * @since 23.1
      */
     public void removeThemeVariants(GridProVariant... variants) {
-        getThemeNames().removeAll(
-                Stream.of(variants).map(GridProVariant::getVariantName)
-                        .collect(Collectors.toList()));
+        getThemeNames().removeAll(Stream.of(variants)
+                .map(GridProVariant::getVariantName).toList());
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxViewDemoPage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxViewDemoPage.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.listbox.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
@@ -147,7 +146,7 @@ public class ListBoxViewDemoPage extends Div {
             item.setName(name);
             item.setStock((int) (Math.random() * 5) + 1);
             return item;
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     public static class Item {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.AttachEvent;
@@ -294,8 +293,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
         synchronized (dataProvider) {
             final AtomicInteger itemCounter = new AtomicInteger(0);
             items = (List<ITEM>) getDataProvider()
-                    .fetch(DataViewUtils.getQuery(this))
-                    .collect(Collectors.toList());
+                    .fetch(DataViewUtils.getQuery(this)).toList();
             items.stream().map(this::createItemComponent).forEach(component -> {
                 add(component);
                 itemCounter.incrementAndGet();
@@ -358,8 +356,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     @SuppressWarnings("unchecked")
     List<VaadinItem<ITEM>> getItemComponents() {
         return getChildren().filter(VaadinItem.class::isInstance)
-                .map(component -> (VaadinItem<ITEM>) component)
-                .collect(Collectors.toList());
+                .map(component -> (VaadinItem<ITEM>) component).toList();
     }
 
     /**

--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/src/main/java/com/vaadin/flow/component/listbox/testbench/ListBoxElement.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.listbox.testbench;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openqa.selenium.By;
@@ -49,7 +48,7 @@ public class ListBoxElement extends TestBenchElement
     }
 
     public List<String> getOptions() {
-        return getItems().map(WebElement::getText).collect(Collectors.toList());
+        return getItems().map(WebElement::getText).toList();
     }
 
     private Stream<WebElement> getItems() {

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/src/main/java/com/vaadin/flow/component/menubar/testbench/MenuBarElement.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.menubar.testbench;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
@@ -37,7 +36,7 @@ public class MenuBarElement extends TestBenchElement {
     public List<MenuBarButtonElement> getButtons() {
         return $(MenuBarButtonElement.class).all().stream().filter(
                 element -> !isOverflowButton(element) && isVisible(element))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -204,7 +203,7 @@ public class MessageList extends Component
         return SignalBindingUtil.effectBinding(this, ITEMS_BINDING, itemsSignal,
                 signalItems -> {
                     var messageItems = signalItems.stream().map(Signal::get)
-                            .collect(Collectors.toList());
+                            .toList();
                     updateItems(messageItems);
                 });
     }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.notification.tests;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -101,7 +100,7 @@ public class NotificationIT extends AbstractComponentIT {
 
     private void assertNotificationContent(String expected) {
         List<String> notifications = getNotifications().stream()
-                .map(WebElement::getText).collect(Collectors.toList());
+                .map(WebElement::getText).toList();
         Assert.assertTrue(String.format(
                 "Expected any of the notifications to contain the string '%s' but neither of them did. Notifications: '%s'",
                 expected, notifications),

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.notification.tests;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,7 +55,7 @@ public class NotificationTestPageIT extends AbstractComponentIT {
         checkNotificationIsOpen();
 
         List<String> notifications = getNotifications().stream()
-                .map(WebElement::getText).collect(Collectors.toList());
+                .map(WebElement::getText).toList();
         Assert.assertEquals(
                 "Expect to have two notification pop-ups for two notification buttons clicked",
                 2, notifications.size());

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -22,7 +22,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
@@ -645,8 +644,7 @@ public class Notification extends Component implements HasComponents, HasStyle,
 
         this.getElement().setPropertyList("virtualChildNodeIds",
                 getElement().getChildren()
-                        .map(element -> element.getNode().getId())
-                        .collect(Collectors.toList()));
+                        .map(element -> element.getNode().getId()).toList());
 
         this.getElement().callJsFunction("requestContentUpdate");
     }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationChildrenTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.notification;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -177,14 +176,14 @@ class NotificationChildrenTest {
         // Get a List of the node ids
         var childIds = Arrays.stream(components)
                 .map(component -> component.getElement().getNode().getId())
-                .collect(Collectors.toList());
+                .toList();
 
         // Get the virtualChildNodeIds property from the dialog as a JsonArray
         var jsonArrayOfIds = (ArrayNode) JacksonUtils.getMapper().readTree(
                 notification.getElement().getProperty("virtualChildNodeIds"));
 
         var virtualChildNodeIds = JacksonUtils.stream(jsonArrayOfIds)
-                .mapToInt(JsonNode::asInt).boxed().collect(Collectors.toList());
+                .mapToInt(JsonNode::asInt).boxed().toList();
 
         Assertions.assertEquals(childIds, virtualChildNodeIds);
     }

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -51,21 +50,20 @@ class NotificationTest {
 
         Notification notification = new Notification(span1, span2);
 
-        List<Component> children = notification.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = notification.getChildren().toList();
         Assertions.assertEquals(2, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span2));
 
         notification.add(span3);
-        children = notification.getChildren().collect(Collectors.toList());
+        children = notification.getChildren().toList();
         Assertions.assertEquals(3, children.size());
         Assertions.assertTrue(children.contains(span1));
         Assertions.assertTrue(children.contains(span2));
         Assertions.assertTrue(children.contains(span3));
 
         notification.remove(span2);
-        children = notification.getChildren().collect(Collectors.toList());
+        children = notification.getChildren().toList();
         Assertions.assertEquals(2, children.size());
         Assertions.assertTrue(children.contains(span1),
                 "Children should contain span1");
@@ -73,13 +71,13 @@ class NotificationTest {
                 "Children should contain span3");
 
         span1.getElement().removeFromParent();
-        children = notification.getChildren().collect(Collectors.toList());
+        children = notification.getChildren().toList();
         Assertions.assertEquals(1, children.size());
         Assertions.assertTrue(children.contains(span3),
                 "Children should contain span3");
 
         notification.removeAll();
-        children = notification.getChildren().collect(Collectors.toList());
+        children = notification.getChildren().toList();
         Assertions.assertEquals(0, children.size());
     }
 
@@ -89,8 +87,7 @@ class NotificationTest {
         Div container2 = new Div(container1);
 
         Notification notification = new Notification(container2);
-        List<Component> children = notification.getChildren()
-                .collect(Collectors.toList());
+        List<Component> children = notification.getChildren().toList();
         Assertions.assertEquals(1, children.size());
         Assertions.assertTrue(children.contains(container2),
                 "Children should contain container2");
@@ -261,8 +258,8 @@ class NotificationTest {
         // Check that the notification is opened and attached to the parent
         // container
         Assertions.assertTrue(notification.isOpened());
-        Assertions.assertTrue(parent.getChildren().collect(Collectors.toList())
-                .contains(notification));
+        Assertions.assertTrue(
+                parent.getChildren().toList().contains(notification));
 
         // Remove the modal parent container from the UI
         ui.remove(parent);
@@ -274,8 +271,8 @@ class NotificationTest {
         Assertions.assertFalse(notification.isOpened());
         // The notification should have been automatically removed from the
         // parent container
-        Assertions.assertFalse(parent.getChildren().collect(Collectors.toList())
-                .contains(notification));
+        Assertions.assertFalse(
+                parent.getChildren().toList().contains(notification));
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupSignalTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupSignalTest.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.radiobutton;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -91,7 +90,6 @@ class RadioButtonGroupSignalTest extends AbstractSignalsTest {
     @SuppressWarnings("unchecked")
     private List<RadioButton<String>> getRadioButtons() {
         return group.getChildren().filter(RadioButton.class::isInstance)
-                .map(child -> (RadioButton<String>) child)
-                .collect(Collectors.toList());
+                .map(child -> (RadioButton<String>) child).toList();
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -164,8 +163,7 @@ class RadioButtonGroupTest {
         group.addValueChangeListener(events::add);
 
         List<String> keys = group.getChildren().map(Component::getElement)
-                .map(element -> element.getProperty("value"))
-                .collect(Collectors.toList());
+                .map(element -> element.getProperty("value")).toList();
         String enabledKey = keys.get(0);
         String disabledKey = keys.get(1);
 
@@ -189,8 +187,7 @@ class RadioButtonGroupTest {
         group.setItemEnabledProvider("enabled"::equals);
 
         List<RadioButton<String>> children = group.getChildren()
-                .map(child -> (RadioButton<String>) child)
-                .collect(Collectors.toList());
+                .map(child -> (RadioButton<String>) child).toList();
 
         Assertions.assertTrue(children.get(0).isEnabled());
         Assertions.assertFalse(children.get(1).isEnabled());
@@ -244,8 +241,7 @@ class RadioButtonGroupTest {
         dataView.refreshItem(item1);
         dataView.refreshItem(item2);
 
-        List<Component> components = group.getChildren()
-                .collect(Collectors.toList());
+        List<Component> components = group.getChildren().toList();
         RadioButton<ItemHelper> radioZoo = (RadioButton<ItemHelper>) components
                 .get(0);
         RadioButton<ItemHelper> radioBar = (RadioButton<ItemHelper>) components
@@ -271,8 +267,7 @@ class RadioButtonGroupTest {
         item2.setName("bar");
         dataView.refreshItem(item2);
 
-        List<Component> components = group.getChildren()
-                .collect(Collectors.toList());
+        List<Component> components = group.getChildren().toList();
         RadioButton<ItemHelper> radioFoo = (RadioButton<ItemHelper>) components
                 .get(0);
         RadioButton<ItemHelper> radioBar = (RadioButton<ItemHelper>) components

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-testbench/src/main/java/com/vaadin/flow/component/radiobutton/testbench/RadioButtonGroupElement.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-testbench/src/main/java/com/vaadin/flow/component/radiobutton/testbench/RadioButtonGroupElement.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.radiobutton.testbench;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasSelectByText;
@@ -41,7 +40,7 @@ public class RadioButtonGroupElement extends TestBenchElement
      */
     public List<String> getOptions() {
         return getRadioButtons().stream().map(RadioButtonElement::getItem)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererTestComponentWrapper.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/src/main/java/com/vaadin/flow/data/renderer/tests/LitRendererTestComponentWrapper.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.data.renderer.tests;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.binder.HasDataProvider;
@@ -122,8 +121,7 @@ public class LitRendererTestComponentWrapper extends Div
     }
 
     private List<LitRendererTestComponent> getComponents() {
-        return getChildren().map(LitRendererTestComponent.class::cast)
-                .collect(Collectors.toList());
+        return getChildren().map(LitRendererTestComponent.class::cast).toList();
     }
 
     @Override

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/src/main/java/com/vaadin/flow/component/richtexteditor/testbench/RichTextEditorElement.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/src/main/java/com/vaadin/flow/component/richtexteditor/testbench/RichTextEditorElement.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.richtexteditor.testbench;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
@@ -28,8 +27,7 @@ public class RichTextEditorElement extends TestBenchElement {
         List<TestBenchElement> buttonTooltips = toolbar
                 .$("button + vaadin-tooltip").all();
         return buttonTooltips.stream()
-                .map(tooltip -> tooltip.getProperty("text"))
-                .collect(Collectors.toList());
+                .map(tooltip -> tooltip.getProperty("text")).toList();
     }
 
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/test/java/com/vaadin/flow/component/select/SelectTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -651,9 +650,8 @@ class SelectTest {
 
         Assertions.assertEquals("<span slot=\"prefix\">prefix1</span>", select
                 .getChildren().findFirst().get().getElement().getOuterHTML());
-        Assertions.assertEquals("<span slot=\"prefix\">prefix2</span>",
-                select.getChildren().collect(Collectors.toList()).get(1)
-                        .getElement().getOuterHTML());
+        Assertions.assertEquals("<span slot=\"prefix\">prefix2</span>", select
+                .getChildren().toList().get(1).getElement().getOuterHTML());
 
         select.remove(span);
 

--- a/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/src/main/java/com/vaadin/flow/component/select/testbench/SelectElement.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.select.testbench;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openqa.selenium.By;
@@ -86,7 +85,7 @@ public class SelectElement extends TestBenchElement implements HasSelectByText,
     }
 
     public List<ItemElement> getItems() {
-        return getItemsStream().collect(Collectors.toList());
+        return getItemsStream().toList();
     }
 
     @Override

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavElement.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.sidenav.testbench;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openqa.selenium.By;
@@ -60,7 +59,7 @@ public class SideNavElement extends TestBenchElement {
     }
 
     public List<SideNavItemElement> getItems(boolean includeNestedItems) {
-        return getItemsStream(includeNestedItems).collect(Collectors.toList());
+        return getItemsStream(includeNestedItems).toList();
     }
 
     public SideNavItemElement getSelectedItem() {

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/src/main/java/com/vaadin/flow/component/sidenav/testbench/SideNavItemElement.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.sidenav.testbench;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openqa.selenium.By;
@@ -38,7 +37,7 @@ public class SideNavItemElement extends TestBenchElement {
     }
 
     public List<SideNavItemElement> getItems(boolean includeNestedItems) {
-        return getItemsStream(includeNestedItems).collect(Collectors.toList());
+        return getItemsStream(includeNestedItems).toList();
     }
 
     public String getLabel() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/component/spreadsheet/client/SpreadsheetConnectorBundleLoaderFactory.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/component/spreadsheet/client/SpreadsheetConnectorBundleLoaderFactory.java
@@ -11,7 +11,6 @@ package com.vaadin.component.spreadsheet.client;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
@@ -33,6 +32,6 @@ public class SpreadsheetConnectorBundleLoaderFactory
         return super.getConnectorsForWidgetset(logger, typeOracle).stream()
                 .filter(c -> usedConnectors
                         .contains(c.getQualifiedSourceName()))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -14,7 +14,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.junit.Assert;
@@ -187,8 +186,7 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
                 By.className("namedrangebox"))
                 .findElements(By.tagName("option"));
 
-        return options.stream().map(WebElement::getText)
-                .collect(Collectors.toList());
+        return options.stream().map(WebElement::getText).toList();
     }
 
     public void selectNamedRange(String name) {
@@ -661,6 +659,6 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
                 // we always have this error
                 .filter(logEntry -> !logEntry.getMessage()
                         .contains("favicon.ico"))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CellDeletionIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CellDeletionIT.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.spreadsheet.test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -111,7 +110,7 @@ public class CellDeletionIT extends AbstractSpreadsheetIT {
 
     private void assertNotificationContent(String expected) {
         List<String> notifications = getNotifications().stream()
-                .map(WebElement::getText).collect(Collectors.toList());
+                .map(WebElement::getText).toList();
         Assert.assertTrue(String.format(
                 "Expected any of the notifications to contain the string '%s' but neither of them did. Notifications: '%s'",
                 expected, notifications),

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ImageIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/ImageIT.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.flow.component.spreadsheet.test;
 
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -58,7 +59,8 @@ public class ImageIT extends AbstractSpreadsheetIT {
         // Get all type3 pictures (absolute position)
         var type3 = findElementsInShadowRoot(
                 By.cssSelector(cellToCSS("A1") + " img")).stream()
-                .map(image -> image.getRect()).collect(Collectors.toList());
+                .map(image -> image.getRect())
+                .collect(Collectors.toCollection(ArrayList::new));
         Assert.assertEquals(3, type3.size());
 
         // Sort the pictures by their position starting from the left

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetTable.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetTable.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
@@ -199,7 +198,7 @@ public class SpreadsheetTable implements Serializable {
                     .map(filterColumn -> new CellReference(sheet.getSheetName(),
                             fullTableRegion.getFirstRow(),
                             (int) filterColumn.getColId(), true, true))
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/FilterTableTest.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.component.spreadsheet.tests;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.junit.jupiter.api.Assertions;
@@ -248,8 +247,7 @@ class FilterTableTest {
     }
 
     private List<Component> getPopupButtonChildren(int column) {
-        return getPopupButton(column).getContent().getChildren()
-                .collect(Collectors.toList());
+        return getPopupButton(column).getContent().getChildren().toList();
     }
 
     private PopupButton getPopupButton(int column) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationView.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationView.java
@@ -23,7 +23,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.UI;
@@ -45,8 +44,7 @@ public class TimePickerLocalizationView extends Div
         NativeSelect localesSelect = new NativeSelect();
         localesSelect.setWidth("230px");
         localesSelect.setOptions(TimePicker.getSupportedAvailableLocales()
-                .map(Locale::toLanguageTag).sorted()
-                .collect(Collectors.toList()));
+                .map(Locale::toLanguageTag).sorted().toList());
         localesSelect.setId("locale-picker");
 
         timePicker = new TimePicker();

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadI18nView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/UploadI18nView.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.upload.tests;
 
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.html.Div;
@@ -57,10 +56,8 @@ public class UploadI18nView extends Div {
                                     .setUnexpectedServerError(
                                             "Неожиданная ошибка сервера")
                                     .setForbidden("Загрузка запрещена")))
-            .setUnits(Stream
-                    .of("Б", "Кбайт", "Мбайт", "Гбайт", "Тбайт", "Пбайт",
-                            "Эбайт", "Збайт", "Ибайт")
-                    .collect(Collectors.toList()), 1024);
+            .setUnits(Stream.of("Б", "Кбайт", "Мбайт", "Гбайт", "Тбайт",
+                    "Пбайт", "Эбайт", "Збайт", "Ибайт").toList(), 1024);
 
     public UploadI18nView() {
         MemoryBuffer buffer = new MemoryBuffer();

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListPage.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListPage.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.Text;
@@ -269,7 +268,7 @@ public class VirtualListPage extends Div {
         list.setHeight("100px");
 
         List<String> items = IntStream.range(1, 101).mapToObj(i -> "Item " + i)
-                .collect(Collectors.toList());
+                .toList();
 
         list.setRenderer(new ComponentRenderer<>(item -> {
             Div text = new Div(new Text(item));

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListScrollToPage.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListScrollToPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.virtuallist.tests;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.html.Div;
@@ -34,7 +33,7 @@ public class VirtualListScrollToPage extends Div
 
     public VirtualListScrollToPage() {
         List<String> items = IntStream.rangeClosed(1, 1000)
-                .mapToObj(String::valueOf).collect(Collectors.toList());
+                .mapToObj(String::valueOf).toList();
 
         virtualList = new VirtualList<>();
         virtualList.setItems(items);

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListScrollToPage.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/main/java/com/vaadin/flow/component/virtuallist/tests/VirtualListScrollToPage.java
@@ -15,8 +15,10 @@
  */
 package com.vaadin.flow.component.virtuallist.tests;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.html.Div;
@@ -33,7 +35,8 @@ public class VirtualListScrollToPage extends Div
 
     public VirtualListScrollToPage() {
         List<String> items = IntStream.rangeClosed(1, 1000)
-                .mapToObj(String::valueOf).toList();
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toCollection(ArrayList::new));
 
         virtualList = new VirtualList<>();
         virtualList.setItems(items);

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/src/test/java/com/vaadin/flow/component/virtuallist/tests/VirtualListViewIT.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -169,7 +168,7 @@ public class VirtualListViewIT extends AbstractComponentIT {
                 .findElements(By.cssSelector("vaadin-vertical-layout")).stream()
                 .filter(element -> !element.getDomProperty("innerHTML")
                         .contains("-----")) // placeholders
-                .collect(Collectors.toList());
+                .toList();
 
         waitUntil(driver -> content.get(0).getDomAttribute("disabled") != null);
         Optional<WebElement> notDisabled = content.stream()


### PR DESCRIPTION
Replaces `.collect(Collectors.toList())` with the more concise `Stream.toList()`, which has been available since Java 16.

Since `Stream.toList()` returns an unmodifiable list while `Collectors.toList()` in practice returned a mutable `ArrayList`, places where the resulting list is mutated afterwards (directly, through `ListDataProvider.getItems()`, or through list data view methods like `addItem`) now use `Collectors.toCollection(ArrayList::new)` to make the mutability explicit. A few call sites also needed explicit type arguments (e.g. `.<ColumnBase<?>> map(...)`) because the Eclipse compiler infers stricter types than javac for `toList()`.