### PR TITLE
chore: fix npm update script (25.1) [skip ic]

### DIFF
--- a/scripts/updateNpmVer.js
+++ b/scripts/updateNpmVer.js
@@ -11,7 +11,7 @@
 const fs = require('fs');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
-const replace = require('replace-in-file');
+const { replaceInFile } = require('replace-in-file');
 const {getAnnotations, computeVersionToUpdate} = require('./lib/versions.js');
 
 let exclude=[];
@@ -26,7 +26,7 @@ async function updateFiles(moduleData){
         to: updatedNpm,
       };
       try {
-        const results = await replace(options)
+        const results = await replaceInFile(options)
         console.log('\x1b[33m', "Updated "+ moduleData.package + " from version " +
                     moduleData.version + " to " + moduleData.updatedVersion);
       }


### PR DESCRIPTION
replace-in-file has been upgraded in  https://github.com/vaadin/flow-components/commit/534faf31986db611d2bbebb2b175c99f7795664d

Cause: replace-in-file 8.x removed the callable default export — it now exports only { processFile, processFileSync, replaceInFile, replaceInFileSync }. The script was calling the module object itself, hence TypeError: replace is not a function.    