### PR TITLE
feat: add date metadata support to DateTimePicker

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataPage.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datetimepicker;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.vaadin.flow.component.datepicker.DateMetadata;
+import com.vaadin.flow.component.datepicker.DateRange;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-date-time-picker/date-metadata")
+public class DateTimePickerDateMetadataPage extends Div {
+
+    // January 2023 starts on a Sunday, so the weekend days are 7, 8, 14, 15,
+    // 21, 22, 28 and 29. The days below are picked so that each one is disabled
+    // by exactly one constraint.
+    public static final LocalDateTime INITIAL_VALUE = LocalDate.of(2023, 1, 5)
+            .atTime(12, 0);
+    public static final String MONTH_HEADER = "January 2023";
+    public static final int ENABLED_DAY = 12;
+    public static final int FIXED_DISABLED_DAY = 10;
+    public static final int OTHER_FIXED_DISABLED_DAY = 20;
+    public static final int SATURDAY_DAY = 7;
+    public static final int SUNDAY_DAY = 8;
+    public static final int PROVIDER_DISABLED_DAY = 17;
+    public static final int REFRESHED_DISABLED_DAY = 18;
+    public static final int PART_NAME_DAY = 25;
+    public static final String PART_NAME = "busy";
+    private final Set<Integer> disabledDays = new LinkedHashSet<>(
+            List.of(PROVIDER_DISABLED_DAY));
+
+    public DateTimePickerDateMetadataPage() {
+        DateTimePicker dateTimePicker = new DateTimePicker();
+        dateTimePicker.setId("date-time-picker");
+        dateTimePicker.setValue(INITIAL_VALUE);
+        dateTimePicker.setDisabledDates(
+                List.of(LocalDate.of(2023, 1, FIXED_DISABLED_DAY),
+                        LocalDate.of(2023, 1, OTHER_FIXED_DISABLED_DAY)));
+        dateTimePicker.setDisabledWeekdays(
+                List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY));
+        dateTimePicker.setDateMetadataProvider(this::getDateMetadata);
+
+        NativeButton refresh = new NativeButton("Refresh date metadata",
+                event -> {
+                    disabledDays.add(REFRESHED_DISABLED_DAY);
+                    dateTimePicker.refreshDateMetadata();
+                });
+        refresh.setId("refresh");
+
+        add(dateTimePicker, refresh);
+    }
+
+    /**
+     * Answers from the mutable set of disabled days, so that a refresh can
+     * change the answer without the provider being set again.
+     */
+    private Collection<DateMetadata> getDateMetadata(DateRange range) {
+        List<DateMetadata> metadata = new ArrayList<>();
+        for (LocalDate date = range.start(); !date
+                .isAfter(range.end()); date = date.plusDays(1)) {
+            if (disabledDays.contains(date.getDayOfMonth())) {
+                metadata.add(new DateMetadata(date, true));
+            } else if (date.getDayOfMonth() == PART_NAME_DAY) {
+                metadata.add(new DateMetadata(date, PART_NAME));
+            }
+        }
+        return metadata;
+    }
+
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationPage.java
@@ -15,8 +15,12 @@
  */
 package com.vaadin.flow.component.datetimepicker.validation;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
+import com.vaadin.flow.component.datepicker.DateMetadata;
+import com.vaadin.flow.component.datepicker.DateMetadataProvider;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.router.Route;
 import com.vaadin.tests.validation.AbstractValidationPage;
@@ -27,6 +31,8 @@ public class BasicValidationPage
     public static final String REQUIRED_BUTTON = "required-button";
     public static final String MIN_INPUT = "min-input";
     public static final String MAX_INPUT = "max-input";
+    public static final String DISABLED_DATES_INPUT = "disabled-dates-input";
+    public static final String METADATA_PROVIDER_INPUT = "metadata-provider-input";
     public static final String CLEAR_VALUE_BUTTON = "clear-value-button";
 
     public static final String REQUIRED_ERROR_MESSAGE = "Field is required";
