### PR TITLE
fix: focus selected item correctly when filtering

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 
@@ -38,6 +39,15 @@ public class ComboBoxFocusSelectedItemPage extends Div {
     private static final String LAZY_WITH_PROVIDER = "lazy-with-provider";
     private static final String IN_MEMORY = "in-memory";
     private static final String LAZY_TOGGLE_OFF = "lazy-toggle-off";
+    private static final String CLIENT_FILTER = "client-filter";
+
+    // Fits into a single page, so that the combo box filters on the client and
+    // the server never learns about the filter. "Banana 5" is at index 15 of
+    // all items, and at index 5 among the items matching a "B" filter.
+    private static final List<String> CLIENT_FILTER_ITEMS = Stream
+            .concat(IntStream.range(0, 10).mapToObj(i -> "Apple " + i),
+                    IntStream.range(0, 20).mapToObj(i -> "Banana " + i))
+            .toList();
 
     public ComboBoxFocusSelectedItemPage() {
         ComboBox<String> withProvider = lazyCombo(LAZY_WITH_PROVIDER);
@@ -52,7 +62,9 @@ public class ComboBoxFocusSelectedItemPage extends Div {
         inMemory.setItems(ALL_ITEMS.subList(0, 100));
         inMemory.setFocusSelectedItem(true);
         inMemory.setValue("Item 30");
-        addSection("In-memory combo, toggle on, preset Item 30", inMemory);
+        addSection("In-memory combo, toggle on, preset Item 30", inMemory,
+                button(IN_MEMORY + "-open", "Open from server",
+                        () -> inMemory.setOpened(true)));
         addSeparator();
 
         ComboBox<String> toggleOff = lazyCombo(LAZY_TOGGLE_OFF);
@@ -67,6 +79,21 @@ public class ComboBoxFocusSelectedItemPage extends Div {
                             getElement().removeChild(toggleOff.getElement());
                             getElement().appendChild(toggleOff.getElement());
                         }));
+        addSeparator();
+
+        ComboBox<String> clientFilter = new ComboBox<>();
+        clientFilter.setId(CLIENT_FILTER);
+        clientFilter.setItems(CLIENT_FILTER_ITEMS);
+        clientFilter.setFocusSelectedItem(true);
+        clientFilter.setValue("Banana 5");
+        Span clientFilterValue = new Span(clientFilter.getValue());
+        clientFilterValue.setId(CLIENT_FILTER + "-value");
+        clientFilter.addValueChangeListener(event -> clientFilterValue
+                .setText(String.valueOf(event.getValue())));
+        addSection(
+                "In-memory combo that filters on the client, toggle on, preset Banana 5",
+                clientFilter);
+        add(clientFilterValue);
     }
 
     private ComboBox<String> lazyCombo(String id) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -102,6 +103,73 @@ public class ComboBoxFocusSelectedItemIT extends AbstractComboBoxIT {
     @Test
     public void lazyToggleOff_open_doesNotScroll() {
         openAndAssertContains("lazy-toggle-off", "Item 0");
+    }
+
+    @Test
+    public void inMemory_openFromServer_scrollsToSelected() {
+        // Opening from the server reaches the connector through a different
+        // ordering than the client opening the dropdown itself
+        clickButton("in-memory-open");
+        ComboBoxElement combo = $(ComboBoxElement.class).id("in-memory");
+        assertLoadingStateResolved(combo);
+        assertOverlayContains(combo, "Item 30");
+    }
+
+    @Test
+    public void clientFilter_filterActive_focusesSelectedItem() {
+        ComboBoxElement combo = $(ComboBoxElement.class).id("client-filter");
+        filterWithoutOpening(combo, "B");
+
+        // The server resolves index 15 for "Banana 5" against all items, while
+        // the dropdown only shows the items matching "B", where it sits at
+        // index 5
+        waitUntil(driver -> getFocusedItemLabel(combo) != null);
+        Assert.assertEquals("Banana 5", getFocusedItemLabel(combo));
+    }
+
+    @Test
+    public void clientFilter_filterActive_focusOut_valueUnchanged() {
+        ComboBoxElement combo = $(ComboBoxElement.class).id("client-filter");
+        filterWithoutOpening(combo, "B");
+        waitUntil(driver -> getFocusedItemLabel(combo) != null);
+
+        // Closing the dropdown without selecting anything commits the focused
+        // item, which must still be the selected one
+        combo.sendKeys(Keys.TAB);
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertEquals("Banana 5", combo.getSelectedText());
+        Assert.assertEquals("Banana 5",
+                $("span").id("client-filter-value").getText());
+    }
+
+    /**
+     * Replaces the input value of the combo box with the given filter in a
+     * single edit, without clicking it. Clicking the combo box would open the
+     * dropdown while the filter is still empty, and sending the keys one by one
+     * would apply a filter per key, both of which resolve the index against
+     * other items than the ones the dropdown ends up showing.
+     */
+    private void filterWithoutOpening(ComboBoxElement combo, String filter) {
+        combo.focus();
+        executeScript("""
+                const input = arguments[0].inputElement;
+                input.value = arguments[1];
+                input.dispatchEvent(
+                        new Event('input', { bubbles: true, composed: true }));
+                """, combo, filter);
+    }
+
+    /**
+     * Returns the label of the item that the dropdown highlights, or null when
+     * no item is highlighted.
+     */
+    private String getFocusedItemLabel(ComboBoxElement combo) {
+        return (String) executeScript("""
+                const item = arguments[0]._scroller
+                        .querySelector('vaadin-combo-box-item[focused]');
+                return item ? item.textContent.trim() : null;
+                """, combo);
     }
 
     private ComboBoxElement openAndAssertContains(String id, String label) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
-import { comboBoxConnector, FlowComboBox, init } from './shared.ts';
+import { comboBoxConnector, FlowComboBox, init, Item } from './shared.ts';
 import '@vaadin/combo-box';
 import * as sinon from 'sinon';
 
@@ -157,6 +157,176 @@ describe('combo-box connector', () => {
       // Reset triggers a single fresh fetch; the cancelled debounced fetch
       // must not also fire.
       expect(comboBox.$server.setViewportRange).to.be.calledOnce;
+    });
+  });
+
+  describe('focusSelectedItem', () => {
+    const APPLES: Item[] = Array.from({ length: 10 }, (_, i) => ({ key: `a${i}`, label: `Apple ${i}` }));
+    const BANANAS: Item[] = Array.from({ length: 20 }, (_, i) => ({ key: `b${i}`, label: `Banana ${i}` }));
+    const ITEMS: Item[] = [...APPLES, ...BANANAS];
+    // "Banana 5" is at index 15 of all items, and at index 5 among the bananas
+    const SELECTED_KEY = 'b5';
+    const SELECTED_INDEX = 15;
+
+    let focusIndex: sinon.SinonStub;
+
+    beforeEach(() => {
+      focusIndex = sinon.stub(comboBox, '__focusIndex');
+    });
+
+    // Runs the round-trip that passes all items to the combo box, which then
+    // shows them either as they are or filtered on the client
+    function loadItems(): void {
+      comboBox.$connector.updateSize(ITEMS.length);
+      comboBox.__dataProviderController.loadFirstPage();
+      comboBox.$connector.set(0, ITEMS, '');
+      comboBox.$connector.confirm(1, '');
+    }
+
+    // The server only requests focusing the selected item while the dropdown is
+    // open, which is also the only state a filter can be typed in
+    async function open(): Promise<void> {
+      comboBox.opened = true;
+      await comboBox.updateComplete;
+    }
+
+    async function openAndFilter(filter: string): Promise<void> {
+      comboBox.opened = true;
+      comboBox.filter = filter;
+      await comboBox.updateComplete;
+    }
+
+    // Runs the round-trip that passes the items matching a server-side filter,
+    // skipping the debounce that the typed filter is otherwise delayed by
+    function loadFilteredItems(filter: string): void {
+      comboBox._filterDebouncer?.flush();
+      comboBox.$connector.updateSize(BANANAS.length);
+      comboBox.$connector.set(0, BANANAS, filter);
+      comboBox.$connector.confirm(1, filter);
+      // Guards the tests below against passing for lack of items to focus
+      expect(comboBox._dropdownItems).to.have.lengthOf(BANANAS.length);
+    }
+
+    it('should focus the item at the index resolved by the server', async () => {
+      loadItems();
+      comboBox.value = SELECTED_KEY;
+      await open();
+
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+
+      expect(focusIndex).to.be.calledOnceWith(SELECTED_INDEX);
+    });
+
+    it('should focus the selected item at its index among client-side filtered items', async () => {
+      comboBox._clientSideFilter = true;
+      loadItems();
+      comboBox.value = SELECTED_KEY;
+      await openAndFilter('Banana');
+
+      // The server resolved the index against all items, while the dropdown
+      // only shows the bananas
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+
+      expect(focusIndex).to.be.calledOnceWith(5);
+    });
+
+    it('should not focus any item when the selected item does not match the client-side filter', async () => {
+      comboBox._clientSideFilter = true;
+      loadItems();
+      comboBox.value = SELECTED_KEY;
+      await openAndFilter('Apple');
+
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+
+      expect(focusIndex).to.be.not.called;
+    });
+
+    it('should focus the index resolved by the server when the selected item is not loaded', async () => {
+      // A selection outside the loaded pages, as with lazy loading: only the
+      // server can tell where the item is
+      comboBox.value = 'b99';
+      await openAndFilter('Banana');
+      loadFilteredItems('Banana');
+
+      comboBox.$connector.focusSelectedItem(60, 'Banana');
+
+      expect(focusIndex).to.be.calledOnceWith(60);
+    });
+
+    it('should not focus the index resolved by the server for another filter', async () => {
+      comboBox.value = 'b99';
+      await openAndFilter('Banana');
+      loadFilteredItems('Banana');
+
+      // The typed filter had not reached the server yet when it resolved the
+      // index, so the index counts other items than the dropdown shows
+      comboBox.$connector.focusSelectedItem(60, '');
+
+      expect(focusIndex).to.be.not.called;
+    });
+
+    it('should focus the selected item once the filtered items arrive', async () => {
+      comboBox._clientSideFilter = true;
+      comboBox.value = SELECTED_KEY;
+      await openAndFilter('Banana');
+
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+      expect(focusIndex).to.be.not.called;
+
+      loadItems();
+
+      expect(focusIndex).to.be.calledOnceWith(5);
+    });
+
+    it('should not focus any item once the connector has been reset', async () => {
+      comboBox.value = SELECTED_KEY;
+      await open();
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+
+      comboBox.$connector.reset();
+      loadItems();
+
+      expect(focusIndex).to.be.not.called;
+    });
+
+    it('should focus the selected item once the items arrive with a server-side filter', async () => {
+      comboBox.value = SELECTED_KEY;
+      await open();
+
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+      expect(focusIndex, 'no items to resolve the request against yet').to.be.not.called;
+
+      loadItems();
+
+      expect(focusIndex).to.be.calledOnceWith(SELECTED_INDEX);
+    });
+
+    it('should not focus any item once the dropdown has been closed', async () => {
+      comboBox.value = SELECTED_KEY;
+      await open();
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+
+      // The user closes the dropdown before any items arrive. Focusing an item
+      // now would be committed as the value the next time it closes.
+      comboBox.opened = false;
+      await comboBox.updateComplete;
+      loadItems();
+
+      expect(focusIndex).to.be.not.called;
+    });
+
+    it('should not focus any item once the value has changed', async () => {
+      comboBox.value = SELECTED_KEY;
+      await open();
+      comboBox.$connector.focusSelectedItem(SELECTED_INDEX, '');
+
+      // The server clears the value while the request is still pending, and
+      // sends no new request because there is no selected item to focus
+      comboBox.value = '';
+      await comboBox.updateComplete;
+      loadItems();
+
+      expect(focusIndex).to.be.not.called;
     });
   });
 });

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/shared.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/shared.ts
@@ -37,5 +37,9 @@ export function init(comboBox: FlowComboBox): void {
     resetDataCommunicator: sinon.spy()
   };
 
