### PR TITLE
fix: remove broken isEnabled overrides from TestBench elements

### DIFF
--- a/vaadin-avatar-flow-parent/vaadin-avatar-testbench/src/main/java/com/vaadin/flow/component/avatar/testbench/AvatarElement.java
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-testbench/src/main/java/com/vaadin/flow/component/avatar/testbench/AvatarElement.java
@@ -25,11 +25,6 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("vaadin-avatar")
 public class AvatarElement extends TestBenchElement {
 
-    @Override
-    public boolean isEnabled() {
-        return !getPropertyBoolean("disabled");
-    }
-
     /**
      * Gets the title displayed as a tooltip.
      *

--- a/vaadin-details-flow-parent/vaadin-details-testbench/src/main/java/com/vaadin/flow/component/details/testbench/DetailsElement.java
+++ b/vaadin-details-flow-parent/vaadin-details-testbench/src/main/java/com/vaadin/flow/component/details/testbench/DetailsElement.java
@@ -55,13 +55,6 @@ public class DetailsElement extends TestBenchElement {
     }
 
     /**
-     * Whether the component is enabled or not
-     */
-    public boolean isEnabled() {
-        return !getPropertyBoolean("disabled");
-    }
-
-    /**
      * Returns a wrapper of the summary component
      */
     public TestBenchElement getSummaryWrapper() {

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabElement.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/src/main/java/com/vaadin/flow/component/tabs/testbench/TabElement.java
@@ -24,11 +24,6 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("vaadin-tab")
 public class TabElement extends TestBenchElement {
 
-    @Override
-    public boolean isEnabled() {
-        return !getPropertyBoolean("disabled");
-    }
-
     /**
      * Gets the label of the tab.
      *


### PR DESCRIPTION
`AvatarElement`, `DetailsElement` and `TabElement` override `isEnabled()` with `!getPropertyBoolean("disabled")`. `getPropertyBoolean` returns `null` when the `disabled` property is not defined on the element, and unboxing `null` throws a `NullPointerException`.

The inherited `TestBenchElement#isEnabled` already checks the `disabled` attribute in a null-safe way, so the overrides can just be removed. This is safe for each element:

- `AvatarElement`: `vaadin-avatar` has no `disabled` property at all, so the override threw on every call. Flow stores the disabled state only in the `disabled` attribute, which is exactly what the inherited method checks.
- `DetailsElement`: `vaadin-details` gets its `disabled` property from `DisabledMixin`, which reflects it to the attribute, so the inherited check returns the same result as the override.
- `TabElement`: same as `DetailsElement`, its `disabled` comes from `DisabledMixin` through `ItemMixin`.

Fixes #4678
Fixes #5194