@@ -34,6 +40,7 @@ public class BasicValidationPage
     public static final String INCOMPLETE_INPUT_ERROR_MESSAGE = "Must fill in both date and time";
     public static final String MIN_ERROR_MESSAGE = "Date is too early";
     public static final String MAX_ERROR_MESSAGE = "Date is too late";
+    public static final String DISABLED_DATE_ERROR_MESSAGE = "Date is disabled";
 
     public BasicValidationPage() {
         super();
@@ -43,7 +50,8 @@ public class BasicValidationPage
                 .setIncompleteInputErrorMessage(INCOMPLETE_INPUT_ERROR_MESSAGE)
                 .setBadInputErrorMessage(BAD_INPUT_ERROR_MESSAGE)
                 .setMinErrorMessage(MIN_ERROR_MESSAGE)
-                .setMaxErrorMessage(MAX_ERROR_MESSAGE));
+                .setMaxErrorMessage(MAX_ERROR_MESSAGE)
+                .setDisabledDateErrorMessage(DISABLED_DATE_ERROR_MESSAGE));
 
         add(createButton(REQUIRED_BUTTON, "Enable required", event -> {
             testField.setRequiredIndicatorVisible(true);
@@ -58,6 +66,20 @@ public class BasicValidationPage
             var value = LocalDateTime.parse(event.getValue());
             testField.setMax(value);
         }));
