### PR TITLE
fix: restore sub menu when a hidden menu item becomes visible

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityPage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu.it;
+
+import com.vaadin.flow.component.contextmenu.ContextMenu;
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-context-menu/sub-menu-visibility")
+public class SubMenuVisibilityPage extends Div {
+
+    public SubMenuVisibilityPage() {
+        Paragraph target = new Paragraph("target");
+        target.setId("target");
+
+        ContextMenu contextMenu = new ContextMenu(target);
+        MenuItem item = contextMenu.addItem("Item");
+        item.getSubMenu().addItem("Sub item 1");
+        item.getSubMenu().addItem("Sub item 2");
+        item.setVisible(false);
+
+        NativeButton showItem = new NativeButton("Show item",
+                event -> item.setVisible(true));
+        showItem.setId("show-item");
+
+        add(target, showItem);
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.contextmenu.testbench.ContextMenuElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("vaadin-context-menu/sub-menu-visibility")
+public class SubMenuVisibilityIT extends AbstractContextMenuIT {
+
+    private TestBenchElement target;
+
+    @Before
+    public void init() {
+        open();
+        target = $("p").id("target");
+    }
+
+    @Test
+    public void hiddenItem_show_subMenuRendered() {
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        Assert.assertFalse("Expected the item to be hidden initially",
+                menu.getMenuItems().get(0).isDisplayed());
+        clickBody();
+        menu.waitUntilClosed();
+
+        $("button").id("show-item").click();
+
+        menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
+        Assert.assertArrayEquals(new String[] { "Sub item 1", "Sub item 2" },
+                getMenuItemCaptions(getMenuItems(subMenu)));
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -315,6 +315,43 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         return HasComponents.super.bindEnabled(enabledSignal);
     }
 
+    @Override
+    public void setVisible(boolean visible) {
+        boolean becomingVisible = visible && !isVisible();
+        super.setVisible(visible);
+        if (becomingVisible) {
+            resetContentIfParentItem();
+        }
+    }
+
+    @Override
+    public SignalBinding<Boolean> bindVisible(Signal<Boolean> visibleSignal) {
+        // This also runs when the binding is first applied. Binding a hidden
+        // item to a signal that is already true is how such an item is
+        // typically shown, and that case is indistinguishable from binding an
+        // already visible item, so the content is regenerated for both.
+        return super.bindVisible(visibleSignal).onChange(context -> {
+            if (Boolean.TRUE.equals(context.getNewValue())) {
+                resetContentIfParentItem();
+            }
+        });
+    }
+
+    /**
+     * Regenerates the menu content so that the client rebuilds its items array.
+     * Flow withholds property changes for invisible elements, so an item that
+     * was invisible when the content was last generated ended up in that array
+     * without the sub menu that its {@code _containerNodeId} property points
+     * to. Showing the item delivers the property, but only a regeneration makes
+     * the client read it again.
+     */
+    private void resetContentIfParentItem() {
+        // Checking the field first avoids creating a sub menu for leaf items
+        if (subMenu != null && isParentItem()) {
+            contentReset.run();
+        }
+    }
+
     /**
      * Adds one or more theme names to this item. Multiple theme names can be
      * specified by using multiple parameters.

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemSignalTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemSignalTest.java
@@ -15,10 +15,13 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.signals.local.ValueSignal;
 import com.vaadin.tests.AbstractSignalsTest;
 
@@ -60,5 +63,81 @@ class MenuItemSignalTest extends AbstractSignalsTest {
     @Test
     void bindEnabled_disableOnClickNotActive_doesNotThrow() {
         item.bindEnabled(new ValueSignal<>(true));
+    }
+
+    @Test
+    void bindVisible_hiddenParentItem_signalAlreadyTrue_menuContentGenerated() {
+        item.getSubMenu().addItem("sub item");
+        item.setVisible(false);
+        flushPendingInvocations();
+
+        item.bindVisible(new ValueSignal<>(true));
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void bindVisible_visibleParentItem_signalAlreadyTrue_menuContentGenerated() {
+        // The binding can not tell this case apart from the one above, where
+        // regenerating is required, so it regenerates here as well
+        item.getSubMenu().addItem("sub item");
+        flushPendingInvocations();
+
+        item.bindVisible(new ValueSignal<>(true));
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void bindVisible_hiddenParentItem_signalTurnsTrue_menuContentGenerated() {
+        item.getSubMenu().addItem("sub item");
+        var visibleSignal = new ValueSignal<>(false);
+        item.bindVisible(visibleSignal);
+        flushPendingInvocations();
+
+        visibleSignal.set(true);
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void bindVisible_hiddenLeafItem_signalTurnsTrue_menuContentNotGenerated() {
+        var visibleSignal = new ValueSignal<>(false);
+        item.bindVisible(visibleSignal);
+        flushPendingInvocations();
+
+        visibleSignal.set(true);
+
+        Assertions.assertEquals(0, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void bindVisible_visibleParentItem_signalTurnsFalse_menuContentNotGenerated() {
+        item.getSubMenu().addItem("sub item");
+        var visibleSignal = new ValueSignal<>(true);
+        item.bindVisible(visibleSignal);
+        // Discards the regeneration from applying the binding, which is
+        // asserted by bindVisible_visibleParentItem_signalAlreadyTrue_*
+        flushPendingInvocations();
+
+        visibleSignal.set(false);
+
+        Assertions.assertEquals(0, getGenerateItemsInvocations().size());
+    }
+
+    private List<PendingJavaScriptInvocation> getGenerateItemsInvocations() {
+        return getPendingInvocations()
+                .stream().filter(invocation -> invocation.getInvocation()
+                        .getExpression().contains("$connector.generateItems"))
+                .toList();
+    }
+
+    private void flushPendingInvocations() {
+        getPendingInvocations();
+    }
+
+    private List<PendingJavaScriptInvocation> getPendingInvocations() {
+        ui.fakeClientCommunication();
+        return ui.dumpPendingJavaScriptInvocations();
     }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemVisibilityTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemVisibilityTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.tests.MockUIExtension;
+
+class MenuItemVisibilityTest {
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
+
+    private ContextMenu contextMenu;
+
+    @BeforeEach
+    void setup() {
+        contextMenu = new ContextMenu();
+        ui.add(contextMenu);
+    }
+
+    @Test
+    void hiddenParentItem_show_menuContentGenerated() {
+        MenuItem item = contextMenu.addItem("item");
+        item.getSubMenu().addItem("sub item");
+        item.setVisible(false);
+        flushPendingInvocations();
+
+        item.setVisible(true);
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void hiddenNestedParentItem_show_menuContentGenerated() {
+        MenuItem item = contextMenu.addItem("item");
+        MenuItem subItem = item.getSubMenu().addItem("sub item");
+        subItem.getSubMenu().addItem("sub sub item");
+        subItem.setVisible(false);
+        flushPendingInvocations();
+
+        subItem.setVisible(true);
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void hiddenLeafItem_show_menuContentNotGenerated() {
+        MenuItem item = contextMenu.addItem("item");
+        item.setVisible(false);
+        flushPendingInvocations();
+
+        item.setVisible(true);
+
+        Assertions.assertEquals(0, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void visibleParentItem_hide_menuContentNotGenerated() {
+        MenuItem item = contextMenu.addItem("item");
+        item.getSubMenu().addItem("sub item");
+        flushPendingInvocations();
+
+        item.setVisible(false);
+
+        Assertions.assertEquals(0, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void visibleParentItem_showAgain_menuContentNotGenerated() {
+        MenuItem item = contextMenu.addItem("item");
+        item.getSubMenu().addItem("sub item");
+        flushPendingInvocations();
+
+        item.setVisible(true);
+
+        Assertions.assertEquals(0, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void hiddenParentItem_showHideShow_menuContentGeneratedOnEachShow() {
+        MenuItem item = contextMenu.addItem("item");
+        item.getSubMenu().addItem("sub item");
+        item.setVisible(false);
+        flushPendingInvocations();
+
+        item.setVisible(true);
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+
+        item.setVisible(false);
+        Assertions.assertEquals(0, getGenerateItemsInvocations().size());
+
+        item.setVisible(true);
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void hiddenParentItems_showAllInSameRoundTrip_menuContentGeneratedOnce() {
+        MenuItem firstItem = contextMenu.addItem("first item");
+        firstItem.getSubMenu().addItem("first sub item");
+        MenuItem secondItem = contextMenu.addItem("second item");
+        secondItem.getSubMenu().addItem("second sub item");
+        firstItem.setVisible(false);
+        secondItem.setVisible(false);
+        flushPendingInvocations();
+
+        firstItem.setVisible(true);
+        secondItem.setVisible(true);
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    @Test
+    void hiddenParentItem_showDuringBeforeClientResponse_menuContentGeneratedOnce() {
+        MenuItem item = contextMenu.addItem("item");
+        item.getSubMenu().addItem("sub item");
+        item.setVisible(false);
+        flushPendingInvocations();
+
+        ui.getUI().beforeClientResponse(contextMenu,
+                context -> item.setVisible(true));
+
+        Assertions.assertEquals(1, getGenerateItemsInvocations().size());
+    }
+
+    private List<PendingJavaScriptInvocation> getGenerateItemsInvocations() {
+        return getPendingInvocations()
+                .stream().filter(invocation -> invocation.getInvocation()
+                        .getExpression().contains("$connector.generateItems"))
+                .toList();
+    }
+
+    private void flushPendingInvocations() {
+        getPendingInvocations();
+    }
+
+    private List<PendingJavaScriptInvocation> getPendingInvocations() {
+        ui.fakeClientCommunication();
+        return ui.dumpPendingJavaScriptInvocations();
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityPage.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-menu-bar/sub-menu-visibility")
+public class MenuBarSubMenuVisibilityPage extends Div {
+
+    public MenuBarSubMenuVisibilityPage() {
+        add(createRootItemLayout(), createSubItemLayout());
+    }
+
+    private Div createRootItemLayout() {
+        MenuBar menuBar = new MenuBar();
+        menuBar.setId("root-item-menu-bar");
+        MenuItem rootItem = menuBar.addItem("Root item");
+        rootItem.getSubMenu().addItem("Sub item 1");
+        rootItem.getSubMenu().addItem("Sub item 2");
+        rootItem.setVisible(false);
+
+        NativeButton showRootItem = new NativeButton("Show root item",
+                event -> rootItem.setVisible(true));
+        showRootItem.setId("show-root-item");
+
+        return new Div(menuBar, showRootItem);
+    }
+
+    private Div createSubItemLayout() {
+        MenuBar menuBar = new MenuBar();
+        menuBar.setId("sub-item-menu-bar");
+        MenuItem rootItem = menuBar.addItem("Root item");
+        MenuItem subItem = rootItem.getSubMenu().addItem("Sub item");
+        subItem.getSubMenu().addItem("Sub sub item");
+        subItem.setVisible(false);
+
+        NativeButton showSubItem = new NativeButton("Show sub item",
+                event -> subItem.setVisible(true));
+        showSubItem.setId("show-sub-item");
+
+        return new Div(menuBar, showSubItem);
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.flow.component.menubar.testbench.MenuBarItemElement;
+import com.vaadin.flow.component.menubar.testbench.MenuBarSubMenuElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-menu-bar/sub-menu-visibility")
+public class MenuBarSubMenuVisibilityIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void hiddenRootItem_show_subMenuRenders() {
+        MenuBarElement menuBar = $(MenuBarElement.class)
+                .id("root-item-menu-bar");
+        Assert.assertTrue("Expected no buttons while the root item is hidden",
+                menuBar.getButtons().isEmpty());
+
+        $("button").id("show-root-item").click();
+
+        MenuBarSubMenuElement subMenu = menuBar.getButtons().get(0)
+                .openSubMenu();
+        Assert.assertArrayEquals(new String[] { "Sub item 1", "Sub item 2" },
+                getMenuItemContents(subMenu.getMenuItems()));
+    }
+
+    @Test
+    public void hiddenSubItem_show_subSubMenuRenders() {
+        MenuBarElement menuBar = $(MenuBarElement.class)
+                .id("sub-item-menu-bar");
+
+        $("button").id("show-sub-item").click();
+
+        MenuBarSubMenuElement subMenu = menuBar.getButtons().get(0)
+                .openSubMenu();
+        MenuBarSubMenuElement subSubMenu = subMenu.getMenuItem("Sub item")
+                .orElseThrow().openSubMenu();
+        Assert.assertArrayEquals(new String[] { "Sub sub item" },
+                getMenuItemContents(subSubMenu.getMenuItems()));
+    }
+
+    private String[] getMenuItemContents(List<MenuBarItemElement> menuItems) {
+        return menuItems.stream().map(MenuBarItemElement::getText)
+                .toArray(String[]::new);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #1042
Depends on #9906

Flow withholds property changes for invisible elements, so a menu item that is hidden when
the items array is generated never receives the `_containerNodeId` that links it to its sub
menu. Showing the item later delivers the property, but the connector only re-syncs the
hidden and disabled state from the existing items tree, so the sub menu stayed lost forever.

- Regenerated the menu content when a parent item becomes visible, so the client rebuilds its
  items array and reads the `_containerNodeId` it previously had to skip
- Ran the same regeneration when visibility comes from a `bindVisible` signal, including the
  binding's initial application
  - A hidden item bound to a signal that is already `true` is how such an item is typically
    shown, and the server cannot tell that apart from binding an already visible item
- Skipped leaf items, which have no sub menu link to restore
- Added unit tests for the imperative and reactive paths, the leaf-item skip, repeat hide/show
  cycles, and several items shown in one round trip regenerating once
- Added integration tests for a menu-bar root item, a nested menu-bar sub item, and a context
  menu item hidden at first render

## Type of change

- Bugfix

## How to test

1. Open `vaadin-menu-bar/sub-menu-visibility`, click **Show root item**, then click the
   **Root item** button — the sub menu opens with `Sub item 1` and `Sub item 2`.
2. In the second menu bar, click **Show sub item**, open **Root item**, then hover
   **Sub item** — its sub menu opens with `Sub sub item`.
3. Open `vaadin-context-menu/sub-menu-visibility`, click **Show item**, right-click
   **target**, then open the sub menu of **Item** — it lists both sub items.

> [!NOTE]
> Showing a parent item while a menu overlay is open leaves that overlay empty until it is
> reopened. That is a pre-existing web-components defect — assigning `items` does not re-run
> the overlay renderer, and `menu-bar` never re-points an open sub menu at the new children —
> reproducible on `main` without this change by calling `addItem` from a `keepOpen` item's
> click handler. This change adds one more trigger for it. Fixing it belongs upstream:
> vaadin/web-components#5400 covers the context-menu half.
