### PR TITLE
fix: run signal-binding checks in Card index-based add

### DIFF
--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -336,7 +336,6 @@ public class Card extends Component implements HasSize, HasAriaLabel,
 
     @Override
     public void addComponentAtIndex(int index, Component component) {
-        Objects.requireNonNull(component, "Component should not be null");
         if (index < 0) {
             throw new IllegalArgumentException(
                     "Cannot add a component with a negative index");

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -352,13 +352,14 @@ public class Card extends Component implements HasSize, HasAriaLabel,
                             + children.size() + ").");
         }
 
-        if (index == children.size()) {
-            getElement().appendChild(component.getElement());
-        } else {
-            var reference = children.get(index);
-            var actualIndex = getElement().indexOfChild(reference.getElement());
-            getElement().insertChild(actualIndex, component.getElement());
-        }
+        // The default-slot index is relative to getChildren(), which excludes
+        // the slotted children (header, footer, ...) that are interleaved in
+        // the element tree. Translate it to the element index and delegate to
+        // the default implementation so its signal-binding checks still run.
+        var elementIndex = index == children.size()
+                ? getElement().getChildCount()
+                : getElement().indexOfChild(children.get(index).getElement());
+        HasComponents.super.addComponentAtIndex(elementIndex, component);
     }
 
     private void doSetTitle(String title) {

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.card;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.signals.BindingActiveException;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.AbstractSignalsTest;
+
+class CardSignalTest extends AbstractSignalsTest {
+
+    private Card card;
+
+    @BeforeEach
+    void setup() {
+        card = new Card();
+        UI.getCurrent().add(card);
+    }
+
+    @Test
+    void bindChildren_addsChildrenToDefaultSlot() {
+        var textSignal1 = new ValueSignal<>("Item 1");
+        var textSignal2 = new ValueSignal<>("Item 2");
+        var listSignal = new ValueSignal<>(List.of(textSignal1, textSignal2));
+
+        card.bindChildren(listSignal, Span::new);
+
+        Assertions.assertEquals(2, card.getChildren().count());
+        Assertions.assertEquals("Item 1",
+                card.getChildren().findFirst().get().getElement().getText());
+    }
+
+    @Test
+    void bindChildren_slottedContentPreserved() {
+        var header = new Div();
+        card.setHeader(header);
+
+        var textSignal = new ValueSignal<>("Item 1");
+        var listSignal = new ValueSignal<>(List.of(textSignal));
+        card.bindChildren(listSignal, Span::new);
+
+        // The children binding manages only the default slot; slotted content
+        // stays in place and is excluded from getChildren().
+        Assertions.assertSame(header, card.getHeader());
+        Assertions.assertEquals(1, card.getChildren().count());
+    }
+
+    @Test
+    void childrenBindingActive_addComponentAtIndex_throws() {
+        var textSignal = new ValueSignal<>("Item 1");
+        var listSignal = new ValueSignal<>(List.of(textSignal));
+        card.bindChildren(listSignal, Span::new);
+
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> card.addComponentAtIndex(0, new Span()));
+    }
+
+    @Test
+    void childrenBindingActive_addComponentAsFirst_throws() {
+        var textSignal = new ValueSignal<>("Item 1");
+        var listSignal = new ValueSignal<>(List.of(textSignal));
+        card.bindChildren(listSignal, Span::new);
+
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> card.addComponentAsFirst(new Span()));
+    }
+}

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.signals.BindingActiveException;
@@ -35,7 +34,7 @@ class CardSignalTest extends AbstractSignalsTest {
     @BeforeEach
     void setup() {
         card = new Card();
-        UI.getCurrent().add(card);
+        ui.add(card);
     }
 
     @Test

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
@@ -39,20 +39,7 @@ class CardSignalTest extends AbstractSignalsTest {
     }
 
     @Test
-    void bindChildren_addsChildrenToDefaultSlot() {
-        var textSignal1 = new ValueSignal<>("Item 1");
-        var textSignal2 = new ValueSignal<>("Item 2");
-        var listSignal = new ValueSignal<>(List.of(textSignal1, textSignal2));
-
-        card.bindChildren(listSignal, Span::new);
-
-        Assertions.assertEquals(2, card.getChildren().count());
-        Assertions.assertEquals("Item 1",
-                card.getChildren().findFirst().get().getElement().getText());
-    }
-
-    @Test
-    void bindChildren_slottedContentPreserved() {
+    void bindChildren_slottedContentExcludedFromChildren() {
         var header = new Div();
         card.setHeader(header);
 
@@ -60,10 +47,11 @@ class CardSignalTest extends AbstractSignalsTest {
         var listSignal = new ValueSignal<>(List.of(textSignal));
         card.bindChildren(listSignal, Span::new);
 
-        // The children binding manages only the default slot; slotted content
-        // stays in place and is excluded from getChildren().
+        // The binding owns the default slot, which getChildren() reports, while
+        // the header stays in its slot and out of the filtered view.
+        Assertions.assertEquals(List.of("Item 1"), card.getChildren()
+                .map(child -> child.getElement().getText()).toList());
         Assertions.assertSame(header, card.getHeader());
-        Assertions.assertEquals(1, card.getChildren().count());
     }
 
     @Test
@@ -72,8 +60,11 @@ class CardSignalTest extends AbstractSignalsTest {
         var listSignal = new ValueSignal<>(List.of(textSignal));
         card.bindChildren(listSignal, Span::new);
 
+        var component = new Span();
         Assertions.assertThrows(BindingActiveException.class,
-                () -> card.addComponentAtIndex(0, new Span()));
+                () -> card.addComponentAtIndex(0, component));
+        Assertions.assertEquals(1, card.getChildren().count());
+        Assertions.assertFalse(component.isAttached());
     }
 
     @Test
@@ -82,7 +73,10 @@ class CardSignalTest extends AbstractSignalsTest {
         var listSignal = new ValueSignal<>(List.of(textSignal));
         card.bindChildren(listSignal, Span::new);
 
+        var component = new Span();
         Assertions.assertThrows(BindingActiveException.class,
-                () -> card.addComponentAsFirst(new Span()));
+                () -> card.addComponentAsFirst(component));
+        Assertions.assertEquals(1, card.getChildren().count());
+        Assertions.assertFalse(component.isAttached());
     }
 }


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/9280

`Card.addComponentAtIndex` wrote to the element directly, so the checks in the default `HasComponents` implementation never ran. With a `bindChildren` binding active on the default slot, the inherited `Card.add(...)` already threw `BindingActiveException` while index-based adds silently changed the DOM and left it out of sync with the signal.

- Translated the default-slot index to an element index and delegated to `HasComponents.super.addComponentAtIndex(...)`, so the text- and children-binding checks run
  - Insert positions are unchanged: `appendChild` is `insertChild(getChildCount(), …)`, and `insertChild` already adjusts the index when the component is already a child
- Covered `addComponentAsFirst` by the same change, as the default implementation routes it through `addComponentAtIndex`
- Added `CardSignalTest` covering `bindChildren` on the default slot, slotted content surviving a binding, and `BindingActiveException` from both index-based add methods

## Type of change

- Behavior altering fix

## Note

With this change, application code that calls `addComponentAtIndex` or `addComponentAsFirst` while a children binding is active now gets a `BindingActiveException` instead of a silent DOM change (previous behavior).