### PR TITLE
feat: add HasLabel and HasPlaceholder to TimePickerElement

### DIFF
--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/src/main/java/com/vaadin/flow/component/timepicker/testbench/TimePickerElement.java
@@ -21,6 +21,8 @@ import org.openqa.selenium.Keys;
 
 import com.vaadin.testbench.HasClearButton;
 import com.vaadin.testbench.HasHelper;
+import com.vaadin.testbench.HasLabel;
+import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasSelectByText;
 import com.vaadin.testbench.HasStringValueProperty;
 import com.vaadin.testbench.HasValidation;
@@ -33,8 +35,8 @@ import com.vaadin.testbench.elementsbase.Element;
  */
 @Element("vaadin-time-picker")
 public class TimePickerElement extends TestBenchElement
-        implements HasStringValueProperty, HasSelectByText, HasHelper,
-        HasClearButton, HasValidation {
+        implements HasStringValueProperty, HasSelectByText, HasLabel,
+        HasPlaceholder, HasHelper, HasClearButton, HasValidation {
     /**
      * Gets the <code>&lt;input&gt;</code> element inside the
      * <code>&lt;vaadin-time-picker&gt;</code> element.


### PR DESCRIPTION
## Motivation

`TimePickerElement` did not implement the `HasLabel` interface, so its label could not be queried from TestBench. The same applied to `HasPlaceholder`. The Flow `TimePicker` component has a `label` property and implements `HasPlaceholder`, and comparable field elements (`DatePickerElement`, `ComboBoxElement`) already expose these.

## Changes

Added `HasLabel` and `HasPlaceholder` to `TimePickerElement`.

Fixes #9898

---

🤖 Generated with [Claude Code](https://claude.ai/code)