### PR TITLE
fix: pass content reset callback to GridMenuItem super constructor

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridMenuItem.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridMenuItem.java
@@ -47,7 +47,7 @@ public class GridMenuItem<T> extends
      */
     public GridMenuItem(GridContextMenu<T> contextMenu,
             SerializableRunnable contentReset) {
-        super(contextMenu);
+        super(contextMenu, contentReset);
         Objects.requireNonNull(contextMenu);
         Objects.requireNonNull(contentReset);
         this.contentReset = contentReset;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridMenuItemTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridMenuItemTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.contextmenu;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
+import com.vaadin.tests.MockUIExtension;
+
+class GridMenuItemTest {
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
+
+    private GridContextMenu<String> contextMenu;
+    private GridMenuItem<String> item;
+
+    @BeforeEach
+    void setup() {
+        Grid<String> grid = new Grid<>();
+        contextMenu = grid.addContextMenu();
+        item = contextMenu.addItem("item");
+        ui.add(grid);
+        ui.add(contextMenu);
+    }
+
+    @Test
+    void setTooltipText_menuContentGenerated() {
+        flushPendingInvocations();
+
+        item.setTooltipText("tooltip");
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void setTooltipPosition_menuContentGenerated() {
+        flushPendingInvocations();
+
+        item.setTooltipPosition(TooltipPosition.END);
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    private List<PendingJavaScriptInvocation> getGenerateItemsInvocations() {
+        return getPendingInvocations()
+                .stream().filter(invocation -> invocation.getInvocation()
+                        .getExpression().contains("$connector.generateItems"))
+                .toList();
+    }
+
+    private void flushPendingInvocations() {
+        getPendingInvocations();
+    }
+
+    private List<PendingJavaScriptInvocation> getPendingInvocations() {
+        ui.fakeClientCommunication();
+        return ui.dumpPendingJavaScriptInvocations();
+    }
+}


### PR DESCRIPTION
## Description

Related to #1042

`GridMenuItem` receives a `contentReset` callback and keeps it for building sub menus, but
called the single-argument `MenuItemBase` constructor, which installs a no-op callback in the
base class. Every base-class feature that regenerates the menu content therefore did nothing
on grid menu items.

- Passed `contentReset` to the `MenuItemBase` super constructor, so base-class content
  regeneration reaches `GridContextMenu`
- Fixed `setTooltipText` and `setTooltipPosition` on `GridMenuItem`, which set their element
  property but never rebuilt the client-side items array, so the tooltip never reached the
  browser
- Added `GridMenuItemTest` asserting the pending `$connector.generateItems` invocation for
  both setters

## Type of change

- Bugfix

## How to test

No existing view sets a tooltip on a grid menu item, so one line has to be added:

1. In `vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridPage.java`,
   call `setTooltipText("Tooltip")` on one of the items added to the grid context menu.
2. Start the server and open `vaadin-grid/context-menu-grid`.
3. Right-click a grid row to open the context menu.
4. Hover the item — the tooltip is shown. Without this change no tooltip appears.
