### PR TITLE
fix: name the unsupported locale in the time picker error

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/time-picker-connector.test.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/test/time-picker-connector.test.ts
@@ -94,6 +94,12 @@ describe('time-picker connector', () => {
     });
   });
 
+  describe('unsupported locale', () => {
+    it('should name the unsupported locale in the error', () => {
+      expect(() => timePicker.$connector.setLocale('en_US')).to.throw('en_US');
+    });
+  });
+
   describe('locale change', () => {
     beforeEach(async () => {
       timePicker.$connector.setLocale('de-DE');

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
@@ -23,11 +23,8 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
       // Check whether the locale is supported by the browser or not
       TEST_PM_TIME.toLocaleTimeString(locale);
     } catch (e) {
-      locale = 'en-US';
       // FIXME should do a callback for server to throw an exception ?
-      throw new Error(
-        'vaadin-time-picker: The locale ' + locale + ' is not supported, falling back to default locale setting(en-US).'
-      );
+      throw new Error('vaadin-time-picker: The locale ' + locale + ' is not supported.');
     }
 
     // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
@@ -24,7 +24,7 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
       TEST_PM_TIME.toLocaleTimeString(locale);
     } catch (e) {
       // FIXME should do a callback for server to throw an exception ?
-      throw new Error('vaadin-time-picker: The locale ' + locale + ' is not supported.');
+      throw new Error(`vaadin-time-picker: The locale ${locale} is not supported.`);
     }
 
     // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?


### PR DESCRIPTION
The connector checks whether the browser supports the locale, and reports an error when it does not. The `catch` block reassigned `locale` to `en-US` before building the message, so the error always read `The locale en-US is not supported` and never named the locale that actually failed.

The reassignment was also dead, since the `throw` exits before anything reads `locale` again. No fallback ever happened, so the message no longer promises one.

```java
// before: "vaadin-time-picker: The locale en-US is not supported, falling back to default locale setting(en-US)."
// after:  "vaadin-time-picker: The locale en_US is not supported."
timePicker.setLocale(...); // with a locale the browser rejects
```

Extracted from #9871 to keep that PR about the connector cleanup only. Based on the same branch, since the test uses the web-test-runner suite added there.

Making the fallback real, which `TimePicker.setLocale` javadoc promises, is a behavior change and is left out of this PR.

---

🤖 Generated with Claude Code
