### PR TITLE
fix: include descendant items in TreeGrid selectAll (CP: 24.10)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -221,9 +221,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
     @Override
     public void selectAll() {
         updateSelection(
-                (Set<T>) getGrid().getDataCommunicator().getDataProvider()
-                        .fetch(getGrid().getDataCommunicator().buildQuery(0,
-                                Integer.MAX_VALUE))
+                fetchAllItems()
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Collections.emptySet());
         selectionColumn.setSelectAllCheckboxState(true);
@@ -405,18 +403,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (!isSelectAllCheckboxVisible()) {
             return;
         }
-        Stream<T> allItemsStream;
-        DataProvider<T, ?> dataProvider = getGrid().getDataCommunicator()
-                .getDataProvider();
-        if (dataProvider instanceof HierarchicalDataProvider) {
-            allItemsStream = fetchAllHierarchical(
-                    (HierarchicalDataProvider<T, ?>) dataProvider);
-        } else {
-            allItemsStream = dataProvider.fetch(getGrid().getDataCommunicator()
-                    .buildQuery(0, Integer.MAX_VALUE));
-        }
         doUpdateSelection(
-                allItemsStream
+                fetchAllItems()
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Collections.emptySet(), true);
         selectionColumn.setSelectAllCheckboxState(true);
@@ -428,15 +416,20 @@ public abstract class AbstractGridMultiSelectionModel<T>
     }
 
     /**
-     * Fetch all items from the given hierarchical data provider.
+     * Fetch all items from the data provider. For hierarchical data providers,
+     * this includes all descendant items.
      *
-     * @param dataProvider
-     *            the data provider to fetch from
      * @return all items in the data provider
      */
-    private Stream<T> fetchAllHierarchical(
-            HierarchicalDataProvider<T, ?> dataProvider) {
-        return fetchAllDescendants(null, dataProvider);
+    private Stream<T> fetchAllItems() {
+        DataProvider<T, ?> dataProvider = getGrid().getDataCommunicator()
+                .getDataProvider();
+        if (dataProvider instanceof HierarchicalDataProvider) {
+            return fetchAllDescendants(null,
+                    (HierarchicalDataProvider<T, ?>) dataProvider);
+        }
+        return dataProvider.fetch(getGrid().getDataCommunicator().buildQuery(0,
+                Integer.MAX_VALUE));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.dom.Element;
 
 public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
@@ -132,6 +133,39 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
     }
 
     @Test
+    public void selectAll_selectsAllItemsIncludingDescendants() {
+        treeGrid.setTreeData(createTreeData());
+
+        ((GridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .selectAll();
+
+        Assert.assertEquals(Set.of("Item 0", "Item 0-0", "Item 0-0-0",
+                "Item 0-1", "Item 1"), treeGrid.getSelectedItems());
+    }
+
+    @Test
+    public void selectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        ((GridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
+    }
+
+    @Test
+    public void clientSelectAll_selectsAllItemsIncludingDescendants() {
+        treeGrid.setTreeData(createTreeData());
+
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+
+        Assert.assertEquals(Set.of("Item 0", "Item 0-0", "Item 0-0-0",
+                "Item 0-1", "Item 1"), treeGrid.getSelectedItems());
+    }
+
+    @Test
     public void clientSelectAll_updatesCheckboxStates() {
         Element columnElement = getGridSelectionColumn(treeGrid).getElement();
 
@@ -201,6 +235,14 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
         Assert.assertFalse((boolean) columnElement.getPropertyRaw("selectAll"));
         Assert.assertFalse(
                 (boolean) columnElement.getPropertyRaw("_indeterminate"));
+    }
+
+    private TreeData<String> createTreeData() {
+        TreeData<String> treeData = new TreeData<>();
+        treeData.addRootItems("Item 0", "Item 1");
+        treeData.addItems("Item 0", "Item 0-0", "Item 0-1");
+        treeData.addItems("Item 0-0", "Item 0-0-0");
+        return treeData;
     }
 
     private <T> GridSelectionColumn getGridSelectionColumn(Grid<T> grid) {


### PR DESCRIPTION
Calling `selectAll()` on `GridMultiSelectionModel` fetched items with a non-hierarchical query. Hierarchical data providers reject such queries, so on a TreeGrid the call failed with `IllegalArgumentException: Hierarchical data provider doesn't support non-hierarchical queries`.

The select all checkbox (`clientSelectAll`) already handles hierarchical data providers by fetching all descendants recursively. This change extracts that logic into a shared method and makes `selectAll()` use it too, so both behave the same.

Manual backport of #9819 to 24.10, since the automated pick would not compile there: the unit tests on `main` use JUnit 6 and the `HierarchyFormat` API from Vaadin 25. The tests are adapted to JUnit 4 and the APIs available in 24.x.

Fixes #9816