### PR TITLE
feat: add per-date factory for date metadata provider

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadataProvider.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/DateMetadataProvider.java
@@ -16,7 +16,11 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Objects;
+
+import com.vaadin.flow.function.SerializableFunction;
 
 /**
  * A callback that provides metadata for a range of dates, for example to mark
@@ -57,4 +61,33 @@ public interface DateMetadataProvider extends Serializable {
      *         empty collection if none have
      */
     Collection<DateMetadata> getDateMetadata(DateRange range);
+
+    /**
+     * Creates a provider that builds the metadata one date at a time. The given
+     * function is called for every date in the requested range, and returns the
+     * metadata for that date, or {@code null} for a date that has none:
+     *
+     * <pre>
+     * datePicker.setDateMetadataProvider(DateMetadataProvider.perDate(
+     *         date -&gt; isFullyBooked(date) ? new DateMetadata(date, true)
+     *                 : null));
+     * </pre>
+     *
+     * The function is called once per date, and a range can cover up to a year,
+     * so it has to answer from memory. A function that queries a backend would
+     * query it once per date; implement the provider directly instead, so that
+     * a single query can answer for the whole range.
+     *
+     * @param generator
+     *            the function that returns the metadata for a single date, or
+     *            {@code null} for a date that has none, not {@code null}
+     * @return a provider backed by the given function
+     * @since 25.3
+     */
+    static DateMetadataProvider perDate(
+            SerializableFunction<LocalDate, DateMetadata> generator) {
+        Objects.requireNonNull(generator, "Generator cannot be null");
+        return range -> range.start().datesUntil(range.end().plusDays(1))
+                .map(generator).filter(Objects::nonNull).toList();
+    }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataTest.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/test/java/com/vaadin/flow/component/datepicker/DatePickerDateMetadataTest.java
@@ -373,6 +373,58 @@ class DatePickerDateMetadataTest {
     }
 
     @Test
+    void perDate_returnsEntriesForDatesWithMetadata() {
+        DateMetadataProvider provider = DateMetadataProvider
+                .perDate(date -> date.getDayOfMonth() % 3 == 0
+                        ? new DateMetadata(date, true)
+                        : null);
+
+        List<DateMetadata> metadata = List.copyOf(
+                provider.getDateMetadata(new DateRange(LocalDate.of(2023, 1, 1),
+                        LocalDate.of(2023, 1, 10))));
+
+        Assertions.assertEquals(
+                List.of(new DateMetadata(LocalDate.of(2023, 1, 3), true),
+                        new DateMetadata(LocalDate.of(2023, 1, 6), true),
+                        new DateMetadata(LocalDate.of(2023, 1, 9), true)),
+                metadata);
+    }
+
+    @Test
+    void perDate_calledOncePerDateInRange() {
+        AtomicInteger calls = new AtomicInteger();
+        DateMetadataProvider provider = DateMetadataProvider.perDate(date -> {
+            calls.incrementAndGet();
+            return null;
+        });
+
+        provider.getDateMetadata(new DateRange(LocalDate.of(2023, 1, 1),
+                LocalDate.of(2023, 1, 10)));
+
+        Assertions.assertEquals(10, calls.get());
+    }
+
+    @Test
+    void perDate_singleDayRange_bothBoundsIncluded() {
+        DateMetadataProvider provider = DateMetadataProvider
+                .perDate(date -> new DateMetadata(date, true));
+
+        List<DateMetadata> metadata = List.copyOf(
+                provider.getDateMetadata(new DateRange(LocalDate.of(2023, 1, 5),
+                        LocalDate.of(2023, 1, 5))));
+
+        Assertions.assertEquals(
+                List.of(new DateMetadata(LocalDate.of(2023, 1, 5), true)),
+                metadata);
+    }
+
+    @Test
+    void perDate_nullGenerator_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> DateMetadataProvider.perDate(null));
+    }
+
+    @Test
     void dateMetadata_partNameConstructor_isNotDisabled() {
         DateMetadata metadata = new DateMetadata(LocalDate.of(2023, 1, 10),
                 "busy");


### PR DESCRIPTION
`DateMetadataProvider` is called with a range of dates, so a rule that only looks at one date at a time has to iterate the range and collect the entries by hand:

```java
datePicker.setDateMetadataProvider(
        range -> range.start().datesUntil(range.end().plusDays(1))
                .filter(date -> isFullyBooked(date))
                .map(date -> new DateMetadata(date, true))
                .toList());
```

For rules that answer from memory, that is boilerplate. The new factory takes a function from a date to its metadata, or `null` for a date that has none:

```java
datePicker.setDateMetadataProvider(DateMetadataProvider.perDate(
        date -> isFullyBooked(date) ? new DateMetadata(date, true) : null));
```

## Changes

The factory is a static method on `DateMetadataProvider`, not a new setter on the components. `setDateMetadataProvider` stays the only entry point, `getDateMetadataProvider()` keeps a single answer, and nothing has to be mirrored on Date Time Picker later.

The function runs once per date in the requested range, which can cover up to a year. The Javadoc says it has to answer from memory, and points rules that query a backend at implementing the provider directly, where a single query can answer for the whole range. Making the per-date shape look this convenient is exactly how a query-per-date ends up in an application, so the warning sits on the factory itself.

Part of vaadin/platform#2867

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
