### PR TITLE
fix: keep menu item tooltip when the item was hidden

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
 import com.vaadin.flow.dom.SignalBinding;
@@ -66,6 +67,8 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
             this);
 
     private final SerializableRunnable contentReset;
+
+    private PendingJavaScriptResult pendingTooltipUpdate;
 
     /**
      * Default constructor
@@ -381,6 +384,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         ensureTooltipElement();
         getElement().setProperty("tooltip", tooltipText);
         contentReset.run();
+        updateTooltip();
     }
 
     /**
@@ -399,6 +403,30 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
         getElement().setProperty("tooltipPosition",
                 position != null ? position.getPosition() : null);
         contentReset.run();
+        updateTooltip();
+    }
+
+    /**
+     * Copies the tooltip into the generated items array. The connector reads
+     * the tooltip off the item element when it generates that array, and the
+     * web component then reads it from the array instead of from the element.
+     * Flow does not send property changes for invisible elements, so a tooltip
+     * set while the item is invisible would be missing from the array.
+     * <p>
+     * The call is made through the item element so that Flow holds it back for
+     * as long as the item is invisible, and runs it once the item is shown,
+     * which is when the array needs the value.
+     */
+    private void updateTooltip() {
+        if (pendingTooltipUpdate != null
+                && !pendingTooltipUpdate.isSentToBrowser()) {
+            pendingTooltipUpdate.cancelExecution();
+        }
+
+        pendingTooltipUpdate = getElement().executeJs(
+                "window.Vaadin.Flow.contextMenuConnector.setTooltip(this, $0, $1)",
+                getElement().getProperty("tooltip"),
+                getElement().getProperty("tooltipPosition"));
     }
 
     protected void ensureTooltipElement() {

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -98,7 +98,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
                 setChecked(!isChecked());
             }
         });