+  // The Flow component identifies the generated wrapper items by their key
+  comboBox.itemValuePath = 'key';
+  comboBox.itemIdPath = 'key';
+
   comboBoxConnector.initLazy(comboBox);
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -399,6 +399,8 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * index can be resolved against the current sorting. Opening the dropdown
      * throws {@link UnsupportedOperationException} otherwise.
      * <p>
+     * When the user opens the dropdown by typing a filter, the selected item is
+     * focused only if it matches that filter.
      *
      * @param focusSelectedItem
      *            {@code true} to scroll to and focus the selected item when the
@@ -445,7 +447,12 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
         if (index == null || index < 0) {
             return;
         }
-        getElement().callJsFunction("__focusIndex", index);
+        // The connector reconciles the index with the items that the dropdown
+        // shows. Optional chaining is needed because opening the combo box from
+        // the server before it is attached schedules this call before the
+        // connector is initialized.
+        getElement().executeJs("this.$connector?.focusSelectedItem($0, $1)",
+                index, getDataController().getLastFilter());
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxDataController.java
@@ -197,6 +197,15 @@ class ComboBoxDataController<TItem>
     }
 
     /**
+     * Accesses the filter that the client last requested data with, which is
+     * the filter that the data communicator applies to its queries. Returns an
+     * empty string when the client has not requested data with a filter yet.
+     */
+    String getLastFilter() {
+        return lastFilter != null ? lastFilter : "";
+    }
+
+    /**
      * Updates the page size in the data communicator and triggers a full
      * refresh
      */

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
@@ -21,6 +21,7 @@ export class ComboBoxConnector {
   #lastRequestedRange: ItemRange = [-1, -1];
   #lastRequestedFilter = '';
   #needsDataCommunicatorReset = false;
+  #pendingFocus: { index: number; serverFilter: string; value: string } | null = null;
 
   constructor(comboBox: FlowComboBox) {
     this.#comboBox = comboBox;
@@ -117,6 +118,7 @@ export class ComboBoxConnector {
     this.#cache = {};
     this.#lastRequestedRange = [-1, -1];
     this.#lastTypedFilter = '';
+    this.#pendingFocus = null;
     comboBox.clearCache();
   }
 
@@ -143,8 +145,78 @@ export class ComboBoxConnector {
       delete this.#cache[page];
     });
 
+    // Items that a pending focus request was waiting for may have arrived
+    this.#applyPendingFocus();
+
     // Let server know we're done
     comboBox.$server.confirmUpdate(id);
+  }
+
+  /**
+   * Focuses the selected item in the dropdown. Called by the server when the
+   * dropdown opens while `focusSelectedItem` is enabled.
+   *
+   * The server resolves `index` against the items matching `serverFilter`. The
+   * dropdown does not necessarily show that same set of items: with client-side
+   * filtering the typed filter never reaches the server, and with server-side
+   * filtering it is debounced, so it can reach the server only after the
+   * dropdown has opened. Applying the index as is would focus an unrelated
+   * item, which the combo box commits as its value once the dropdown is closed
+   * without an explicit selection.
+   *
+   * A request that cannot be resolved right away, because no items have reached
+   * the dropdown yet, is retried once they do. The latest request wins.
+   */
+  focusSelectedItem(index: number, serverFilter: string): void {
+    this.#pendingFocus = { index, serverFilter, value: this.#comboBox.value };
+    this.#applyPendingFocus();
+  }
+
+  /**
+   * Resolves a pending focus request against the items that the dropdown
+   * currently shows, as long as there are any.
+   */
+  #applyPendingFocus(): void {
+    const pending = this.#pendingFocus;
+    if (!pending) {
+      return;
+    }
+
+    const comboBox = this.#comboBox;
+
+    // The request only applies to the dropdown session it was made for, and
+    // only as long as it still describes the selected item. The server sends a
+    // new request every time the dropdown opens, so dropping it here loses
+    // nothing while it keeps a stale index from focusing an unrelated item.
+    if (!comboBox.opened || comboBox.value !== pending.value) {
+      this.#pendingFocus = null;
+      return;
+    }
+
+    const items = comboBox._dropdownItems;
+    if (!items || items.length === 0) {
+      // Nothing to focus yet, retry once items are passed to the combo box
+      return;
+    }
+    // Cleared before focusing, so that the retries which follow one item
+    // delivery do not apply the same request twice
+    this.#pendingFocus = null;
+
+    // Where the selected item sits in the dropdown is correct regardless of how
+    // either side filtered the items, so prefer it over the server index
+    const selectedIndex = comboBox.__getItemIndexByValue(items, comboBox.value);
+    if (selectedIndex > -1) {
+      comboBox.__focusIndex(selectedIndex);
+      return;
+    }
+
+    // The selected item is not among the items the dropdown shows: it may sit
+    // outside the loaded pages, where only the server can tell where it is. The
+    // server index counts the items matching the filter the server used, which
+    // makes it meaningless for any other filter.
+    if (comboBox.filter === pending.serverFilter) {
+      comboBox.__focusIndex(pending.index);
+    }
   }
 
   #loadPage(params: ComboBoxDataProviderParams, callback: ComboBoxDataProviderCallback<Item>): void {
