### PR TITLE
feat: add DatePicker date metadata TestBench API and ITs

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataPage.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
@@ -45,19 +44,6 @@ public class DatePickerDateMetadataPage extends Div {
     public static final int REFRESHED_DISABLED_DAY = 18;
     public static final int PART_NAME_DAY = 25;
     public static final String PART_NAME = "busy";
-    public static final String DISABLED_DATE_ERROR_MESSAGE = "Date is not available";
-    public static final int SLOW_PROVIDER_DISABLED_DAY = 15;
-    // The calendar fetches metadata a year at a time and already has the year
-    // of the initial value when the page is ready, so only the months of the
-    // neighboring year that the overlay renders are still loading when it
-    // opens.
-    public static final String LOADING_MONTH_HEADER = "December 2022";
-    public static final String LOADING_MONTH_VALUE_PREFIX = "2022-12-";
-
-    // Long enough for the test to observe the loading state between two
-    // WebDriver round-trips.
-    private static final int SLOW_PROVIDER_DELAY_MS = 3000;
-
     private final Set<Integer> disabledDays = new LinkedHashSet<>(
             List.of(PROVIDER_DISABLED_DAY));
 
@@ -70,8 +56,6 @@ public class DatePickerDateMetadataPage extends Div {
                         LocalDate.of(2023, 1, OTHER_FIXED_DISABLED_DAY)));
         datePicker.setDisabledWeekdays(
                 List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY));
-        datePicker.setI18n(new DatePickerI18n()
-                .setDisabledDateErrorMessage(DISABLED_DATE_ERROR_MESSAGE));
         datePicker.setDateMetadataProvider(this::getDateMetadata);
 
         NativeButton refresh = new NativeButton("Refresh date metadata",
@@ -81,13 +65,7 @@ public class DatePickerDateMetadataPage extends Div {
                 });
         refresh.setId("refresh");
 
