### PR TITLE
refactor: fully type combo box connector frontend file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ types.d.ts
 tsconfig.json
 !**/test/tsconfig.json
 !vaadin-grid-flow-parent/vaadin-grid-flow/tsconfig.json
+!vaadin-combo-box-flow-parent/vaadin-combo-box-flow/tsconfig.json
 webpack.*
 vite.generated.ts
 /vite.config.ts

--- a/guidelines/component-implementation.md
+++ b/guidelines/component-implementation.md
@@ -98,11 +98,12 @@ element for the same server-side instance after detach/re-attach. The
 connector must re-initialise each time; running it once in the constructor
 leaves the second client element without a connector.
 
-Typical connectors: `comboBoxConnector.js` (lazy `dataProvider` ↔
-`DataCommunicator`), `contextMenuConnector.js` / `menuBarConnector.js` (nested
-menu structure), `flow-component-renderer.js` (server components inside cells).
-These older connectors still sit directly under `META-INF/frontend/` — that
-placement is legacy; new files always go in a component-named subfolder.
+Typical connectors: `vaadin-combo-box/comboBoxConnector.ts` (lazy
+`dataProvider` ↔ `DataCommunicator`), `contextMenuConnector.js` /
+`menuBarConnector.js` (nested menu structure), `flow-component-renderer.js`
+(server components inside cells). Some older connectors still sit directly
+under `META-INF/frontend/` — that placement is legacy; new files always go in a
+component-named subfolder.
 
 ## Property synchronization & trust (security)
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/env-setup.ts
@@ -1,3 +1,3 @@
-window.Vaadin ||= {};
+window.Vaadin ||= {} as Vaadin;
 // @ts-expect-error
 window.Vaadin.Flow = {};

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/shared.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/shared.ts
@@ -1,39 +1,34 @@
 import './env-setup.js';
