### PR TITLE
fix: truncate DateTimePickerElement.setDateTime to millis

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/src/main/java/com/vaadin/flow/component/datetimepicker/testbench/DateTimePickerElement.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/src/main/java/com/vaadin/flow/component/datetimepicker/testbench/DateTimePickerElement.java
@@ -57,7 +57,9 @@ public class DateTimePickerElement extends TestBenchElement
         if (dateTime == null) {
             setValue("");
         } else {
-            setValue(dateTime.toString());
+            // Date time needs to be truncated to millisecond precision,
+            // otherwise the web component will not update the value
+            setValue(dateTime.truncatedTo(ChronoUnit.MILLIS).toString());
         }
     }
 


### PR DESCRIPTION
Aligns `DateTimePickerElement.setDateTime` with `setTime`, which already truncates to millisecond precision. The web component's ISO parser accepts at most 3 fractional digits, so a `LocalDateTime` with sub-millisecond precision was silently rejected and the value left unchanged.

Fixes #1994

Generated with [Claude Code](https://claude.ai/code)