### PR TITLE
feat: add autoFocusPartialMatch to combo boxes

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/AutoFocusPartialMatch.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/AutoFocusPartialMatch.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.combobox;
 
+import java.util.Arrays;
+
 /**
  * Defines whether an item whose label partially matches the typed filter is
  * automatically focused in the dropdown of a combo box.
@@ -54,5 +56,19 @@ public enum AutoFocusPartialMatch {
      */
     public String getClientName() {
         return clientName;
+    }
+
+    /**
+     * Gets the mode matching the given client-side name, or {@link #NONE} if no
+     * mode matches.
+     *
+     * @param clientName
+     *            the client-side name of the mode
+     * @return the matching mode, or {@link #NONE}
+     */
+    static AutoFocusPartialMatch fromClientName(String clientName) {
+        return Arrays.stream(values())
+                .filter(mode -> mode.getClientName().equals(clientName))
+                .findFirst().orElse(NONE);
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/AutoFocusPartialMatch.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/AutoFocusPartialMatch.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox;
+
+/**
+ * Defines whether an item whose label partially matches the typed filter is
+ * automatically focused in the dropdown of a combo box.
+ *
+ * @author Vaadin Ltd.
+ * @see ComboBoxBase#setAutoFocusPartialMatch(AutoFocusPartialMatch)
+ * @since 25.3
+ */
+public enum AutoFocusPartialMatch {
+
+    /**
+     * Partial matches are not focused.
+     */
+    NONE("none"),
+
+    /**
+     * The first item in the filtered results is focused.
+     */
+    FIRST_MATCH("first-match"),
+
+    /**
+     * The item is focused when filtering narrows the results to a single item.
+     */
+    ONLY_MATCH("only-match");
+
+    private final String clientName;
+
+    AutoFocusPartialMatch(String clientName) {
+        this.clientName = clientName;
+    }
+
+    /**
+     * Gets the name that is used in the client-side representation of the
+     * component.
+     *
+     * @return the name used in the client-side representation of the component
+     */
+    public String getClientName() {
+        return clientName;
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -334,13 +334,29 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * {@link #addCustomValueSetListener(ComponentEventListener)}. When set to
      * {@code false}, an unfocused ComboBox will always display the label of the
      * currently selected item.
+     * <p>
+     * Custom values cannot be used together with
+     * {@link #setAutoFocusPartialMatch(AutoFocusPartialMatch)}. Enabling custom
+     * values while the auto focus partial match mode is other than
+     * {@link AutoFocusPartialMatch#NONE} throws an exception.
      *
      * @param allowCustomValue
      *            {@code true} to enable custom value set events, {@code false}
      *            to disable them
+     * @throws IllegalStateException
+     *             when enabling custom values while the auto focus partial
+     *             match mode is other than {@link AutoFocusPartialMatch#NONE}
      * @see #addCustomValueSetListener(ComponentEventListener)
      */
     public void setAllowCustomValue(boolean allowCustomValue) {
+        if (allowCustomValue
+                && getAutoFocusPartialMatch() != AutoFocusPartialMatch.NONE) {
+            throw new IllegalStateException("""
+                    Custom values cannot be allowed when auto focus partial \
+                    match is used. Disable it with \
+                    setAutoFocusPartialMatch(AutoFocusPartialMatch.NONE) \
+                    first.""");
+        }
         getElement().setProperty("allowCustomValue", allowCustomValue);
     }
 
@@ -367,18 +383,30 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * <p>
      * An item whose label matches the filter exactly is always focused,
      * regardless of the mode. Matching is case-insensitive. A partial match is
-     * not focused when custom values are allowed with
-     * {@link #setAllowCustomValue(boolean)}, or while the dropdown is closed.
-     * For example, when auto-open is disabled with
-     * {@link #setAutoOpen(boolean)}, typing does not focus or select a match
-     * until the dropdown is opened.
+     * not focused while the dropdown is closed. For example, when auto-open is
+     * disabled with {@link #setAutoOpen(boolean)}, typing does not focus or
+     * select a match until the dropdown is opened.
+     * <p>
+     * This feature cannot be used together with custom values. Setting a mode
+     * other than {@link AutoFocusPartialMatch#NONE} while custom values are
+     * allowed with {@link #setAllowCustomValue(boolean)} throws an exception.
      *
      * @param mode
      *            the mode to set, not {@code null}
+     * @throws IllegalStateException
+     *             when setting a mode other than
+     *             {@link AutoFocusPartialMatch#NONE} while custom values are
+     *             allowed
      * @since 25.3
      */
     public void setAutoFocusPartialMatch(AutoFocusPartialMatch mode) {
         Objects.requireNonNull(mode, "The mode cannot be null");
+        if (mode != AutoFocusPartialMatch.NONE && isAllowCustomValue()) {
+            throw new IllegalStateException("""
+                    Auto focus partial match cannot be used when custom \
+                    values are allowed. Disable custom values with \
+                    setAllowCustomValue(false) first.""");
+        }
         getElement().setProperty("autoFocusPartialMatch", mode.getClientName());
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -353,10 +353,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * @since 25.3
      */
     public AutoFocusPartialMatch getAutoFocusPartialMatch() {
-        String clientName = getElement().getProperty("autoFocusPartialMatch");
-        return Stream.of(AutoFocusPartialMatch.values())
-                .filter(mode -> mode.getClientName().equals(clientName))
-                .findFirst().orElse(AutoFocusPartialMatch.NONE);
+        return AutoFocusPartialMatch.fromClientName(
+                getElement().getProperty("autoFocusPartialMatch"));
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -346,7 +346,8 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
 
     /**
      * Gets the mode that controls whether an item whose label partially matches
-     * the typed filter is automatically focused.
+     * the typed filter is automatically focused. Defaults to
+     * {@link AutoFocusPartialMatch#NONE}.
      *
      * @return the mode, not {@code null}
      * @see #setAutoFocusPartialMatch(AutoFocusPartialMatch)

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -377,7 +377,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * @since 25.3
      */
     public void setAutoFocusPartialMatch(AutoFocusPartialMatch mode) {
-        Objects.requireNonNull(mode, "The mode to be set cannot be null");
+        Objects.requireNonNull(mode, "The mode cannot be null");
         getElement().setProperty("autoFocusPartialMatch", mode.getClientName());
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -345,6 +345,41 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
     }
 
     /**
+     * Gets the mode that controls whether an item whose label partially matches
+     * the typed filter is automatically focused.
+     *
+     * @return the mode, not {@code null}
+     * @see #setAutoFocusPartialMatch(AutoFocusPartialMatch)
+     * @since 25.3
+     */
+    public AutoFocusPartialMatch getAutoFocusPartialMatch() {
+        String clientName = getElement().getProperty("autoFocusPartialMatch");
+        return Stream.of(AutoFocusPartialMatch.values())
+                .filter(mode -> mode.getClientName().equals(clientName))
+                .findFirst().orElse(AutoFocusPartialMatch.NONE);
+    }
+
+    /**
+     * Sets the mode that controls whether an item whose label partially matches
+     * the typed filter is automatically focused. The focused item is
+     * highlighted in the dropdown while typing and is selected when committing
+     * the value, for example on blur, Enter press, or outside click.
+     * <p>
+     * An item whose label matches the filter exactly is always focused,
+     * regardless of the mode. Matching is case-insensitive. A partial match is
+     * not focused when custom values are allowed with
+     * {@link #setAllowCustomValue(boolean)}.
+     *
+     * @param mode
+     *            the mode to set, not {@code null}
+     * @since 25.3
+     */
+    public void setAutoFocusPartialMatch(AutoFocusPartialMatch mode) {
+        Objects.requireNonNull(mode, "The mode to be set cannot be null");
+        getElement().setProperty("autoFocusPartialMatch", mode.getClientName());
+    }
+
+    /**
      * Filtering string the user has typed into the input field.
      *
      * @return the filter string

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -363,12 +363,16 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * Sets the mode that controls whether an item whose label partially matches
      * the typed filter is automatically focused. The focused item is
      * highlighted in the dropdown while typing and is selected when committing
-     * the value, for example on blur, Enter press, or outside click.
+     * the value, for example on Enter press. Defaults to
+     * {@link AutoFocusPartialMatch#NONE}.
      * <p>
      * An item whose label matches the filter exactly is always focused,
      * regardless of the mode. Matching is case-insensitive. A partial match is
      * not focused when custom values are allowed with
-     * {@link #setAllowCustomValue(boolean)}.
+     * {@link #setAllowCustomValue(boolean)}, or while the dropdown is closed.
+     * For example, when auto-open is disabled with
+     * {@link #setAutoOpen(boolean)}, typing does not focus or select a match
+     * until the dropdown is opened.
      *
      * @param mode
      *            the mode to set, not {@code null}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -121,6 +121,25 @@ abstract class ComboBoxBaseTest {
     }
 
     @Test
+    void setAutoFocusPartialMatch_getAutoFocusPartialMatch() {
+        ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
+        Assertions.assertEquals(AutoFocusPartialMatch.NONE,
+                comboBox.getAutoFocusPartialMatch());
+        comboBox.setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH);
+        Assertions.assertEquals("first-match",
+                comboBox.getElement().getProperty("autoFocusPartialMatch"));
+        Assertions.assertEquals(AutoFocusPartialMatch.FIRST_MATCH,
+                comboBox.getAutoFocusPartialMatch());
+    }
+
+    @Test
+    void setAutoFocusPartialMatchNull_throws() {
+        ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> comboBox.setAutoFocusPartialMatch(null));
+    }
+
+    @Test
     void setEnabled() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
         comboBox.setEnabled(true);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -125,6 +125,7 @@ abstract class ComboBoxBaseTest {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
         Assertions.assertEquals(AutoFocusPartialMatch.NONE,
                 comboBox.getAutoFocusPartialMatch());
+
         comboBox.setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH);
         Assertions.assertEquals("first-match",
                 comboBox.getElement().getProperty("autoFocusPartialMatch"));

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -141,6 +141,26 @@ abstract class ComboBoxBaseTest {
     }
 
     @Test
+    void allowCustomValue_setAutoFocusPartialMatch_throws() {
+        ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
+        comboBox.setAllowCustomValue(true);
+        Assertions.assertThrows(IllegalStateException.class, () -> comboBox
+                .setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH));
+        Assertions.assertDoesNotThrow(() -> comboBox
+                .setAutoFocusPartialMatch(AutoFocusPartialMatch.NONE));
+    }
+
+    @Test
+    void autoFocusPartialMatch_setAllowCustomValue_throws() {
+        ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
+        comboBox.setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> comboBox.setAllowCustomValue(true));
+        Assertions
+                .assertDoesNotThrow(() -> comboBox.setAllowCustomValue(false));
+    }
+
+    @Test
     void setEnabled() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
         comboBox.setEnabled(true);


### PR DESCRIPTION
This PR adds `setAutoFocusPartialMatch(AutoFocusPartialMatch)` with `NONE` (default), `FIRST_MATCH`, and `ONLY_MATCH` values to ComboBox and MultiSelectComboBox to support the `autoFocusPartialMatch` property added to the web components in vaadin/web-components#12438.

Part of vaadin/web-components#1280