-import { ComboBox } from '@vaadin/combo-box';
-import { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
-import '../frontend/generated/jar-resources/comboBoxConnector.js';
+import '../frontend/generated/jar-resources/vaadin-combo-box/comboBoxConnector.ts';
 import * as sinon from 'sinon';
+import type {
+  ComboBoxConnector as ConnectorComboBoxConnector,
+  ComboBoxServer as ConnectorComboBoxServer,
+  FlowComboBox as ConnectorFlowComboBox,
+  Item as ConnectorItem
+} from '../frontend/generated/jar-resources/vaadin-combo-box/vaadin-combo-box-types.js';
 
-export type ComboBoxConnector = {
-  initLazy: (comboBox: ComboBox) => void;
-  reset: () => void;
-  set: (index: number, items: unknown[], filter: string) => void;
-  confirm: (id: number, filter: string) => void;
+export type Item = ConnectorItem & {
+  label?: string;
 };
 
 export type ComboBoxServer = {
-  setViewportRange: sinon.SinonSpy;
-  confirmUpdate: sinon.SinonSpy;
-  resetDataCommunicator: sinon.SinonSpy;
+  [K in keyof ConnectorComboBoxServer]: ConnectorComboBoxServer[K] & sinon.SinonSpy;
 };
 
-export type FlowComboBox = ComboBox & {
+// The connector API retyped with the test Item, so that tests can pass item
+// literals with test-specific properties without excess property errors
+export type ComboBoxConnector = Omit<ConnectorComboBoxConnector, 'set' | 'updateData'> & {
+  set(index: number, items: Item[], filter: string): void;
+  updateData(items: Item[]): void;
+};
+
+export type FlowComboBox = ConnectorFlowComboBox & {
   $connector: ComboBoxConnector;
   $server: ComboBoxServer;
-  _filterTimeout: number;
-  _filterDebouncer: unknown;
-  __dataProviderController: DataProviderController<unknown, Record<string, unknown>>;
 };
 
-type Vaadin = {
-  Flow: {
-    comboBoxConnector: ComboBoxConnector;
-  };
-};
-
-const Vaadin = window.Vaadin as Vaadin;
-
-export const comboBoxConnector = Vaadin.Flow.comboBoxConnector;
+export const comboBoxConnector = window.Vaadin.Flow.comboBoxConnector;
 
 export function init(comboBox: FlowComboBox): void {
   comboBox.$server = {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -92,7 +92,7 @@ import tools.jackson.databind.node.ObjectNode;
 @NpmPackage(value = "@vaadin/combo-box", version = "25.3.0-alpha9")
 @JsModule("@vaadin/combo-box/src/vaadin-combo-box.js")
 @JsModule("./flow-component-renderer.js")
-@JsModule("./comboBoxConnector.js")
+@JsModule("./vaadin-combo-box/comboBoxConnector.ts")
 public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         implements HasPrefix, HasThemeVariant<ComboBoxVariant> {
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBox.java
@@ -101,7 +101,7 @@ import tools.jackson.databind.node.ObjectNode;
 @NpmPackage(value = "@vaadin/multi-select-combo-box", version = "25.3.0-alpha9")
 @JsModule("@vaadin/multi-select-combo-box/src/vaadin-multi-select-combo-box.js")
 @JsModule("./flow-component-renderer.js")
-@JsModule("./comboBoxConnector.js")
+@JsModule("./vaadin-combo-box/comboBoxConnector.ts")
 public class MultiSelectComboBox<TItem>
         extends ComboBoxBase<MultiSelectComboBox<TItem>, TItem, Set<TItem>>
         implements MultiSelect<MultiSelectComboBox<TItem>, TItem>,

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
@@ -1,23 +1,28 @@
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
+import type {
+  ComboBoxDataProviderCallback,
+  ComboBoxDataProviderParams
+} from '@vaadin/combo-box/src/vaadin-combo-box-data-provider-mixin.js';
+import type { FlowComboBox, Item, ItemRange } from './vaadin-combo-box-types.js';
 
 /**
  * comboBoxConnector is a communication layer between ComboBox's flow component
  * (server-side) and web component (client-side).
  */
 export class ComboBoxConnector {
-  #comboBox;
-  #placeholder = new window.Vaadin.ComboBoxPlaceholder();
+  readonly #comboBox: FlowComboBox;
+  readonly #placeholder = new window.Vaadin.ComboBoxPlaceholder();
 
-  #cache = {};
+  #cache: Record<number, Item[]> = {};
 
   #lastTypedFilter = '';
-  #lastRequestedRange = [-1, -1];
+  #lastRequestedRange: ItemRange = [-1, -1];
   #lastRequestedFilter = '';
   #needsDataCommunicatorReset = false;
 
-  constructor(comboBox) {
+  constructor(comboBox: FlowComboBox) {
     this.#comboBox = comboBox;
 
     // Prevent setting the custom value as the 'value'-prop automatically
@@ -30,7 +35,7 @@ export class ComboBoxConnector {
     comboBox.dataProvider = (params, callback) => this.#loadPage(params, callback);
   }
 
-  clear(start, length) {
+  clear(start: number, length: number): void {
     const comboBox = this.#comboBox;
     const { pageSize } = comboBox;
     const firstPage = Math.floor(start / pageSize);
@@ -40,14 +45,16 @@ export class ComboBoxConnector {
       delete this.#cache[page];
     }
 
+    const filteredItems = comboBox.filteredItems ?? [];
     for (let index = firstPage * pageSize; index < lastPage * pageSize; index++) {
-      if (comboBox.filteredItems[index]) {
-        comboBox.filteredItems[index] = this.#placeholder;
+      if (filteredItems[index]) {
+        // The placeholder stands in for an item that is being loaded
+        filteredItems[index] = this.#placeholder as Item;
       }
     }
   }
 
-  set(index, items, filter) {
+  set(index: number, items: Item[], filter: string): void {
     const comboBox = this.#comboBox;
 
     if (filter !== this.#lastTypedFilter) {
@@ -77,16 +84,16 @@ export class ComboBoxConnector {
     }
   }
 
-  updateData(items) {
+  updateData(items: Item[]): void {
     const comboBox = this.#comboBox;
-    const itemsMap = new Map(items.map((item) => [item.key, item]));
+    const itemsMap = new Map<string, Item>(items.map((item) => [item.key, item]));
 
-    comboBox.filteredItems = comboBox.filteredItems.map((item) => {
+    comboBox.filteredItems = comboBox.filteredItems?.map((item) => {
       return itemsMap.get(item.key) || item;
     });
   }
 
-  updateSize(newSize) {
+  updateSize(newSize: number): void {
     const comboBox = this.#comboBox;
 
     if (!comboBox._clientSideFilter) {
@@ -102,7 +109,7 @@ export class ComboBoxConnector {
     }
   }
 
-  reset() {
+  reset(): void {
     const comboBox = this.#comboBox;
 
     comboBox._filterDebouncer?.cancel();
@@ -113,7 +120,7 @@ export class ComboBoxConnector {
     comboBox.clearCache();
   }
 
-  confirm(id, filter) {
+  confirm(id: number, filter: string): void {
     const comboBox = this.#comboBox;
 
     if (filter !== this.#lastTypedFilter) {
@@ -123,7 +130,8 @@ export class ComboBoxConnector {
     // We're done applying changes from this batch, resolve pending
     // callbacks
     const { pendingRequests } = comboBox.__dataProviderController.rootCache;
-    Object.entries(pendingRequests).forEach(([page, callback]) => {
+    Object.entries(pendingRequests).forEach(([key, callback]) => {
+      const page = Number(key);
       const items = this.#cache[page];
 
       if (comboBox._clientSideFilter && items) {
@@ -139,7 +147,7 @@ export class ComboBoxConnector {
     comboBox.$server.confirmUpdate(id);
   }
 
-  #loadPage(params, callback) {
+  #loadPage(params: ComboBoxDataProviderParams, callback: ComboBoxDataProviderCallback<Item>): void {
     const comboBox = this.#comboBox;
 
     if (params.pageSize != comboBox.pageSize) {
@@ -194,16 +202,17 @@ export class ComboBoxConnector {
    * Asks the server for the pages around the viewport, so that scrolling has
    * data ready ahead of rendering.
    */
-  #requestPage(page, filter) {
+  #requestPage(page: number, filter: string): void {
     const comboBox = this.#comboBox;
 
     const viewportRange = this.#getViewportRange();
     const buffer = viewportRange[1] - viewportRange[0];
-    const sizeLimit = Number.isFinite(comboBox.size) ? comboBox.size : Number.POSITIVE_INFINITY;
+    const { size } = comboBox;
+    const sizeLimit = size !== undefined && Number.isFinite(size) ? size : Number.POSITIVE_INFINITY;
     viewportRange[0] = Math.max(viewportRange[0] - buffer, 0);
     viewportRange[1] = Math.min(viewportRange[1] + buffer, sizeLimit - 1);
 
-    let viewportPageRange = [
+    let viewportPageRange: ItemRange = [
       Math.floor(viewportRange[0] / comboBox.pageSize),
       Math.floor(viewportRange[1] / comboBox.pageSize)
     ];
@@ -230,7 +239,7 @@ export class ComboBoxConnector {
   }
 
   /** The range of item indexes currently rendered in the dropdown */
-  #getViewportRange() {
+  #getViewportRange(): ItemRange {
     const comboBox = this.#comboBox;
 
     const indices = Array.from(comboBox._scroller?.children ?? [])
@@ -243,11 +252,9 @@ export class ComboBoxConnector {
     return [indices[0], indices[indices.length - 1]];
   }
 
-  #matchesFilter(item, filter) {
+  #matchesFilter(item: Item, filter: string): boolean {
     filter = filter ? filter.toString().toLowerCase() : '';
-    return (
-      this.#comboBox._getItemLabel(item, this.#comboBox.itemLabelPath).toString().toLowerCase().indexOf(filter) > -1
-    );
+    return this.#comboBox._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;
   }
 
   /**
@@ -256,7 +263,7 @@ export class ComboBoxConnector {
    * The filter used is the one from combobox, not the lastFilter stored since
    * that may not reflect user's input.
    */
-  #performClientSideFilter(page, filter, callback) {
+  #performClientSideFilter(page: Item[], filter: string, callback: ComboBoxDataProviderCallback<Item>): void {
     let filteredItems = page;
 
     if (filter) {
@@ -267,7 +274,7 @@ export class ComboBoxConnector {
   }
 }
 
-function initLazy(comboBox) {
+function initLazy(comboBox: FlowComboBox): void {
   // Init the connector only once for the combo box
   comboBox.$connector ??= new ComboBoxConnector(comboBox);
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-placeholder.d.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-placeholder.d.ts
@@ -1,0 +1,5 @@
+// Declares the untyped @vaadin/combo-box placeholder module
+declare module '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js' {
+  /** Placeholder object representing an item that is being loaded */
+  export class ComboBoxPlaceholder {}
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-types.d.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-types.d.ts
@@ -1,0 +1,63 @@
+// Types for the Flow-specific combo box API, including the private/protected
+// @vaadin/combo-box API that the connector relies on. The public API types
+// come from the @vaadin npm packages, resolved from the integration tests
+// module's node_modules (see tsconfig.json in the module root).
+import type { ComboBox } from '@vaadin/combo-box/src/vaadin-combo-box.js';
+import type { ComboBoxItem } from '@vaadin/combo-box/src/vaadin-combo-box-item.js';
+import type { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
+import type { ComboBoxScroller } from '@vaadin/combo-box/src/vaadin-combo-box-scroller.js';
+import type { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
+import type { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import type { ComboBoxConnector } from './comboBoxConnector.js';
+
+export type { ComboBoxConnector };
+
+/** An item sent by the server-side data communicator */
+export interface Item {
+  key: string;
+  className?: string;
+}
+
+/** An inclusive range of item indexes: [start, end] */
+export type ItemRange = [start: number, end: number];
+
+/** The server-side RPC proxy of the combo box */
+export interface ComboBoxServer {
+  confirmUpdate(id: number): void;
+  resetDataCommunicator(): void;
+  setViewportRange(startIndex: number, size: number, filter: string): void;
+}
+
+/** The dropdown scroller, whose children are the rendered item elements */
+export type FlowComboBoxScroller = Omit<ComboBoxScroller, 'children'> & {
+  children: HTMLCollectionOf<ComboBoxItem<Item>>;
+};
+
+/**
+ * The private/protected @vaadin/combo-box API and the Flow-specific API that
+ * the combo box connector relies on.
+ */
+export interface FlowComboBoxInternals {
+  $connector: ComboBoxConnector;
+  $server: ComboBoxServer;
+  __dataProviderController: DataProviderController<Item, Record<string, unknown>>;
+  _clientSideFilter: boolean;
+  _filterDebouncer: Debouncer | null;
+  _filterTimeout?: number;
+  _scroller?: FlowComboBoxScroller;
+  _getItemLabel(item: Item): string;
+}
+
+/** The Flow combo box element, also used by the multi-select combo box */
+export type FlowComboBox = ComboBox<Item> & FlowComboBoxInternals;
+
+declare global {
+  // Augments the global Vaadin interface declared by @vaadin/component-base
+  // with the Flow namespace used by the connector
+  interface Vaadin {
+    ComboBoxPlaceholder: typeof ComboBoxPlaceholder;
+    Flow: {
+      comboBoxConnector: { initLazy(comboBox: FlowComboBox): void };
+    };
+  }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/tsconfig.json
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "useDefineForClassFields": false,
+    // Resolve @vaadin package types from the integration tests module, whose
+    // node_modules is populated by the Maven frontend build
+    "paths": {
+      "@vaadin/*": ["../vaadin-combo-box-flow-integration-tests/node_modules/@vaadin/*"]
+    }
+  },
+  "include": ["src/main/resources/META-INF/frontend/**/*"]
+}


### PR DESCRIPTION
## Summary
- The connector was plain JavaScript, so nothing checked how it uses the web component API. As TypeScript, changes to it are checked at compile time and the IDE can help when working on it.
- Public API types come from the `@vaadin` packages, resolved from the integration tests module's `node_modules` through a repo-local `tsconfig.json` that is not included in the jar. The private API the connector relies on is declared in type-only files that ship with it.
- The connector also moves into a component-named subfolder, which is where the conventions say new frontend files belong. Landing this after the class conversion in #9850 keeps the move a rename git can detect.

Follow-up to #9850, Related to #9784, #9847

🤖 Generated with [Claude Code](https://claude.com/claude-code)