@@ -271,6 +343,9 @@ export class ComboBoxConnector {
     }
 
     callback(filteredItems, filteredItems.length);
+
+    // Items that a pending focus request was waiting for have arrived
+    this.#applyPendingFocus();
   }
 }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-types.d.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-types.d.ts
@@ -42,9 +42,12 @@ export interface FlowComboBoxInternals {
   $server: ComboBoxServer;
   __dataProviderController: DataProviderController<Item, Record<string, unknown>>;
   _clientSideFilter: boolean;
+  _dropdownItems?: Item[];
   _filterDebouncer: Debouncer | null;
   _filterTimeout?: number;
   _scroller?: FlowComboBoxScroller;
+  __focusIndex(index: number): void;
+  __getItemIndexByValue(items: Item[], value: string): number;
   _getItemLabel(item: Item): string;
 }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -272,14 +272,108 @@ class ComboBoxTest extends ComboBoxBaseTest {
         comboBox.setValue("C");
         comboBox.setOpened(true);
 
-        var invocations = ui.dumpPendingJavaScriptInvocations().stream()
+        var parameters = focusSelectedItemParameters(comboBox);
+        Assertions.assertEquals(1, parameters.size());
+        // Parameter 0 is the item index, parameter 1 is the filter the index
+        // was resolved against
+        Assertions.assertEquals(2, parameters.get(0).get(0));
+        Assertions.assertEquals("", parameters.get(0).get(1));
+    }
+
+    @Test
+    void focusSelectedItem_clientRequestedDataWithFilter_indexAndFilterOfFilteredItems() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("Cherry");
+        // Simulate the client requesting data with a filter that only "Cherry"
+        // matches, so that its index among the filtered items is 0 instead of 2
+        comboBox.getDataController().setViewportRange(0, 50, "err");
+        comboBox.setOpened(true);
+
+        var parameters = focusSelectedItemParameters(comboBox);
+        Assertions.assertEquals(1, parameters.size());
+        Assertions.assertEquals(0, parameters.get(0).get(0));
+        Assertions.assertEquals("err", parameters.get(0).get(1));
+    }
+
+    @Test
+    void focusSelectedItem_selectedItemNotMatchingServerFilter_noInvocation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("Cherry");
+        comboBox.getDataController().setViewportRange(0, 50, "Ban");
+        comboBox.setOpened(true);
+
+        Assertions.assertEquals(List.of(),
+                focusSelectedItemParameters(comboBox));
+    }
+
+    @Test
+    void focusSelectedItem_disabled_open_noInvocation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setValue("Cherry");
+        comboBox.setOpened(true);
+
+        Assertions.assertEquals(List.of(),
+                focusSelectedItemParameters(comboBox));
+    }
+
+    @Test
+    void focusSelectedItem_noValue_open_noInvocation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setOpened(true);
+
+        Assertions.assertEquals(List.of(),
+                focusSelectedItemParameters(comboBox));
+    }
+
+    @Test
+    void focusSelectedItem_openedBeforeAttach_invocationToleratesMissingConnector() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("Cherry");
+        // Opening before attaching schedules the invocation before the
+        // connector
+        // is initialized, as the connector is initialized on attach
+        comboBox.setOpened(true);
+        ui.add(comboBox);
+
+        var expressions = focusSelectedItemExpressions();
+        Assertions.assertEquals(1, expressions.size());
+        Assertions.assertTrue(expressions.get(0).contains("$connector?."),
+                "Expected the connector to be accessed with optional chaining, but was: "
+                        + expressions.get(0));
+    }
+
+    /**
+     * Returns the parameters of every pending focusSelectedItem invocation that
+     * the given combo box has scheduled on the connector.
+     */
+    private List<List<Object>> focusSelectedItemParameters(
+            ComboBox<?> comboBox) {
+        return ui.dumpPendingJavaScriptInvocations().stream()
                 .map(PendingJavaScriptInvocation::getInvocation)
                 .filter(invocation -> invocation.getExpression()
-                        .contains("__focusIndex"))
+                        .contains("focusSelectedItem"))
+                .map(invocation -> List.copyOf(invocation.getParameters()))
                 .toList();
