### PR TITLE
fix: avoid NPE when popover target is set again during auto-add

### DIFF
--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/main/java/com/vaadin/flow/component/popover/Popover.java
@@ -747,12 +747,12 @@ public class Popover extends Component implements HasAriaLabel, HasAriaRole,
 
         // Target's JavaScript needs to be executed on each attach,
         // because Flow creates a new client-side element
-        target.getUI().ifPresent(this::onTargetAttach);
         targetAttachRegistration = target
                 .addAttachListener(e -> onTargetAttach(e.getUI()));
         targetDetachRegistration = target.addDetachListener(e -> {
             removeFromUiIfAutoAdded();
         });
+        target.getUI().ifPresent(this::onTargetAttach);
     }
 
     private void removeFromUiIfAutoAdded() {

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/src/test/java/com/vaadin/flow/component/popover/PopoverAutoAddTest.java
@@ -156,6 +156,43 @@ class PopoverAutoAddTest {
     }
 
     @Test
+    void setTarget_setAnotherTargetDuringAutoAdd_autoAdded() {
+        Div target = new Div();
+        Div other = new Div();
+        ui.add(target);
+        ui.add(other);
+
+        Popover popover = new Popover();
+        popover.addAttachListener(event -> popover.setTarget(other));
+
+        popover.setTarget(target);
+
+        ui.fakeClientCommunication();
+        Assertions.assertEquals(other, popover.getTarget());
+        Assertions.assertEquals(ui.getUI().getElement(),
+                popover.getElement().getParent());
+    }
+
+    @Test
+    void setTarget_setAnotherTargetDuringAutoAdd_detachFirstTarget_notAutoRemoved() {
+        Div target = new Div();
+        Div other = new Div();
+        ui.add(target);
+        ui.add(other);
+
+        Popover popover = new Popover();
+        popover.addAttachListener(event -> popover.setTarget(other));
+
+        popover.setTarget(target);
+        ui.fakeClientCommunication();
+
+        ui.remove(target);
+        ui.fakeClientCommunication();
+        Assertions.assertEquals(ui.getUI().getElement(),
+                popover.getElement().getParent());
+    }
+
+    @Test
     void setTarget_openModal_popoverIsAttachedToUi() {
         Div target = new Div();
         Popover popover = new Popover();


### PR DESCRIPTION
When `setTarget` is called with a target that is already attached, the popover is auto-added to the UI right away. The auto-add fires the popover's attach listeners, and if one of them calls `setTarget` again, that call fails with a `NullPointerException`. This happens because the first call assigns `targetAttachRegistration` and `targetDetachRegistration` only after the auto-add, so the nested call finds a non-null target but null registrations. 

`setTarget` now assigns both registrations before running the initial attach logic. Only adding null checks around the `remove()` calls would also avoid the exception, but it would leak listeners: the nested call would register its own listeners on the target, and the first call would then overwrite them without removing them. The leaked detach listener could later remove the popover from the UI even though its target had already changed. A separate test covers this by detaching the first target and checking that the popover stays in the UI.

Fixes #7758
