### PR TITLE
test: read item text content in SelectListDataViewIT

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/SelectListDataViewIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/SelectListDataViewIT.java
@@ -128,12 +128,12 @@ public class SelectListDataViewIT extends AbstractComponentIT {
 
         Assert.assertEquals("Unexpected sort order", "John,Mike,Paul",
                 select.$("vaadin-select-item").all().stream()
-                        .map(TestBenchElement::getText)
+                        .map(SelectListDataViewIT::getItemText)
                         .collect(Collectors.joining(",")));
 
         Assert.assertEquals("Unexpected sort order", "John,Paul,Mike",
                 otherSelect.$("vaadin-select-item").all().stream()
-                        .map(TestBenchElement::getText)
+                        .map(SelectListDataViewIT::getItemText)
                         .collect(Collectors.joining(",")));
     }
 
@@ -144,13 +144,22 @@ public class SelectListDataViewIT extends AbstractComponentIT {
         Assert.assertEquals("Unexpected filtered items count", 1,
                 select.$("vaadin-select-item").all().size());
         Assert.assertEquals("Unexpected filtered item", "Paul",
-                select.$("vaadin-select-item").all().get(0).getText());
+                getItemText(select.$("vaadin-select-item").all().get(0)));
 
         Assert.assertEquals("No filter expected", 3,
                 otherSelect.$("vaadin-select-item").all().size());
         Assert.assertArrayEquals("No filter expected",
                 new String[] { "John", "Paul", "Mike" },
                 otherSelect.$("vaadin-select-item").all().stream()
-                        .map(TestBenchElement::getText).toArray());
+                        .map(SelectListDataViewIT::getItemText).toArray());
+    }
+
+    /*
+     * Reads the item's text content instead of using getText(), which only
+     * returns text of rendered elements. The items are projected into the
+     * select's overlay, which is not rendered while the dropdown is closed.
+     */
+    private static String getItemText(TestBenchElement item) {
+        return item.getPropertyString("textContent").trim();
     }
 }


### PR DESCRIPTION
The sorting and filtering tests in `SelectListDataViewIT` read item labels with `getText()`, which returns only the text of *rendered* elements. Select items are projected into the overlay, and the overlay is `display: none` while the dropdown is closed, so the items are not rendered and `getText()` returns empty strings. The element queries themselves are unaffected, which is why the item *count* assertions kept passing.

Whether `getText()` falls back to `textContent` for such elements depends on the browser version, so the tests failed consistently on a newer local Chrome while mostly staying green in CI.

```
SelectListDataViewIT.sorting_itemsSortedOnlyInOneComponent:129
  Unexpected sort order expected:<[John,Mike,Paul]> but was:<[,,]>
SelectListDataViewIT.filtering_itemsFilteredOnlyInOneComponent:146
  Unexpected filtered item expected:<[Paul]> but was:<[]>
```

Read the `textContent` property instead, the same way `SelectElement.selectByText` already does. The other tests in the class are not affected because they go through `SelectElement.getItems()`, which opens the dropdown first.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)