### PR TITLE
test: fix flaky spreadsheet custom editor ITs

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -449,8 +449,12 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
         // re-rendering (e.g. right after adding a freeze pane), so click
         // again until the editor shows up.
         waitUntil(driver -> {
-            clickCell(cellAddress);
-            return getInputInCustomEditorFromCell(cellAddress).isPresent();
+            try {
+                clickCell(cellAddress);
+                return getInputInCustomEditorFromCell(cellAddress).isPresent();
+            } catch (StaleElementReferenceException e) {
+                return false;
+            }
         });
 
         var editor = getInputInCustomEditorFromCell(cellAddress).orElseThrow();

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -559,18 +559,30 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
     }
 
     private void assertEditorInCellIsFocused(String cellAddress) {
-        var activeElement = getActiveElement();
-        String slotName = activeElement.getDomAttribute("slot");
-        if (!(slotName != null && slotName.startsWith("custom-editor"))) {
-            var parentElement = getActiveElement().findElement(By.xpath(".."));
-            slotName = parentElement.getDomAttribute("slot");
-        }
-
-        Assert.assertNotNull("Slot name is null", slotName);
-
-        var result = getSpreadsheet().getCellAt(cellAddress)
-                .findElements(By.cssSelector("slot[name='" + slotName + "']"));
-        Assert.assertEquals(1, result.size());
+        // Focus moves into the editor only after the spreadsheet has
+        // processed the key press, so wait instead of asserting immediately.
+        waitUntil(driver -> {
+            try {
+                var activeElement = getActiveElement();
+                String slotName = activeElement.getDomAttribute("slot");
+                if (!(slotName != null
+                        && slotName.startsWith("custom-editor"))) {
+                    var parentElement = activeElement
+                            .findElement(By.xpath(".."));
+                    slotName = parentElement.getDomAttribute("slot");
+                }
+                if (slotName == null) {
+                    return false;
+                }
+                return getSpreadsheet().getCellAt(cellAddress)
+                        .findElements(
+                                By.cssSelector("slot[name='" + slotName + "']"))
+                        .size() == 1;
+            } catch (StaleElementReferenceException
+                    | NoSuchElementException e) {
+                return false;
+            }
+        });
     }
 
     private WebElement getActiveElement() {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -445,11 +445,15 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
     private void performKeyboardTestsToCell(String column) {
         final String cellAddress = column + "2";
 
-        clickCell(cellAddress);
-        var maybeEditor = getInputInCustomEditorFromCell(cellAddress);
-        Assert.assertTrue(maybeEditor.isPresent());
+        // A click on the cell can get lost while the spreadsheet is still
+        // re-rendering (e.g. right after adding a freeze pane), so click
+        // again until the editor shows up.
+        waitUntil(driver -> {
+            clickCell(cellAddress);
+            return getInputInCustomEditorFromCell(cellAddress).isPresent();
+        });
 
-        var editor = maybeEditor.get();
+        var editor = getInputInCustomEditorFromCell(cellAddress).orElseThrow();
 
         // Test Esc with arrow keys persistence on cell
         editor.sendKeys("EscWithArrowKeys", Keys.ESCAPE, Keys.ARROW_DOWN);


### PR DESCRIPTION
## Summary
- `CustomEditorIT` has become flaky recently: the frozen-cell tests and `customEditorVisible_pressCharKey_editorIsFocused` fail intermittently, both locally and in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)