### PR TITLE
fix: do not focus selected item while filtering

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemPage.java
@@ -20,11 +20,13 @@ import java.util.Locale;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 
@@ -38,6 +40,15 @@ public class ComboBoxFocusSelectedItemPage extends Div {
     private static final String LAZY_WITH_PROVIDER = "lazy-with-provider";
     private static final String IN_MEMORY = "in-memory";
     private static final String LAZY_TOGGLE_OFF = "lazy-toggle-off";
+    private static final String CLIENT_FILTER = "client-filter";
+
+    // Fits into a single page, so that the combo box filters on the client and
+    // the server never learns about the filter. "Banana 5" is at index 15 of
+    // all items, and at index 5 among the items matching a "B" filter.
+    private static final List<String> CLIENT_FILTER_ITEMS = Stream
+            .concat(IntStream.range(0, 10).mapToObj(i -> "Apple " + i),
+                    IntStream.range(0, 20).mapToObj(i -> "Banana " + i))
+            .toList();
 
     public ComboBoxFocusSelectedItemPage() {
         ComboBox<String> withProvider = lazyCombo(LAZY_WITH_PROVIDER);
@@ -67,6 +78,20 @@ public class ComboBoxFocusSelectedItemPage extends Div {
                             getElement().removeChild(toggleOff.getElement());
                             getElement().appendChild(toggleOff.getElement());
                         }));
