### PR TITLE
refactor: drop manual reformatting after time picker locale change

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/env-setup.ts
@@ -1,0 +1,3 @@
+window.Vaadin ||= {};
+// @ts-expect-error
+window.Vaadin.Flow = {};

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/shared.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/shared.ts
@@ -1,0 +1,43 @@
+import './env-setup.js';
+import '@vaadin/time-picker/src/vaadin-time-picker.js';
+import '../frontend/generated/jar-resources/vaadin-time-picker/timepickerConnector.js';
+import type { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
+import type {} from '@web/test-runner-mocha';
+
+export type FlowTimePickerTime = {
+  hours: number;
+  minutes: number;
+  seconds: number;
+  milliseconds: number;
+};
+
+export type TimePickerConnector = {
+  initLazy: (timePicker: TimePicker) => void;
+  setLocale: (locale: string) => void;
+};
+
+export type FlowTimePicker = TimePicker & {
+  $connector: TimePickerConnector;
+};
+
+type Vaadin = {
+  Flow: {
+    timepickerConnector: TimePickerConnector;
+  };
+};
+
+const Vaadin = window.Vaadin as Vaadin;
+
+export const timepickerConnector = Vaadin.Flow.timepickerConnector;
+
+export function init(timePicker: FlowTimePicker): void {
+  timepickerConnector.initLazy(timePicker);
+}
+
+/**
+ * Returns the text shown in the input element, with the non-breaking spaces
+ * that some locales use around the AM/PM token replaced with normal spaces.
+ */
+export function getInputValue(timePicker: FlowTimePicker): string {
+  return timePicker.inputElement!.value.replace(/[\u00a0\u202f]/g, ' ');
+}

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/time-picker-connector.test.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/time-picker-connector.test.ts
@@ -1,0 +1,124 @@
+import { expect } from 'chai';
+import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
+import { getInputValue, init, timepickerConnector, type FlowTimePicker } from './shared.js';
+
+describe('time-picker connector', () => {
+  let timePicker: FlowTimePicker;
+
+  beforeEach(async () => {
+    timePicker = fixtureSync('<vaadin-time-picker></vaadin-time-picker>');
+    init(timePicker);
+    await nextUpdate(timePicker);
+  });
+
+  it('should not reinitialize the connector', () => {
+    const connector = timePicker.$connector;
+    timepickerConnector.initLazy(timePicker);
+    expect(timePicker.$connector).to.equal(connector);
+  });
+
+  describe('12 hour clock locale', () => {
+    beforeEach(() => {
+      timePicker.$connector.setLocale('en-US');
+    });
+
+    it('should format time with the AM/PM token', () => {
+      expect(timePicker.i18n.formatTime!({ hours: 13, minutes: 30, seconds: 0, milliseconds: 0 })).to.equal(
+        '1:30 PM'
+      );
+    });
+
+    it('should parse time with the AM/PM token', () => {
+      expect(timePicker.i18n.parseTime!('1:30 PM')).to.eql({
+        hours: 13,
+        minutes: 30,
+        seconds: 0,
+        milliseconds: 0
+      });
+    });
+
+    it('should parse time without the AM/PM token', () => {
+      expect(timePicker.i18n.parseTime!('1:30')).to.eql({
+        hours: 1,
+        minutes: 30,
+        seconds: 0,
+        milliseconds: 0
+      });
+    });
+
+    it('should not parse an empty string', () => {
+      expect(timePicker.i18n.parseTime!('')).to.be.undefined;
+    });
+
+    it('should format seconds when the step is below a minute', () => {
+      timePicker.step = 1;
+      expect(timePicker.i18n.formatTime!({ hours: 13, minutes: 30, seconds: 15, milliseconds: 0 })).to.equal(
+        '1:30:15 PM'
+      );
+    });
+
+    it('should format milliseconds when the step is below a second', () => {
+      timePicker.step = 0.5;
+      expect(timePicker.i18n.formatTime!({ hours: 13, minutes: 30, seconds: 15, milliseconds: 250 })).to.equal(
+        '1:30:15.250 PM'
+      );
+    });
+
+    it('should parse milliseconds when the step is below a second', () => {
+      timePicker.step = 0.5;
+      expect(timePicker.i18n.parseTime!('1:30:15.250 PM')).to.eql({
+        hours: 13,
+        minutes: 30,
+        seconds: 15,
+        milliseconds: 250
+      });
+    });
+  });
+
+  describe('24 hour clock locale', () => {
+    beforeEach(() => {
+      timePicker.$connector.setLocale('de-DE');
+    });
+
+    it('should format time without the AM/PM token', () => {
+      expect(timePicker.i18n.formatTime!({ hours: 13, minutes: 30, seconds: 0, milliseconds: 0 })).to.equal('13:30');
+    });
+
+    it('should parse time without the AM/PM token', () => {
+      expect(timePicker.i18n.parseTime!('13:30')).to.eql({
+        hours: 13,
+        minutes: 30,
+        seconds: 0,
+        milliseconds: 0
+      });
+    });
+  });
+
+  describe('locale change', () => {
+    beforeEach(async () => {
+      timePicker.$connector.setLocale('de-DE');
+      timePicker.value = '13:00';
+      await nextUpdate(timePicker);
+    });
+
+    it('should reformat the value when the locale changes', async () => {
+      timePicker.$connector.setLocale('en-US');
+      await nextUpdate(timePicker);
+      expect(getInputValue(timePicker)).to.equal('1:00 PM');
+    });
+
+    it('should keep the value when the locale changes', async () => {
+      timePicker.$connector.setLocale('en-US');
+      await nextUpdate(timePicker);
+      expect(timePicker.value).to.equal('13:00');
+    });
+
+    it('should not reformat an empty value when the locale changes', async () => {
+      timePicker.value = '';
+      await nextUpdate(timePicker);
+      timePicker.$connector.setLocale('en-US');
+      await nextUpdate(timePicker);
+      expect(getInputValue(timePicker)).to.equal('');
+    });
+  });
+});

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/web-test-runner.config.mjs
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+
+/** @type {import('@web/test-runner').TestRunnerConfig} */
+export default {
+  ...sharedConfig,
+
+  plugins: [
+    frontendSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-time-picker-flow/src/main/resources/META-INF/frontend')
+    ]),
+
+    ...sharedConfig.plugins
+  ]
+};

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
@@ -8,31 +8,6 @@ import {
   getSeparator,
   searchAmOrPmToken
 } from './helpers.js';
