### PR TITLE
test: run hierarchical multi-selection tests with both formats

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -15,33 +15,45 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalDataProvider.HierarchyFormat;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.tests.MockUIExtension;
 
+@ParameterizedClass
+@EnumSource(HierarchyFormat.class)
 class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
     @RegisterExtension
     MockUIExtension ui = new MockUIExtension();
+
+    @Parameter
+    HierarchyFormat hierarchyFormat;
 
     private TreeGrid<String> treeGrid;
 
     @BeforeEach
     void setup() {
+        TreeData<String> treeData = new TreeData<>();
+        treeData.addRootItems("Item 0", "Item 1");
+        treeData.addItems("Item 0", "Item 0-0", "Item 0-1");
+        treeData.addItems("Item 0-0", "Item 0-0-0");
+
         treeGrid = new TreeGrid<>();
-        // Data provider with only two root items, we don't need any nested
-        // items for the test cases (so far)
-        treeGrid.setItems(Arrays.asList("foo", "bar"),
-                root -> Collections.emptyList());
+        treeGrid.setDataProvider(
+                new TreeDataProvider<>(treeData, hierarchyFormat));
         treeGrid.setSelectionMode(Grid.SelectionMode.MULTI);
 
         ui.add(treeGrid);
@@ -52,16 +64,19 @@ class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         Element columnElement = getGridSelectionColumn(treeGrid).getElement();
 
         // select first
-        treeGrid.getSelectionModel().select("foo");
+        treeGrid.getSelectionModel().select("Item 0");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
-        // select second, which equals all selected
+        // select remaining, which equals all selected
         // with hierarchical data provider we can not detect whether all are
         // selected, so should still be indeterminate
-        treeGrid.getSelectionModel().select("bar");
+        treeGrid.getSelectionModel().select("Item 0-0");
+        treeGrid.getSelectionModel().select("Item 0-0-0");
+        treeGrid.getSelectionModel().select("Item 0-1");
+        treeGrid.getSelectionModel().select("Item 1");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
@@ -73,16 +88,19 @@ class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         Element columnElement = getGridSelectionColumn(treeGrid).getElement();
 
         // select first
-        treeGrid.getSelectionModel().selectFromClient("foo");
+        treeGrid.getSelectionModel().selectFromClient("Item 0");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
-        // select second, which equals all selected
+        // select remaining, which equals all selected
         // with hierarchical data provider we can not detect whether all are
         // selected, so should still be indeterminate
-        treeGrid.getSelectionModel().selectFromClient("bar");
+        treeGrid.getSelectionModel().selectFromClient("Item 0-0");
+        treeGrid.getSelectionModel().selectFromClient("Item 0-0-0");
+        treeGrid.getSelectionModel().selectFromClient("Item 0-1");
+        treeGrid.getSelectionModel().selectFromClient("Item 1");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
@@ -102,14 +120,17 @@ class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect first
-        treeGrid.getSelectionModel().deselect("foo");
+        treeGrid.getSelectionModel().deselect("Item 0");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
-        // deselect second, which equals none selected
-        treeGrid.getSelectionModel().deselect("bar");
+        // deselect remaining, which equals none selected
+        treeGrid.getSelectionModel().deselect("Item 0-0");
+        treeGrid.getSelectionModel().deselect("Item 0-0-0");
+        treeGrid.getSelectionModel().deselect("Item 0-1");
+        treeGrid.getSelectionModel().deselect("Item 1");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertFalse(
@@ -129,14 +150,17 @@ class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // deselect first
-        treeGrid.getSelectionModel().deselectFromClient("foo");
+        treeGrid.getSelectionModel().deselectFromClient("Item 0");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
-        // deselect second, which equals none selected
-        treeGrid.getSelectionModel().deselectFromClient("bar");
+        // deselect remaining, which equals none selected
+        treeGrid.getSelectionModel().deselectFromClient("Item 0-0");
+        treeGrid.getSelectionModel().deselectFromClient("Item 0-0-0");
+        treeGrid.getSelectionModel().deselectFromClient("Item 0-1");
+        treeGrid.getSelectionModel().deselectFromClient("Item 1");
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertFalse(
@@ -201,22 +225,23 @@ class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         // Select all
         // with hierarchical data provider we can not detect whether all are
         // selected, so should still be indeterminate
-        treeGrid.asMultiSelect().updateSelection(Set.of("foo", "bar"),
-                Set.of());
+        treeGrid.asMultiSelect().updateSelection(Set.of("Item 0", "Item 0-0",
+                "Item 0-0-0", "Item 0-1", "Item 1"), Set.of());
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
         // Deselect single
-        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("foo"));
+        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("Item 0"));
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertTrue(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
 
-        // Deselect all
-        treeGrid.asMultiSelect().updateSelection(Set.of(), Set.of("bar"));
+        // Deselect remaining, which equals none selected
+        treeGrid.asMultiSelect().updateSelection(Set.of(),
+                Set.of("Item 0-0", "Item 0-0-0", "Item 0-1", "Item 1"));
         Assertions.assertFalse(
                 (boolean) columnElement.getPropertyRaw("selectAll"));
         Assertions.assertFalse(


### PR DESCRIPTION
Selection behavior with hierarchical data providers can depend on the hierarchy format, for example the select all checkbox is planned to support a determinate state with `HierarchyFormat.FLATTENED` (#8306). The multi-selection tests only ran with the default nested format, using a data provider without child items.

This change parameterizes `AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest` to run every test with both hierarchy formats and adds descendant items to the data provider, adjusting the existing tests accordingly.

Part of #9816, #8306
