### PR TITLE
feat: add setDefaultTime to DateTimePicker

### DIFF
--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerPage.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerPage.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.datetimepicker;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -89,6 +90,17 @@ public class DateTimePickerPage extends Div {
         picker5.setId("date-time-picker-high-precision-initial-value");
 
         add(new Hr(), new H1("Set initial value with high precision"), picker5);
+
+        // Default time
+        Div message6 = createMessageDiv("message-default-time");
+
+        DateTimePicker picker6 = new DateTimePicker();
+        picker6.setId("date-time-picker-default-time");
+        picker6.setDefaultTime(LocalTime.of(9, 0));
+        picker6.addValueChangeListener(
+                event -> updateMessage(message6, picker6));
+
+        add(new Hr(), new H1("Default time"), picker6, message6);
     }
 
     private void updateMessage(Div message, DateTimePicker dateTimePicker) {

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerIT.java
@@ -83,6 +83,19 @@ public class DateTimePickerIT extends AbstractComponentIT {
     }
 
     @Test
+    public void setDefaultTime_selectDate_defaultTimeFilledIn() {
+        DateTimePickerElement picker = $(DateTimePickerElement.class)
+                .id("date-time-picker-default-time");
+        TestBenchElement message = $("div").id("message-default-time");
+
+        picker.setDate(LocalDate.of(1985, 1, 11));
+
+        Assert.assertEquals(LocalTime.of(9, 0), picker.getTime());
+        Assert.assertTrue("Message should contain the completed date-time",
+                message.getText().contains("1985-01-11 09:00:00"));
+    }
+
+    @Test
     public void focus() {
         TestBenchElement focusButton = $("button").id("button-focus");
         TestBenchCommandExecutor cmd = focusButton.getCommandExecutor();

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -713,6 +713,11 @@ public class DateTimePicker
      * outside the range defined by {@link #setMin(LocalDateTime)} and
      * {@link #setMax(LocalDateTime)} is filled in as is and makes the component
      * invalid.
+     * <p>
+     * The default time itself will be truncated to millisecond precision, as
+     * that is the maximum that the time picker supports. This means that
+     * {@link #getDefaultTime()} might return a different value than what was
+     * passed in.
      *
      * @param defaultTime
      *            the default time, or {@code null} to remove the default time

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePicker.java
@@ -20,6 +20,7 @@ import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Locale;
@@ -681,6 +682,49 @@ public class DateTimePicker
         double stepsValue = getElement().getProperty("step", 0.0);
 
         return StepsUtil.convertStepsValueToDuration(stepsValue);
+    }
+
+    /**
+     * Gets the time that is filled in automatically when the user selects a
+     * date while the time field is empty. Defaults to {@code null}.
+     *
+     * @return the default time, or {@code null} if no default time is set
+     * @see #setDefaultTime(LocalTime)
+     * @since 25.3
+     */
+    public LocalTime getDefaultTime() {
+        String defaultTime = getElement().getProperty("defaultTime");
+        return defaultTime == null || defaultTime.isEmpty() ? null
+                : LocalTime.parse(defaultTime);
+    }
+
+    /**
+     * Sets the time that is filled in automatically when the user selects a
+     * date while the time field is empty. Defaults to {@code null}, in which
+     * case selecting a date leaves the time field empty and the component has
+     * no value until a time is entered as well.
+     * <p>
+     * The default time is only filled in for a date that the user selects or
+     * types, never for a value set with {@link #setValue(LocalDateTime)}. A
+     * time that the user has already entered is never overwritten.
+     * <p>
+     * The filled in time uses the precision defined by
+     * {@link #setStep(Duration)}, a more precise time is truncated. A time
+     * outside the range defined by {@link #setMin(LocalDateTime)} and
+     * {@link #setMax(LocalDateTime)} is filled in as is and makes the component
+     * invalid.
+     *
+     * @param defaultTime
+     *            the default time, or {@code null} to remove the default time
+     * @since 25.3
+     */
+    public void setDefaultTime(LocalTime defaultTime) {
+        if (defaultTime == null) {
+            getElement().removeProperty("defaultTime");
+        } else {
+            getElement().setProperty("defaultTime",
+                    defaultTime.truncatedTo(ChronoUnit.MILLIS).toString());
+        }
     }
 
     /**

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
@@ -133,6 +134,36 @@ class DateTimePickerTest {
         picker.setMax(LocalDateTime.of(2018, 4, 25, 13, 45, 10));
         assertEquals(LocalDateTime.of(2018, 4, 25, 13, 45, 10),
                 picker.getMax());
+    }
+
+    @Test
+    void setDefaultTime() {
+        DateTimePicker picker = new DateTimePicker();
+        Assertions.assertNull(picker.getDefaultTime());
+        assertFalse(picker.getElement().hasProperty("defaultTime"));
+
+        picker.setDefaultTime(LocalTime.of(9, 0));
+        assertEquals("09:00", picker.getElement().getProperty("defaultTime"));
+        assertEquals(LocalTime.of(9, 0), picker.getDefaultTime());
+
+        picker.setDefaultTime(LocalTime.of(9, 30, 15));
+        assertEquals("09:30:15",
+                picker.getElement().getProperty("defaultTime"));
+        assertEquals(LocalTime.of(9, 30, 15), picker.getDefaultTime());
+
+        picker.setDefaultTime(null);
+        Assertions.assertNull(picker.getDefaultTime());
+        assertFalse(picker.getElement().hasProperty("defaultTime"));
+    }
+
+    @Test
+    void setDefaultTime_truncatesToMilliseconds() {
+        DateTimePicker picker = new DateTimePicker();
+        picker.setDefaultTime(LocalTime.of(9, 30, 15, 123_456_789));
+        assertEquals("09:30:15.123",
+                picker.getElement().getProperty("defaultTime"));
+        assertEquals(LocalTime.of(9, 30, 15, 123_000_000),
+                picker.getDefaultTime());
     }
 
     @Test


### PR DESCRIPTION
## Description

Part of #1850
Depends on https://github.com/vaadin/web-components/pull/12451

- Added `setDefaultTime(LocalTime)` and `getDefaultTime()` that fill the time field when the user commits a date while it is empty
  - The `LocalTime` is truncated to millisecond precision, the finest precision the web component parses
  - All behavior comes from the web component: only for a date the user commits, never overwriting a time already entered, precision following `setStep`, a time outside `min` / `max` applied as is
  - No `bindDefaultTime` — `defaultTime` is configure-once state
- Added unit tests for the property round-trip in all three ISO time precisions, for clearing with `null`, and for the millisecond truncation
- Added a "Default time" section to `DateTimePickerPage` and a smoke integration test covering a committed date filling the time field and the complete value reaching the server

## Type of change

- Feature

## How to test

Until https://github.com/vaadin/web-components/pull/12451 is released in an alpha, point `LOCAL_WEB_COMPONENTS_PATH` in `.env` at a checkout of that branch.

1. Start the server: `mvn package jetty:run -Dvaadin.frontend.hotdeploy=true -am -B -q -DskipTests -pl vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests`
2. Open `http://localhost:8080/vaadin-date-time-picker/date-time-picker-it` and scroll to the "Default time" section — the view is `vaadin-date-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerPage.java`
3. Pick a date in the calendar — the time field fills in with `09:00` and the completed date-time is shown below the field
4. Clear the time field, then pick another date — `09:00` is filled in again
5. Type a time first, then change the date — the typed time is kept

> [!NOTE]
> `DateTimePickerIT.setDefaultTime_selectDate_defaultTimeFilledIn` fails until vaadin/web-components#12451 is merged and released in an alpha. The whole `DateTimePickerIT` suite passes against that branch locally.