+        addSeparator();
+
+        ComboBox<String> clientFilter = new ComboBox<>();
+        clientFilter.setId(CLIENT_FILTER);
+        clientFilter.setItems(CLIENT_FILTER_ITEMS);
+        clientFilter.setFocusSelectedItem(true);
+        clientFilter.setValue("Banana 5");
+        Span clientFilterValue = new Span(clientFilter.getValue());
+        clientFilterValue.setId(CLIENT_FILTER + "-value");
+        clientFilter.addValueChangeListener(event -> clientFilterValue
+                .setText(String.valueOf(event.getValue())));
+        addSection(
+                "In-memory combo that filters on the client, toggle on, preset Banana 5",
+                clientFilter, clientFilterValue);
     }
 
     private ComboBox<String> lazyCombo(String id) {
@@ -107,10 +132,10 @@ public class ComboBoxFocusSelectedItemPage extends Div {
     }
 
     private void addSection(String title, ComboBox<String> combo,
-            NativeButton... controls) {
+            Component... controls) {
         add(new Paragraph(title));
         add(combo);
-        for (NativeButton control : controls) {
+        for (Component control : controls) {
             add(control);
         }
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxFocusSelectedItemIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
@@ -102,6 +103,25 @@ public class ComboBoxFocusSelectedItemIT extends AbstractComboBoxIT {
     @Test
     public void lazyToggleOff_open_doesNotScroll() {
         openAndAssertContains("lazy-toggle-off", "Item 0");
+    }
+
+    @Test
+    public void clientFilter_filterActive_focusOut_valueUnchanged() {
+        ComboBoxElement combo = $(ComboBoxElement.class).id("client-filter");
+        setFilterValue(combo, "B");
+        assertLoadingStateResolved(combo);
+
+        // Closing without selecting commits the focused item
+        combo.sendKeys(Keys.TAB);
+        getCommandExecutor().waitForVaadin();
+
+        Assert.assertEquals("Banana 5", combo.getSelectedText());
+        Assert.assertEquals("Banana 5",
+                $("span").id("client-filter-value").getText());
+    }
+
+    private void setFilterValue(ComboBoxElement combo, String filter) {
+        combo.sendKeys(Keys.chord(Keys.SHIFT, Keys.HOME), filter);
     }
 
     private ComboBoxElement openAndAssertContains(String id, String label) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -399,6 +399,8 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
      * index can be resolved against the current sorting. Opening the dropdown
      * throws {@link UnsupportedOperationException} otherwise.
      * <p>
+     * The dropdown opens at the top while a filter is active, so that filtering
+     * always starts from the first matching item.
      *
      * @param focusSelectedItem
      *            {@code true} to scroll to and focus the selected item when the
@@ -425,6 +427,12 @@ public class ComboBox<T> extends ComboBoxBase<ComboBox<T>, T, T>
 
     private void focusOnSelectedItem() {
         if (getValue() == null) {
+            return;
+        }
+        String filter = getFilter();
+        if (filter != null && !filter.isEmpty()) {
+            // Filtering starts from the first match, so there is no index to
+            // resolve, which for a lazy data view would query the backend
             return;
         }
         DataProvider<T, ?> dataProvider = getDataProvider();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -272,14 +272,61 @@ class ComboBoxTest extends ComboBoxBaseTest {
         comboBox.setValue("C");
         comboBox.setOpened(true);
 
-        var invocations = ui.dumpPendingJavaScriptInvocations().stream()
-                .map(PendingJavaScriptInvocation::getInvocation)
-                .filter(invocation -> invocation.getExpression()
-                        .contains("__focusIndex"))
-                .toList();
-        Assertions.assertEquals(1, invocations.size());
+        var parameters = focusSelectedItemParameters();
+        Assertions.assertEquals(1, parameters.size());
         // Parameter 0 is the target element, parameter 1 is the item index
-        Assertions.assertEquals(2, invocations.get(0).getParameters().get(1));
+        Assertions.assertEquals(2, parameters.get(0).get(1));
+    }
+
+    @Test
+    void focusSelectedItem_filterActive_open_noInvocation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("Cherry");
+        // The filter property is only ever set by the client
+        comboBox.getElement().setProperty("filter", "C");
+        comboBox.setOpened(true);
+
+        Assertions.assertEquals(List.of(), focusSelectedItemParameters());
+    }
+
+    @Test
+    void focusSelectedItem_filterCleared_open_scrollsToSelectedItem() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setValue("Cherry");
+        comboBox.getElement().setProperty("filter", "");
+        comboBox.setOpened(true);
+
+        var parameters = focusSelectedItemParameters();
+        Assertions.assertEquals(1, parameters.size());
+        Assertions.assertEquals(2, parameters.get(0).get(1));
+    }
+
+    @Test
+    void focusSelectedItem_disabled_open_noInvocation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setValue("Cherry");
+        comboBox.setOpened(true);
+
+        Assertions.assertEquals(List.of(), focusSelectedItemParameters());
+    }
+
+    @Test
+    void focusSelectedItem_noValue_open_noInvocation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ui.add(comboBox);
+        comboBox.setItems("Apple", "Banana", "Cherry");
+        comboBox.setFocusSelectedItem(true);
+        comboBox.setOpened(true);
+
+        Assertions.assertEquals(List.of(), focusSelectedItemParameters());
     }
 
     @Test
@@ -293,6 +340,15 @@ class ComboBoxTest extends ComboBoxBaseTest {
         Assertions.assertEquals(750, comboBox.getFilterTimeout());
         Assertions.assertEquals(750,
                 comboBox.getElement().getProperty("_filterTimeout", 0));
+    }
+
+    private List<List<Object>> focusSelectedItemParameters() {
+        return ui.dumpPendingJavaScriptInvocations().stream()
+                .map(PendingJavaScriptInvocation::getInvocation)
+                .filter(invocation -> invocation.getExpression()
+                        .contains("__focusIndex"))
+                .map(invocation -> List.copyOf(invocation.getParameters()))
+                .toList();
     }
 
     @Tag("div")


### PR DESCRIPTION
## Description

Fixes #9883
Depends on https://github.com/vaadin/web-components/pull/12441

The server resolves the selected item's index when the dropdown opens, but with in-memory items that fit a single page the combo box filters on the client, so the index counts other items than the dropdown shows — an unrelated item gets focused and is then committed as the value when the dropdown closes. Translating the index into the filtered list was tried in #9890 and dropped in favour of not focusing at all: as noted in #9194 review, entering a filter means the user wants to pick something else, so the dropdown should stay at the first match.

- `focusOnSelectedItem` now returns early while `getFilter()` is non-empty, so no index is resolved — which for a lazy data view would query the backend on every keystroke that opens the dropdown
  - Ignoring an index that reaches the client while the filter is set is handled by the web component, see the linked PR
- Documented on `setFocusSelectedItem` that the dropdown opens at the top while a filter is active
- Added unit tests for the invocation matrix: filter active, filter cleared, no value, and toggle off
- Added one integration test as a smoke test: typing a filter and moving focus out leaves the value unchanged

## Type of change

- Bugfix

## How to test

1. Open `vaadin-combo-box/focus-selected-item` (`ComboBoxFocusSelectedItemPage.java`) and scroll to the last combo box, "In-memory combo that filters on the client".
2. Focus it with <kbd>Tab</kbd> without clicking it, select the text in the input and type `B` — the dropdown opens at "Banana 0" and no item is highlighted.
3. Click outside the combo box — the value stays "Banana 5", shown in the label next to the field.
4. Open the same combo box by clicking it, without typing — "Banana 5" is highlighted and scrolled into view.
