### PR TITLE
feat: add custom date part names to DatePicker

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadata.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadata.java
@@ -26,12 +26,19 @@ import java.util.Objects;
  *            the date the metadata applies to, not {@code null}
  * @param disabled
  *            whether the date cannot be selected
+ * @param partName
+ *            custom CSS part names for the date, or {@code null} for none.
+ *            Either a single name, or several names separated by spaces. Do not
+ *            use the names the component sets itself, such as {@code disabled},
+ *            {@code selected} or {@code today}: a theme already styles those,
+ *            and borrowing one can make a date look and behave as if it were in
+ *            that state.
  *
  * @author Vaadin Ltd
  * @since 25.3
  */
-public record DateMetadata(LocalDate date,
-        boolean disabled) implements Serializable {
+public record DateMetadata(LocalDate date, boolean disabled,
+        String partName) implements Serializable {
 
     /**
      * Creates new metadata for the given date.
@@ -40,8 +47,36 @@ public record DateMetadata(LocalDate date,
      *            the date the metadata applies to, not {@code null}
      * @param disabled
      *            whether the date cannot be selected
+     * @param partName
+     *            custom CSS part names for the date, or {@code null} for none
      */
     public DateMetadata {
         Objects.requireNonNull(date, "Date cannot be null");
+    }
+
+    /**
+     * Creates new metadata that only marks the date as disabled or not, without
+     * any custom part names.
+     *
+     * @param date
+     *            the date the metadata applies to, not {@code null}
+     * @param disabled
+     *            whether the date cannot be selected
+     */
+    public DateMetadata(LocalDate date, boolean disabled) {
+        this(date, disabled, null);
+    }
+
+    /**
+     * Creates new metadata that only adds custom part names to the date,
+     * leaving it selectable.
+     *
+     * @param date
+     *            the date the metadata applies to, not {@code null}
+     * @param partName
+     *            custom CSS part names for the date, or {@code null} for none
+     */
+    public DateMetadata(LocalDate date, String partName) {
+        this(date, false, partName);
     }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadataProvider.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadataProvider.java
@@ -33,6 +33,10 @@ import java.util.Collection;
  * unusable. A date selected before the answer arrives is reported invalid by
  * server-side validation.
  * <p>
+ * Entries can also carry custom CSS part names, so that a theme can style
+ * particular dates. A part name only affects styling, never whether a date can
+ * be selected. See {@link DateMetadata} for the details.
+ * <p>
  * Results are cached per month in the browser, but not on the server, so an
  * expensive implementation should cache its own results. Call
  * {@link DatePicker#refreshDateMetadata()} when the data behind the callback

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadataProvider.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadataProvider.java
@@ -34,8 +34,7 @@ import java.util.Collection;
  * server-side validation.
  * <p>
  * Entries can also carry custom CSS part names, so that a theme can style
- * particular dates. A part name only affects styling, never whether a date can
- * be selected. See {@link DateMetadata} for the details.
+ * particular dates. See {@link DateMetadata} for the details.
  * <p>
  * Results are cached per month in the browser, but not on the server, so an
  * expensive implementation should cache its own results. Call

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DatePicker.java
@@ -651,6 +651,10 @@ public class DatePicker
      * as well as with the minimum and maximum date: a date cannot be selected
      * if any of these constraints disables it. By default, no provider is set.
      * <p>
+     * Entries can also carry custom CSS part names, so that a theme can style
+     * particular dates. A part name only affects styling, never whether a date
+     * can be selected.
+     * <p>
      * The provider is also called during server-side validation, with the date
      * being validated, so that a disabled date cannot be committed even if the
      * browser was never told about it. Setting a provider does not re-validate
@@ -740,7 +744,8 @@ public class DatePicker
      *            the first date of the range, as an ISO 8601 date
      * @param end
      *            the last date of the range, as an ISO 8601 date
-     * @return the metadata entries for the disabled dates in the range
+     * @return the metadata entries for the dates in the range that are disabled
+     *         or have custom part names
      */
     @AllowInert
     @ClientCallable(DisabledUpdateMode.ALWAYS)
@@ -759,15 +764,25 @@ public class DatePicker
         }
 
         metadata.stream().filter(Objects::nonNull)
-                .filter(DateMetadata::disabled).forEach(entry -> {
+                .filter(entry -> entry.disabled() || hasPartName(entry))
+                .forEach(entry -> {
                     ObjectNode node = JacksonUtils.createObjectNode();
                     node.put("year", entry.date().getYear());
                     node.put("month", entry.date().getMonthValue() - 1);
                     node.put("day", entry.date().getDayOfMonth());
-                    node.put("disabled", true);
+                    if (entry.disabled()) {
+                        node.put("disabled", true);
+                    }
+                    if (hasPartName(entry)) {
+                        node.put("part", entry.partName());
+                    }
                     entries.add(node);
                 });
         return entries;
+    }
+
+    private static boolean hasPartName(DateMetadata entry) {
+        return entry.partName() != null && !entry.partName().isBlank();
     }
 
     private boolean hasDateMetadataConfig() {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataTest.java
@@ -253,6 +253,73 @@ class DatePickerDateMetadataTest {
     }
 
     @Test
+    void requestDateMetadata_includesPartName() {
+        picker.setDateMetadataProvider(range -> List
+                .of(new DateMetadata(LocalDate.of(2023, 1, 10), "busy")));
+
+        ArrayNode entries = picker.requestDateMetadata("2023-01-01",
+                "2023-01-31");
+
+        Assertions.assertEquals(1, entries.size());
+        Assertions.assertEquals("busy",
+                entries.get(0).get("part").stringValue());
+    }
+
+    @Test
+    void requestDateMetadata_partNameOnlyEntry_isIncluded() {
+        picker.setDateMetadataProvider(range -> List.of(
+                new DateMetadata(LocalDate.of(2023, 1, 10), false, "busy")));
+
+        ArrayNode entries = picker.requestDateMetadata("2023-01-01",
+                "2023-01-31");
+
+        Assertions.assertEquals(1, entries.size());
+        JsonNode entry = entries.get(0);
+        Assertions.assertEquals(10, entry.get("day").intValue());
+        Assertions.assertEquals("busy", entry.get("part").stringValue());
+        Assertions.assertFalse(entry.has("disabled"));
+    }
+
+    @Test
+    void requestDateMetadata_disabledEntryWithoutPartName_hasNoPartKey() {
+        picker.setDateMetadataProvider(range -> List
+                .of(new DateMetadata(LocalDate.of(2023, 1, 10), true)));
+
+        ArrayNode entries = picker.requestDateMetadata("2023-01-01",
+                "2023-01-31");
+
+        Assertions.assertEquals(1, entries.size());
+        JsonNode entry = entries.get(0);
+        Assertions.assertTrue(entry.get("disabled").booleanValue());
+        Assertions.assertFalse(entry.has("part"));
+    }
+
+    @Test
+    void requestDateMetadata_blankPartName_isSkipped() {
+        picker.setDateMetadataProvider(range -> List
+                .of(new DateMetadata(LocalDate.of(2023, 1, 10), false, "  ")));
+
+        ArrayNode entries = picker.requestDateMetadata("2023-01-01",
+                "2023-01-31");
+
+        Assertions.assertEquals(0, entries.size());
+    }
+
+    @Test
+    void requestDateMetadata_disabledAndPartName_includesBoth() {
+        picker.setDateMetadataProvider(range -> List
+                .of(new DateMetadata(LocalDate.of(2023, 1, 10), true, "busy")));
+
+        ArrayNode entries = picker.requestDateMetadata("2023-01-01",
+                "2023-01-31");
+
+        Assertions.assertEquals(1, entries.size());
+        JsonNode entry = entries.get(0);
+        Assertions.assertTrue(entry.get("disabled").booleanValue());
+        Assertions.assertEquals("busy", entry.get("part").stringValue());
+    }
+
+    @Test
     void requestDateMetadata_providerReturnsNull_returnsEmptyArray() {
         picker.setDateMetadataProvider(range -> null);
 
@@ -303,6 +370,24 @@ class DatePickerDateMetadataTest {
     void dateMetadata_nullDate_throws() {
         Assertions.assertThrows(NullPointerException.class,
                 () -> new DateMetadata(null, true));
+    }
+
+    @Test
+    void dateMetadata_partNameConstructor_isNotDisabled() {
+        DateMetadata metadata = new DateMetadata(LocalDate.of(2023, 1, 10),
+                "busy");
+
+        Assertions.assertFalse(metadata.disabled());
+        Assertions.assertEquals("busy", metadata.partName());
+    }
+
+    @Test
+    void dateMetadata_twoArgConstructor_hasNoPartName() {
+        DateMetadata metadata = new DateMetadata(LocalDate.of(2023, 1, 10),
+                true);
+
+        Assertions.assertTrue(metadata.disabled());
+        Assertions.assertNull(metadata.partName());
     }
 
     @Test


### PR DESCRIPTION
The date metadata provider can say that a date cannot be selected, but not that a date is worth pointing out. Applications often want to show a day as busy or almost fully booked while still letting the user pick it, which is a styling concern rather than a constraint.

Metadata entries can now carry CSS part names, which are added to the date cell so a theme can style it with `::part()`:

```java
datePicker.setDateMetadataProvider(range -> availability.forRange(range).stream()
        .map(day -> day.isFull()
                ? new DateMetadata(day.date(), true)
                : new DateMetadata(day.date(), "almost-full"))
        .toList());
```

```css
vaadin-date-picker-overlay::part(almost-full) {
  color: var(--lumo-warning-text-color);
}
```

## Changes

`DateMetadata` gains a `partName` component. The two-argument `(date, disabled)` form stays available as a convenience constructor, and a new `(date, partName)` form covers the styling-only case so it does not have to pass a meaningless `false`.

A part name never affects whether a date can be selected, so an entry is now sent to the browser when it is disabled **or** has a part name, instead of only when it is disabled. The `disabled` and `part` keys are each written only when they apply, which keeps the payload the same as before for callers that do not use part names. A blank part name counts as none.

The connector needs no change: it already forwards the server's answer to the web component untouched, and the entry shape is the web component's own.

The Javadoc warns against reusing the built-in part names (`date`, `disabled`, `selected`, `focused`, `today`, `past`, `future`, `loading`). Those come with the theme's own rules — Lumo removes pointer events from `[part~='disabled']`, so a date borrowing that name could not be clicked even though the component still counts it as selectable.

## Scope

This completes the Date Picker side of the feature. TestBench additions with integration tests, and the same API on Date Time Picker, follow separately.

Part of vaadin/platform#2867

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
