### PR TITLE
fix: reject Card removeAll while a children binding is active

### DIFF
--- a/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/main/java/com/vaadin/flow/component/card/Card.java
@@ -32,6 +32,8 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.shared.HasThemeVariant;
 import com.vaadin.flow.component.shared.SlotUtils;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
+import com.vaadin.flow.signals.BindingActiveException;
 
 /**
  * Card is a visual content container for creating a card-based layout.
@@ -331,7 +333,28 @@ public class Card extends Component implements HasSize, HasAriaLabel,
 
     @Override
     public void removeAll() {
+        // Removing the children one by one only rejects an active binding
+        // while the bound list is non-empty.
+        if (hasChildrenBinding()) {
+            throw new BindingActiveException(
+                    "removeAll is not allowed while a binding for children exists.");
+        }
         getChildren().toList().forEach(this::remove);
+    }
+
+    /**
+     * Checks whether a children binding set up with {@code bindChildren} is
+     * active on this component's element. Mirrors the check that Flow performs
+     * internally, reading the binding state from the element node.
+     *
+     * @return {@code true} if a children binding is active
+     */
+    private boolean hasChildrenBinding() {
+        return getElement().getNode()
+                .getFeatureIfInitialized(SignalBindingFeature.class)
+                .map(feature -> feature
+                        .hasBinding(SignalBindingFeature.CHILDREN))
+                .orElse(false);
     }
 
     @Override

--- a/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
+++ b/vaadin-card-flow-parent/vaadin-card-flow/src/test/java/com/vaadin/flow/component/card/CardSignalTest.java
@@ -67,6 +67,36 @@ class CardSignalTest extends AbstractSignalsTest {
     }
 
     @Test
+    void childrenBindingActive_removeAll_throws() {
+        var textSignal = new ValueSignal<>("Item 1");
+        var listSignal = new ValueSignal<>(List.of(textSignal));
+        card.bindChildren(listSignal, Span::new);
+
+        var exception = Assertions.assertThrows(BindingActiveException.class,
+                () -> card.removeAll());
+        // The message names the method that was called, not the per-child
+        // remove that the implementation uses internally.
+        Assertions.assertTrue(exception.getMessage().startsWith("removeAll"),
+                "Unexpected message: " + exception.getMessage());
+        Assertions.assertEquals(1, card.getChildren().count());
+    }
+
+    @Test
+    void childrenBindingActive_emptyDefaultSlot_removeAll_throws() {
+        var header = new Div();
+        card.setHeader(header);
+
+        var listSignal = new ValueSignal<>(List.<ValueSignal<String>> of());
+        card.bindChildren(listSignal, Span::new);
+
+        // Nothing is in the default slot, so there is no child whose removal
+        // would report the active binding.
+        Assertions.assertThrows(BindingActiveException.class,
+                () -> card.removeAll());
+        Assertions.assertSame(header, card.getHeader());
+    }
+
+    @Test
     void childrenBindingActive_addComponentAsFirst_throws() {
         var textSignal = new ValueSignal<>("Item 1");
         var listSignal = new ValueSignal<>(List.of(textSignal));


### PR DESCRIPTION
## Description

Follow-up to #9893

`Card` cannot delegate to the default `removeAll()`, which calls `Element.removeAllChildren()` and would clear the header, footer, title and media slots too, so it removes the default-slot children one by one instead. That loop does not run when the default slot is empty, so `removeAll()` silently did nothing while a children binding was active — and when the slot was not empty, the rejection came from `remove(...)` and named that method instead.

- Rejected `removeAll()` with `BindingActiveException` while a children binding is active, matching the contract the default implementation defines
- Added a private `hasChildrenBinding()` helper that reads the binding state from the element node, since Flow's own `throwIfChildrenBindingIsActive` and `hasChildrenBinding` are private to `HasComponentsOfType` — the same approach `Breadcrumbs` and `Button` already use
- Added tests for a non-empty bound list, asserting the message names `removeAll`, and for an empty bound list with a header set, where nothing was thrown before

## Type of change

- Bugfix

> [!NOTE]
> Only the children binding is checked, not the text binding that the default `removeAll()` also rejects: `Card` implements no `HasText` and `HasComponentsOfType` exposes no `bindText`, so a text binding cannot be established through Card's API.