-        DatePicker slowDatePicker = new DatePicker();
-        slowDatePicker.setId("slow-date-picker");
-        slowDatePicker.setValue(INITIAL_VALUE);
-        slowDatePicker.setDateMetadataProvider(
-                DatePickerDateMetadataPage::getSlowDateMetadata);
-
-        add(datePicker, refresh, slowDatePicker);
+        add(datePicker, refresh);
     }
 
     /**
@@ -107,26 +85,4 @@ public class DatePickerDateMetadataPage extends Div {
         return metadata;
     }
 
-    /**
-     * Takes a fixed time to answer, so that the loading state of the calendar
-     * can be observed. The delay has to be a sleep: the provider runs while
-     * Flow holds the session lock, so waiting for a second request to release
-     * it would deadlock.
-     */
-    private static Collection<DateMetadata> getSlowDateMetadata(
-            DateRange range) {
-        try {
-            Thread.sleep(SLOW_PROVIDER_DELAY_MS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        List<DateMetadata> metadata = new ArrayList<>();
-        for (LocalDate date = range.start(); !date
-                .isAfter(range.end()); date = date.plusDays(1)) {
-            if (date.getDayOfMonth() == SLOW_PROVIDER_DISABLED_DAY) {
-                metadata.add(new DateMetadata(date, true));
-            }
-        }
-        return metadata;
-    }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataPage.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-date-picker/date-metadata")
+public class DatePickerDateMetadataPage extends Div {
+
+    // January 2023 starts on a Sunday, so the weekend days are 7, 8, 14, 15,
+    // 21, 22, 28 and 29. The days below are picked so that each one is disabled
+    // by exactly one constraint.
+    public static final LocalDate INITIAL_VALUE = LocalDate.of(2023, 1, 5);
+    public static final String MONTH_HEADER = "January 2023";
+    public static final int ENABLED_DAY = 12;
+    public static final int FIXED_DISABLED_DAY = 10;
+    public static final int OTHER_FIXED_DISABLED_DAY = 20;
+    public static final int SATURDAY_DAY = 7;
+    public static final int SUNDAY_DAY = 8;
+    public static final int PROVIDER_DISABLED_DAY = 17;
+    public static final int REFRESHED_DISABLED_DAY = 18;
+    public static final int PART_NAME_DAY = 25;
+    public static final String PART_NAME = "busy";
+    public static final String DISABLED_DATE_ERROR_MESSAGE = "Date is not available";
+    public static final int SLOW_PROVIDER_DISABLED_DAY = 15;
+    // The calendar fetches metadata a year at a time and already has the year
+    // of the initial value when the page is ready, so only the months of the
+    // neighboring year that the overlay renders are still loading when it
+    // opens.
+    public static final String LOADING_MONTH_HEADER = "December 2022";
+    public static final String LOADING_MONTH_VALUE_PREFIX = "2022-12-";
+
+    // Long enough for the test to observe the loading state between two
+    // WebDriver round-trips.
+    private static final int SLOW_PROVIDER_DELAY_MS = 3000;
+
+    private final Set<Integer> disabledDays = new LinkedHashSet<>(
+            List.of(PROVIDER_DISABLED_DAY));
+
+    public DatePickerDateMetadataPage() {
+        DatePicker datePicker = new DatePicker();
+        datePicker.setId("date-picker");
+        datePicker.setValue(INITIAL_VALUE);
+        datePicker.setDisabledDates(
+                List.of(LocalDate.of(2023, 1, FIXED_DISABLED_DAY),
+                        LocalDate.of(2023, 1, OTHER_FIXED_DISABLED_DAY)));
+        datePicker.setDisabledWeekdays(
+                List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY));
+        datePicker.setI18n(new DatePickerI18n()
+                .setDisabledDateErrorMessage(DISABLED_DATE_ERROR_MESSAGE));
+        datePicker.setDateMetadataProvider(this::getDateMetadata);
+
+        NativeButton refresh = new NativeButton("Refresh date metadata",
+                event -> {
+                    disabledDays.add(REFRESHED_DISABLED_DAY);
+                    datePicker.refreshDateMetadata();
+                });
+        refresh.setId("refresh");
+
+        DatePicker slowDatePicker = new DatePicker();
+        slowDatePicker.setId("slow-date-picker");
+        slowDatePicker.setValue(INITIAL_VALUE);
+        slowDatePicker.setDateMetadataProvider(
+                DatePickerDateMetadataPage::getSlowDateMetadata);
+
+        add(datePicker, refresh, slowDatePicker);
+    }
+
+    /**
+     * Answers from the mutable set of disabled days, so that a refresh can
+     * change the answer without the provider being set again.
+     */
+    private Collection<DateMetadata> getDateMetadata(DateRange range) {
+        List<DateMetadata> metadata = new ArrayList<>();
+        for (LocalDate date = range.start(); !date
+                .isAfter(range.end()); date = date.plusDays(1)) {
+            if (disabledDays.contains(date.getDayOfMonth())) {
+                metadata.add(new DateMetadata(date, true));
+            } else if (date.getDayOfMonth() == PART_NAME_DAY) {
+                metadata.add(new DateMetadata(date, PART_NAME));
+            }
+        }
+        return metadata;
+    }
+
+    /**
+     * Takes a fixed time to answer, so that the loading state of the calendar
+     * can be observed. The delay has to be a sleep: the provider runs while
+     * Flow holds the session lock, so waiting for a second request to release
+     * it would deadlock.
+     */
+    private static Collection<DateMetadata> getSlowDateMetadata(
+            DateRange range) {
+        try {
+            Thread.sleep(SLOW_PROVIDER_DELAY_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        List<DateMetadata> metadata = new ArrayList<>();
+        for (LocalDate date = range.start(); !date
+                .isAfter(range.end()); date = date.plusDays(1)) {
+            if (date.getDayOfMonth() == SLOW_PROVIDER_DISABLED_DAY) {
+                metadata.add(new DateMetadata(date, true));
+            }
+        }
+        return metadata;
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datepicker/validation/BasicValidationPage.java
@@ -16,7 +16,10 @@
 package com.vaadin.flow.component.datepicker.validation;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import com.vaadin.flow.component.datepicker.DateMetadata;
+import com.vaadin.flow.component.datepicker.DateMetadataProvider;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
@@ -26,12 +29,15 @@ public class BasicValidationPage extends AbstractValidationPage<DatePicker> {
     public static final String REQUIRED_BUTTON = "required-button";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String DISABLED_DATES_INPUT = "disabled-dates-input";
+    public static final String METADATA_PROVIDER_INPUT = "metadata-provider-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
     public static final String BAD_INPUT_ERROR_MESSAGE = "Date has incorrect format";
     public static final String MIN_ERROR_MESSAGE = "Date is too small";
     public static final String MAX_ERROR_MESSAGE = "Date is too big";
+    public static final String DISABLED_DATE_ERROR_MESSAGE = "Date is disabled";
 
     public BasicValidationPage() {
         super();
@@ -40,7 +46,8 @@ public class BasicValidationPage extends AbstractValidationPage<DatePicker> {
                 .setRequiredErrorMessage(REQUIRED_ERROR_MESSAGE)
                 .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
                 .setMinErrorMessage(MIN_ERROR_MESSAGE)
-                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE)
+                .setDisabledDateErrorMessage(DISABLED_DATE_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequired(true);
@@ -55,6 +62,20 @@ public class BasicValidationPage extends AbstractValidationPage<DatePicker> {
             LocalDate value = LocalDate.parse(event.getValue());
             testField.setMax(value);
         }));
+
+        add(createInput(DISABLED_DATES_INPUT, "Set disabled dates", event -> {
+            LocalDate value = LocalDate.parse(event.getValue());
+            testField.setDisabledDates(List.of(value));
+        }));
+
+        add(createInput(METADATA_PROVIDER_INPUT,
+                "Set date metadata provider disabling a date", event -> {
+                    LocalDate disabledDate = LocalDate.parse(event.getValue());
+                    testField.setDateMetadataProvider(DateMetadataProvider
+                            .perDate(date -> date.equals(disabledDate)
+                                    ? new DateMetadata(date, true)
+                                    : null));
+                }));
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
@@ -165,7 +165,7 @@ public class DatePickerDateMetadataIT extends AbstractComponentIT {
             Assert.assertFalse(
                     calendar.isDateDisabled(SLOW_PROVIDER_DISABLED_DAY));
 
-            clickDate(calendar, SLOW_PROVIDER_DISABLED_DAY);
+            calendar.clickDate(SLOW_PROVIDER_DISABLED_DAY);
             Assert.assertEquals(
                     LOADING_MONTH_VALUE_PREFIX + SLOW_PROVIDER_DISABLED_DAY,
                     slowDatePicker.getPropertyString("value"));
@@ -197,14 +197,4 @@ public class DatePickerDateMetadataIT extends AbstractComponentIT {
                 .findFirst().orElse(null));
     }
 
-    private void clickDate(MonthCalendarElement calendar, int day) {
-        executeScript(
-                """
-                        Array.from(
-                                arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
-                                .find((date) => date.textContent.trim() === String(arguments[1]))
-                                .click();
-                        """,
-                calendar, day);
-    }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datepicker;
+
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.DISABLED_DATE_ERROR_MESSAGE;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.ENABLED_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.FIXED_DISABLED_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.LOADING_MONTH_HEADER;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.LOADING_MONTH_VALUE_PREFIX;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.MONTH_HEADER;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.OTHER_FIXED_DISABLED_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.PART_NAME;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.PART_NAME_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.PROVIDER_DISABLED_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.REFRESHED_DISABLED_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SATURDAY_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SLOW_PROVIDER_DISABLED_DAY;
+import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SUNDAY_DAY;
+
+import java.time.LocalDate;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.MonthCalendarElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.OverlayContentElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * Integration tests for the {@link DatePickerDateMetadataPage}.
+ */
+@TestPath("vaadin-date-picker/date-metadata")
+public class DatePickerDateMetadataIT extends AbstractComponentIT {
+
+    private DatePickerElement datePicker;
+
+    @Before
+    public void init() {
+        open();
+        datePicker = $(DatePickerElement.class).id("date-picker");
+    }
+
+    @Test
+    public void openOverlay_fixedDatesAreDisabled() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        Assert.assertTrue(calendar.isDateDisabled(FIXED_DISABLED_DAY));
+        Assert.assertTrue(calendar.isDateDisabled(OTHER_FIXED_DISABLED_DAY));
+        Assert.assertFalse(calendar.isDateDisabled(ENABLED_DAY));
+    }
+
+    @Test
+    public void openOverlay_weekendsAreDisabled() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        Assert.assertTrue(calendar.isDateDisabled(SATURDAY_DAY));
+        Assert.assertTrue(calendar.isDateDisabled(SUNDAY_DAY));
+    }
+
+    @Test
+    public void openOverlay_providerDisablesDate() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        waitUntil(driver -> calendar.isDateDisabled(PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(calendar.isDateDisabled(ENABLED_DAY));
+    }
+
+    @Test
+    public void openOverlay_disabledDateHasAriaDisabled() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        waitUntil(driver -> calendar.isDateDisabled(PROVIDER_DISABLED_DAY));
+        Assert.assertEquals("true",
+                calendar.getDateAriaDisabled(FIXED_DISABLED_DAY));
+        Assert.assertEquals("true",
+                calendar.getDateAriaDisabled(PROVIDER_DISABLED_DAY));
+        Assert.assertEquals("false", calendar.getDateAriaDisabled(ENABLED_DAY));
+    }
+
+    @Test
+    public void openOverlay_providerAddsPartName() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        waitUntil(driver -> calendar.hasDatePart(PART_NAME_DAY, PART_NAME));
+        Assert.assertFalse(calendar.isDateDisabled(PART_NAME_DAY));
+    }
+
+    @Test
+    public void setDisabledDate_fieldIsInvalidWithI18nMessage() {
+        datePicker.setInputValue("1/" + FIXED_DISABLED_DAY + "/2023");
+
+        waitUntil(driver -> datePicker.isInvalid());
+        Assert.assertEquals(DISABLED_DATE_ERROR_MESSAGE,
+                datePicker.getErrorMessage());
+    }
+
+    @Test
+    public void setProviderDisabledDate_fieldIsInvalid() {
+        datePicker.setInputValue("1/" + PROVIDER_DISABLED_DAY + "/2023");
+
+        waitUntil(driver -> datePicker.isInvalid());
+        Assert.assertEquals(DISABLED_DATE_ERROR_MESSAGE,
+                datePicker.getErrorMessage());
+    }
+
+    @Test
+    public void setEnabledDate_fieldIsValid() {
+        datePicker.setInputValue("1/" + ENABLED_DAY + "/2023");
+
+        waitUntil(driver -> LocalDate.of(2023, 1, ENABLED_DAY)
+                .equals(datePicker.getDate()));
+        Assert.assertFalse(datePicker.isInvalid());
+    }
+
+    @Test
+    public void refreshDateMetadata_disabledDatesAreUpdated() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+        waitUntil(driver -> calendar.isDateDisabled(PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(calendar.isDateDisabled(REFRESHED_DISABLED_DAY));
+
+        datePicker.close();
+        clickElementWithJs("refresh");
+
+        MonthCalendarElement refreshedCalendar = openCalendar(datePicker,
+                MONTH_HEADER);
+        waitUntil(driver -> refreshedCalendar
+                .isDateDisabled(REFRESHED_DISABLED_DAY));
+    }
+
+    @Test
+    public void openOverlay_slowProvider_datesLoadingButSelectable() {
+        DatePickerElement slowDatePicker = $(DatePickerElement.class)
+                .id("slow-date-picker");
+
+        // The provider blocks the session lock while it answers, so waiting for
+        // the server would also wait for the loading state to be over.
+        getCommandExecutor().disableWaitForVaadin();
+        try {
+            // The metadata for the year of the initial value is already
+            // fetched when the page is ready, so the loading state shows on
+            // the months of the neighboring year that the overlay renders.
+            slowDatePicker.open();
+            MonthCalendarElement calendar = getCalendar(slowDatePicker,
+                    LOADING_MONTH_HEADER);
+            waitUntil(driver -> calendar
+                    .isDateLoading(SLOW_PROVIDER_DISABLED_DAY));
+
+            Assert.assertTrue(slowDatePicker.getOverlayContent().isLoading());
+            Assert.assertFalse(
+                    calendar.isDateDisabled(SLOW_PROVIDER_DISABLED_DAY));
+
+            clickDate(calendar, SLOW_PROVIDER_DISABLED_DAY);
+            Assert.assertEquals(
+                    LOADING_MONTH_VALUE_PREFIX + SLOW_PROVIDER_DISABLED_DAY,
+                    slowDatePicker.getPropertyString("value"));
+        } finally {
+            getCommandExecutor().enableWaitForVaadin();
+        }
+
+        // Once the provider has answered, the date is no longer loading and is
+        // rendered as disabled.
+        MonthCalendarElement calendar = openCalendar(slowDatePicker,
+                LOADING_MONTH_HEADER);
+        waitUntil(
+                driver -> calendar.isDateDisabled(SLOW_PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(calendar.isDateLoading(SLOW_PROVIDER_DISABLED_DAY));
+    }
+
+    private MonthCalendarElement openCalendar(DatePickerElement picker,
+            String monthHeader) {
+        picker.open();
+        return getCalendar(picker, monthHeader);
+    }
+
+    private MonthCalendarElement getCalendar(DatePickerElement picker,
+            String monthHeader) {
+        OverlayContentElement overlayContent = picker.getOverlayContent();
+        return waitUntil(driver -> overlayContent
+                .getVisibleMonthCalendars().stream().filter(calendar -> calendar
+                        .getHeaderText().contains(monthHeader))
+                .findFirst().orElse(null));
+    }
+
+    private void clickDate(MonthCalendarElement calendar, int day) {
+        executeScript(
+                """
+                        Array.from(
+                                arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
+                                .find((date) => date.textContent.trim() === String(arguments[1]))
+                                .click();
+                        """,
+                calendar, day);
+    }
+}

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
@@ -26,11 +26,14 @@ import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.RE
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SATURDAY_DAY;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SUNDAY_DAY;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.DayElement;
 import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.MonthCalendarElement;
 import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.OverlayContentElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -54,48 +57,58 @@ public class DatePickerDateMetadataIT extends AbstractComponentIT {
     public void openOverlay_fixedDatesAreDisabled() {
         MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
 
-        Assert.assertTrue(calendar.isDateDisabled(FIXED_DISABLED_DAY));
-        Assert.assertTrue(calendar.isDateDisabled(OTHER_FIXED_DISABLED_DAY));
-        Assert.assertFalse(calendar.isDateDisabled(ENABLED_DAY));
+        Assert.assertTrue(isDayDisabled(calendar, FIXED_DISABLED_DAY));
+        Assert.assertTrue(isDayDisabled(calendar, OTHER_FIXED_DISABLED_DAY));
+        Assert.assertFalse(isDayDisabled(calendar, ENABLED_DAY));
     }
 
     @Test
     public void openOverlay_weekendsAreDisabled() {
         MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
 
-        Assert.assertTrue(calendar.isDateDisabled(SATURDAY_DAY));
-        Assert.assertTrue(calendar.isDateDisabled(SUNDAY_DAY));
+        Assert.assertTrue(isDayDisabled(calendar, SATURDAY_DAY));
+        Assert.assertTrue(isDayDisabled(calendar, SUNDAY_DAY));
     }
 
     @Test
     public void openOverlay_providerDisablesDate() {
         MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
 
-        waitUntil(driver -> calendar.isDateDisabled(PROVIDER_DISABLED_DAY));
-        Assert.assertFalse(calendar.isDateDisabled(ENABLED_DAY));
+        waitUntil(driver -> isDayDisabled(calendar, PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(isDayDisabled(calendar, ENABLED_DAY));
     }
 
     @Test
     public void openOverlay_providerAddsPartName() {
         MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
 
-        waitUntil(driver -> calendar.hasDatePart(PART_NAME_DAY, PART_NAME));
-        Assert.assertFalse(calendar.isDateDisabled(PART_NAME_DAY));
+        waitUntil(driver -> hasDayPart(calendar.getDay(PART_NAME_DAY),
+                PART_NAME));
+        Assert.assertFalse(isDayDisabled(calendar, PART_NAME_DAY));
     }
 
     @Test
     public void refreshDateMetadata_disabledDatesAreUpdated() {
         MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
-        waitUntil(driver -> calendar.isDateDisabled(PROVIDER_DISABLED_DAY));
-        Assert.assertFalse(calendar.isDateDisabled(REFRESHED_DISABLED_DAY));
+        waitUntil(driver -> isDayDisabled(calendar, PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(isDayDisabled(calendar, REFRESHED_DISABLED_DAY));
 
         datePicker.close();
         clickElementWithJs("refresh");
 
         MonthCalendarElement refreshedCalendar = openCalendar(datePicker,
                 MONTH_HEADER);
-        waitUntil(driver -> refreshedCalendar
-                .isDateDisabled(REFRESHED_DISABLED_DAY));
+        waitUntil(driver -> isDayDisabled(refreshedCalendar,
+                REFRESHED_DISABLED_DAY));
+    }
+
+    private boolean isDayDisabled(MonthCalendarElement calendar, int day) {
+        return calendar.getDay(day).hasAttribute("disabled");
+    }
+
+    private boolean hasDayPart(DayElement day, String partName) {
+        return List.of(day.getDomAttribute("part").split(" "))
+                .contains(partName);
     }
 
     private MonthCalendarElement openCalendar(DatePickerElement picker,

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataIT.java
@@ -15,11 +15,8 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.DISABLED_DATE_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.ENABLED_DAY;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.FIXED_DISABLED_DAY;
-import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.LOADING_MONTH_HEADER;
-import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.LOADING_MONTH_VALUE_PREFIX;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.MONTH_HEADER;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.OTHER_FIXED_DISABLED_DAY;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.PART_NAME;
@@ -27,10 +24,7 @@ import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.PA
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.PROVIDER_DISABLED_DAY;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.REFRESHED_DISABLED_DAY;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SATURDAY_DAY;
-import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SLOW_PROVIDER_DISABLED_DAY;
 import static com.vaadin.flow.component.datepicker.DatePickerDateMetadataPage.SUNDAY_DAY;
-
-import java.time.LocalDate;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -82,50 +76,11 @@ public class DatePickerDateMetadataIT extends AbstractComponentIT {
     }
 
     @Test
-    public void openOverlay_disabledDateHasAriaDisabled() {
-        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
-
-        waitUntil(driver -> calendar.isDateDisabled(PROVIDER_DISABLED_DAY));
-        Assert.assertEquals("true",
-                calendar.getDateAriaDisabled(FIXED_DISABLED_DAY));
-        Assert.assertEquals("true",
-                calendar.getDateAriaDisabled(PROVIDER_DISABLED_DAY));
-        Assert.assertEquals("false", calendar.getDateAriaDisabled(ENABLED_DAY));
-    }
-
-    @Test
     public void openOverlay_providerAddsPartName() {
         MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
 
         waitUntil(driver -> calendar.hasDatePart(PART_NAME_DAY, PART_NAME));
         Assert.assertFalse(calendar.isDateDisabled(PART_NAME_DAY));
-    }
-
-    @Test
-    public void setDisabledDate_fieldIsInvalidWithI18nMessage() {
-        datePicker.setInputValue("1/" + FIXED_DISABLED_DAY + "/2023");
-
-        waitUntil(driver -> datePicker.isInvalid());
-        Assert.assertEquals(DISABLED_DATE_ERROR_MESSAGE,
-                datePicker.getErrorMessage());
-    }
-
-    @Test
-    public void setProviderDisabledDate_fieldIsInvalid() {
-        datePicker.setInputValue("1/" + PROVIDER_DISABLED_DAY + "/2023");
-
-        waitUntil(driver -> datePicker.isInvalid());
-        Assert.assertEquals(DISABLED_DATE_ERROR_MESSAGE,
-                datePicker.getErrorMessage());
-    }
-
-    @Test
-    public void setEnabledDate_fieldIsValid() {
-        datePicker.setInputValue("1/" + ENABLED_DAY + "/2023");
-
-        waitUntil(driver -> LocalDate.of(2023, 1, ENABLED_DAY)
-                .equals(datePicker.getDate()));
-        Assert.assertFalse(datePicker.isInvalid());
     }
 
     @Test
@@ -141,45 +96,6 @@ public class DatePickerDateMetadataIT extends AbstractComponentIT {
                 MONTH_HEADER);
         waitUntil(driver -> refreshedCalendar
                 .isDateDisabled(REFRESHED_DISABLED_DAY));
-    }
-
-    @Test
-    public void openOverlay_slowProvider_datesLoadingButSelectable() {
-        DatePickerElement slowDatePicker = $(DatePickerElement.class)
-                .id("slow-date-picker");
-
-        // The provider blocks the session lock while it answers, so waiting for
-        // the server would also wait for the loading state to be over.
-        getCommandExecutor().disableWaitForVaadin();
-        try {
-            // The metadata for the year of the initial value is already
-            // fetched when the page is ready, so the loading state shows on
-            // the months of the neighboring year that the overlay renders.
-            slowDatePicker.open();
-            MonthCalendarElement calendar = getCalendar(slowDatePicker,
-                    LOADING_MONTH_HEADER);
-            waitUntil(driver -> calendar
-                    .isDateLoading(SLOW_PROVIDER_DISABLED_DAY));
-
-            Assert.assertTrue(slowDatePicker.getOverlayContent().isLoading());
-            Assert.assertFalse(
-                    calendar.isDateDisabled(SLOW_PROVIDER_DISABLED_DAY));
-
-            calendar.clickDate(SLOW_PROVIDER_DISABLED_DAY);
-            Assert.assertEquals(
-                    LOADING_MONTH_VALUE_PREFIX + SLOW_PROVIDER_DISABLED_DAY,
-                    slowDatePicker.getPropertyString("value"));
-        } finally {
-            getCommandExecutor().enableWaitForVaadin();
-        }
-
-        // Once the provider has answered, the date is no longer loading and is
-        // rendered as disabled.
-        MonthCalendarElement calendar = openCalendar(slowDatePicker,
-                LOADING_MONTH_HEADER);
-        waitUntil(
-                driver -> calendar.isDateDisabled(SLOW_PROVIDER_DISABLED_DAY));
-        Assert.assertFalse(calendar.isDateLoading(SLOW_PROVIDER_DISABLED_DAY));
     }
 
     private MonthCalendarElement openCalendar(DatePickerElement picker,

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/validation/BasicValidationIT.java
@@ -17,8 +17,11 @@ package com.vaadin.flow.component.datepicker.validation;
 
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.DISABLED_DATES_INPUT;
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.DISABLED_DATE_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MAX_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MAX_INPUT;
+import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.METADATA_PROVIDER_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MIN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.MIN_INPUT;
 import static com.vaadin.flow.component.datepicker.validation.BasicValidationPage.REQUIRED_BUTTON;
@@ -112,6 +115,41 @@ public class BasicValidationIT extends AbstractValidationIT<DatePickerElement> {
         assertErrorMessage("");
 
         testField.setInputValue("");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
+        assertErrorMessage("");
+    }
+
+    @Test
+    public void disabledDates_changeValue_assertValidity() {
+        $("input").id(DISABLED_DATES_INPUT).sendKeys("2022-03-01", Keys.ENTER);
+
+        testField.setInputValue("3/1/2022");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(DISABLED_DATE_ERROR_MESSAGE);
+
+        testField.setInputValue("3/2/2022");
+        assertValidationCount(1);
+        assertClientValid();
+        assertServerValid();
+        assertErrorMessage("");
+    }
+
+    @Test
+    public void dateMetadataProvider_changeValue_assertValidity() {
+        $("input").id(METADATA_PROVIDER_INPUT).sendKeys("2022-03-01",
+                Keys.ENTER);
+
+        testField.setInputValue("3/1/2022");
+        assertValidationCount(1);
+        assertClientInvalid();
+        assertServerInvalid();
+        assertErrorMessage(DISABLED_DATE_ERROR_MESSAGE);
+
+        testField.setInputValue("3/2/2022");
         assertValidationCount(1);
         assertClientValid();
         assertServerValid();

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -72,19 +72,6 @@ public class DatePickerElement extends TestBenchElement
     }
 
     public static class MonthCalendarElement extends TestBenchElement {
-
-        /**
-         * Finds the date cell for the day passed as the second script argument
-         * and stores it in a {@code cell} variable, which is {@code undefined}
-         * if the month calendar does not show that day. Prepend this to a
-         * script that reads something from the cell.
-         */
-        private static final String FIND_DATE_CELL = """
-                const cell = Array.from(
-                        arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
-                        .find((date) => date.textContent.trim() === String(arguments[1]));
-                """;
-
         /**
          * Gets the header text of the month calendar, e.g. `January 1999`
          *
@@ -106,52 +93,58 @@ public class DatePickerElement extends TestBenchElement
         }
 
         /**
-         * Gets whether the date cell for the given day of the month is rendered
-         * as disabled.
+         * Gets the day cells that show a day of the month rendered by the month
+         * calendar.
          *
-         * @param day
-         *            the day of the month
-         * @return {@code true} if the date cell is disabled, {@code false}
-         *         otherwise or if the month calendar does not show the given
-         *         day
+         * @return the day cells
          */
-        public boolean isDateDisabled(int day) {
-            return hasDatePart(day, "disabled");
+        public List<DayElement> getDays() {
+            return getDayCells(
+                    """
+                            return Array.from(
+                                    arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
+                                    .filter((date) => date.textContent.trim() !== '');
+                            """);
         }
 
         /**
-         * Gets whether the date cell for the given day of the month has the
-         * given CSS part name.
+         * Gets the day cell for the given day of the month. The cell renders
+         * the state of the day: for example, a day that cannot be selected has
+         * a {@code disabled} attribute, and custom part names from the date
+         * metadata show up in its {@code part} attribute.
          *
          * @param day
          *            the day of the month
-         * @param partName
-         *            the part name to look for
-         * @return {@code true} if the date cell has the part name,
-         *         {@code false} otherwise or if the month calendar does not
+         * @return the day cell, or {@code null} if the month calendar does not
          *         show the given day
          */
-        public boolean hasDatePart(int day, String partName) {
-            return Boolean.TRUE.equals(executeScript(FIND_DATE_CELL + """
-                    return cell?.part.contains(arguments[2]) ?? false;
-                    """, this, day, partName));
+        public DayElement getDay(int day) {
+            List<DayElement> cells = getDayCells(
+                    """
+                            return Array.from(
+                                    arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
+                                    .filter((date) => date.textContent.trim() === String(arguments[1]));
+                            """,
+                    day);
+            return cells.isEmpty() ? null : cells.get(0);
         }
 
-        /**
-         * Clicks the date cell for the given day of the month. Fails if the
-         * month calendar does not show the given day.
-         *
-         * @param day
-         *            the day of the month
-         */
-        public void clickDate(int day) {
-            executeScript(FIND_DATE_CELL + """
-                    cell.click();
-                    """, this, day);
+        private List<DayElement> getDayCells(String script, Object... args) {
+            Object[] arguments = new Object[args.length + 1];
+            arguments[0] = this;
+            System.arraycopy(args, 0, arguments, 1, args.length);
+            @SuppressWarnings("unchecked")
+            List<TestBenchElement> cells = (List<TestBenchElement>) executeScript(
+                    script, arguments);
+            return cells.stream().map(cell -> cell.wrap(DayElement.class))
+                    .toList();
         }
     }
 
     public static class WeekdayElement extends TestBenchElement {
+    }
+
+    public static class DayElement extends TestBenchElement {
     }
 
     /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -69,18 +69,6 @@ public class DatePickerElement extends TestBenchElement
             return this.$(ButtonElement.class)
                     .withAttribute("slot", "cancel-button").first();
         }
-
-        /**
-         * Gets whether the overlay is waiting for date metadata. While waiting,
-         * the affected dates are rendered in a loading state, but stay
-         * selectable.
-         *
-         * @return {@code true} if the overlay is waiting for date metadata,
-         *         {@code false} otherwise
-         */
-        public boolean isLoading() {
-            return hasAttribute("loading");
-        }
     }
 
     public static class MonthCalendarElement extends TestBenchElement {
@@ -118,21 +106,6 @@ public class DatePickerElement extends TestBenchElement
         }
 
         /**
-         * Gets the CSS part names of the date cell for the given day of the
-         * month, as a space separated string.
-         *
-         * @param day
-         *            the day of the month
-         * @return the part names of the date cell, or {@code null} if the month
-         *         calendar does not show the given day
-         */
-        public String getDatePart(int day) {
-            return (String) executeScript(FIND_DATE_CELL + """
-                    return cell ? cell.getAttribute('part') : null;
-                    """, this, day);
-        }
-
-        /**
          * Gets whether the date cell for the given day of the month is rendered
          * as disabled.
          *
@@ -144,21 +117,6 @@ public class DatePickerElement extends TestBenchElement
          */
         public boolean isDateDisabled(int day) {
             return hasDatePart(day, "disabled");
-        }
-
-        /**
-         * Gets whether the date cell for the given day of the month is rendered
-         * as loading, which is the case while the date metadata for it is being
-         * fetched.
-         *
-         * @param day
-         *            the day of the month
-         * @return {@code true} if the date cell is loading, {@code false}
-         *         otherwise or if the month calendar does not show the given
-         *         day
-         */
-        public boolean isDateLoading(int day) {
-            return hasDatePart(day, "loading");
         }
 
         /**
@@ -175,23 +133,8 @@ public class DatePickerElement extends TestBenchElement
          */
         public boolean hasDatePart(int day, String partName) {
             return Boolean.TRUE.equals(executeScript(FIND_DATE_CELL + """
-                    return cell ? cell.part.contains(arguments[2]) : false;
+                    return cell?.part.contains(arguments[2]) ?? false;
                     """, this, day, partName));
-        }
-
-        /**
-         * Gets the value of the {@code aria-disabled} attribute of the date
-         * cell for the given day of the month.
-         *
-         * @param day
-         *            the day of the month
-         * @return the attribute value, or {@code null} if the month calendar
-         *         does not show the given day
-         */
-        public String getDateAriaDisabled(int day) {
-            return (String) executeScript(FIND_DATE_CELL + """
-                    return cell ? cell.getAttribute('aria-disabled') : null;
-                    """, this, day);
         }
 
         /**

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -193,6 +193,19 @@ public class DatePickerElement extends TestBenchElement
                     return cell ? cell.getAttribute('aria-disabled') : null;
                     """, this, day);
         }
+
+        /**
+         * Clicks the date cell for the given day of the month. Fails if the
+         * month calendar does not show the given day.
+         *
+         * @param day
+         *            the day of the month
+         */
+        public void clickDate(int day) {
+            executeScript(FIND_DATE_CELL + """
+                    cell.click();
+                    """, this, day);
+        }
     }
 
     public static class WeekdayElement extends TestBenchElement {

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -69,9 +69,34 @@ public class DatePickerElement extends TestBenchElement
             return this.$(ButtonElement.class)
                     .withAttribute("slot", "cancel-button").first();
         }
+
+        /**
+         * Gets whether the overlay is waiting for date metadata. While waiting,
+         * the affected dates are rendered in a loading state, but stay
+         * selectable.
+         *
+         * @return {@code true} if the overlay is waiting for date metadata,
+         *         {@code false} otherwise
+         */
+        public boolean isLoading() {
+            return hasAttribute("loading");
+        }
     }
 
     public static class MonthCalendarElement extends TestBenchElement {
+
+        /**
+         * Finds the date cell for the day passed as the second script argument
+         * and stores it in a {@code cell} variable, which is {@code undefined}
+         * if the month calendar does not show that day. Prepend this to a
+         * script that reads something from the cell.
+         */
+        private static final String FIND_DATE_CELL = """
+                const cell = Array.from(
+                        arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
+                        .find((date) => date.textContent.trim() === String(arguments[1]));
+                """;
+
         /**
          * Gets the header text of the month calendar, e.g. `January 1999`
          *
@@ -90,6 +115,83 @@ public class DatePickerElement extends TestBenchElement
         public List<WeekdayElement> getWeekdays() {
             return this.$(WeekdayElement.class).withAttribute("part", "weekday")
                     .all();
+        }
+
+        /**
+         * Gets the CSS part names of the date cell for the given day of the
+         * month, as a space separated string.
+         *
+         * @param day
+         *            the day of the month
+         * @return the part names of the date cell, or {@code null} if the month
+         *         calendar does not show the given day
+         */
+        public String getDatePart(int day) {
+            return (String) executeScript(FIND_DATE_CELL + """
+                    return cell ? cell.getAttribute('part') : null;
+                    """, this, day);
+        }
+
+        /**
+         * Gets whether the date cell for the given day of the month is rendered
+         * as disabled.
+         *
+         * @param day
+         *            the day of the month
+         * @return {@code true} if the date cell is disabled, {@code false}
+         *         otherwise or if the month calendar does not show the given
+         *         day
+         */
+        public boolean isDateDisabled(int day) {
+            return hasDatePart(day, "disabled");
+        }
+
+        /**
+         * Gets whether the date cell for the given day of the month is rendered
+         * as loading, which is the case while the date metadata for it is being
+         * fetched.
+         *
+         * @param day
+         *            the day of the month
+         * @return {@code true} if the date cell is loading, {@code false}
+         *         otherwise or if the month calendar does not show the given
+         *         day
+         */
+        public boolean isDateLoading(int day) {
+            return hasDatePart(day, "loading");
+        }
+
+        /**
+         * Gets whether the date cell for the given day of the month has the
+         * given CSS part name.
+         *
+         * @param day
+         *            the day of the month
+         * @param partName
+         *            the part name to look for
+         * @return {@code true} if the date cell has the part name,
+         *         {@code false} otherwise or if the month calendar does not
+         *         show the given day
+         */
+        public boolean hasDatePart(int day, String partName) {
+            return Boolean.TRUE.equals(executeScript(FIND_DATE_CELL + """
+                    return cell ? cell.part.contains(arguments[2]) : false;
+                    """, this, day, partName));
+        }
+
+        /**
+         * Gets the value of the {@code aria-disabled} attribute of the date
+         * cell for the given day of the month.
+         *
+         * @param day
+         *            the day of the month
+         * @return the attribute value, or {@code null} if the month calendar
+         *         does not show the given day
+         */
+        public String getDateAriaDisabled(int day) {
+            return (String) executeScript(FIND_DATE_CELL + """
+                    return cell ? cell.getAttribute('aria-disabled') : null;
+                    """, this, day);
         }
     }
 

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/src/main/java/com/vaadin/flow/component/datepicker/testbench/DatePickerElement.java
@@ -99,12 +99,9 @@ public class DatePickerElement extends TestBenchElement
          * @return the day cells
          */
         public List<DayElement> getDays() {
-            return getDayCells(
-                    """
-                            return Array.from(
-                                    arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
-                                    .filter((date) => date.textContent.trim() !== '');
-                            """);
+            return this.$(DayElement.class)
+                    .withAttributeContainingWord("part", "date")
+                    .withCondition(day -> !day.getText().isEmpty()).all();
         }
 
         /**
@@ -119,25 +116,10 @@ public class DatePickerElement extends TestBenchElement
          *         show the given day
          */
         public DayElement getDay(int day) {
-            List<DayElement> cells = getDayCells(
-                    """
-                            return Array.from(
-                                    arguments[0].shadowRoot.querySelectorAll('[part~="date"]'))
-                                    .filter((date) => date.textContent.trim() === String(arguments[1]));
-                            """,
-                    day);
-            return cells.isEmpty() ? null : cells.get(0);
-        }
-
-        private List<DayElement> getDayCells(String script, Object... args) {
-            Object[] arguments = new Object[args.length + 1];
-            arguments[0] = this;
-            System.arraycopy(args, 0, arguments, 1, args.length);
-            @SuppressWarnings("unchecked")
-            List<TestBenchElement> cells = (List<TestBenchElement>) executeScript(
-                    script, arguments);
-            return cells.stream().map(cell -> cell.wrap(DayElement.class))
-                    .toList();
+            return this.$(DayElement.class)
+                    .withAttributeContainingWord("part", "date")
+                    .withText(String.valueOf(day)).all().stream().findFirst()
+                    .orElse(null);
         }
     }
 


### PR DESCRIPTION
## Description

- Added `DayElement`, `getDays()` and `getDay()` APIs to `MonthCalendarElement`.
- Added ITs for validation to `BasicValidationIT` and `DatePickerDateMetadataIT`

Part of vaadin/platform#2867

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
