### PR TITLE
fix: escape time separator before using it in a regular expression

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/time-picker-connector.test.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/time-picker-connector.test.ts
@@ -100,6 +100,50 @@ describe('time-picker connector', () => {
     });
   });
 
+  describe('dot separator locale', () => {
+    beforeEach(() => {
+      timePicker.$connector.setLocale('fi-FI');
+    });
+
+    it('should format time using the dot separator', () => {
+      expect(timePicker.i18n.formatTime!({ hours: 13, minutes: 30, seconds: 0, milliseconds: 0 })).to.equal('13.30');
+    });
+
+    it('should parse time using the dot separator', () => {
+      expect(timePicker.i18n.parseTime!('13.30')).to.eql({
+        hours: 13,
+        minutes: 30,
+        seconds: 0,
+        milliseconds: 0
+      });
+    });
+
+    [
+      { text: '1234', hours: 12, minutes: 34 },
+      { text: '2359', hours: 23, minutes: 59 },
+      { text: '130', hours: 13, minutes: 0 }
+    ].forEach(({ text, hours, minutes }) => {
+      it(`should parse ${text} typed without a separator`, () => {
+        expect(timePicker.i18n.parseTime!(text)).to.eql({
+          hours,
+          minutes,
+          seconds: 0,
+          milliseconds: 0
+        });
+      });
+    });
+
+    it('should parse milliseconds using the dot separator', () => {
+      timePicker.step = 0.5;
+      expect(timePicker.i18n.parseTime!('2.03.04.555')).to.eql({
+        hours: 2,
+        minutes: 3,
+        seconds: 4,
+        milliseconds: 555
+      });
+    });
+  });
+
   describe('locale change', () => {
     beforeEach(async () => {
       timePicker.$connector.setLocale('de-DE');

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/helpers.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/helpers.js
@@ -18,7 +18,7 @@ const EASTERN_ARABIC_DIGIT_MAP = {
  * @param {string} string
  * @return {string}
  */
-function escapeRegExp(string) {
+export function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
@@ -1,5 +1,6 @@
 import {
   TEST_PM_TIME,
+  escapeRegExp,
   formatMilliseconds,
   parseMillisecondsIntoInteger,
   parseDigitsIntoInteger,
@@ -33,6 +34,8 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
 
     // 2. What is the separator ?
     const separator = getSeparator(locale);
+    // The separator can be a regexp special character, such as the dot used by fi-FI
+    const escapedSeparator = escapeRegExp(separator || '');
 
     const includeSeconds = function () {
       return timepicker.step && timepicker.step < 60;
@@ -89,7 +92,7 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
           .trim();
 
         // A regexp that allows to find the numbers with optional separator and continuing searching after it.
-        const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + separator + ')?', 'g');
+        const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + escapedSeparator + ')?', 'g');
 
         let hours = numbersRegExp.exec(numbersOnlyTimeString);
         if (hours) {


### PR DESCRIPTION
In locales that use a dot as the time separator, such as `fi-FI` and `da-DK`, digits typed without a separator were parsed into the wrong time, and the wrong time was also sent to the server.

The connector built its parse pattern by putting the localized separator straight into a regular expression, so for a dot the optional separator group became `(?:.)?`, which matches any character. That group took the third digit with it, and `formatTime` then let `Date.setHours` roll the out-of-range hour over into a valid but different time, so the field never showed the invalid state. `helpers.js` already had `escapeRegExp` for the AM/PM token search, and it is now used for the separator as well.

## Reproduction

```java
TimePicker timePicker = new TimePicker("Time");
timePicker.setLocale(new Locale("fi", "FI"));
add(timePicker);
```

Typing `1234` in the field:

| Locale | Typed | Before | After |
| --- | --- | --- | --- |
| `fi-FI` | `1234` | `3.04`, value `03:04` | `12.34`, value `12:34` |
| `fi-FI` | `2359` | `19.09`, value `19:09` | `23.59`, value `23:59` |
| `fi-FI` | `130` | `10.00`, value `10:00` | `13.00`, value `13:00` |

Locales with a colon separator, such as `en-US` and `de-DE`, were not affected.

## Changes

`escapeRegExp` is now exported from `helpers.js`. The escaped separator is computed once per locale next to `getSeparator`, since the pattern is rebuilt on every parse.

The new client-side tests cover the three inputs above, and also dot-separated input with milliseconds, which parsed correctly before and still does.

Fixes #9870

---

🤖 Generated with Claude Code
