### PR TITLE
fix: include descendant items in TreeGrid selectAll (#9819) (CP: 25.1)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -221,9 +221,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
     @Override
     public void selectAll() {
         updateSelection(
-                (Set<T>) getGrid().getDataCommunicator().getDataProvider()
-                        .fetch(getGrid().getDataCommunicator().buildQuery(0,
-                                Integer.MAX_VALUE))
+                fetchAllItems()
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Collections.emptySet());
         selectionColumn.setSelectAllCheckboxState(true);
@@ -405,18 +403,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
         if (!isSelectAllCheckboxVisible()) {
             return;
         }
-        Stream<T> allItemsStream;
-        DataProvider<T, ?> dataProvider = getGrid().getDataCommunicator()
-                .getDataProvider();
-        if (dataProvider instanceof HierarchicalDataProvider) {
-            allItemsStream = fetchAllHierarchical(
-                    (HierarchicalDataProvider<T, ?>) dataProvider);
-        } else {
-            allItemsStream = dataProvider.fetch(getGrid().getDataCommunicator()
-                    .buildQuery(0, Integer.MAX_VALUE));
-        }
         doUpdateSelection(
-                allItemsStream
+                fetchAllItems()
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Collections.emptySet(), true);
         selectionColumn.setSelectAllCheckboxState(true);
@@ -428,15 +416,20 @@ public abstract class AbstractGridMultiSelectionModel<T>
     }
 
     /**
-     * Fetch all items from the given hierarchical data provider.
+     * Fetch all items from the data provider. For hierarchical data providers,
+     * this includes all descendant items.
      *
-     * @param dataProvider
-     *            the data provider to fetch from
      * @return all items in the data provider
      */
-    private Stream<T> fetchAllHierarchical(
-            HierarchicalDataProvider<T, ?> dataProvider) {
-        return fetchAllDescendants(null, dataProvider);
+    private Stream<T> fetchAllItems() {
+        DataProvider<T, ?> dataProvider = getGrid().getDataCommunicator()
+                .getDataProvider();
+        if (dataProvider instanceof HierarchicalDataProvider) {
+            return fetchAllDescendants(null,
+                    (HierarchicalDataProvider<T, ?>) dataProvider);
+        }
+        return dataProvider.fetch(getGrid().getDataCommunicator().buildQuery(0,
+                Integer.MAX_VALUE));
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest.java
@@ -161,6 +161,35 @@ public class AbstractGridMultiSelectionModelWithHierarchicalDataProviderTest {
     }
 
     @Test
+    public void selectAll_selectsAllItemsIncludingDescendants() {
+        ((GridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .selectAll();
+
+        Assert.assertEquals(Set.of("Item 0", "Item 0-0", "Item 0-0-0",
+                "Item 0-1", "Item 1"), treeGrid.getSelectedItems());
+    }
+
+    @Test
+    public void selectAll_updatesCheckboxStates() {
+        Element columnElement = getGridSelectionColumn(treeGrid).getElement();
+
+        ((GridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .selectAll();
+        Assert.assertTrue((boolean) columnElement.getPropertyRaw("selectAll"));
+        Assert.assertFalse(
+                (boolean) columnElement.getPropertyRaw("_indeterminate"));
+    }
+
+    @Test
+    public void clientSelectAll_selectsAllItemsIncludingDescendants() {
+        ((AbstractGridMultiSelectionModel<String>) treeGrid.getSelectionModel())
+                .clientSelectAll();
+
+        Assert.assertEquals(Set.of("Item 0", "Item 0-0", "Item 0-0-0",
+                "Item 0-1", "Item 1"), treeGrid.getSelectedItems());
+    }
+
+    @Test
     public void clientSelectAll_updatesCheckboxStates() {
         Element columnElement = getGridSelectionColumn(treeGrid).getElement();
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9819 to branch 25.1.

---

> Calling `selectAll()` on GridMultiSelectionModel used to fetch items with a non-hierarchical query. With a hierarchical data provider, this resulted in an IllegalArgumentException in Vaadin 23 and 24.
>
> Since Vaadin 25, `HierarchicalDataCommunicator.buildQuery` returns a root-level hierarchical query, so the exception is gone, but `selectAll()` still selects only root items.
>
> The `clientSelectAll` method already handles hierarchical data providers by fetching all descendants recursively. This change extracts that logic into a shared method and makes `selectAll()` use it too, so both behave the same.
>
> Fixes #9816
