### PR TITLE
fix: drop CvdlName manifest entry from AI extensions module

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/pom.xml
@@ -20,7 +20,6 @@
         <osgi.bundle.license>https://vaadin.com/commercial-license-and-service-terms</osgi.bundle.license>
         <osgi.export.package>com.vaadin.flow.component.ai.extensions</osgi.export.package>
         <osgi.export.package.additional>com.vaadin.flow.component.ai.chart,com.vaadin.flow.component.ai.form,com.vaadin.flow.component.ai.grid</osgi.export.package.additional>
-        <cvdlName>vaadin-ai-extensions</cvdlName>
         <spotless.licence-header>${maven.multiModuleProjectDirectory}/scripts/templates/vaadin-commercial-license-header.txt</spotless.licence-header>
         <surefire.argLine>-javaagent:${org.mockito:mockito-core:jar}</surefire.argLine>
     </properties>


### PR DESCRIPTION
## Summary
- Flow's production build license validation flags any classpath jar whose manifest has a `CvdlName` attribute. Unlike the npm-based detection, this Java-side check has no usage filtering — being on the classpath is enough.
- Since `com.vaadin:vaadin` now includes `vaadin-ai-extensions-flow`, every app depending on the umbrella artifact failed to build without a license key, even when the AI controllers were not used (caught by the ecosystem smoke test).
- Removing the `cvdlName` property drops the manifest entry, so license enforcement relies on the development-mode check in the controllers, like Collaboration Engine. The entry can be restored once Flow only flags Java components the application actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)