-
+        addAttachListener(event -> updateTooltip());
     }
 
     /**
@@ -415,9 +415,16 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
      * <p>
      * The call is made through the item element so that Flow holds it back for
      * as long as the item is invisible, and runs it once the item is shown,
-     * which is when the array needs the value.
+     * which is when the array needs the value. A held back call is dropped when
+     * the item element is detached, which generating the content does to every
+     * item, so this also runs from the attach handler.
      */
     private void updateTooltip() {
+        if (!getElement().hasProperty("tooltip")
+                && !getElement().hasProperty("tooltipPosition")) {
+            return;
+        }
+
         if (pendingTooltipUpdate != null
                 && !pendingTooltipUpdate.isSentToBrowser()) {
             pendingTooltipUpdate.cancelExecution();

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuConnector.js
@@ -115,10 +115,28 @@ function setTheme(component, theme) {
   }
 }
 
+/**
+ * Sets the tooltip for a context menu item.
+ *
+ * This method is supposed to be called when the context menu item is closed,
+ * so there is no need for triggering a re-render eagarly.
+ *
+ * @param {HTMLElement} component
+ * @param {string | undefined | null} tooltip
+ * @param {string | undefined | null} tooltipPosition
+ */
+function setTooltip(component, tooltip, tooltipPosition) {
+  if (component._item) {
+    component._item.tooltip = tooltip;
+    component._item.tooltipPosition = tooltipPosition;
+  }
+}
+
 window.Vaadin.Flow.contextMenuConnector = {
   initLazy,
   generateItemsTree,
   setChecked,
   setKeepOpen,
-  setTheme
+  setTheme,
+  setTooltip
 };

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTooltipTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTooltipTest.java
@@ -84,6 +84,42 @@ class MenuItemTooltipTest {
     }
 
     @Test
+    void hiddenItemWithTooltip_menuContentRegenerated_show_tooltipSynced() {
+        MenuItem hiddenItem = contextMenu.addItem("hidden item");
+        hiddenItem.setTooltipText("Tooltip");
+        hiddenItem.setVisible(false);
+        flushPendingInvocations();
+
+        // Regenerating the content re-attaches every item element
+        contextMenu.addItem("another item");
+        flushPendingInvocations();
+
+        hiddenItem.setVisible(true);
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals("Tooltip", getParameter(invocations.get(0), 0));
+    }
+
+    @Test
+    void hiddenItemWithTooltip_menuDetachedAndAttached_show_tooltipSynced() {
+        MenuItem hiddenItem = contextMenu.addItem("hidden item");
+        hiddenItem.setTooltipText("Tooltip");
+        hiddenItem.setVisible(false);
+        flushPendingInvocations();
+
+        ui.remove(contextMenu);
+        ui.add(contextMenu);
+        flushPendingInvocations();
+
+        hiddenItem.setVisible(true);
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals("Tooltip", getParameter(invocations.get(0), 0));
+    }
+
+    @Test
     void setTooltipTextTwice_onlyLatestSynced() {
         flushPendingInvocations();
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTooltipTest.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/test/java/com/vaadin/flow/component/contextmenu/MenuItemTooltipTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.shared.Tooltip.TooltipPosition;
+import com.vaadin.tests.MockUIExtension;
+
+class MenuItemTooltipTest {
+
+    @RegisterExtension
+    MockUIExtension ui = new MockUIExtension();
+
+    private ContextMenu contextMenu;
+    private MenuItem item;
+
+    @BeforeEach
+    void setup() {
+        contextMenu = new ContextMenu();
+        item = contextMenu.addItem("item");
+        ui.add(contextMenu);
+    }
+
+    @Test
+    void setTooltipText_tooltipSynced() {
+        flushPendingInvocations();
+
+        item.setTooltipText("Tooltip");
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals("Tooltip", getParameter(invocations.get(0), 0));
+    }
+
+    @Test
+    void hiddenItem_setTooltipText_syncDeferredUntilShown() {
+        item.setVisible(false);
+        flushPendingInvocations();
+
+        item.setTooltipText("Tooltip");
+
+        Assertions.assertEquals(0, getSetTooltipInvocations().size(),
+                "Expected the sync to be held back while the item is hidden");
+
+        item.setVisible(true);
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals("Tooltip", getParameter(invocations.get(0), 0));
+    }
+
+    @Test
+    void hiddenItemWithTooltip_show_tooltipSynced() {
+        MenuItem hiddenItem = contextMenu.addItem("hidden item");
+        hiddenItem.setTooltipText("Tooltip");
+        hiddenItem.setVisible(false);
+        flushPendingInvocations();
+
+        hiddenItem.setVisible(true);
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals("Tooltip", getParameter(invocations.get(0), 0));
+    }
+
+    @Test
+    void setTooltipTextTwice_onlyLatestSynced() {
+        flushPendingInvocations();
+
+        item.setTooltipText("First");
+        item.setTooltipText("Second");
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals("Second", getParameter(invocations.get(0), 0));
+    }
+
+    @Test
+    void setTooltipPosition_positionSynced() {
+        flushPendingInvocations();
+
+        item.setTooltipPosition(TooltipPosition.END);
+
+        List<PendingJavaScriptInvocation> invocations = getSetTooltipInvocations();
+        Assertions.assertEquals(1, invocations.size());
+        Assertions.assertEquals(TooltipPosition.END.getPosition(),
+                getParameter(invocations.get(0), 1));
+    }
+
+    @Test
+    void noTooltip_nothingSynced() {
+        flushPendingInvocations();
+
+        item.setText("Other text");
+
+        Assertions.assertEquals(0, getSetTooltipInvocations().size());
+    }
+
+    private Object getParameter(PendingJavaScriptInvocation invocation,
+            int index) {
+        return invocation.getInvocation().getParameters().get(index);
+    }
+
+    private List<PendingJavaScriptInvocation> getSetTooltipInvocations() {
+        return getPendingInvocations().stream()
+                .filter(invocation -> invocation.getInvocation().getExpression()
+                        .contains("contextMenuConnector.setTooltip"))
+                .toList();
+    }
+
+    private void flushPendingInvocations() {
+        getPendingInvocations();
+    }
+
+    private List<PendingJavaScriptInvocation> getPendingInvocations() {
+        ui.fakeClientCommunication();
+        return ui.dumpPendingJavaScriptInvocations();
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java
@@ -54,6 +54,15 @@ public class MenuBarTooltipPage extends Div {
                 "Item 0-2 / Tooltip");
         item0_2.setTooltipPosition(TooltipPosition.TOP);
 
+        // Hidden before the first render, so the generated items array is
+        // created without its tooltip
+        var item3 = menuBar.addItem("Item 3", "Item 3 / Tooltip");
+        item3.setVisible(false);
+
+        var showItem3 = new NativeButton("Show Item 3",
+                event -> item3.setVisible(true));
+        showItem3.setId("show-item-3");
+
         var attach = new NativeButton("Attach", event -> add(menuBar));
         attach.setId("attach");
         var detach = new NativeButton("Detach", event -> remove(menuBar));
@@ -65,6 +74,6 @@ public class MenuBarTooltipPage extends Div {
         });
         updateTooltips.setId("update-tooltips");
 
-        add(attach, detach, updateTooltips, menuBar);
+        add(attach, detach, updateTooltips, showItem3, menuBar);
     }
 }

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipIT.java
@@ -69,6 +69,15 @@ public class MenuBarTooltipIT extends AbstractComponentIT {
     }
 
     @Test
+    public void showHiddenItem_hoverOverItem_tooltipDisplayed() {
+        clickElementWithJs("show-item-3");
+
+        var buttons = menuBar.getButtons();
+        buttons.get(buttons.size() - 1).hover();
+        Assert.assertEquals("Item 3 / Tooltip", menuBarTooltip.getText());
+    }
+
+    @Test
     public void updateTooltip_updatedTooltipDisplayed() {
         clickElementWithJs("update-tooltips");
 


### PR DESCRIPTION
## Description

Related to #9911

The connector copies the tooltip off the item element into the generated items array, and
the web component then reads it from that array instead of from the element. Flow does not
send property changes for invisible elements, so an item that was hidden when the array was
generated ends up in it without a tooltip, and showing the item does not put one there.

- Added a `setTooltip` function to the context menu connector that writes the tooltip and
  its position into the generated items array, next to the existing `setChecked`,
  `setKeepOpen` and `setTheme` functions
- Called it from `setTooltipText` and `setTooltipPosition` through the item element, so Flow
  holds the call back for as long as the item is invisible and runs it once the item is shown
- Cancelled a call that has not been sent yet before scheduling the next one, so several
  tooltip changes in one round trip result in a single client call
- Added unit tests for a visible item, the deferral for a hidden one, the tooltip position,
  and repeated calls in one round trip
- Added a hidden item with a tooltip to `MenuBarTooltipPage` and an integration test that
  shows it and checks the tooltip

## Type of change

- Bugfix

## How to test

1. Open `vaadin-menu-bar/tooltip`
   (`vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarTooltipPage.java`).
2. Click **Show Item 3**.
3. Hover **Item 3** — the tooltip `Item 3 / Tooltip` is shown. Without this change no
   tooltip appears.
