### PR TITLE
refactor: small cleanups in spreadsheet custom editor code

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetConnector.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetConnector.java
@@ -400,7 +400,13 @@ public class SpreadsheetConnector extends AbstractHasComponentsConnector
             StateChangeEvent stateChangeEvent) {
         final SpreadsheetWidget widget = getWidget();
         SpreadsheetState state = getState();
-        if (stateChangeEvent.hasPropertyChanged("componentIDtoCellKeysMap")) {
+        boolean componentMapChanged = stateChangeEvent
+                .hasPropertyChanged("componentIDtoCellKeysMap");
+        boolean editorMapChanged = stateChangeEvent
+                .hasPropertyChanged("cellKeysToEditorIdMap");
+        boolean showOnFocusChanged = stateChangeEvent
+                .hasPropertyChanged("showCustomEditorOnFocus");
+        if (componentMapChanged) {
             HashMap<String, String> cellKeysToComponentIdMap = state.componentIDtoCellKeysMap;
             HashMap<String, Widget> customWidgetMap = new HashMap<String, Widget>();
             if (cellKeysToComponentIdMap != null
@@ -414,22 +420,17 @@ public class SpreadsheetConnector extends AbstractHasComponentsConnector
                 });
             }
             widget.showCellCustomComponents(customWidgetMap);
-            if (!state.showCustomEditorOnFocus) {
-                widget.showCellCustomEditors(state.cellKeysToEditorIdMap);
-            }
         }
-        if (stateChangeEvent.hasPropertyChanged("cellKeysToEditorIdMap")) {
+        if (editorMapChanged) {
             setupCustomEditors();
-            if (!state.showCustomEditorOnFocus) {
-                widget.showCellCustomEditors(state.cellKeysToEditorIdMap);
-            }
         }
-        if (stateChangeEvent.hasPropertyChanged("showCustomEditorOnFocus")) {
-            if (state.showCustomEditorOnFocus) {
-                widget.removeCellCustomEditors(getCustomEditors());
-            } else {
-                widget.showCellCustomEditors(state.cellKeysToEditorIdMap);
-            }
+        // Mount the editors once, after the factory has been set up, however
+        // many of the properties above changed in this round trip
+        if (showOnFocusChanged && state.showCustomEditorOnFocus) {
+            widget.removeCellCustomEditors(getCustomEditors());
+        } else if ((componentMapChanged || editorMapChanged
+                || showOnFocusChanged) && !state.showCustomEditorOnFocus) {
+            widget.showCellCustomEditors(state.cellKeysToEditorIdMap);
         }
         if (stateChangeEvent.hasPropertyChanged("cellComments")
                 || stateChangeEvent.hasPropertyChanged("cellCommentAuthors")) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -370,6 +370,7 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
                 getCellValue(address)));
     }
 
+    @Test
     public void customEditorShared_persistsValuesCorrectly() {
         createNewSpreadsheet();
         loadTestFixture(TestFixtures.CustomEditorShared);

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -2516,11 +2516,9 @@ public class Spreadsheet extends Component
         // if the selected cell is of type formula, there is a change that the
         // formula has been changed.
         selectionManager.reSelectSelectedCell();
-        // Update the cell comments as well to show them instantly after adding
-        // them
-        loadCellComments();
 
-        // update custom components, editors
+        // update custom components, editors, and the rest of the visible
+        // contents, including cell comments
         reloadVisibleCellContents(recreateEditors);
     }
 


### PR DESCRIPTION
Three independent cleanups in the custom editor code, follow-ups to #9814. They
were opened as a stack (#9826, #9827) whose bases merged into this branch, so
they now travel together.

## Changes

**Mount editors once per state change** (`SpreadsheetConnector`)

`loadStateChangeDataToWidget` had three sibling branches that each ended in
`showCellCustomEditors(...)`. The server sets `componentIDtoCellKeysMap` and
`cellKeysToEditorIdMap` together in `loadCustomComponents()`, so the common case
walked the whole editor map twice per round trip. Enabling
`showCustomEditorOnFocus` was worse: the first two branches mounted the editors
and the third removed them again.

The order was also wrong. The `componentIDtoCellKeysMap` branch called
`showCellCustomEditors(...)` before the `cellKeysToEditorIdMap` branch had run
`setupCustomEditors()`, so it could mount editors before the factory was set up.

Now the three changed properties are recorded first, then the editors are
mounted or removed once, after `setupCustomEditors()`. The end state is the same
in every combination of changed properties.

**Drop duplicate cell comment load** (`Spreadsheet.updateMarkedCells`)

The method loaded the cell comments itself and then again through
`reloadVisibleCellContents()` -> `updateRowAndColumnRangeCellData()`, so every
`refreshCells()` call scanned all comments twice. Application code calls
`refreshCells()` from value change listeners, so this runs per committed cell.
Only the first call is removed; the second still shows comments as soon as they
are added.

**Enable shared custom editor test** (`CustomEditorIT`)

`customEditorShared_persistsValuesCorrectly` had no `@Test` annotation, so JUnit
never ran it. It is the only test covering `CustomEditorSharedFixture`, which
therefore had no executed coverage at all while looking covered in the file. The
test passes as written, so this only adds the annotation.

Follow-up to #9814

---

🤖 Generated with Claude Code
