### PR TITLE
refactor: convert combo box connector to a class

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -22,8 +22,8 @@ describe('combo-box connector', () => {
   it('should not throw when initialized while opened', () => {
     // When a combo box is made visible and opened in the same round-trip,
     // initLazy runs while it is already opened. Assigning the data provider
-    // then triggers a first-page load that calls back into the connector, so
-    // all $connector functions must already be defined by then.
+    // then triggers a first-page load that calls back into the connector,
+    // before `$connector` has even been assigned on the combo box.
     comboBox = fixtureSync('<vaadin-combo-box opened></vaadin-combo-box>');
     expect(() => init(comboBox)).to.not.throw();
   });

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/comboBoxConnector.js
@@ -2,31 +2,153 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
 
-window.Vaadin.Flow.comboBoxConnector = {};
-window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
-  // Check whether the connector was already initialized for the ComboBox
-  if (comboBox.$connector) {
-    return;
+/**
+ * comboBoxConnector is a communication layer between ComboBox's flow component
+ * (server-side) and web component (client-side).
+ */
+export class ComboBoxConnector {
+  #comboBox;
+  #placeholder = new window.Vaadin.ComboBoxPlaceholder();
+
+  #cache = {};
+
+  #lastTypedFilter = '';
+  #lastRequestedRange = [-1, -1];
+  #lastRequestedFilter = '';
+  #needsDataCommunicatorReset = false;
+
+  constructor(comboBox) {
+    this.#comboBox = comboBox;
+
+    // Prevent setting the custom value as the 'value'-prop automatically
+    comboBox.addEventListener('custom-value-set', (e) => e.preventDefault());
+
+    comboBox.itemClassNameGenerator = (item) => item.className || '';
+
+    // Assign last: setting the data provider can synchronously trigger a first
+    // page load that calls back into the connector.
+    comboBox.dataProvider = (params, callback) => this.#loadPage(params, callback);
   }
 
-  comboBox.$connector = {};
+  clear(start, length) {
+    const comboBox = this.#comboBox;
+    const { pageSize } = comboBox;
+    const firstPage = Math.floor(start / pageSize);
+    const lastPage = firstPage + Math.ceil(length / pageSize);
 
-  let cache = {};
-  const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
+    for (let page = firstPage; page < lastPage; page++) {
+      delete this.#cache[page];
+    }
 
-  let lastTypedFilter = '';
-  let lastRequestedRange = [-1, -1];
-  let lastRequestedFilter = '';
-  let needsDataCommunicatorReset = false;
+    for (let index = firstPage * pageSize; index < lastPage * pageSize; index++) {
+      if (comboBox.filteredItems[index]) {
+        comboBox.filteredItems[index] = this.#placeholder;
+      }
+    }
+  }
 
-  const dataProvider = function (params, callback) {
+  set(index, items, filter) {
+    const comboBox = this.#comboBox;
+
+    if (filter !== this.#lastTypedFilter) {
+      return;
+    }
+
+    if (index % comboBox.pageSize != 0) {
+      throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
+    }
+
+    const { pendingRequests } = comboBox.__dataProviderController.rootCache;
+    if (index === 0 && items.length === 0 && pendingRequests[0]) {
+      // Makes sure that the dataProvider callback is called even when server
+      // returns empty data set (no items match the filter).
+      this.#cache[0] = [];
+      return;
+    }
+
+    const firstPageToSet = index / comboBox.pageSize;
+    const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
+
+    for (let i = 0; i < updatedPageCount; i++) {
+      const page = firstPageToSet + i;
+      const slice = items.slice(i * comboBox.pageSize, (i + 1) * comboBox.pageSize);
+
+      this.#cache[page] = slice;
+    }
+  }
+
+  updateData(items) {
+    const comboBox = this.#comboBox;
+    const itemsMap = new Map(items.map((item) => [item.key, item]));
+
+    comboBox.filteredItems = comboBox.filteredItems.map((item) => {
+      return itemsMap.get(item.key) || item;
+    });
+  }
+
+  updateSize(newSize) {
+    const comboBox = this.#comboBox;
+
+    if (!comboBox._clientSideFilter) {
+      // FIXME: It may be that this size set is unnecessary, since when
+      // providing data to combobox via callback we may use data's size.
+      // However, if this size reflect the whole data size, including
+      // data not fetched yet into client side, and combobox expect it
+      // to be set as such, the at least, we don't need it in case the
+      // filter is clientSide only, since it'll increase the height of
+      // the popup at only at first user filter to this size, while the
+      // filtered items count are less.
+      comboBox.size = newSize;
+    }
+  }
+
+  reset() {
+    const comboBox = this.#comboBox;
+
+    comboBox._filterDebouncer?.cancel();
+    comboBox._filterDebouncer = null;
+    this.#cache = {};
+    this.#lastRequestedRange = [-1, -1];
+    this.#lastTypedFilter = '';
+    comboBox.clearCache();
+  }
+
+  confirm(id, filter) {
+    const comboBox = this.#comboBox;
+
+    if (filter !== this.#lastTypedFilter) {
+      return;
+    }
+
+    // We're done applying changes from this batch, resolve pending
+    // callbacks
+    const { pendingRequests } = comboBox.__dataProviderController.rootCache;
+    Object.entries(pendingRequests).forEach(([page, callback]) => {
+      const items = this.#cache[page];
+
+      if (comboBox._clientSideFilter && items) {
+        this.#performClientSideFilter(items, comboBox.filter, callback);
+        return;
+      }
+
+      callback(items ?? [], comboBox.size);
+      delete this.#cache[page];
+    });
+
+    // Let server know we're done
+    comboBox.$server.confirmUpdate(id);
+  }
+
+  #loadPage(params, callback) {
+    const comboBox = this.#comboBox;
+
     if (params.pageSize != comboBox.pageSize) {
       throw 'Invalid pageSize';
     }
 
     if (comboBox._clientSideFilter) {
-      if (cache[0]) {
-        performClientSideFilter(cache[0], params.filter, callback);
+      if (this.#cache[0]) {
+        this.#performClientSideFilter(this.#cache[0], params.filter, callback);
         return;
       }
 
@@ -34,18 +156,18 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
       params = { ...params, filter: '' };
     }
 
-    if (lastTypedFilter !== params.filter) {
-      cache = {};
-      lastTypedFilter = params.filter;
-      lastRequestedRange = [-1, -1];
+    if (this.#lastTypedFilter !== params.filter) {
+      this.#cache = {};
+      this.#lastTypedFilter = params.filter;
+      this.#lastRequestedRange = [-1, -1];
 
       comboBox._filterDebouncer = Debouncer.debounce(
         comboBox._filterDebouncer,
         timeOut.after(comboBox._filterTimeout ?? 500),
         () => {
           // Filter cycled back to what server last received — force re-emit.
-          if (params.filter === lastRequestedFilter) {
-            needsDataCommunicatorReset = true;
+          if (params.filter === this.#lastRequestedFilter) {
+            this.#needsDataCommunicatorReset = true;
           }
 
           comboBox.clearCache();
@@ -60,27 +182,22 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
 
     // If buffer-prefetch already cached this page, commit it without a server
     // round-trip; otherwise ask the server.
-    if (cache[params.page]) {
-      callback(cache[params.page], comboBox.size);
+    if (this.#cache[params.page]) {
+      callback(this.#cache[params.page], comboBox.size);
       return;
     }
 
-    comboBox.$connector.requestPage(params.page, params.filter);
-  };
+    this.#requestPage(params.page, params.filter);
+  }
 
-  comboBox.$connector.getViewportRange = function () {
-    const indices = Array.from(comboBox._scroller?.children ?? [])
-      .map((child) => child.index)
-      .filter((index) => Number.isFinite(index))
-      .sort((a, b) => a - b);
-    if (indices.length === 0) {
-      return [0, 0];
-    }
-    return [indices[0], indices[indices.length - 1]];
-  };
+  /**
+   * Asks the server for the pages around the viewport, so that scrolling has
+   * data ready ahead of rendering.
+   */
+  #requestPage(page, filter) {
+    const comboBox = this.#comboBox;
 
-  comboBox.$connector.requestPage = function (page, filter) {
-    let viewportRange = comboBox.$connector.getViewportRange();
+    const viewportRange = this.#getViewportRange();
     const buffer = viewportRange[1] - viewportRange[0];
     const sizeLimit = Number.isFinite(comboBox.size) ? comboBox.size : Number.POSITIVE_INFINITY;
     viewportRange[0] = Math.max(viewportRange[0] - buffer, 0);
@@ -97,148 +214,64 @@ window.Vaadin.Flow.comboBoxConnector.initLazy = (comboBox) => {
       viewportPageRange = [page, page];
     }
 
-    if (lastRequestedRange[0] != viewportPageRange[0] || lastRequestedRange[1] != viewportPageRange[1]) {
+    if (this.#lastRequestedRange[0] != viewportPageRange[0] || this.#lastRequestedRange[1] != viewportPageRange[1]) {
       const startIndex = viewportPageRange[0] * comboBox.pageSize;
       const endIndex = (viewportPageRange[1] + 1) * comboBox.pageSize;
       comboBox.$server.setViewportRange(startIndex, endIndex - startIndex, filter);
     }
 
-    if (needsDataCommunicatorReset) {
+    if (this.#needsDataCommunicatorReset) {
       comboBox.$server.resetDataCommunicator();
-      needsDataCommunicatorReset = false;
+      this.#needsDataCommunicatorReset = false;
     }
 
-    lastRequestedRange = viewportPageRange;
-    lastRequestedFilter = filter;
-  };
+    this.#lastRequestedRange = viewportPageRange;
+    this.#lastRequestedFilter = filter;
+  }
 
-  comboBox.$connector.clear = (start, length) => {
-    const { pageSize } = comboBox;
-    const firstPage = Math.floor(start / pageSize);
-    const lastPage = firstPage + Math.ceil(length / pageSize);
+  /** The range of item indexes currently rendered in the dropdown */
+  #getViewportRange() {
+    const comboBox = this.#comboBox;
 
-    for (let page = firstPage; page < lastPage; page++) {
-      delete cache[page];
+    const indices = Array.from(comboBox._scroller?.children ?? [])
+      .map((child) => child.index)
+      .filter((index) => Number.isFinite(index))
+      .sort((a, b) => a - b);
+    if (indices.length === 0) {
+      return [0, 0];
     }
+    return [indices[0], indices[indices.length - 1]];
+  }
 
-    for (let index = firstPage * pageSize; index < lastPage * pageSize; index++) {
-      if (comboBox.filteredItems[index]) {
-        comboBox.filteredItems[index] = placeHolder;
-      }
-    }
-  };
-
-  comboBox.$connector.filter = (item, filter) => {
+  #matchesFilter(item, filter) {
     filter = filter ? filter.toString().toLowerCase() : '';
-    return comboBox._getItemLabel(item, comboBox.itemLabelPath).toString().toLowerCase().indexOf(filter) > -1;
-  };
+    return (
+      this.#comboBox._getItemLabel(item, this.#comboBox.itemLabelPath).toString().toLowerCase().indexOf(filter) > -1
+    );
+  }
 
-  comboBox.$connector.set = (index, items, filter) => {
-    if (filter !== lastTypedFilter) {
-      return;
-    }
-
-    if (index % comboBox.pageSize != 0) {
-      throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
-    }
-
-    const { pendingRequests } = comboBox.__dataProviderController.rootCache;
-    if (index === 0 && items.length === 0 && pendingRequests[0]) {
-      // Makes sure that the dataProvider callback is called even when server
-      // returns empty data set (no items match the filter).
-      cache[0] = [];
-      return;
-    }
-
-    const firstPageToSet = index / comboBox.pageSize;
-    const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
-
-    for (let i = 0; i < updatedPageCount; i++) {
-      let page = firstPageToSet + i;
-      let slice = items.slice(i * comboBox.pageSize, (i + 1) * comboBox.pageSize);
-
-      cache[page] = slice;
-    }
-  };
-
-  comboBox.$connector.updateData = (items) => {
-    const itemsMap = new Map(items.map((item) => [item.key, item]));
-
-    comboBox.filteredItems = comboBox.filteredItems.map((item) => {
-      return itemsMap.get(item.key) || item;
-    });
-  };
-
-  comboBox.$connector.updateSize = function (newSize) {
-    if (!comboBox._clientSideFilter) {
-      // FIXME: It may be that this size set is unnecessary, since when
-      // providing data to combobox via callback we may use data's size.
-      // However, if this size reflect the whole data size, including
-      // data not fetched yet into client side, and combobox expect it
-      // to be set as such, the at least, we don't need it in case the
-      // filter is clientSide only, since it'll increase the height of
-      // the popup at only at first user filter to this size, while the
-      // filtered items count are less.
-      comboBox.size = newSize;
-    }
-  };
-
-  comboBox.$connector.reset = function () {
-    comboBox._filterDebouncer?.cancel();
-    comboBox._filterDebouncer = null;
-    cache = {};
-    lastRequestedRange = [-1, -1];
-    lastTypedFilter = '';
-    comboBox.clearCache();
-  };
-
-  comboBox.$connector.confirm = function (id, filter) {
-    if (filter !== lastTypedFilter) {
-      return;
-    }
-
-    // We're done applying changes from this batch, resolve pending
-    // callbacks
-    const { pendingRequests } = comboBox.__dataProviderController.rootCache;
-    Object.entries(pendingRequests).forEach(([page, callback]) => {
-      const items = cache[page];
-
-      if (comboBox._clientSideFilter && items) {
-        performClientSideFilter(items, comboBox.filter, callback);
-        return;
-      }
-
-      callback(items ?? [], comboBox.size);
-      delete cache[page];
-    });
-
-    // Let server know we're done
-    comboBox.$server.confirmUpdate(id);
-  };
-
-  // Perform filter on client side (here) using the items from specified page
-  // and submitting the filtered items to specified callback.
-  // The filter used is the one from combobox, not the lastFilter stored since
-  // that may not reflect user's input.
-  const performClientSideFilter = function (page, filter, callback) {
+  /**
+   * Perform filter on client side (here) using the items from specified page
+   * and submitting the filtered items to specified callback.
+   * The filter used is the one from combobox, not the lastFilter stored since
+   * that may not reflect user's input.
+   */
+  #performClientSideFilter(page, filter, callback) {
     let filteredItems = page;
 
     if (filter) {
-      filteredItems = page.filter((item) => comboBox.$connector.filter(item, filter));
+      filteredItems = page.filter((item) => this.#matchesFilter(item, filter));
     }
 
     callback(filteredItems, filteredItems.length);
-  };
+  }
+}
 
-  // Prevent setting the custom value as the 'value'-prop automatically
-  comboBox.addEventListener('custom-value-set', (e) => e.preventDefault());
+function initLazy(comboBox) {
+  // Init the connector only once for the combo box
+  comboBox.$connector ??= new ComboBoxConnector(comboBox);
+}
 
-  comboBox.itemClassNameGenerator = function (item) {
-    return item.className || '';
-  };
-
-  // Assign last, after all `$connector` functions are defined.
-  comboBox.dataProvider = dataProvider;
-};
+window.Vaadin.Flow.comboBoxConnector = { initLazy };
 
 window.Vaadin.ComboBoxPlaceholder = ComboBoxPlaceholder;


### PR DESCRIPTION
## Summary
- The connector was one init function that assembled the `$connector` object out of closures, which made it hard to tell what is state, what is the API the server calls, and what is internal wiring. As a class those are separate: private fields, public methods, private methods.
- It stays plain JavaScript on purpose. Doing the restructuring first, at the current path, keeps the follow-up typing PR's move to `vaadin-combo-box/comboBoxConnector.ts` a rename git can detect (80% similar, vs 31% the other way round), so the file keeps its history. #9847 did typing first and was closed for this reason.
- Same change #9789 made to the grid connector.

Related to #9789, #9847

🤖 Generated with [Claude Code](https://claude.com/claude-code)