### PR TITLE
test: read item text content when dropdown is closed

### DIFF
--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/AbstractSelectIT.java
@@ -304,6 +304,15 @@ public abstract class AbstractSelectIT extends AbstractComponentIT {
         open(getDefaultParameter());
     }
 
+    /*
+     * Reads the item's text content instead of using getText(), which only
+     * returns text of rendered elements. Items are projected into the select's
+     * overlay, which is not rendered while the dropdown is closed.
+     */
+    protected static String getItemText(TestBenchElement item) {
+        return item.getPropertyString("textContent").trim();
+    }
+
     protected abstract int getInitialNumberOfItems();
 
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/DataProviderIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/tests/DataProviderIT.java
@@ -171,7 +171,7 @@ public class DataProviderIT extends AbstractSelectIT {
         Assert.assertEquals("invalid key", 3 + "",
                 itemElement.getPropertyString("value"));
         Assert.assertEquals("invalid text", "Item-2-UPDATED",
-                itemElement.getText());
+                getItemText(itemElement));
         verify.selectedItem("Item-2-UPDATED");
     }
 }


### PR DESCRIPTION
`DataProviderIT.testDataProvider_testRefreshSelectedItem_itemIsUpdatedCorrectly` keeps a reference to an item, selects it, and then checks that refreshing the item updates that same element. Selecting an item closes the dropdown, so by the time the text is read the item sits in the overlay, which is `display: none` while closed. `getText()` returns the text of rendered elements only, so the assertion got an empty string.

```
DataProviderIT.testDataProvider_testRefreshSelectedItem_itemIsUpdatedCorrectly:173
  invalid text expected:<[Item-2-UPDATED]> but was:<[]>
```

Whether `getText()` falls back to `textContent` for such elements depends on the browser version, so this failed locally while staying green in CI.

Read the `textContent` property instead, as the previously fixed tests already do. The helper is on `AbstractSelectIT` so the other select ITs can use it as well.

I checked every other `getText()` call in the select ITs. They are fine, because each one either follows `getItems()` / `getSelectedOptionItem()`, which open the dropdown first, or reads the value button, which is always visible. A full run of the suite confirms this: before the change 54 tests ran with this single failure, after it all 54 pass.

The item reference is kept rather than looked up again, since checking that the refresh updates the same element is the point of the test.

Follow-up to #9851

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)