+
+        add(createInput(DISABLED_DATES_INPUT, "Set disabled dates", event -> {
+            var value = LocalDate.parse(event.getValue());
+            testField.setDisabledDates(List.of(value));
+        }));
+
+        add(createInput(METADATA_PROVIDER_INPUT,
+                "Set date metadata provider disabling a date", event -> {
+                    var disabledDate = LocalDate.parse(event.getValue());
+                    testField.setDateMetadataProvider(DateMetadataProvider
+                            .perDate(date -> date.equals(disabledDate)
+                                    ? new DateMetadata(date, true)
+                                    : null));
+                }));
 
         add(createButton(CLEAR_VALUE_BUTTON, "Clear value", event -> {
             testField.clear();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datetimepicker;
+
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.ENABLED_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.FIXED_DISABLED_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.MONTH_HEADER;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.OTHER_FIXED_DISABLED_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.PART_NAME;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.PART_NAME_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.PROVIDER_DISABLED_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.REFRESHED_DISABLED_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.SATURDAY_DAY;
+import static com.vaadin.flow.component.datetimepicker.DateTimePickerDateMetadataPage.SUNDAY_DAY;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.DayElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.MonthCalendarElement;
+import com.vaadin.flow.component.datepicker.testbench.DatePickerElement.OverlayContentElement;
+import com.vaadin.flow.component.datetimepicker.testbench.DateTimePickerElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+/**
+ * Integration tests for the {@link DateTimePickerDateMetadataPage}.
+ */
+@TestPath("vaadin-date-time-picker/date-metadata")
+public class DateTimePickerDateMetadataIT extends AbstractComponentIT {
+
+    private DatePickerElement datePicker;
+
+    @Before
+    public void init() {
+        open();
+        datePicker = $(DateTimePickerElement.class).id("date-time-picker")
+                .getDatePicker();
+    }
+
+    @Test
+    public void openOverlay_fixedDatesAreDisabled() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        Assert.assertTrue(isDayDisabled(calendar, FIXED_DISABLED_DAY));
+        Assert.assertTrue(isDayDisabled(calendar, OTHER_FIXED_DISABLED_DAY));
+        Assert.assertFalse(isDayDisabled(calendar, ENABLED_DAY));
+    }
+
+    @Test
+    public void openOverlay_weekendsAreDisabled() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        Assert.assertTrue(isDayDisabled(calendar, SATURDAY_DAY));
+        Assert.assertTrue(isDayDisabled(calendar, SUNDAY_DAY));
+    }
+
+    @Test
+    public void openOverlay_providerDisablesDate() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        waitUntil(driver -> isDayDisabled(calendar, PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(isDayDisabled(calendar, ENABLED_DAY));
+    }
+
+    @Test
+    public void openOverlay_providerAddsPartName() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+
+        waitUntil(driver -> hasDayPart(calendar.getDay(PART_NAME_DAY),
+                PART_NAME));
+        Assert.assertFalse(isDayDisabled(calendar, PART_NAME_DAY));
+    }
+
+    @Test
+    public void refreshDateMetadata_disabledDatesAreUpdated() {
+        MonthCalendarElement calendar = openCalendar(datePicker, MONTH_HEADER);
+        waitUntil(driver -> isDayDisabled(calendar, PROVIDER_DISABLED_DAY));
+        Assert.assertFalse(isDayDisabled(calendar, REFRESHED_DISABLED_DAY));
+
+        datePicker.close();
+        clickElementWithJs("refresh");
+
+        MonthCalendarElement refreshedCalendar = openCalendar(datePicker,
+                MONTH_HEADER);
+        waitUntil(driver -> isDayDisabled(refreshedCalendar,
+                REFRESHED_DISABLED_DAY));
+    }
+
+    private boolean isDayDisabled(MonthCalendarElement calendar, int day) {
+        return calendar.getDay(day).hasAttribute("disabled");
+    }
+
+    private boolean hasDayPart(DayElement day, String partName) {
+        return List.of(day.getDomAttribute("part").split(" "))
+                .contains(partName);
+    }
+
+    private MonthCalendarElement openCalendar(DatePickerElement picker,
+            String monthHeader) {
+        picker.open();
+        return getCalendar(picker, monthHeader);
+    }
+
+    private MonthCalendarElement getCalendar(DatePickerElement picker,
+            String monthHeader) {
+        OverlayContentElement overlayContent = picker.getOverlayContent();
+        return waitUntil(driver -> overlayContent
+                .getVisibleMonthCalendars().stream().filter(calendar -> calendar
+                        .getHeaderText().contains(monthHeader))
+                .findFirst().orElse(null));
+    }
+
+}

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -17,9 +17,12 @@ package com.vaadin.flow.component.datetimepicker.validation;
 
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.BAD_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.CLEAR_VALUE_BUTTON;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.DISABLED_DATES_INPUT;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.DISABLED_DATE_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.INCOMPLETE_INPUT_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MAX_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MAX_INPUT;
+import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.METADATA_PROVIDER_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MIN_ERROR_MESSAGE;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.MIN_INPUT;
 import static com.vaadin.flow.component.datetimepicker.validation.BasicValidationPage.REQUIRED_BUTTON;
@@ -126,6 +129,38 @@ public class BasicValidationIT extends AbstractDateTimePickerValidationIT {
 
         setTimeInputValue("11:00");
         assertValidation(true, "");
+    }
+
+    @Test
+    public void disabledDates_changeValue_assertValidity() {
+        $("input").id(DISABLED_DATES_INPUT).sendKeys("2000-02-02", Keys.ENTER);
+
+        // The disabled date is reported even though the time is still missing
+        setDateInputValue("2/2/2000");
+        assertValidation(false, DISABLED_DATE_ERROR_MESSAGE);
+
+        setTimeInputValue("12:00");
+        assertValidation(false, DISABLED_DATE_ERROR_MESSAGE);
+
+        setDateInputValue("2/3/2000");
+        assertValidation(true, "");
+    }
+
+    @Test
+    public void dateMetadataProvider_changeValue_assertValidity() {
+        $("input").id(METADATA_PROVIDER_INPUT).sendKeys("2000-02-02",
+                Keys.ENTER);
+
+        setDateInputValue("2/2/2000");
+        setTimeInputValue("12:00");
+        // The client only asks the provider about the dates that the calendar
+        // renders, so with the overlay closed only the server rejects the date
+        assertServerInvalid();
+        assertErrorMessage(DISABLED_DATE_ERROR_MESSAGE);
+
+        setDateInputValue("2/3/2000");
+        assertServerValid();
+        assertErrorMessage("");
     }
 
     @Test

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -151,16 +151,13 @@ public class BasicValidationIT extends AbstractDateTimePickerValidationIT {
         $("input").id(METADATA_PROVIDER_INPUT).sendKeys("2000-02-02",
                 Keys.ENTER);
 
-        setDateInputValue("2/2/2000");
-        setTimeInputValue("12:00");
-        // The client only asks the provider about the dates that the calendar
-        // renders, so with the overlay closed only the server rejects the date
-        assertServerInvalid();
-        assertErrorMessage(DISABLED_DATE_ERROR_MESSAGE);
+        // The client cannot tell that the provider disables the date, so the
+        // component waits for both pickers to be filled before committing
+        setValue("2/2/2000", "12:00");
+        assertValidation(false, DISABLED_DATE_ERROR_MESSAGE);
 
         setDateInputValue("2/3/2000");
-        assertServerValid();
-        assertErrorMessage("");
+        assertValidation(true, "");
     }
 
     @Test

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/validation/BasicValidationIT.java
@@ -151,8 +151,6 @@ public class BasicValidationIT extends AbstractDateTimePickerValidationIT {
         $("input").id(METADATA_PROVIDER_INPUT).sendKeys("2000-02-02",
                 Keys.ENTER);
 
-        // The client cannot tell that the provider disables the date, so the
-        // component waits for both pickers to be filled before committing
         setValue("2/2/2000", "12:00");
         assertValidation(false, DISABLED_DATE_ERROR_MESSAGE);
 

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -16,12 +16,16 @@
 package com.vaadin.flow.component.datetimepicker;
 
 import java.io.Serializable;
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
@@ -32,6 +36,7 @@ import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.SignalPropertySupport;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.datepicker.DateMetadataProvider;
 import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -67,6 +72,10 @@ class DateTimePickerDatePicker
 
     boolean isPickerInputUnparsable() {
         return super.isInputUnparsable();
+    }
+
+    boolean isPickerDateDisabled(LocalDate date) {
+        return super.isDateDisabled(date);
     }
 }
 
@@ -154,6 +163,11 @@ public class DateTimePicker
             if (minResult.isError()) {
                 return minResult;
             }
+
+            if (datePicker.isPickerDateDisabled(datePicker.getValue())) {
+                return ValidationResult.error(getI18nErrorMessage(
+                        DateTimePickerI18n::getDisabledDateErrorMessage));
+            }
         }
 
         // Report error if only one of the pickers has a value
