### PR TITLE
feat: add background execution api for llm

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -72,7 +72,8 @@ public interface AIController {
      * successfully or with an error, but also when the turn fails before a
      * stream ever opens. Fires at most once per prompt: a prompt rejected by
      * the {@link RequestInterceptor} and a postponed prompt abandoned because
-     * its UI was detached end without firing it.
+     * its UI was detached end without firing it, and a turn whose UI is
+     * detached when it ends skips the hook (it requires {@code ui.access()}).
      * <p>
      * On success {@code error} is {@code null}; use the call to commit staged
      * state or run deferred UI updates. On failure {@code error} carries the

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -49,7 +49,9 @@ public interface AIController {
      * conversation history and the {@link RequestListener} only after this
      * method returns successfully. Implementations can prepare for the turn —
      * locking UI surfaces, snapshotting state the tool definitions depend on,
-     * and so on.
+     * and so on. Since tools may execute on a background thread, this is the
+     * moment to capture any state that depends on Vaadin thread locals such as
+     * {@code UI.getCurrent()} or {@code VaadinSession.getCurrent()}.
      * <p>
      * The default does nothing. Throwing from this method aborts the turn
      * before the commit step: the conversation history is unchanged, the
@@ -64,12 +66,13 @@ public interface AIController {
     }
 
     /**
-     * Called on the UI thread under the session lock when the turn ends —
-     * normally when the LLM stream has completed, successfully or with an
-     * error, but also when the turn fails before a stream ever opens. Fires at
-     * most once per prompt: a prompt rejected by the {@link RequestInterceptor}
-     * and a postponed prompt abandoned because its UI was detached end without
-     * firing it.
+     * Called through {@code ui.access()} — with the session lock held and
+     * Vaadin thread locals bound, though not necessarily on a request thread —
+     * when the turn ends: normally when the LLM stream has completed,
+     * successfully or with an error, but also when the turn fails before a
+     * stream ever opens. Fires at most once per prompt: a prompt rejected by
+     * the {@link RequestInterceptor} and a postponed prompt abandoned because
+     * its UI was detached end without firing it.
      * <p>
      * On success {@code error} is {@code null}; use the call to commit staged
      * state or run deferred UI updates. On failure {@code error} carries the

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,7 +63,9 @@ import com.vaadin.flow.component.upload.UploadHelper;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.communication.PushMode;
 
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import tools.jackson.databind.JsonNode;
 
@@ -195,6 +198,16 @@ public class AIOrchestrator implements Serializable {
     private AttachmentClickListener attachmentClickListener;
     private ResponseListener responseListener;
     private SerializableSupplier<String> contextSupplier;
+    private boolean backgroundExecution;
+    /**
+     * Custom executor for background execution. Transient like the provider —
+     * restored via {@link Reconnector#withBackgroundExecution(Executor)} after
+     * deserialization; when absent, the built-in scheduler is used as long as
+     * {@link #backgroundExecution} is set.
+     */
+    private transient Executor backgroundExecutor;
+    private final AtomicBoolean backgroundDeliveryWarned = new AtomicBoolean(
+            false);
     private final Map<AIMessage, String> itemToMessageId = new HashMap<>();
     private final List<ChatMessage> conversationHistory = new CopyOnWriteArrayList<>();
 
@@ -434,6 +447,13 @@ public class AIOrchestrator implements Serializable {
         var responseBuilder = new StringBuilder();
         var responseStream = provider.stream(request)
                 .timeout(Duration.ofSeconds(TIMEOUT_SECONDS));
+        if (backgroundExecution) {
+            // Move the subscription — where a non-streaming provider runs its
+            // blocking chat call and where tool round-trips execute — off the
+            // caller's (UI) thread, so the session lock is free while the LLM
+            // works. Everything before this point stays on the UI thread.
+            responseStream = responseStream.subscribeOn(backgroundScheduler());
+        }
         responseStream.doFinally(signal -> {
             isProcessing.set(false);
         }).subscribe(token -> {
@@ -465,6 +485,42 @@ public class AIOrchestrator implements Serializable {
             fireResponseListener(responseText, null, ui);
             LOGGER.debug("LLM streaming completed successfully");
         });
+    }
+
+    /**
+     * Scheduler that carries a background-executed turn. An app-supplied
+     * executor wins; otherwise Reactor's shared blocking-tolerant pool is used
+     * (also the fallback after deserialization when a custom executor was not
+     * restored via {@link Reconnector#withBackgroundExecution(Executor)}).
+     */
+    private Scheduler backgroundScheduler() {
+        return backgroundExecutor != null
+                ? Schedulers.fromExecutor(backgroundExecutor)
+                : Schedulers.boundedElastic();
+    }
+
+    /**
+     * Logs a one-time warning when a background-executed turn cannot reach the
+     * browser on its own: without automatic push or polling, UI changes made
+     * through {@code ui.access()} from the background thread are only delivered
+     * with the next request the client happens to make. Manual push counts as
+     * blocked too — the orchestrator never calls {@code ui.push()}, so its
+     * updates sit in the queue until the application pushes or the client makes
+     * a request.
+     */
+    private void warnIfBackgroundDeliveryBlocked(UI ui) {
+        if (PushMode.AUTOMATIC.equals(ui.getPushConfiguration().getPushMode())
+                || ui.getPollInterval() > 0) {
+            return;
+        }
+        if (backgroundDeliveryWarned.compareAndSet(false, true)) {
+            LOGGER.warn("Background execution is enabled but neither "
+                    + "automatic push nor polling is active, so the response "
+                    + "will not appear in the browser until the next request "
+                    + "(with manual push mode, until the application calls "
+                    + "ui.push()). Annotate the application shell or UI with "
+                    + "@Push, or enable polling with UI.setPollInterval().");
+        }
     }
 
     private void doPrompt(String userMessage,
@@ -539,6 +595,9 @@ public class AIOrchestrator implements Serializable {
      */
     private void startTurn(UI ui, String userMessage,
             List<AIAttachment> attachments) {
+        if (backgroundExecution) {
+            warnIfBackgroundDeliveryBlocked(ui);
+        }
         var userAIMessage = messageList == null ? null
                 : messageList.addMessage(userMessage, userName, attachments);
         var assistantMessage = createAssistantMessagePlaceholder();
@@ -940,10 +999,10 @@ public class AIOrchestrator implements Serializable {
      * {@link AIOrchestrator#reconnect(LLMProvider)}.
      * <p>
      * The provider is specified when the reconnector is created. Optional
-     * transient dependencies (tools, controller, and file attachments) can be
-     * restored via chained methods before calling {@link #apply()}. The
-     * {@code apply()} call replays the existing conversation history onto the
-     * new provider but does not modify the UI.
+     * transient dependencies (tools, controller, file attachments, and the
+     * background executor) can be restored via chained methods before calling
+     * {@link #apply()}. The {@code apply()} call replays the existing
+     * conversation history onto the new provider but does not modify the UI.
      * </p>
      *
      * <pre>
@@ -959,6 +1018,7 @@ public class AIOrchestrator implements Serializable {
         private Object[] tools;
         private AIController controller;
         private Map<String, List<AIAttachment>> attachmentsByMessageId;
+        private Executor backgroundExecutor;
 
         private Reconnector(AIOrchestrator orchestrator, LLMProvider provider) {
             this.orchestrator = orchestrator;
@@ -1024,6 +1084,34 @@ public class AIOrchestrator implements Serializable {
         }
 
         /**
+         * Restores background execution with the given executor. Like the
+         * provider, an executor passed to
+         * {@link Builder#withBackgroundExecution(Executor)} is transient and
+         * lost on serialization; pass it again here to keep running turns on
+         * it. Calling this on an orchestrator built without background
+         * execution enables it — the same semantics as the builder method.
+         * <p>
+         * If background execution was enabled at build time and this method is
+         * not called, turns keep running in the background on the built-in
+         * scheduler — which is why there is no no-arg variant here.
+         * Reconnection restores or extends the build-time configuration; it
+         * cannot switch background execution off. To change the execution mode
+         * itself, build a new orchestrator.
+         *
+         * @param executor
+         *            the executor to run turns on, not {@code null}
+         * @return this reconnector
+         * @throws NullPointerException
+         *             if executor is {@code null}
+         * @since 25.3
+         */
+        public Reconnector withBackgroundExecution(Executor executor) {
+            Objects.requireNonNull(executor, "Executor cannot be null");
+            this.backgroundExecutor = executor;
+            return this;
+        }
+
+        /**
          * Applies the reconnection, restoring the provider, tools, and
          * conversation history on the new provider. The existing conversation
          * history is replayed onto the new provider's memory so that it has
@@ -1038,6 +1126,10 @@ public class AIOrchestrator implements Serializable {
             orchestrator.provider = provider;
             orchestrator.tools = tools;
             orchestrator.controller = controller;
+            if (backgroundExecutor != null) {
+                orchestrator.backgroundExecution = true;
+                orchestrator.backgroundExecutor = backgroundExecutor;
+            }
             if (!orchestrator.conversationHistory.isEmpty()) {
                 provider.setHistory(
                         List.copyOf(orchestrator.conversationHistory),
@@ -1097,6 +1189,11 @@ public class AIOrchestrator implements Serializable {
      * interpret relative date/time references; pass {@code null} to disable, or
      * a custom supplier to include tenant, locale, page state, or anything else
      * worth keeping out of the system prompt.</li>
+     * <li>{@link #withBackgroundExecution()} or
+     * {@link #withBackgroundExecution(Executor)} – runs each turn on a
+     * background thread so a blocking (non-streaming) LLM call does not hold
+     * the UI thread and the session lock. Synchronous execution is the
+     * default.</li>
      * </ul>
      * <p>
      * Both Flow components ({@link MessageInput}, {@link MessageList},
@@ -1123,6 +1220,8 @@ public class AIOrchestrator implements Serializable {
         private Map<String, List<AIAttachment>> historyAttachments;
         private SerializableSupplier<String> contextSupplier;
         private boolean contextSupplierSet;
+        private boolean backgroundExecution;
+        private Executor backgroundExecutor;
 
         private Builder(LLMProvider provider, String systemPrompt) {
             Objects.requireNonNull(provider, "Provider cannot be null");
@@ -1429,10 +1528,15 @@ public class AIOrchestrator implements Serializable {
          * response text is empty or a partial stream that was received before
          * the failure.
          * <p>
-         * The listener is called from a background thread (Reactor scheduler).
-         * It is safe to perform blocking I/O (e.g. database writes) directly.
+         * The thread the listener runs on depends on the configuration: with a
+         * streaming provider or with {@link #withBackgroundExecution()}
+         * enabled, it is called from a background thread where blocking I/O
+         * (e.g. database writes) is safe. With a non-streaming provider in the
+         * default synchronous mode, the whole turn — this listener included —
+         * runs on the UI thread, where blocking prolongs the current request.
          * To update Vaadin UI components from this listener, use
-         * {@code ui.access()}.
+         * {@code ui.access()}. See {@link ResponseListener} for the full
+         * threading contract.
          * <p>
          * The listener is not called when history is restored via
          * {@link #withHistory(List, Map)}.
@@ -1493,6 +1597,107 @@ public class AIOrchestrator implements Serializable {
         }
 
         /**
+         * Runs each turn on a background thread instead of the thread that
+         * triggers the prompt.
+         * <p>
+         * By default the orchestrator subscribes to the LLM provider's response
+         * stream on the calling thread. With a non-streaming provider, whose
+         * blocking LLM call runs at subscription time, the entire turn — every
+         * LLM round-trip and tool call included — then runs on the UI thread
+         * while holding the session lock, so nothing reaches the browser and
+         * the application appears frozen until the turn ends. With this option
+         * enabled, the subscription moves to a background thread: the UI thread
+         * is released as soon as the turn starts, the user message and the
+         * assistant placeholder render immediately, and the blocking work
+         * happens without the session lock.
+         * <p>
+         * What runs where when this option is enabled:
+         * <ul>
+         * <li>Still on the UI thread, before the stream opens: the
+         * {@link RequestInterceptor}, adding the user message and the assistant
+         * placeholder to the message list, {@link AIController#onRequest()},
+         * the {@link RequestListener}, and the session context supplier.</li>
+         * <li>On the background thread: the LLM call(s), tool executions (both
+         * vendor-annotated tools and {@link LLMProvider.ToolSpec} tools), and
+         * the {@link ResponseListener}.</li>
+         * </ul>
+         * <p>
+         * <b>Delivering updates to the browser:</b> UI changes made while the
+         * turn runs in the background reach the client through automatic server
+         * push or polling. Enable push with {@code @Push} on the application
+         * shell or UI class, or enable polling with
+         * {@link UI#setPollInterval(int)}; otherwise the response appears only
+         * with the next request the browser happens to make. Manual push mode
+         * is not enough on its own — the orchestrator never calls
+         * {@code ui.push()}, so the application would have to push after each
+         * turn itself. A warning is logged when neither automatic push nor
+         * polling is active.
+         * <p>
+         * <b>Tool implementations:</b> on the background thread, Vaadin thread
+         * locals such as {@link UI#getCurrent()} and framework contexts such as
+         * Spring Security's {@code SecurityContext} are not available, and UI
+         * components must not be accessed directly. Wrap component access in
+         * {@code ui.access()}, or capture the needed state up front in
+         * {@link AIController#onRequest()}, which still runs on the UI thread.
+         * The built-in controllers ({@code GridAIController},
+         * {@code ChartAIController}, {@code FormAIController}) already handle
+         * this. To propagate framework contexts, use
+         * {@link #withBackgroundExecution(Executor)} with a context-propagating
+         * executor.
+         * <p>
+         * Calling this method after {@link #withBackgroundExecution(Executor)}
+         * discards the executor and reverts to the built-in pool.
+         *
+         * @return this builder
+         * @see #withBackgroundExecution(Executor)
+         * @since 25.3
+         */
+        public Builder withBackgroundExecution() {
+            warnIfAlreadySet(this.backgroundExecutor, "Background executor");
+            this.backgroundExecution = true;
+            this.backgroundExecutor = null;
+            return this;
+        }
+
+        /**
+         * Runs each turn on the given executor instead of the thread that
+         * triggers the prompt. See {@link #withBackgroundExecution()} for the
+         * full contract; this variant additionally lets the application control
+         * which threads carry the turns — for example a virtual thread per task
+         * executor, a bounded application pool, or a context-propagating
+         * wrapper such as Spring Security's
+         * {@code DelegatingSecurityContextExecutor}.
+         * <p>
+         * The executor's lifecycle is owned by the application; the
+         * orchestrator never shuts it down. Each turn submits a single task
+         * that occupies a thread for the whole turn, so size the executor by
+         * the number of concurrent turns to allow.
+         * <p>
+         * <b>Serialization:</b> the executor is transient. After
+         * deserialization, restore it via
+         * {@code reconnect(provider).withBackgroundExecution(executor)};
+         * otherwise background execution continues on the built-in scheduler.
+         * <p>
+         * The later call wins in either direction: calling this after
+         * {@link #withBackgroundExecution()} switches from the built-in pool to
+         * the executor, and vice versa.
+         *
+         * @param executor
+         *            the executor to run turns on, not {@code null}
+         * @return this builder
+         * @throws NullPointerException
+         *             if executor is {@code null}
+         * @since 25.3
+         */
+        public Builder withBackgroundExecution(Executor executor) {
+            Objects.requireNonNull(executor, "Executor cannot be null");
+            warnIfAlreadySet(this.backgroundExecutor, "Background executor");
+            this.backgroundExecution = true;
+            this.backgroundExecutor = executor;
+            return this;
+        }
+
+        /**
          * Sets the conversation history and associated attachments to restore
          * when the orchestrator is built. This restores the LLM provider's
          * conversation context (including multimodal content), the message list
@@ -1545,6 +1750,8 @@ public class AIOrchestrator implements Serializable {
             orchestrator.responseListener = responseListener;
             orchestrator.contextSupplier = contextSupplierSet ? contextSupplier
                     : defaultContextSupplier();
+            orchestrator.backgroundExecution = backgroundExecution;
+            orchestrator.backgroundExecutor = backgroundExecutor;
             try {
                 if (input != null) {
                     input.addSubmitListener(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -62,6 +62,7 @@ import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadHelper;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.flow.shared.communication.PushMode;
 
@@ -459,7 +460,7 @@ public class AIOrchestrator implements Serializable {
         }).subscribe(token -> {
             responseBuilder.append(token);
             if (assistantMessage != null && messageList != null) {
-                ui.access(() -> assistantMessage.appendText(token));
+                accessIfAttached(ui, () -> assistantMessage.appendText(token));
             }
         }, error -> {
             String userMessage;
@@ -472,7 +473,8 @@ public class AIOrchestrator implements Serializable {
                 LOGGER.error("Error during LLM streaming", error);
             }
             if (assistantMessage != null && messageList != null) {
-                ui.access(() -> assistantMessage.setText(userMessage));
+                accessIfAttached(ui,
+                        () -> assistantMessage.setText(userMessage));
             }
             fireResponseListener("", error, ui);
         }, () -> {
@@ -710,6 +712,23 @@ public class AIOrchestrator implements Serializable {
     }
 
     /**
+     * Runs a UI update for the current turn, tolerating a UI that was detached
+     * while the turn ran in the background: the update is skipped and logged at
+     * debug instead of surfacing {@link UIDetachedException} as a stream error.
+     * The turn itself is unaffected — the conversation history and the
+     * {@link ResponseListener} are UI-independent.
+     */
+    private static void accessIfAttached(UI ui, Command command) {
+        try {
+            ui.access(command);
+        } catch (UIDetachedException e) {
+            LOGGER.debug(
+                    "Skipped a UI update for an abandoned turn (UI detached)",
+                    e);
+        }
+    }
+
+    /**
      * Ends a postponed prompt that failed or timed out. Nothing was displayed
      * for the prompt, so no UI cleanup is needed beyond reporting — which is
      * why the flag is released before touching the UI: a detached UI must not
@@ -717,12 +736,7 @@ public class AIOrchestrator implements Serializable {
      */
     private void abortPostponedPrompt(UI ui, Throwable failure) {
         isProcessing.set(false);
-        try {
-            fireResponseListener("", failure, ui);
-        } catch (UIDetachedException e) {
-            LOGGER.warn("Postponed prompt failed after its UI was detached",
-                    failure);
-        }
+        fireResponseListener("", failure, ui);
     }
 
     /**
@@ -928,7 +942,7 @@ public class AIOrchestrator implements Serializable {
             }
         }
         if (controller != null) {
-            ui.access(() -> {
+            accessIfAttached(ui, () -> {
                 try {
                     controller.onResponse(error);
                 } catch (Exception e) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
@@ -48,13 +48,16 @@ import java.util.Optional;
  * The listener is <b>not</b> called when history is restored via
  * {@code Builder.withHistory()}.
  * <p>
- * <b>Threading:</b> the listener is called from whichever thread ends the turn:
- * a blocking-tolerant Reactor thread for stream completion, stream errors, and
- * interception timeouts — blocking I/O (e.g. database writes) is safe there —
- * the UI thread for synchronous failures, where blocking delays the current
- * request, or the application's own thread when it completes a postponed
- * prompt. To update Vaadin UI components from this listener, use
- * {@code ui.access()}.
+ * <b>Threading:</b> the listener is called from whichever thread ends the turn.
+ * With a streaming provider, or when background execution is enabled via
+ * {@code AIOrchestrator.Builder.withBackgroundExecution()}, stream completion
+ * and stream errors arrive on a background thread — blocking I/O (e.g. database
+ * writes) is safe there. With a non-streaming provider in the default
+ * synchronous mode, the whole turn runs on the UI thread and the listener runs
+ * there too, where blocking prolongs the current request. Interception timeouts
+ * arrive on a blocking-tolerant Reactor thread, synchronous failures on the UI
+ * thread, and a postponed prompt completes on the application's own thread. To
+ * update Vaadin UI components from this listener, use {@code ui.access()}.
  * 
  * @since 25.2
  */

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -53,6 +53,13 @@ public interface LLMProvider {
      * become available from the LLM. The provider manages conversation history
      * internally, so each call to this method adds to the ongoing conversation
      * context.
+     * <p>
+     * Implementations may run blocking work at subscription time, as the
+     * built-in non-streaming providers do. The caller decides which thread
+     * subscribes — the orchestrator subscribes on the calling thread by default
+     * and on a background thread when background execution is enabled — so
+     * implementations must not assume a specific thread, such as the UI thread
+     * with Vaadin thread locals bound.
      *
      * @param request
      *            the LLM request containing user message, system prompt,
@@ -245,6 +252,14 @@ public interface LLMProvider {
          * <p>
          * Implementations should return a human-readable result string on
          * success. On failure, they may throw any runtime exception.
+         * </p>
+         * <p>
+         * May be invoked from a background thread — with a streaming provider,
+         * or when background execution is enabled on the orchestrator — where
+         * Vaadin thread locals such as {@code UI.getCurrent()} are not
+         * available. Wrap UI component access in {@code ui.access()}, or work
+         * on state captured in
+         * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}.
          * </p>
          *
          * @param arguments

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/AIComponentsSerializableTest.java
@@ -20,6 +20,10 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -181,6 +185,105 @@ class AIComponentsSerializableTest extends ClassesSerializableTest {
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(newProvider).stream(captor.capture());
         Assertions.assertEquals("second", captor.getValue().userMessage());
+    }
+
+    @Test
+    void serialization_roundTrip_preservesBackgroundExecution()
+            throws Throwable {
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution().build();
+        var deserialized = serializeAndDeserialize(orchestrator);
+
+        var newProvider = Mockito.mock(LLMProvider.class);
+        var subscribeThread = new AtomicReference<Thread>();
+        var subscribed = new CountDownLatch(1);
+        Mockito.when(
+                newProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.defer(() -> {
+                    subscribeThread.set(Thread.currentThread());
+                    subscribed.countDown();
+                    return Flux.just("Response");
+                }));
+        deserialized.reconnect(newProvider).apply();
+
+        deserialized.prompt("Hello");
+
+        Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                "Provider stream was never subscribed");
+        Assertions.assertNotSame(Thread.currentThread(), subscribeThread.get(),
+                "Background execution must survive serialization");
+    }
+
+    @Test
+    void serialization_roundTrip_reconnectRestoresBackgroundExecutor()
+            throws Throwable {
+        // The build-time executor is transient and lost on serialization;
+        // a direct executor keeps this turn-free until the restore.
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution(Runnable::run).build();
+        var deserialized = serializeAndDeserialize(orchestrator);
+
+        var restoredExecutor = Executors.newSingleThreadExecutor(
+                runnable -> new Thread(runnable, "restored-executor"));
+        try {
+            var newProvider = Mockito.mock(LLMProvider.class);
+            var subscribeThread = new AtomicReference<Thread>();
+            var subscribed = new CountDownLatch(1);
+            Mockito.when(newProvider
+                    .stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                    .thenReturn(Flux.defer(() -> {
+                        subscribeThread.set(Thread.currentThread());
+                        subscribed.countDown();
+                        return Flux.just("Response");
+                    }));
+            deserialized.reconnect(newProvider)
+                    .withBackgroundExecution(restoredExecutor).apply();
+
+            deserialized.prompt("Hello");
+
+            Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                    "Provider stream was never subscribed");
+            Assertions.assertEquals("restored-executor",
+                    subscribeThread.get().getName(),
+                    "The restored executor must carry the turn");
+        } finally {
+            restoredExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void reconnect_withBackgroundExecution_enablesBackgroundExecution()
+            throws Throwable {
+        var orchestrator = AIOrchestrator.builder(mockProvider, null).build();
+        var deserialized = serializeAndDeserialize(orchestrator);
+
+        var executor = Executors.newSingleThreadExecutor(
+                runnable -> new Thread(runnable, "enabled-executor"));
+        try {
+            var newProvider = Mockito.mock(LLMProvider.class);
+            var subscribeThread = new AtomicReference<Thread>();
+            var subscribed = new CountDownLatch(1);
+            Mockito.when(newProvider
+                    .stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                    .thenReturn(Flux.defer(() -> {
+                        subscribeThread.set(Thread.currentThread());
+                        subscribed.countDown();
+                        return Flux.just("Response");
+                    }));
+            deserialized.reconnect(newProvider)
+                    .withBackgroundExecution(executor).apply();
+
+            deserialized.prompt("Hello");
+
+            Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                    "Provider stream was never subscribed");
+            Assertions.assertEquals("enabled-executor",
+                    subscribeThread.get().getName(),
+                    "Reconnecting with an executor must enable background "
+                            + "execution on an orchestrator built without it");
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,6 +61,7 @@ import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
 
@@ -2935,10 +2937,13 @@ class AIOrchestratorTest {
         // a resource that build() must claim. If you add a new resource
         // with-method (component, controller, ...), do not add it here —
         // ensure build() claims it.
+        // withBackgroundExecution is exempt because an executor is meant to
+        // be shareable across orchestrators (e.g. one application pool).
         Set<String> nonResourceSetters = Set.of("withTools", "withUserName",
                 "withAssistantName", "withRequestInterceptor",
                 "withRequestListener", "withAttachmentClickListener",
-                "withResponseListener", "withHistory", "withMetadata");
+                "withResponseListener", "withHistory", "withMetadata",
+                "withBackgroundExecution");
 
         // Provider is set via the factory method, not a with-method.
         assertClaimed(null, LLMProvider.class);
@@ -3133,6 +3138,326 @@ class AIOrchestratorTest {
         var controller = Mockito.mock(AIController.class);
         Mockito.when(controller.getTools()).thenReturn(List.of());
         return controller;
+    }
+
+    @Test
+    void defaultExecution_streamSubscribedOnCallerThread() {
+        var subscribeThread = new AtomicReference<Thread>();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.defer(() -> {
+                    subscribeThread.set(Thread.currentThread());
+                    return Flux.just("Response");
+                }));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null).build();
+        orchestrator.prompt("Hello");
+
+        Assertions.assertSame(Thread.currentThread(), subscribeThread.get(),
+                "Without background execution the provider stream must be "
+                        + "subscribed on the calling thread");
+    }
+
+    @Test
+    void withBackgroundExecution_streamSubscribedOffCallerThread()
+            throws Exception {
+        var subscribeThread = new AtomicReference<Thread>();
+        var subscribed = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.defer(() -> {
+                    subscribeThread.set(Thread.currentThread());
+                    subscribed.countDown();
+                    return Flux.just("Response");
+                }));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution().build();
+        orchestrator.prompt("Hello");
+
+        Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                "Provider stream was never subscribed");
+        Assertions.assertNotSame(Thread.currentThread(), subscribeThread.get(),
+                "With background execution the provider stream must be "
+                        + "subscribed off the calling thread");
+    }
+
+    @Test
+    void withBackgroundExecution_customExecutor_turnRunsOnExecutorThread()
+            throws Exception {
+        var executor = java.util.concurrent.Executors.newSingleThreadExecutor(
+                runnable -> new Thread(runnable, "custom-turn-thread"));
+        try {
+            var subscribeThread = new AtomicReference<Thread>();
+            var subscribed = new CountDownLatch(1);
+            Mockito.when(mockProvider
+                    .stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                    .thenReturn(Flux.defer(() -> {
+                        subscribeThread.set(Thread.currentThread());
+                        subscribed.countDown();
+                        return Flux.just("Response");
+                    }));
+
+            var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                    .withBackgroundExecution(executor).build();
+            orchestrator.prompt("Hello");
+
+            Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                    "Provider stream was never subscribed");
+            Assertions.assertEquals("custom-turn-thread",
+                    subscribeThread.get().getName(),
+                    "The turn must run on the supplied executor");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void withBackgroundExecution_nullExecutor_throwsNullPointerException() {
+        var builder = AIOrchestrator.builder(mockProvider, null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> builder.withBackgroundExecution(null));
+    }
+
+    @Test
+    void withBackgroundExecution_responseListenerRunsOffCallerThread()
+            throws Exception {
+        var listenerThread = new AtomicReference<Thread>();
+        var listenerCalled = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution().withResponseListener(event -> {
+                    listenerThread.set(Thread.currentThread());
+                    listenerCalled.countDown();
+                }).build();
+        orchestrator.prompt("Hello");
+
+        Assertions.assertTrue(listenerCalled.await(5, TimeUnit.SECONDS),
+                "Response listener was never called");
+        Assertions.assertNotSame(Thread.currentThread(), listenerThread.get(),
+                "With background execution the response listener must run "
+                        + "off the calling thread");
+    }
+
+    @Test
+    void withBackgroundExecution_completedTurn_allowsNextPrompt()
+            throws Exception {
+        var firstDone = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution()
+                .withResponseListener(event -> firstDone.countDown()).build();
+        orchestrator.prompt("First");
+        Assertions.assertTrue(firstDone.await(5, TimeUnit.SECONDS),
+                "First turn never completed");
+
+        // The busy flag is released in the stream's doFinally, which runs
+        // just after the response listener on the background thread — poll
+        // until the next prompt is accepted.
+        var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        var accepted = false;
+        while (!accepted && System.nanoTime() < deadline) {
+            orchestrator.prompt("Second");
+            accepted = Mockito.mockingDetails(mockProvider).getInvocations()
+                    .stream().filter(invocation -> invocation.getMethod()
+                            .getName().equals("stream"))
+                    .count() >= 2;
+            if (!accepted) {
+                Thread.sleep(10);
+            }
+        }
+        Assertions.assertTrue(accepted,
+                "A completed background turn must release the busy flag "
+                        + "so the next prompt is processed");
+    }
+
+    @Test
+    void withBackgroundExecution_noPushNoPolling_logsDeliveryWarningOnce()
+            throws Exception {
+        var firstDone = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution()
+                .withResponseListener(event -> firstDone.countDown()).build();
+        orchestrator.prompt("Hello");
+        Assertions.assertTrue(firstDone.await(5, TimeUnit.SECONDS),
+                "First turn never completed");
+
+        // Ensure the second prompt is actually accepted (not dropped by the
+        // busy guard, which is released just after the listener) so the
+        // warn-once guard really runs a second time.
+        var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        var accepted = false;
+        while (!accepted && System.nanoTime() < deadline) {
+            orchestrator.prompt("Hello again");
+            accepted = Mockito.mockingDetails(mockProvider).getInvocations()
+                    .stream().filter(invocation -> invocation.getMethod()
+                            .getName().equals("stream"))
+                    .count() >= 2;
+            if (!accepted) {
+                Thread.sleep(10);
+            }
+        }
+        Assertions.assertTrue(accepted, "Second prompt was never accepted");
+
+        var warnings = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("neither automatic push nor polling"))
+                .count();
+        Assertions.assertEquals(1, warnings,
+                "Expected exactly one delivery warning across two turns");
+    }
+
+    @Test
+    void withBackgroundExecution_manualPush_logsDeliveryWarning() {
+        Mockito.when(ui.getService().ensurePushAvailable()).thenReturn(true);
+        ui.getUI().getPushConfiguration().setPushMode(PushMode.MANUAL);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution().build();
+        orchestrator.prompt("Hello");
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("neither automatic push nor polling"))
+                .findFirst();
+        Assertions.assertTrue(warning.isPresent(),
+                "Manual push does not deliver the orchestrator's updates, "
+                        + "so the delivery warning is expected");
+    }
+
+    @Test
+    void withBackgroundExecution_pollingEnabled_noDeliveryWarning() {
+        ui.getUI().setPollInterval(500);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution().build();
+        orchestrator.prompt("Hello");
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("neither automatic push nor polling"))
+                .findFirst();
+        Assertions.assertTrue(warning.isEmpty(),
+                "Polling makes background updates reach the browser, so no "
+                        + "delivery warning is expected");
+    }
+
+    @Test
+    void withBackgroundExecution_pushEnabled_noDeliveryWarning() {
+        Mockito.when(ui.getService().ensurePushAvailable()).thenReturn(true);
+        ui.getUI().getPushConfiguration().setPushMode(PushMode.AUTOMATIC);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution().build();
+        orchestrator.prompt("Hello");
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("neither automatic push nor polling"))
+                .findFirst();
+        Assertions.assertTrue(warning.isEmpty(),
+                "Push makes background updates reach the browser, so no "
+                        + "delivery warning is expected");
+    }
+
+    @Test
+    void withBackgroundExecution_streamError_allowsNextPrompt()
+            throws Exception {
+        var firstDone = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.error(new RuntimeException("API Error")));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution()
+                .withResponseListener(event -> firstDone.countDown()).build();
+        orchestrator.prompt("First");
+        Assertions.assertTrue(firstDone.await(5, TimeUnit.SECONDS),
+                "First turn never failed");
+
+        // The busy flag is released in the stream's doFinally, which runs
+        // just after the response listener on the background thread — poll
+        // until the next prompt is accepted.
+        var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        var accepted = false;
+        while (!accepted && System.nanoTime() < deadline) {
+            orchestrator.prompt("Second");
+            accepted = Mockito.mockingDetails(mockProvider).getInvocations()
+                    .stream().filter(invocation -> invocation.getMethod()
+                            .getName().equals("stream"))
+                    .count() >= 2;
+            if (!accepted) {
+                Thread.sleep(10);
+            }
+        }
+        Assertions.assertTrue(accepted,
+                "A failed background turn must release the busy flag so the "
+                        + "next prompt is processed");
+    }
+
+    @Test
+    void builder_backgroundExecutionAfterExecutor_discardsExecutor()
+            throws Exception {
+        var submissions = new AtomicInteger();
+        Executor executor = command -> {
+            submissions.incrementAndGet();
+            new Thread(command).start();
+        };
+        var subscribed = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.defer(() -> {
+                    subscribed.countDown();
+                    return Flux.just("Response");
+                }));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withBackgroundExecution(executor).withBackgroundExecution()
+                .build();
+        orchestrator.prompt("Hello");
+
+        Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                "Provider stream was never subscribed");
+        Assertions.assertEquals(0, submissions.get(),
+                "The no-arg call must discard the executor in favor of the "
+                        + "built-in pool");
+        assertBuilderWarning("backgroundExecutor");
+    }
+
+    @Test
+    void defaultExecution_noPushNoPolling_noDeliveryWarning() {
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null).build();
+        orchestrator.prompt("Hello");
+
+        var warning = logger.getLoggingEvents().stream()
+                .filter(event -> event.getMessage()
+                        .contains("neither automatic push nor polling"))
+                .findFirst();
+        Assertions.assertTrue(warning.isEmpty(),
+                "Synchronous execution must not log the delivery warning");
     }
 
     private AIOrchestrator orchestratorWith(AIController controller) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -3444,6 +3444,90 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void withBackgroundExecution_uiDetachedMidTurn_completesQuietly()
+            throws Exception {
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        var detached = new CountDownLatch(1);
+        var turnEnded = new CountDownLatch(1);
+        var listenerError = new AtomicReference<Throwable>();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.create(sink -> {
+                    try {
+                        detached.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    sink.next("Response");
+                    sink.complete();
+                }));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).withBackgroundExecution()
+                .withResponseListener(event -> {
+                    listenerError.set(event.getError().orElse(null));
+                    turnEnded.countDown();
+                }).build();
+        orchestrator.prompt("Hello");
+
+        // Detach the UI while the provider is still blocking in the
+        // background, then let the turn finish.
+        ui.getUI().getInternals().setSession(null);
+        detached.countDown();
+
+        Assertions.assertTrue(turnEnded.await(5, TimeUnit.SECONDS),
+                "The turn must still end after the UI detached");
+        Assertions.assertNull(listenerError.get(),
+                "A detached UI must not surface as a turn error");
+        var lastMessage = orchestrator.getHistory()
+                .get(orchestrator.getHistory().size() - 1);
+        Assertions.assertEquals("Response", lastMessage.content(),
+                "The response must still be recorded in the history");
+        Assertions.assertTrue(
+                logger.getLoggingEvents().stream()
+                        .noneMatch(event -> event.getMessage()
+                                .contains("Error during LLM streaming")),
+                "A detached UI must not be logged as a streaming error");
+    }
+
+    @Test
+    void withBackgroundExecution_uiDetachedMidTurn_skipsControllerOnResponse()
+            throws Exception {
+        var controller = Mockito.mock(AIController.class);
+        var detached = new CountDownLatch(1);
+        var turnEnded = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.create(sink -> {
+                    try {
+                        detached.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    sink.next("Response");
+                    sink.complete();
+                }));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withController(controller).withBackgroundExecution()
+                .withResponseListener(event -> turnEnded.countDown()).build();
+        orchestrator.prompt("Hello");
+
+        ui.getUI().getInternals().setSession(null);
+        detached.countDown();
+
+        Assertions.assertTrue(turnEnded.await(5, TimeUnit.SECONDS),
+                "The turn must still end after the UI detached");
+        // The listener fires just before the controller hook would run on
+        // the same thread — after() covers that window.
+        Mockito.verify(controller, Mockito.after(500).never())
+                .onResponse(Mockito.any());
+    }
+
+    @Test
     void defaultExecution_noPushNoPolling_noDeliveryWarning() {
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
@@ -483,6 +483,34 @@ class RequestInterceptorTest {
     }
 
     @Test
+    void postponedPrompt_backgroundExecution_resumedTurnRunsOffCallerThread()
+            throws Exception {
+        var continuation = new AtomicReference<RequestInterceptor.RequestContinuation>();
+        var subscribeThread = new AtomicReference<Thread>();
+        var subscribed = new CountDownLatch(1);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.defer(() -> {
+                    subscribeThread.set(Thread.currentThread());
+                    subscribed.countDown();
+                    return Flux.just("Response");
+                }));
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withRequestInterceptor(event -> continuation
+                        .set(event.postpone(Duration.ofMinutes(1))))
+                .withBackgroundExecution().build();
+
+        orchestrator.prompt("Hello");
+        continuation.get().proceed();
+
+        Assertions.assertTrue(subscribed.await(5, TimeUnit.SECONDS),
+                "Provider stream was never subscribed");
+        Assertions.assertNotSame(Thread.currentThread(), subscribeThread.get(),
+                "A resumed postponed prompt must still run in the background");
+    }
+
+    @Test
     void proceed_appliesChangesMadeAfterInterceptReturned() {
         var seen = new AtomicReference<RequestInterceptor.RequestInterceptEvent>();
         var continuation = new AtomicReference<RequestInterceptor.RequestContinuation>();


### PR DESCRIPTION
## Description

On `com.vaadin.flow.component.ai.orchestrator.AIOrchestrator`:

```java
public Builder withBackgroundExecution()

public Builder withBackgroundExecution(Executor executor)

public Reconnector withBackgroundExecution(Executor executor)
```

Fixes https://github.com/orgs/vaadin/projects/103/views/1?filterQuery=&pane=issue&itemId=231351570

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