-        Assertions.assertEquals(1, invocations.size());
-        // Parameter 0 is the target element, parameter 1 is the item index
-        Assertions.assertEquals(2, invocations.get(0).getParameters().get(1));
+    }
+
+    private List<String> focusSelectedItemExpressions() {
+        return ui.dumpPendingJavaScriptInvocations().stream()
+                .map(invocation -> invocation.getInvocation().getExpression())
+                .filter(expression -> expression.contains("focusSelectedItem"))
+                .toList();
     }
 
     @Test


### PR DESCRIPTION
`setFocusSelectedItem(true)` resolves the selected item's index on the server when the dropdown opens, and the client applies it to the items the dropdown shows. Those are not always the same set of items: with in-memory items that fit a single page, the combo box filters on the client and the server never learns about the typed filter. The index then points at an unrelated item, and since closing the dropdown without an explicit selection commits the focused item, the value changed to an item the user never picked.

```java
List<String> items = new ArrayList<>();
IntStream.range(0, 10).forEach(i -> items.add("Apple " + i));
IntStream.range(0, 20).forEach(i -> items.add("Banana " + i));

ComboBox<String> comboBox = new ComboBox<>();
comboBox.setItems(items);
comboBox.setFocusSelectedItem(true);
// Index 15 in the full list, index 5 among the "Banana" items
comboBox.setValue("Banana 5");
```

Focus the combo box with <kbd>Tab</kbd>, select all its text and type `B`: "Banana 15" is focused instead of "Banana 5", and clicking outside changes the value to "Banana 15".

### Changes

- The connector resolves the selected item by its key among the items the dropdown shows. The server index is used only when the filter it was resolved against is still the one in effect, which is what a lazy data provider needs when the selected item is outside the loaded pages.
- A focus request that arrives before any items do is retried once they arrive. It is dropped when the dropdown closes or the value changes, so that a stale index cannot be applied to a later interaction.
- The call to the connector uses optional chaining, because opening the combo box from the server before it is attached schedules the call before the connector is initialized.

Fixes #9883

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