@@ -188,6 +202,12 @@ public class DateTimePicker
                 value, min);
         if (minResult.isError()) {
             return minResult;
+        }
+
+        if (value != null
+                && datePicker.isPickerDateDisabled(value.toLocalDate())) {
+            return ValidationResult.error(getI18nErrorMessage(
+                    DateTimePickerI18n::getDisabledDateErrorMessage));
         }
 
         return ValidationResult.ok();
@@ -984,6 +1004,143 @@ public class DateTimePicker
     }
 
     /**
+     * Gets the individual dates that cannot be selected.
+     *
+     * @return an unmodifiable set of the dates that cannot be selected, empty
+     *         if none are set, never {@code null}
+     * @see #setDisabledDates(Collection)
+     * @since 25.3
+     */
+    public Set<LocalDate> getDisabledDates() {
+        return datePicker.getDisabledDates();
+    }
+
+    /**
+     * Sets individual dates that cannot be selected. Such dates are displayed
+     * as disabled in the calendar overlay, and manual entry of one of them
+     * causes the component to invalidate.
+     * <p>
+     * The dates combine with the disabled weekdays, the date metadata provider,
+     * as well as with the minimum and maximum date and time: a date cannot be
+     * selected if any of these constraints disables it. By default, no
+     * individual dates are disabled.
+     * <p>
+     * Use this for a small, fully known set of dates. For a large or changing
+     * set, use {@link #setDateMetadataProvider(DateMetadataProvider)} instead,
+     * which only fetches the dates that are shown.
+     *
+     * @param dates
+     *            the dates that cannot be selected, or {@code null} to clear
+     *            the constraint
+     * @throws NullPointerException
+     *             if the collection contains {@code null} elements
+     * @see DateTimePickerI18n#setDisabledDateErrorMessage(String)
+     * @since 25.3
+     */
+    public void setDisabledDates(Collection<LocalDate> dates) {
+        datePicker.setDisabledDates(dates);
+    }
+
+    /**
+     * Gets the weekdays whose dates cannot be selected.
+     *
+     * @return an unmodifiable set of the weekdays whose dates cannot be
+     *         selected, empty if none are set, never {@code null}
+     * @see #setDisabledWeekdays(Collection)
+     * @since 25.3
+     */
+    public Set<DayOfWeek> getDisabledWeekdays() {
+        return datePicker.getDisabledWeekdays();
+    }
+
+    /**
+     * Sets the weekdays whose dates cannot be selected. Such dates are
+     * displayed as disabled in the calendar overlay, and manual entry of one of
+     * them causes the component to invalidate.
+     * <p>
+     * The weekdays combine with the individually disabled dates, the date
+     * metadata provider, as well as with the minimum and maximum date and time:
+     * a date cannot be selected if any of these constraints disables it. By
+     * default, no weekdays are disabled.
+     *
+     * @param weekdays
+     *            the weekdays whose dates cannot be selected, or {@code null}
+     *            to clear the constraint
+     * @throws NullPointerException
+     *             if the collection contains {@code null} elements
+     * @see DateTimePickerI18n#setDisabledDateErrorMessage(String)
+     * @since 25.3
+     */
+    public void setDisabledWeekdays(Collection<DayOfWeek> weekdays) {
+        datePicker.setDisabledWeekdays(weekdays);
+    }
+
+    /**
+     * Gets the callback that provides metadata for the dates shown in the
+     * calendar overlay.
+     *
+     * @return the date metadata provider, or {@code null} if none is set
+     * @see #setDateMetadataProvider(DateMetadataProvider)
+     * @since 25.3
+     */
+    public DateMetadataProvider getDateMetadataProvider() {
+        return datePicker.getDateMetadataProvider();
+    }
+
+    /**
+     * Sets a callback that provides metadata for the dates shown in the
+     * calendar overlay, for example to mark dates as not selectable. See
+     * {@link DateMetadataProvider} for the semantics of the callback.
+     * <p>
+     * The provider combines with the individually disabled dates and weekdays,
+     * as well as with the minimum and maximum date and time: a date cannot be
+     * selected if any of these constraints disables it. By default, no provider
+     * is set.
+     * <p>
+     * Entries can also carry custom CSS part names, so that a theme can style
+     * particular dates. A part name only affects styling, never whether a date
+     * can be selected.
+     * <p>
+     * The provider is also called during server-side validation, with the date
+     * being validated, so that a disabled date cannot be committed even if the
+     * browser was never told about it. Setting a provider does not re-validate
+     * the current value. Call {@link #refreshDateMetadata()} when the data
+     * behind the provider changes.
+     *
+     * @param provider
+     *            the date metadata provider, or {@code null} to remove the
+     *            current one
+     * @see DateTimePickerI18n#setDisabledDateErrorMessage(String)
+     * @since 25.3
+     */
+    public void setDateMetadataProvider(DateMetadataProvider provider) {
+        datePicker.setDateMetadataProvider(provider);
+    }
+
+    /**
+     * Discards the date metadata that the browser has cached and fetches it
+     * again for the dates that are shown. Call this when the data behind the
+     * date metadata provider has changed.
+     * <p>
+     * If the field has a value, or only its date part has one, it is also
+     * re-validated, since a date that was selectable before may not be anymore.
+     * Does nothing if no provider is set.
+     *
+     * @see #setDateMetadataProvider(DateMetadataProvider)
+     * @since 25.3
+     */
+    public void refreshDateMetadata() {
+        datePicker.refreshDateMetadata();
+        // The inner date picker only drops the client-side cache, as its own
+        // validate() is a no-op, so run validation on this component instead
+        // and notify Binder about the possibly changed validity.
+        if (datePicker.getDateMetadataProvider() != null
+                && (getValue() != null || !datePicker.isEmpty())) {
+            validate(true);
+        }
+    }
+
+    /**
      * Gets the internationalization object previously set for this component.
      * <p>
      * NOTE: Updating the instance that is returned from this method will not
@@ -1085,6 +1242,7 @@ public class DateTimePicker
         private String requiredErrorMessage;
         private String minErrorMessage;
         private String maxErrorMessage;
+        private String disabledDateErrorMessage;
 
         /**
          * Gets the aria-label suffix for the date picker.
@@ -1306,6 +1464,41 @@ public class DateTimePicker
          */
         public DateTimePickerI18n setMaxErrorMessage(String errorMessage) {
             maxErrorMessage = errorMessage;
+            return this;
+        }
+
+        /**
+         * Gets the error message displayed when the selected date is disabled.
+         *
+         * @return the error message or {@code null} if not set
+         * @see DateTimePicker#setDisabledDates(Collection)
+         * @see DateTimePicker#setDisabledWeekdays(Collection)
+         * @see DateTimePicker#setDateMetadataProvider(DateMetadataProvider)
+         * @since 25.3
+         */
+        @JsonIgnore // Not used on the client side
+        public String getDisabledDateErrorMessage() {
+            return disabledDateErrorMessage;
+        }
+
+        /**
+         * Sets the error message to display when the selected date is disabled.
+         * <p>
+         * Note, custom error messages set with
+         * {@link DateTimePicker#setErrorMessage(String)} take priority over
+         * i18n error messages.
+         *
+         * @param errorMessage
+         *            the error message or {@code null} to clear it
+         * @return this instance for method chaining
+         * @see DateTimePicker#setDisabledDates(Collection)
+         * @see DateTimePicker#setDisabledWeekdays(Collection)
+         * @see DateTimePicker#setDateMetadataProvider(DateMetadataProvider)
+         * @since 25.3
+         */
+        public DateTimePickerI18n setDisabledDateErrorMessage(
+                String errorMessage) {
+            disabledDateErrorMessage = errorMessage;
             return this;
         }
     }

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataTest.java
@@ -51,6 +51,8 @@ class DateTimePickerDateMetadataTest {
 
     private static final String ERROR_MESSAGE = "Date is disabled";
 
+    private static final String INCOMPLETE_INPUT_ERROR_MESSAGE = "Fill in both date and time";
+
     @RegisterExtension
     MockUIExtension ui = new MockUIExtension();
 
@@ -174,6 +176,32 @@ class DateTimePickerDateMetadataTest {
 
         picker.setValue(DISABLED_DATE_TIME);
         Assertions.assertFalse(picker.isInvalid());
+
+        restrictive.set(true);
+        picker.refreshDateMetadata();
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    @Test
+    void refreshDateMetadata_dateOnlySet_revalidates() {
+        picker.setI18n(new DateTimePickerI18n()
+                .setDisabledDateErrorMessage(ERROR_MESSAGE)
+                .setIncompleteInputErrorMessage(
+                        INCOMPLETE_INPUT_ERROR_MESSAGE));
+        AtomicBoolean restrictive = new AtomicBoolean(false);
+        picker.setDateMetadataProvider(range -> restrictive.get()
+                ? List.of(new DateMetadata(DISABLED_DATE, true))
+                : List.of());
+
+        // Simulate incomplete input: date picker has a value, time picker is
+        // empty, so the component value itself stays empty
+        getDatePicker().setValue(DISABLED_DATE);
+        fireUnparsableChangeDomEvent();
+        // Invalid because the time is missing, not because of the date
+        Assertions.assertEquals(INCOMPLETE_INPUT_ERROR_MESSAGE,
+                picker.getErrorMessage());
 
         restrictive.set(true);
         picker.refreshDateMetadata();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerDateMetadataTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.datetimepicker;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.datepicker.DateMetadata;
+import com.vaadin.flow.component.datepicker.DateMetadataProvider;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.datetimepicker.DateTimePicker.DateTimePickerI18n;
+import com.vaadin.flow.component.shared.SlotUtils;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+import com.vaadin.tests.MockUIExtension;
+
+import net.jcip.annotations.NotThreadSafe;
+
+@NotThreadSafe
+class DateTimePickerDateMetadataTest {
+
+    private static final LocalDate DISABLED_DATE = LocalDate.of(2023, 1, 10);
+
+    private static final LocalDateTime DISABLED_DATE_TIME = DISABLED_DATE
+            .atTime(12, 0);
+
+    private static final String ERROR_MESSAGE = "Date is disabled";
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
+
+    private DateTimePicker picker;
+
+    @BeforeEach
+    void setup() {
+        picker = new DateTimePicker();
+        picker.setI18n(new DateTimePickerI18n()
+                .setDisabledDateErrorMessage(ERROR_MESSAGE));
+    }
+
+    @Test
+    void setDisabledDates_delegatesToDatePicker() {
+        picker.setDisabledDates(List.of(DISABLED_DATE));
+
+        Assertions.assertEquals(Set.of(DISABLED_DATE),
+                picker.getDisabledDates());
+        Assertions.assertEquals(Set.of(DISABLED_DATE),
+                getDatePicker().getDisabledDates());
+    }
+
+    @Test
+    void setDisabledWeekdays_delegatesToDatePicker() {
+        picker.setDisabledWeekdays(
+                Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY));
+
+        Assertions.assertEquals(Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
+                picker.getDisabledWeekdays());
+        Assertions.assertEquals(Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
+                getDatePicker().getDisabledWeekdays());
+    }
+
+    @Test
+    void setDateMetadataProvider_delegatesToDatePicker() {
+        DateMetadataProvider provider = range -> List.of();
+        picker.setDateMetadataProvider(provider);
+
+        Assertions.assertSame(provider, picker.getDateMetadataProvider());
+        Assertions.assertSame(provider,
+                getDatePicker().getDateMetadataProvider());
+    }
+
+    @Test
+    void disabledDate_validationFails() {
+        picker.setDisabledDates(List.of(DISABLED_DATE));
+
+        picker.setValue(DISABLED_DATE_TIME);
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    @Test
+    void disabledWeekday_validationFails() {
+        // 2023-01-10 is a Tuesday
+        picker.setDisabledWeekdays(Set.of(DayOfWeek.TUESDAY));
+
+        picker.setValue(DISABLED_DATE_TIME);
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    @Test
+    void providerDisabledDate_validationFails() {
+        picker.setDateMetadataProvider(
+                range -> List.of(new DateMetadata(DISABLED_DATE, true)));
+
+        picker.setValue(DISABLED_DATE_TIME);
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    @Test
+    void disabledDateWithoutTime_validationFails() {
+        picker.setDisabledDates(List.of(DISABLED_DATE));
+
+        // Simulate incomplete input: date picker has a value, time picker is
+        // empty, so the component value itself stays empty
+        getDatePicker().setValue(DISABLED_DATE);
+        fireUnparsableChangeDomEvent();
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    @Test
+    void enabledDate_validationPasses() {
+        picker.setDisabledDates(List.of(DISABLED_DATE.plusDays(1)));
+        picker.setDisabledWeekdays(Set.of(DayOfWeek.SUNDAY));
+        picker.setDateMetadataProvider(
+                range -> List.of(new DateMetadata(DISABLED_DATE, false)));
+
+        picker.setValue(DISABLED_DATE_TIME);
+
+        Assertions.assertFalse(picker.isInvalid());
+    }
+
+    @Test
+    void disabledDateOutsideMinMax_reportsMinMaxErrorMessage() {
+        picker.setI18n(new DateTimePickerI18n()
+                .setDisabledDateErrorMessage(ERROR_MESSAGE)
+                .setMinErrorMessage("Value is too small"));
+        picker.setDisabledDates(List.of(DISABLED_DATE));
+        picker.setMin(DISABLED_DATE.plusDays(5).atStartOfDay());
+
+        picker.setValue(DISABLED_DATE_TIME);
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals("Value is too small", picker.getErrorMessage());
+    }
+
+    @Test
+    void refreshDateMetadata_valueSet_revalidates() {
+        AtomicBoolean restrictive = new AtomicBoolean(false);
+        picker.setDateMetadataProvider(range -> restrictive.get()
+                ? List.of(new DateMetadata(DISABLED_DATE, true))
+                : List.of());
+
+        picker.setValue(DISABLED_DATE_TIME);
+        Assertions.assertFalse(picker.isInvalid());
+
+        restrictive.set(true);
+        picker.refreshDateMetadata();
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    @Test
+    void refreshDateMetadata_valueSet_firesValidationStatusChangeEvent() {
+        picker.setDateMetadataProvider(range -> List.of());
+        picker.setValue(DISABLED_DATE_TIME);
+
+        AtomicInteger events = new AtomicInteger();
+        picker.addValidationStatusChangeListener(
+                event -> events.incrementAndGet());
+
+        picker.refreshDateMetadata();
+
+        Assertions.assertEquals(1, events.get());
+    }
+
+    @Test
+    void refreshDateMetadata_noProvider_doesNotValidate() {
+        picker.setRequiredIndicatorVisible(true);
+
+        picker.refreshDateMetadata();
+
+        Assertions.assertFalse(picker.isInvalid());
+    }
+
+    @Test
+    void perDate_worksThroughDateTimePicker() {
+        picker.setDateMetadataProvider(
+                DateMetadataProvider.perDate(date -> date.equals(DISABLED_DATE)
+                        ? new DateMetadata(date, true)
+                        : null));
+
+        picker.setValue(DISABLED_DATE_TIME);
+
+        Assertions.assertTrue(picker.isInvalid());
+        Assertions.assertEquals(ERROR_MESSAGE, picker.getErrorMessage());
+    }
+
+    private DatePicker getDatePicker() {
+        return (DatePicker) SlotUtils.getChildInSlot(picker, "date-picker");
+    }
+
+    private void fireUnparsableChangeDomEvent() {
+        Element element = picker.getElement();
+        DomEvent domEvent = new DomEvent(element, "unparsable-change",
+                JacksonUtils.createObjectNode());
+        element.getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(domEvent);
+    }
+}


### PR DESCRIPTION
## Description

Date Picker can disable dates through a fixed list, disabled weekdays and a date
metadata provider. Date Time Picker, which contains a date picker, could not.

```java
dateTimePicker.setDisabledWeekdays(List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY));
dateTimePicker.setDateMetadataProvider(DateMetadataProvider.perDate(
        date -> isFullyBooked(date) ? new DateMetadata(date, true) : null));
```

- `setDisabledDates`, `setDisabledWeekdays` and `setDateMetadataProvider`, with their
  getters, delegate to the inner date picker, which drives the calendar overlay on its own.
- `refreshDateMetadata()` delegates the cache drop, then runs this component's own
  validation and fires the validation status change event, so a Binder-bound field
  re-validates.
- Validation does not delegate. The inner date picker's `validate()` deliberately never
  changes the invalid state, so a disabled date would render as disabled in the calendar
  while validating as valid. Date Time Picker checks the disabled date in its own
  validator instead — both when only a date has been entered and when there is a full
  value, after the min/max checks in each case, so an out-of-range date still reports the
  min/max message.
- `DateTimePickerI18n.setDisabledDateErrorMessage(...)` provides the error message.
- The inner date picker subclass reaches the disabled-date check through a small bridge,
  the same way it already reaches `isInputUnparsable`.
- No client-side changes: the inner date picker is a full `<vaadin-date-picker>` with its
  own connector, so the configuration push and the metadata requests already work through it.
- Integration tests mirror the ones #9878 added for Date Picker. The Test Bench day cell
  API needed no changes, since `DateTimePickerElement.getDatePicker()` already returns a
  `DatePickerElement`.

Part of vaadin/platform#2867

## Type of change

- [ ] Bugfix
- [x] Feature

## How to test

```
mvn verify -am -pl vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests \
    -Dit.test='DateTimePickerDateMetadataIT,BasicValidationIT' -DskipUnitTests
```

By hand, open `vaadin-date-time-picker/date-metadata` (view
`DateTimePickerDateMetadataPage`). In January 2023 the calendar shows the 10th and the
20th, both weekends, and the 17th from the provider as disabled, and the 25th with a
`busy` part name. "Refresh date metadata" also disables the 18th without the provider
being set again.

On `vaadin-date-time-picker/validation/basic`, set a disabled date, then type it into the
date field: the field goes invalid with the message even before a time is picked. Setting
a min date past the typed date reports the min message instead.