-import { parseISOTime } from '@vaadin/time-picker/src/vaadin-time-picker-helper.js';
-
-// Execute callback when predicate returns true.
-// Try again later if predicate returns false.
-function when(predicate, callback, timeout = 0) {
-  if (predicate()) {
-    callback();
-  } else {
-    setTimeout(() => when(predicate, callback, 200), timeout);
-  }
-}
-
-function parseISO(text) {
-  // The default i18n parser of the web component is ISO 8601 compliant.
-  const timeObject = parseISOTime(text);
-
-  // The web component returns an object with string values
-  // while the connector expects number values.
-  return {
-    hours: parseInt(timeObject.hours || 0),
-    minutes: parseInt(timeObject.minutes || 0),
-    seconds: parseInt(timeObject.seconds || 0),
-    milliseconds: parseInt(timeObject.milliseconds || 0)
-  };
-}
 
 window.Vaadin.Flow.timepickerConnector = {};
 window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
@@ -44,12 +19,6 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
   timepicker.$connector = {};
 
   timepicker.$connector.setLocale = (locale) => {
-    // capture previous value if any
-    let previousValueObject;
-    if (timepicker.value && timepicker.value !== '') {
-      previousValueObject = parseISO(timepicker.value);
-    }
-
     try {
       // Check whether the locale is supported by the browser or not
       TEST_PM_TIME.toLocaleTimeString(locale);
@@ -163,19 +132,5 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
         }
       }
     };
-
-    if (previousValueObject) {
-      when(
-        () => timepicker.$,
-        () => {
-          const newValue = timepicker.i18n.formatTime(previousValueObject);
-          // FIXME works but uses private API, needs fixes in web component
-          if (timepicker.inputElement.value !== newValue) {
-            timepicker.inputElement.value = newValue;
-            timepicker.value = newValue;
-          }
-        }
-      );
-    }
   };
 };


### PR DESCRIPTION
The connector reformatted the input itself after a locale change: it captured the current value, waited for the element, and wrote the newly formatted text into the input. The web component does this on its own when `i18n` changes, so the block only duplicated work.

It also worked in ways it should not have:

- it wrote to `timepicker.inputElement.value`, which a `FIXME` in the code already flagged as private API
- it assigned a localized string to `timepicker.value`, which expects ISO 8601. The component rejected it and restored the previous value, so the reformatting was a side effect of that rejection.
- its `parseISO()` helper read `timeObject.hours` without checking that `parseISOTime` returned an object, so a value that is not ISO 8601 would throw

Removing the block also removes the `when()` helper, which had no other caller, and the deep import from `@vaadin/time-picker/src`, so the connector no longer reaches into the web component sources.

This adds a web-test-runner suite for the connector, since the module had none. It covers formatting and parsing for a 12 hour and a 24 hour locale, seconds and milliseconds granularity, and the reformat on locale change that the removed code used to do. `TimePickerLocalizationIT` and `TimePickerDetachAttachPageIT` also pass.

Related to #9870

---

🤖 Generated with Claude Code
