### PR TITLE
refactor: drop duplicate cell comment load in updateMarkedCells

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -2516,11 +2516,9 @@ public class Spreadsheet extends Component
         // if the selected cell is of type formula, there is a change that the
         // formula has been changed.
         selectionManager.reSelectSelectedCell();
-        // Update the cell comments as well to show them instantly after adding
-        // them
-        loadCellComments();
 
-        // update custom components, editors
+        // update custom components, editors, and the rest of the visible
+        // contents, including cell comments
         reloadVisibleCellContents(recreateEditors);
     }
 


### PR DESCRIPTION
`updateMarkedCells()` loaded the cell comments itself and then again through
`reloadVisibleCellContents()` -> `updateRowAndColumnRangeCellData()`, so every
`refreshCells()` call scanned all comments twice. Application code calls
`refreshCells()` from value change listeners, so this runs per committed cell.

## Changes

Only the first call is removed. `reloadVisibleCellContents(boolean)` always
calls `updateRowAndColumnRangeCellData(...)`, which loads the comments, so they
are still shown as soon as they are added.

Part of a series of small cleanups in the custom editor code, stacked on #9814.

---

🤖 Generated with Claude Code
