### PR TITLE
refactor: convert remaining connectors to classes

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuTargetConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuTargetConnector.js
@@ -1,67 +1,91 @@
 import * as Gestures from '@vaadin/component-base/src/gestures.js';
 
-function init(target) {
-  if (target.$contextMenuTargetConnector) {
-    return;
+/**
+ * contextMenuTargetConnector listens for the event that opens a context menu on
+ * the menu's target element, and notifies the server so that it can open the
+ * menu after the items have been generated.
+ */
+class ContextMenuTargetConnector {
+  #target;
+  #openOnEventType;
+  #openEvent;
+
+  // Registered as an event listener, so it has to stay the same function object
+  // for the listener to be removable, and it has to be bound to the connector
+  // rather than to the target the event is dispatched on.
+  #openOnHandler = (e) => {
+    const target = this.#target;
+
+    // used by Grid to prevent context menu on selection column click
+    if (target.preventContextMenu && target.preventContextMenu(e)) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    // The menu is opened later, after a server round-trip, when the event has
+    // finished dispatching and `composedPath()` returns an empty array. Capture
+    // the composed path now so the menu can resolve the target inside a shadow
+    // root (e.g. a grid cell) instead of the retargeted host.
+    e.__composedPath = e.composedPath();
+    this.#openEvent = e;
+
+    let detail = {};
+    if (target.getContextMenuBeforeOpenDetail) {
+      detail = target.getContextMenuBeforeOpenDetail(e);
+    }
+    target.dispatchEvent(
+      new CustomEvent('vaadin-context-menu-before-open', {
+        detail: detail
+      })
+    );
+  };
+
+  constructor(target) {
+    this.#target = target;
   }
 
-  target.$contextMenuTargetConnector = {
-    openOnHandler(e) {
-      // used by Grid to prevent context menu on selection column click
-      if (target.preventContextMenu && target.preventContextMenu(e)) {
+  updateOpenOn(eventType) {
+    this.#removeListener();
+    this.#openOnEventType = eventType;
+
+    customElements.whenDefined('vaadin-context-menu').then(() => {
+      if (this.#target.$contextMenuTargetConnector !== this) {
+        // The connector was removed while waiting, so the listener would be
+        // left behind on the target with no way to remove it
         return;
       }
-      e.preventDefault();
-      e.stopPropagation();
-      // The menu is opened later, after a server round-trip, when the event has
-      // finished dispatching and `composedPath()` returns an empty array. Capture
-      // the composed path now so the menu can resolve the target inside a shadow
-      // root (e.g. a grid cell) instead of the retargeted host.
-      e.__composedPath = e.composedPath();
-      this.$contextMenuTargetConnector.openEvent = e;
-      let detail = {};
-      if (target.getContextMenuBeforeOpenDetail) {
-        detail = target.getContextMenuBeforeOpenDetail(e);
+
+      if (Gestures.gestures[eventType]) {
+        Gestures.addListener(this.#target, eventType, this.#openOnHandler);
+      } else {
+        this.#target.addEventListener(eventType, this.#openOnHandler);
       }
-      target.dispatchEvent(
-        new CustomEvent('vaadin-context-menu-before-open', {
-          detail: detail
-        })
-      );
-    },
+    });
+  }
 
-    updateOpenOn(eventType) {
-      this.removeListener();
-      this.openOnEventType = eventType;
+  openMenu(contextMenu) {
+    contextMenu.open(this.#openEvent);
+  }
 
-      customElements.whenDefined('vaadin-context-menu').then(() => {
-        if (Gestures.gestures[eventType]) {
-          Gestures.addListener(target, eventType, this.openOnHandler);
-        } else {
-          target.addEventListener(eventType, this.openOnHandler);
-        }
-      });
-    },
+  removeConnector() {
+    this.#removeListener();
+    this.#target.$contextMenuTargetConnector = undefined;
+  }
 
-    removeListener() {
-      if (this.openOnEventType) {
-        if (Gestures.gestures[this.openOnEventType]) {
-          Gestures.removeListener(target, this.openOnEventType, this.openOnHandler);
-        } else {
-          target.removeEventListener(this.openOnEventType, this.openOnHandler);
-        }
+  #removeListener() {
+    if (this.#openOnEventType) {
+      if (Gestures.gestures[this.#openOnEventType]) {
+        Gestures.removeListener(this.#target, this.#openOnEventType, this.#openOnHandler);
+      } else {
+        this.#target.removeEventListener(this.#openOnEventType, this.#openOnHandler);
       }
-    },
-
-    openMenu(contextMenu) {
-      contextMenu.open(this.openEvent);
-    },
-
-    removeConnector() {
-      this.removeListener();
-      target.$contextMenuTargetConnector = undefined;
     }
-  };
+  }
+}
+
+function init(target) {
+  // Init the connector only once for the target
+  target.$contextMenuTargetConnector ??= new ContextMenuTargetConnector(target);
 }
 
 window.Vaadin.Flow.contextMenuTargetConnector = { init };

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/frontend/datepickerConnector.js
@@ -1,11 +1,7 @@
 import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';
 import dateFnsIsValid from 'date-fns/isValid';
-import {
-  createDate,
-  extractDateParts,
-  parseDate as _parseDate
-} from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
+import { createDate, extractDateParts, parseDate } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 
 function createLocaleBasedDateFormat(locale) {
   try {
@@ -142,7 +138,7 @@ class DatePickerConnector {
   }
 
   #formatDate(dateParts, format) {
-    const date = _parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
+    const date = parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
 
     return dateFnsFormat(date, format);
   }
@@ -200,7 +196,7 @@ class DatePickerConnector {
     }
 
     // Update century if this is the first parse after overlay open.
-    const currentValue = _parseDate(this.#datePicker.value);
+    const currentValue = parseDate(this.#datePicker.value);
     if (
       dateFnsIsValid(currentValue) &&
       currentValue.getDate() === date.getDate() &&

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/frontend/datepickerConnector.js
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/frontend/datepickerConnector.js
@@ -7,187 +7,107 @@ import {
   parseDate as _parseDate
 } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 
-window.Vaadin.Flow.datepickerConnector = {};
-window.Vaadin.Flow.datepickerConnector.initLazy = (datepicker) => {
-  // Check whether the connector was already initialized for the datepicker
-  if (datepicker.$connector) {
-    return;
+function createLocaleBasedDateFormat(locale) {
+  try {
+    // Check whether the locale is supported or not
+    new Date().toLocaleDateString(locale);
+  } catch (e) {
+    console.warn('The locale is not supported, using default format setting (ISO 8601).');
+    return 'yyyy-MM-dd';
   }
 
-  datepicker.$connector = {};
+  // format test date and convert to date-fns pattern
+  const testDate = new Date(Date.UTC(1234, 4, 6));
+  let pattern = testDate.toLocaleDateString(locale, { timeZone: 'UTC' });
+  pattern = pattern
+    // escape date-fns pattern letters by enclosing them in single quotes
+    .replace(/([a-zA-Z]+)/g, "'$1'")
+    // insert date placeholder
+    .replace('06', 'dd')
+    .replace('6', 'd')
+    // insert month placeholder
+    .replace('05', 'MM')
+    .replace('5', 'M')
+    // insert year placeholder
+    .replace('1234', 'yyyy');
+  const isValidPattern = pattern.includes('d') && pattern.includes('M') && pattern.includes('y');
+  if (!isValidPattern) {
+    console.warn('The locale is not supported, using default format setting (ISO 8601).');
+    return 'yyyy-MM-dd';
+  }
 
-  const createLocaleBasedDateFormat = function (locale) {
-    try {
-      // Check whether the locale is supported or not
-      new Date().toLocaleDateString(locale);
-    } catch (e) {
-      console.warn('The locale is not supported, using default format setting (ISO 8601).');
-      return 'yyyy-MM-dd';
+  return pattern;
+}
+
+function getShortYearFormat(format) {
+  if (format.includes('yyyy') && !format.includes('yyyyy')) {
+    return format.replace('yyyy', 'yy');
+  }
+  if (format.includes('YYYY') && !format.includes('YYYYY')) {
+    return format.replace('YYYY', 'YY');
+  }
+  return undefined;
+}
+
+function isFormatWithYear(format) {
+  return format.includes('y') || format.includes('Y');
+}
+
+function isShortYearFormat(format) {
+  // Format is long if it includes a four-digit year.
+  return !format.includes('yyyy') && !format.includes('YYYY');
+}
+
+function getExtendedFormats(formats) {
+  return formats.reduce((acc, format) => {
+    // We first try to match the date with the shorter version,
+    // as short years are supported with the long date format.
+    if (isFormatWithYear(format) && !isShortYearFormat(format)) {
+      acc.push(getShortYearFormat(format));
     }
+    acc.push(format);
+    return acc;
+  }, []);
+}
 
-    // format test date and convert to date-fns pattern
-    const testDate = new Date(Date.UTC(1234, 4, 6));
-    let pattern = testDate.toLocaleDateString(locale, { timeZone: 'UTC' });
-    pattern = pattern
-      // escape date-fns pattern letters by enclosing them in single quotes
-      .replace(/([a-zA-Z]+)/g, "'$1'")
-      // insert date placeholder
-      .replace('06', 'dd')
-      .replace('6', 'd')
-      // insert month placeholder
-      .replace('05', 'MM')
-      .replace('5', 'M')
-      // insert year placeholder
-      .replace('1234', 'yyyy');
-    const isValidPattern = pattern.includes('d') && pattern.includes('M') && pattern.includes('y');
-    if (!isValidPattern) {
-      console.warn('The locale is not supported, using default format setting (ISO 8601).');
-      return 'yyyy-MM-dd';
-    }
+/**
+ * datepickerConnector is a communication layer between DatePicker's flow
+ * component (server-side) and web component (client-side).
+ */
+class DatePickerConnector {
+  #datePicker;
 
-    return pattern;
+  /** `'successful'`, `'error'`, or `undefined` when nothing was parsed since the overlay opened */
+  #lastParseStatus;
+  #lastParsedDate;
+
+  // STABLE reference — created once per connector, never reassigned. Assigning a new function
+  // to `dateMetadataProvider` clears the web component's cache and re-fetches every visible
+  // range, so the same function object is reused for every update.
+  #dateMetadataProvider = ({ start, end }) => {
+    // The range bounds are ISO 8601 dates, which the server parses as they are.
+    return this.#datePicker.$server.requestDateMetadata(start, end);
   };
 
-  function createFormatterAndParser(formats) {
-    if (!formats || formats.length === 0) {
-      throw new Error('Array of custom date formats is null or empty');
-    }
+  constructor(datePicker) {
+    this.#datePicker = datePicker;
 
-    function getShortYearFormat(format) {
-      if (format.includes('yyyy') && !format.includes('yyyyy')) {
-        return format.replace('yyyy', 'yy');
-      }
-      if (format.includes('YYYY') && !format.includes('YYYYY')) {
-        return format.replace('YYYY', 'YY');
-      }
-      return undefined;
-    }
-
-    function isFormatWithYear(format) {
-      return format.includes('y') || format.includes('Y');
-    }
-
-    function isShortYearFormat(format) {
-      // Format is long if it includes a four-digit year.
-      return !format.includes('yyyy') && !format.includes('YYYY');
-    }
-
-    function getExtendedFormats(formats) {
-      return formats.reduce((acc, format) => {
-        // We first try to match the date with the shorter version,
-        // as short years are supported with the long date format.
-        if (isFormatWithYear(format) && !isShortYearFormat(format)) {
-          acc.push(getShortYearFormat(format));
-        }
-        acc.push(format);
-        return acc;
-      }, []);
-    }
-
-    function correctFullYear(date) {
-      // The last parsed date check handles the case where a four-digit year is parsed, then formatted
-      // as a two-digit year, and then parsed again. In this case we want to keep the century of the
-      // originally parsed year, instead of using the century of the reference date.
-
-      // Do not apply any correction if the previous parse attempt was failed.
-      if (datepicker.$connector._lastParseStatus === 'error') {
-        return;
-      }
-
-      // Update century if the last parsed date is the same except the century.
-      if (datepicker.$connector._lastParseStatus === 'successful') {
-        if (
-          datepicker.$connector._lastParsedDate.day === date.getDate() &&
-          datepicker.$connector._lastParsedDate.month === date.getMonth() &&
-          datepicker.$connector._lastParsedDate.year % 100 === date.getFullYear() % 100
-        ) {
-          date.setFullYear(datepicker.$connector._lastParsedDate.year);
-        }
-        return;
-      }
-
-      // Update century if this is the first parse after overlay open.
-      const currentValue = _parseDate(datepicker.value);
-      if (
-        dateFnsIsValid(currentValue) &&
-        currentValue.getDate() === date.getDate() &&
-        currentValue.getMonth() === date.getMonth() &&
-        currentValue.getFullYear() % 100 === date.getFullYear() % 100
-      ) {
-        date.setFullYear(currentValue.getFullYear());
-      }
-    }
-
-    function formatDate(dateParts) {
-      const format = formats[0];
-      const date = _parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
-
-      return dateFnsFormat(date, format);
-    }
-
-    function doParseDate(dateString, format, referenceDate) {
-      // When format does not contain a year, then current year should be used.
-      const refDate = isFormatWithYear(format) ? referenceDate : new Date();
-      const date = dateFnsParse(dateString, format, refDate);
-      if (dateFnsIsValid(date)) {
-        if (isFormatWithYear(format) && isShortYearFormat(format)) {
-          correctFullYear(date);
-        }
-        return {
-          day: date.getDate(),
-          month: date.getMonth(),
-          year: date.getFullYear()
-        };
-      }
-    }
-
-    function parseDate(dateString) {
-      const referenceDate = _getReferenceDate();
-      for (let format of getExtendedFormats(formats)) {
-        const parsedDate = doParseDate(dateString, format, referenceDate);
-        if (parsedDate) {
-          datepicker.$connector._lastParseStatus = 'successful';
-          datepicker.$connector._lastParsedDate = parsedDate;
-          return parsedDate;
-        }
-      }
-      datepicker.$connector._lastParseStatus = 'error';
-      return false;
-    }
-
-    return {
-      formatDate: formatDate,
-      parseDate: parseDate
-    };
+    datePicker.addEventListener('opened-changed', () => (this.#lastParseStatus = undefined));
   }
 
-  function _getReferenceDate() {
-    const { referenceDate } = datepicker.i18n;
-    return referenceDate ? new Date(referenceDate.year, referenceDate.month, referenceDate.day) : new Date();
-  }
-
-  datepicker.$connector.updateI18n = (locale, i18n) => {
+  updateI18n(locale, i18n) {
     // Either use custom formats specified in I18N, or create format from locale
     const hasCustomFormats = i18n && i18n.dateFormats && i18n.dateFormats.length > 0;
     if (i18n && i18n.referenceDate) {
       i18n.referenceDate = extractDateParts(new Date(i18n.referenceDate));
     }
     const usedFormats = hasCustomFormats ? i18n.dateFormats : [createLocaleBasedDateFormat(locale)];
-    const formatterAndParser = createFormatterAndParser(usedFormats);
 
     // Merge new I18N settings with formatting and parsing functions
-    datepicker.i18n = Object.assign({}, i18n, formatterAndParser);
-  };
+    this.#datePicker.i18n = Object.assign({}, i18n, this.#createFormatterAndParser(usedFormats));
+  }
 
-  // STABLE reference — created once per connector, never reassigned. Assigning a new function
-  // to `dateMetadataProvider` clears the web component's cache and re-fetches every visible
-  // range, so the same function object is reused for every update.
-  const dateMetadataProvider = ({ start, end }) => {
-    // The range bounds are ISO 8601 dates, which the server parses as they are.
-    return datepicker.$server.requestDateMetadata(start, end);
-  };
-
-  datepicker.$connector.setDateMetadataConfig = (config) => {
+  setDateMetadataConfig(config) {
     // Keys are `year-month-day` with a 0-based month, matching what the web component
     // passes to `isDateDisabled`, so nothing has to be parsed or converted per date.
     const disabledDates = new Set((config.disabledDates || []).map(([y, m, d]) => `${y}-${m}-${d}`));
@@ -196,15 +116,110 @@ window.Vaadin.Flow.datepickerConnector.initLazy = (datepicker) => {
     const hasDisabledDates = disabledDates.size > 0;
     const hasDisabledWeekdays = disabledWeekdays.size > 0;
 
-    datepicker.isDateDisabled =
+    this.#datePicker.isDateDisabled =
       !hasDisabledDates && !hasDisabledWeekdays
         ? undefined
         : ({ year, month, day }) =>
             (hasDisabledDates && disabledDates.has(`${year}-${month}-${day}`)) ||
             (hasDisabledWeekdays && disabledWeekdays.has(createDate(year, month, day).getDay() || 7));
 
-    datepicker.dateMetadataProvider = config.hasProvider ? dateMetadataProvider : null;
-  };
+    this.#datePicker.dateMetadataProvider = config.hasProvider ? this.#dateMetadataProvider : null;
+  }
 
-  datepicker.addEventListener('opened-changed', () => (datepicker.$connector._lastParseStatus = undefined));
-};
+  /**
+   * Creates the `formatDate` and `parseDate` functions the web component's i18n
+   * object expects, bound to the given date formats.
+   */
+  #createFormatterAndParser(formats) {
+    if (!formats || formats.length === 0) {
+      throw new Error('Array of custom date formats is null or empty');
+    }
+
+    return {
+      formatDate: (dateParts) => this.#formatDate(dateParts, formats[0]),
+      parseDate: (dateString) => this.#parseDate(dateString, formats)
+    };
+  }
+
+  #formatDate(dateParts, format) {
+    const date = _parseDate(`${dateParts.year}-${dateParts.month + 1}-${dateParts.day}`);
+
+    return dateFnsFormat(date, format);
+  }
+
+  #parseDate(dateString, formats) {
+    const referenceDate = this.#getReferenceDate();
+    for (const format of getExtendedFormats(formats)) {
+      const parsedDate = this.#doParseDate(dateString, format, referenceDate);
+      if (parsedDate) {
+        this.#lastParseStatus = 'successful';
+        this.#lastParsedDate = parsedDate;
+        return parsedDate;
+      }
+    }
+    this.#lastParseStatus = 'error';
+    return false;
+  }
+
+  #doParseDate(dateString, format, referenceDate) {
+    // When format does not contain a year, then current year should be used.
+    const refDate = isFormatWithYear(format) ? referenceDate : new Date();
+    const date = dateFnsParse(dateString, format, refDate);
+    if (dateFnsIsValid(date)) {
+      if (isFormatWithYear(format) && isShortYearFormat(format)) {
+        this.#correctFullYear(date);
+      }
+      return {
+        day: date.getDate(),
+        month: date.getMonth(),
+        year: date.getFullYear()
+      };
+    }
+  }
+
+  #correctFullYear(date) {
+    // The last parsed date check handles the case where a four-digit year is parsed, then formatted
+    // as a two-digit year, and then parsed again. In this case we want to keep the century of the
+    // originally parsed year, instead of using the century of the reference date.
+
+    // Do not apply any correction if the previous parse attempt was failed.
+    if (this.#lastParseStatus === 'error') {
+      return;
+    }
+
+    // Update century if the last parsed date is the same except the century.
+    if (this.#lastParseStatus === 'successful') {
+      if (
+        this.#lastParsedDate.day === date.getDate() &&
+        this.#lastParsedDate.month === date.getMonth() &&
+        this.#lastParsedDate.year % 100 === date.getFullYear() % 100
+      ) {
+        date.setFullYear(this.#lastParsedDate.year);
+      }
+      return;
+    }
+
+    // Update century if this is the first parse after overlay open.
+    const currentValue = _parseDate(this.#datePicker.value);
+    if (
+      dateFnsIsValid(currentValue) &&
+      currentValue.getDate() === date.getDate() &&
+      currentValue.getMonth() === date.getMonth() &&
+      currentValue.getFullYear() % 100 === date.getFullYear() % 100
+    ) {
+      date.setFullYear(currentValue.getFullYear());
+    }
+  }
+
+  #getReferenceDate() {
+    const { referenceDate } = this.#datePicker.i18n;
+    return referenceDate ? new Date(referenceDate.year, referenceDate.month, referenceDate.day) : new Date();
+  }
+}
+
+function initLazy(datePicker) {
+  // Init the connector only once for the date picker
+  datePicker.$connector ??= new DatePickerConnector(datePicker);
+}
+
+window.Vaadin.Flow.datepickerConnector = { initLazy };

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/frontend/vaadin-map/mapConnector.js
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/frontend/vaadin-map/mapConnector.js
@@ -19,199 +19,233 @@ import { createLookup, getFeatureInfo } from './util';
 // Internally coordinates will be converted to the projection used by the map's view.
 openLayersSetUserProjection('EPSG:4326');
 
-function init(mapElement) {
-  // Clear default controls from web component, so that we can cleanly synchronize controls from server configuration
-  // Consider changing this in the future, so that the web component comes without default controls
-  mapElement.configuration.getControls().clear();
+/**
+ * mapConnector is a communication layer between Map's flow component
+ * (server-side) and web component (client-side).
+ */
+class MapConnector {
+  #mapElement;
 
-  mapElement.$connector = {
-    /**
-     * Lookup for storing and retrieving every OL instance used in the map's configuration
-     * by its unique ID
-     */
-    lookup: createLookup(),
-    /**
-     * Synchronizes an array of Javascript objects into OL instances.
-     * It is expected that objects that are lower in the configuration hierarchy occur
-     * earlier in the array than objects that are higher in the hierarchy. That ensures
-     * that lower-level objects are synchronized first, before higher-level objects that
-     * reference them.
-     * @param changedObjects array of Javascript objects to be synchronized into OL instances
-     */
-    synchronize(changedObjects) {
-      // Provide synchronization function and the OL instance lookup through context object
-      const context = { synchronize, lookup: this.lookup, mapElement, connector: mapElement.$connector };
+  /**
+   * Lookup for storing and retrieving every OL instance used in the map's configuration
+   * by its unique ID
+   */
+  #lookup = createLookup();
 
-      changedObjects.forEach((change) => {
-        // The OL map instance already exists and should not be created by the
-        // synchronization mechanism. So we put it into the lookup manually.
-        if (change.type === 'ol/Map') {
-          this.lookup.put(change.id, mapElement.configuration);
-        }
+  #forceRenderTimeout;
 
-        synchronize(change, context);
-      });
-    },
-    /**
-     * Forces a render of the OpenLayers map. Some objects in OpenLayers are not observable
-     * and do not trigger change events, for example Style objects or any of their children.
-     * In these cases this method can be called from the synchronization functions of these
-     * objects.
-     * This method will trigger a debounced render of the map by firing a change event from
-     * each layer. We simply render all layers as a sync. function does not know which layer
-     * its synced object is in. Even if the change event is fired from multiple layers, this
-     * only results in a single render of the map.
-     */
-    forceRender() {
-      if (this._forceRenderTimeout) {
+  constructor(mapElement) {
+    this.#mapElement = mapElement;
+
+    // Clear default controls from web component, so that we can cleanly synchronize controls from server configuration
+    // Consider changing this in the future, so that the web component comes without default controls
+    mapElement.configuration.getControls().clear();
+
+    this.#addViewListeners();
+    this.#addClickListeners();
+    this.#addFeatureDragAndDrop();
+  }
+
+  /**
+   * Synchronizes an array of Javascript objects into OL instances.
+   * It is expected that objects that are lower in the configuration hierarchy occur
+   * earlier in the array than objects that are higher in the hierarchy. That ensures
+   * that lower-level objects are synchronized first, before higher-level objects that
+   * reference them.
+   * @param changedObjects array of Javascript objects to be synchronized into OL instances
+   */
+  synchronize(changedObjects) {
+    // Provide synchronization function and the OL instance lookup through context object
+    const context = { synchronize, lookup: this.#lookup, mapElement: this.#mapElement, connector: this };
+
+    changedObjects.forEach((change) => {
+      // The OL map instance already exists and should not be created by the
+      // synchronization mechanism. So we put it into the lookup manually.
+      if (change.type === 'ol/Map') {
+        this.#lookup.put(change.id, this.#mapElement.configuration);
+      }
+
+      synchronize(change, context);
+    });
+  }
+
+  /**
+   * Forces a render of the OpenLayers map. Some objects in OpenLayers are not observable
+   * and do not trigger change events, for example Style objects or any of their children.
+   * In these cases this method can be called from the synchronization functions of these
+   * objects.
+   * This method will trigger a debounced render of the map by firing a change event from
+   * each layer. We simply render all layers as a sync. function does not know which layer
+   * its synced object is in. Even if the change event is fired from multiple layers, this
+   * only results in a single render of the map.
+   */
+  forceRender() {
+    if (this.#forceRenderTimeout) {
+      return;
+    }
+    this.#forceRenderTimeout = setTimeout(() => {
+      this.#forceRenderTimeout = null;
+      this.#mapElement.configuration
+        .getLayers()
+        .getArray()
+        .forEach((layer) => layer.changed());
+    });
+  }
+
+  /**
+   * Adjust the map view to fit the given features.
+   * @param featureIds array of IDs of the features to fit in the map view
+   * @param options optional options for the OL `View.fit` method
+   */
+  zoomToFit(featureIds, options) {
+    // Synchronization call for the referenced features must run beforehand, but may have
+    // been scheduled after this call. Using a timeout to compensate.
+    setTimeout(() => {
+      const features = featureIds.map((id) => this.#lookup.get(id)).filter(Boolean);
+      if (features.length === 0) {
         return;
       }
-      this._forceRenderTimeout = setTimeout(() => {
-        this._forceRenderTimeout = null;
-        mapElement.configuration
-          .getLayers()
-          .getArray()
-          .forEach((layer) => layer.changed());
-      });
-    },
-    /**
-     * Adjust the map view to fit the given features.
-     * @param featureIds array of IDs of the features to fit in the map view
-     * @param options optional options for the OL `View.fit` method
-     */
-    zoomToFit(featureIds, options) {
-      // Synchronization call for the referenced features must run beforehand, but may have
-      // been scheduled after this call. Using a timeout to compensate.
-      setTimeout(() => {
-        const features = featureIds.map((id) => this.lookup.get(id)).filter(Boolean);
-        if (features.length === 0) {
-          return;
+
+      let extent;
+      features.forEach((feature) => {
+        const featureExtent = feature.getGeometry().getExtent();
+        if (!extent) {
+          extent = featureExtent.slice();
+        } else {
+          extend(extent, featureExtent);
         }
-
-        let extent;
-        features.forEach((feature) => {
-          const featureExtent = feature.getGeometry().getExtent();
-          if (!extent) {
-            extent = featureExtent.slice();
-          } else {
-            extend(extent, featureExtent);
-          }
-        });
-
-        const padding = options?.padding ?? 0;
-        const duration = options?.duration ?? 0;
-        // Viewport size in the OL View instance may not have updated yet to the actual map size,
-        // so provide the size explicitly
-        const bounds = mapElement.getBoundingClientRect();
-        const size = [bounds.width, bounds.height];
-
-        mapElement.configuration.getView().fit(extent, {
-          padding: [padding, padding, padding, padding],
-          duration,
-          size
-        });
       });
-    }
-  };
 
-  mapElement.configuration.on('moveend', (_event) => {
-    const view = mapElement.configuration.getView();
-    const center = view.getCenter();
-    const rotation = view.getRotation();
-    const zoom = view.getZoom();
-    const extent = view.calculateExtent();
+      const padding = options?.padding ?? 0;
+      const duration = options?.duration ?? 0;
+      // Viewport size in the OL View instance may not have updated yet to the actual map size,
+      // so provide the size explicitly
+      const bounds = this.#mapElement.getBoundingClientRect();
+      const size = [bounds.width, bounds.height];
 
-    const customEvent = new CustomEvent('map-view-moveend', {
-      detail: {
-        center,
-        rotation,
-        zoom,
-        extent
+      this.#mapElement.configuration.getView().fit(extent, {
+        padding: [padding, padding, padding, padding],
+        duration,
+        size
+      });
+    });
+  }
+
+  #addViewListeners() {
+    this.#mapElement.configuration.on('moveend', (_event) => {
+      const view = this.#mapElement.configuration.getView();
+      const center = view.getCenter();
+      const rotation = view.getRotation();
+      const zoom = view.getZoom();
+      const extent = view.calculateExtent();
+
+      this.#mapElement.dispatchEvent(
+        new CustomEvent('map-view-moveend', {
+          detail: {
+            center,
+            rotation,
+            zoom,
+            extent
+          }
+        })
+      );
+    });
+  }
+
+  #addClickListeners() {
+    this.#mapElement.configuration.on('singleclick', (event) => {
+      // Get the features at the clicked pixel position
+      // In case multiple features exist at that position, OpenLayers
+      // returns the features sorted in the order that they are displayed,
+      // with the front-most feature as the first result, and the
+      // back-most feature as the last result
+      const featuresAtPixel = this.#mapElement.configuration.getFeaturesAtPixel(event.pixel);
+      const featureInfos = featuresAtPixel.map((feature) => getFeatureInfo(this.#mapElement.configuration, feature));
+
+      const nonClusterFeatures = featureInfos.filter((info) => info && !info.isCluster);
+      this.#dispatchMapClick(event, nonClusterFeatures);
+
+      if (nonClusterFeatures.length > 0) {
+        // Send a feature click event for the top-level feature
+        this.#dispatchFeatureClick(event, nonClusterFeatures[0]);
+      }
+
+      const clusterInfos = featureInfos.filter((info) => info && info.isCluster);
+      if (clusterInfos.length > 0) {
+        // Send a cluster click event for the top-level cluster
+        this.#dispatchClusterClick(event, clusterInfos[0]);
       }
     });
+  }
 
-    mapElement.dispatchEvent(customEvent);
-  });
+  #dispatchMapClick(event, features) {
+    this.#mapElement.dispatchEvent(
+      new CustomEvent('map-click', {
+        detail: {
+          coordinate: event.coordinate,
+          features,
+          originalEvent: event.originalEvent
+        }
+      })
+    );
+  }
 
-  mapElement.configuration.on('singleclick', (event) => {
-    const coordinate = event.coordinate;
-    // Get the features at the clicked pixel position
-    // In case multiple features exist at that position, OpenLayers
-    // returns the features sorted in the order that they are displayed,
-    // with the front-most feature as the first result, and the
-    // back-most feature as the last result
-    const pixelCoordinate = event.pixel;
-    const featuresAtPixel = mapElement.configuration.getFeaturesAtPixel(pixelCoordinate);
-    const featureInfos = featuresAtPixel.map((feature) => getFeatureInfo(mapElement.configuration, feature));
-
-    // Map click event
-    const nonClusterFeatures = featureInfos.filter((info) => info && !info.isCluster);
-    const mapClickEvent = new CustomEvent('map-click', {
-      detail: {
-        coordinate,
-        features: nonClusterFeatures,
-        originalEvent: event.originalEvent
-      }
-    });
-
-    mapElement.dispatchEvent(mapClickEvent);
-
-    // Feature click event
-    if (nonClusterFeatures.length > 0) {
-      // Send a feature click event for the top-level feature
-      const featureInfo = nonClusterFeatures[0];
-      const featureClickEvent = new CustomEvent('map-feature-click', {
+  #dispatchFeatureClick(event, featureInfo) {
+    this.#mapElement.dispatchEvent(
+      new CustomEvent('map-feature-click', {
         detail: {
           feature: featureInfo.feature,
           layer: featureInfo.layer,
           originalEvent: event.originalEvent
         }
-      });
+      })
+    );
+  }
 
-      mapElement.dispatchEvent(featureClickEvent);
-    }
-
-    // Cluster click event
-    const clusterInfos = featureInfos.filter((info) => info && info.isCluster);
-    if (clusterInfos.length > 0) {
-      // Send a cluster click event for the top-level cluster
-      const clusterInfo = clusterInfos[0];
-      const clusterClickEvent = new CustomEvent('map-cluster-click', {
+  #dispatchClusterClick(event, clusterInfo) {
+    this.#mapElement.dispatchEvent(
+      new CustomEvent('map-cluster-click', {
         detail: {
           features: clusterInfo.feature.get('features'),
           layer: clusterInfo.layer,
           originalEvent: event.originalEvent
         }
-      });
+      })
+    );
+  }
 
-      mapElement.dispatchEvent(clusterClickEvent);
-    }
-  });
-
-  // Feature drag&drop
-  const translate = new Translate({
-    filter(feature) {
-      return !!feature.draggable;
-    }
-  });
-  translate.on('translateend', (event) => {
-    const feature = event.features.item(0);
-    if (!feature) return;
-
-    const featureInfo = getFeatureInfo(mapElement.configuration, feature);
-    const featureDropEvent = new CustomEvent('map-feature-drop', {
-      detail: {
-        feature,
-        layer: featureInfo.layer,
-        coordinate: event.coordinate,
-        startCoordinate: event.startCoordinate
+  #addFeatureDragAndDrop() {
+    const translate = new Translate({
+      filter(feature) {
+        return !!feature.draggable;
       }
     });
 
-    mapElement.dispatchEvent(featureDropEvent);
-  });
+    translate.on('translateend', (event) => {
+      const feature = event.features.item(0);
+      if (!feature) return;
 
-  mapElement.configuration.addInteraction(translate);
+      const featureInfo = getFeatureInfo(this.#mapElement.configuration, feature);
+      this.#mapElement.dispatchEvent(
+        new CustomEvent('map-feature-drop', {
+          detail: {
+            feature,
+            layer: featureInfo.layer,
+            coordinate: event.coordinate,
+            startCoordinate: event.startCoordinate
+          }
+        })
+      );
+    });
+
+    this.#mapElement.configuration.addInteraction(translate);
+  }
+}
+
+// Called from the component's attach handler, which runs again for every element
+// Flow creates for the component, so the connector is always replaced.
+function init(mapElement) {
+  mapElement.$connector = new MapConnector(mapElement);
 }
 
 /**

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/frontend/menubarConnector.js
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/src/main/resources/META-INF/frontend/menubarConnector.js
@@ -16,17 +16,20 @@
 import './contextMenuConnector.js';
 
 /**
- * Initializes the connector for a menu bar element.
- *
- * @param {HTMLElement} menubar
- * @param {string} appId
+ * menubarConnector is a communication layer between MenuBar's flow component
+ * (server-side) and web component (client-side).
  */
-function initLazy(menubar, appId) {
-  if (menubar.$connector) {
-    return;
-  }
+class MenuBarConnector {
+  #menuBar;
+  #appId;
 
-  const observer = new MutationObserver((records) => {
+  /** The last generated items tree, before hidden items are filtered out */
+  #generatedItems = [];
+
+  // Observe for hidden and disabled attributes in case they are changed by Flow.
+  // When a change occurs, the observer will re-generate items on top of the existing
+  // tree to sync the new attribute values with the corresponding properties in the items array.
+  #observer = new MutationObserver((records) => {
     const hasChangedAttributes = records.some((entry) => {
       const oldValue = entry.oldValue;
       const newValue = entry.target.getAttribute(entry.attributeName);
@@ -34,69 +37,76 @@ function initLazy(menubar, appId) {
     });
 
     if (hasChangedAttributes) {
-      menubar.$connector.generateItems();
+      this.generateItems();
     }
   });
 
-  menubar.$connector = {
-    /**
-     * Generates and assigns the items to the menu bar.
-     *
-     * When the method is called without providing a node id,
-     * the previously generated items tree will be used.
-     * That can be useful if you only want to sync the disabled and hidden properties of root items.
-     *
-     * @param {number | undefined} nodeId
-     */
-    generateItems(nodeId) {
-      if (!menubar.shadowRoot) {
-        // workaround for https://github.com/vaadin/flow/issues/5722
-        setTimeout(() => menubar.$connector.generateItems(nodeId));
-        return;
-      }
+  constructor(menuBar, appId) {
+    this.#menuBar = menuBar;
+    this.#appId = appId;
+  }
 
-      if (!menubar._container) {
-        // Menu-bar defers first buttons render to avoid re-layout
-        // See https://github.com/vaadin/web-components/issues/7271
-        queueMicrotask(() => menubar.$connector.generateItems(nodeId));
-        return;
-      }
+  /**
+   * Generates and assigns the items to the menu bar.
+   *
+   * When the method is called without providing a node id,
+   * the previously generated items tree will be used.
+   * That can be useful if you only want to sync the disabled and hidden properties of root items.
+   *
+   * @param {number | undefined} nodeId
+   */
+  generateItems(nodeId) {
+    const menuBar = this.#menuBar;
 
-      if (nodeId) {
-        menubar.__generatedItems = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(appId, nodeId);
-      }
-
-      let items = menubar.__generatedItems || [];
-
-      items.forEach((item) => {
-        // Propagate disabled state from items to parent buttons
-        item.disabled = item.component.disabled;
-
-        // Saving item to component because `_item` can be reassigned to a new value
-        // when the component goes to the overflow menu
-        item.component._rootItem = item;
-      });
-
-      // Observe for hidden and disabled attributes in case they are changed by Flow.
-      // When a change occurs, the observer will re-generate items on top of the existing tree
-      // to sync the new attribute values with the corresponding properties in the items array.
-      items.forEach((item) => {
-        observer.observe(item.component, {
-          attributeFilter: ['hidden', 'disabled'],
-          attributeOldValue: true
-        });
-      });
-
-      // Remove hidden items entirely from the array. Just hiding them
-      // could cause the overflow button to be rendered without items.
-      //
-      // The items-prop needs to be set even when all items are visible
-      // to update the disabled state and re-render buttons.
-      items = items.filter((item) => !item.component.hidden);
-
-      menubar.items = items;
+    if (!menuBar.shadowRoot) {
+      // workaround for https://github.com/vaadin/flow/issues/5722
+      setTimeout(() => this.generateItems(nodeId));
+      return;
     }
-  };
+
+    if (!menuBar._container) {
+      // Menu-bar defers first buttons render to avoid re-layout
+      // See https://github.com/vaadin/web-components/issues/7271
+      queueMicrotask(() => this.generateItems(nodeId));
+      return;
+    }
+
+    if (nodeId) {
+      this.#generatedItems = window.Vaadin.Flow.contextMenuConnector.generateItemsTree(this.#appId, nodeId) ?? [];
+    }
+
+    this.#generatedItems.forEach((item) => {
+      // Propagate disabled state from items to parent buttons
+      item.disabled = item.component.disabled;
+
+      // Saving item to component because `_item` can be reassigned to a new value
+      // when the component goes to the overflow menu
+      item.component._rootItem = item;
+
+      this.#observer.observe(item.component, {
+        attributeFilter: ['hidden', 'disabled'],
+        attributeOldValue: true
+      });
+    });
+
+    // Remove hidden items entirely from the array. Just hiding them
+    // could cause the overflow button to be rendered without items.
+    //
+    // The items-prop needs to be set even when all items are visible
+    // to update the disabled state and re-render buttons.
+    menuBar.items = this.#generatedItems.filter((item) => !item.component.hidden);
+  }
+}
+
+/**
+ * Initializes the connector for a menu bar element.
+ *
+ * @param {HTMLElement} menuBar
+ * @param {string} appId
+ */
+function initLazy(menuBar, appId) {
+  // Init the connector only once for the menu bar
+  menuBar.$connector ??= new MenuBarConnector(menuBar, appId);
 }
 
 function setClassName(component) {

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/timepickerConnector.js
@@ -10,16 +10,30 @@ import {
   searchAmOrPmToken
 } from './helpers.js';
 
-window.Vaadin.Flow.timepickerConnector = {};
-window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
-  // Check whether the connector was already initialized for the timepicker
-  if (timepicker.$connector) {
-    return;
+/**
+ * timepickerConnector is a communication layer between TimePicker's flow
+ * component (server-side) and web component (client-side).
+ */
+class TimePickerConnector {
+  #timePicker;
+
+  // Locale and the values derived from it, assigned by `setLocale`
+  #locale;
+  #amString;
+  #pmString;
+  #separator;
+  #escapedSeparator;
+
+  // The result of the last successful parse, reused when the same string is
+  // parsed again
+  #cachedTimeString;
+  #cachedTimeObject;
+
+  constructor(timePicker) {
+    this.#timePicker = timePicker;
   }
 
-  timepicker.$connector = {};
-
-  timepicker.$connector.setLocale = (locale) => {
+  setLocale(locale) {
     try {
       // Check whether the locale is supported by the browser or not
       TEST_PM_TIME.toLocaleTimeString(locale);
@@ -28,109 +42,123 @@ window.Vaadin.Flow.timepickerConnector.initLazy = (timepicker) => {
       throw new Error(`vaadin-time-picker: The locale ${locale} is not supported.`);
     }
 
+    this.#locale = locale;
+
     // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?
-    const pmString = getPmString(locale);
-    const amString = getAmString(locale);
+    this.#pmString = getPmString(locale);
+    this.#amString = getAmString(locale);
 
     // 2. What is the separator ?
-    const separator = getSeparator(locale);
+    this.#separator = getSeparator(locale);
     // The separator can be a regexp special character, such as the dot used by fi-FI
-    const escapedSeparator = escapeRegExp(separator || '');
+    this.#escapedSeparator = escapeRegExp(this.#separator || '');
 
-    const includeSeconds = function () {
-      return timepicker.step && timepicker.step < 60;
+    // A cached result was parsed with the previous locale, so it no longer applies
+    this.#cachedTimeString = undefined;
+    this.#cachedTimeObject = undefined;
+
+    // Assigning a new object makes the web component re-format the current value
+    this.#timePicker.i18n = {
+      formatTime: (timeObject) => this.#formatTime(timeObject),
+      parseTime: (timeString) => this.#parseTime(timeString)
     };
+  }
 
-    const includeMilliSeconds = function () {
-      return timepicker.step && timepicker.step < 1;
-    };
+  #includeSeconds() {
+    return this.#timePicker.step && this.#timePicker.step < 60;
+  }
 
-    let cachedTimeString;
-    let cachedTimeObject;
+  #includeMilliseconds() {
+    return this.#timePicker.step && this.#timePicker.step < 1;
+  }
 
-    timepicker.i18n = {
-      formatTime(timeObject) {
-        if (!timeObject) return;
+  #formatTime(timeObject) {
+    if (!timeObject) return;
 
-        const timeToBeFormatted = new Date();
-        timeToBeFormatted.setHours(timeObject.hours);
-        timeToBeFormatted.setMinutes(timeObject.minutes);
-        timeToBeFormatted.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
+    const timeToBeFormatted = new Date();
+    timeToBeFormatted.setHours(timeObject.hours);
+    timeToBeFormatted.setMinutes(timeObject.minutes);
+    timeToBeFormatted.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
 
-        // the web component expects the correct granularity used for the time string,
-        // thus need to format the time object in correct granularity by passing the format options
-        let localeTimeString = timeToBeFormatted.toLocaleTimeString(locale, {
-          hour: 'numeric',
-          minute: 'numeric',
-          second: includeSeconds() ? 'numeric' : undefined
-        });
+    // the web component expects the correct granularity used for the time string,
+    // thus need to format the time object in correct granularity by passing the format options
+    let localeTimeString = timeToBeFormatted.toLocaleTimeString(this.#locale, {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: this.#includeSeconds() ? 'numeric' : undefined
+    });
 
-        // milliseconds not part of the time format API
-        if (includeMilliSeconds()) {
-          localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds, amString, pmString);
+    // milliseconds not part of the time format API
+    if (this.#includeMilliseconds()) {
+      localeTimeString = formatMilliseconds(localeTimeString, timeObject.milliseconds, this.#amString, this.#pmString);
+    }
+
+    return localeTimeString;
+  }
+
+  #parseTime(timeString) {
+    if (timeString && timeString === this.#cachedTimeString && this.#cachedTimeObject) {
+      return this.#cachedTimeObject;
+    }
+
+    if (!timeString) {
+      // when nothing is returned, the component shows the invalid state for the input
+      return;
+    }
+
+    const amToken = searchAmOrPmToken(timeString, this.#amString);
+    const pmToken = searchAmOrPmToken(timeString, this.#pmString);
+
+    const numbersOnlyTimeString = timeString
+      .replace(amToken || '', '')
+      .replace(pmToken || '', '')
+      .trim();
+
+    // A regexp that allows to find the numbers with optional separator and continuing searching after it.
+    const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + this.#escapedSeparator + ')?', 'g');
+
+    let hours = numbersRegExp.exec(numbersOnlyTimeString);
+    if (hours) {
+      hours = parseDigitsIntoInteger(hours[0].replace(this.#separator, ''));
+      // handle 12 am -> 0
+      // do not do anything if am & pm are not used or if those are the same,
+      // as with locale bg-BG there is always ч. at the end of the time
+      if (amToken !== pmToken) {
+        if (hours === 12 && amToken) {
+          hours = 0;
         }
-
-        return localeTimeString;
-      },
-
-      parseTime(timeString) {
-        if (timeString && timeString === cachedTimeString && cachedTimeObject) {
-          return cachedTimeObject;
-        }
-
-        if (!timeString) {
-          // when nothing is returned, the component shows the invalid state for the input
-          return;
-        }
-
-        const amToken = searchAmOrPmToken(timeString, amString);
-        const pmToken = searchAmOrPmToken(timeString, pmString);
-
-        const numbersOnlyTimeString = timeString
-          .replace(amToken || '', '')
-          .replace(pmToken || '', '')
-          .trim();
-
-        // A regexp that allows to find the numbers with optional separator and continuing searching after it.
-        const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + escapedSeparator + ')?', 'g');
-
-        let hours = numbersRegExp.exec(numbersOnlyTimeString);
-        if (hours) {
-          hours = parseDigitsIntoInteger(hours[0].replace(separator, ''));
-          // handle 12 am -> 0
-          // do not do anything if am & pm are not used or if those are the same,
-          // as with locale bg-BG there is always ч. at the end of the time
-          if (amToken !== pmToken) {
-            if (hours === 12 && amToken) {
-              hours = 0;
-            }
-            if (hours !== 12 && pmToken) {
-              hours += 12;
-            }
-          }
-          const minutes = numbersRegExp.exec(numbersOnlyTimeString);
-          const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
-          // detecting milliseconds from input, expects am/pm removed from end, eg. .0 or .00 or .000
-          const millisecondRegExp = /[[\.][\d\u0660-\u0669]{1,3}$/;
-          // reset to end or things can explode
-          let milliseconds = seconds && includeMilliSeconds() && millisecondRegExp.exec(numbersOnlyTimeString);
-          // handle case where last numbers are seconds and . is the separator (invalid regexp match)
-          if (milliseconds && milliseconds['index'] <= seconds['index']) {
-            milliseconds = undefined;
-          }
-          // hours is a number at this point, others are either arrays or null
-          // the string in [0] from the arrays includes the separator too
-          cachedTimeObject = hours !== undefined && {
-            hours: hours,
-            minutes: minutes ? parseDigitsIntoInteger(minutes[0].replace(separator, '')) : 0,
-            seconds: seconds ? parseDigitsIntoInteger(seconds[0].replace(separator, '')) : 0,
-            milliseconds:
-              minutes && seconds && milliseconds ? parseMillisecondsIntoInteger(milliseconds[0].replace('.', '')) : 0
-          };
-          cachedTimeString = timeString;
-          return cachedTimeObject;
+        if (hours !== 12 && pmToken) {
+          hours += 12;
         }
       }
-    };
-  };
-};
+      const minutes = numbersRegExp.exec(numbersOnlyTimeString);
+      const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
+      // detecting milliseconds from input, expects am/pm removed from end, eg. .0 or .00 or .000
+      const millisecondRegExp = /[[\.][\d\u0660-\u0669]{1,3}$/;
+      // reset to end or things can explode
+      let milliseconds = seconds && this.#includeMilliseconds() && millisecondRegExp.exec(numbersOnlyTimeString);
+      // handle case where last numbers are seconds and . is the separator (invalid regexp match)
+      if (milliseconds && milliseconds['index'] <= seconds['index']) {
+        milliseconds = undefined;
+      }
+      // hours is a number at this point, others are either arrays or null
+      // the string in [0] from the arrays includes the separator too
+      this.#cachedTimeObject = {
+        hours: hours,
+        minutes: minutes ? parseDigitsIntoInteger(minutes[0].replace(this.#separator, '')) : 0,
+        seconds: seconds ? parseDigitsIntoInteger(seconds[0].replace(this.#separator, '')) : 0,
+        milliseconds:
+          minutes && seconds && milliseconds ? parseMillisecondsIntoInteger(milliseconds[0].replace('.', '')) : 0
+      };
+      this.#cachedTimeString = timeString;
+      return this.#cachedTimeObject;
+    }
+  }
+}
+
+function initLazy(timePicker) {
+  // Init the connector only once for the time picker
+  timePicker.$connector ??= new TimePickerConnector(timePicker);
+}
+
+window.Vaadin.Flow.timepickerConnector = { initLazy };

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/frontend/virtualListConnector.js
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/frontend/virtualListConnector.js
@@ -1,152 +1,180 @@
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 
-window.Vaadin.Flow.virtualListConnector = {
-  initLazy: function (list) {
-    // Check whether the connector was already initialized for the virtual list
-    if (list.$connector) {
-      return;
-    }
+const EXTRA_ITEMS_BUFFER = 20;
 
-    const extraItemsBuffer = 20;
+/**
+ * virtualListConnector is a communication layer between VirtualList's flow
+ * component (server-side) and web component (client-side).
+ */
+class VirtualListConnector {
+  /** The item the renderer uses to render items that are being loaded */
+  placeholderItem = { __placeholder: true };
 
-    let lastRequestedRange = [0, 0];
+  #list;
+  #placeholderElement;
+  #lastRequestedRange = [0, 0];
 
-    list.$connector = {};
-    list.$connector.placeholderItem = { __placeholder: true };
+  constructor(list) {
+    this.#list = list;
 
     list.itemAccessibleNameGenerator = (item) => item && item.accessibleName;
 
-    const updateRequestedItem = function () {
-      /*
-       * TODO virtual list seems to do a small index adjustment after scrolling
-       * has stopped. This causes a redundant request to be sent to make a
-       * corresponding minimal change to the buffer. We should avoid these
-       * requests by making the logic skip doing a request if the available
-       * buffer is within some tolerance compared to the requested buffer.
-       */
-      const visibleIndexes = [...list.children]
-        .filter((el) => '__virtualListIndex' in el)
-        .map((el) => el.__virtualListIndex);
-      const firstNeededItem = Math.min(...visibleIndexes);
-      const lastNeededItem = Math.max(...visibleIndexes);
-
-      let first = Math.max(0, firstNeededItem - extraItemsBuffer);
-      let last = Math.min(lastNeededItem + extraItemsBuffer, list.items.length);
-
-      if (lastRequestedRange[0] != first || lastRequestedRange[1] != last) {
-        lastRequestedRange = [first, last];
-        const count = 1 + last - first;
-        list.$server.setViewportRange(first, count);
-      }
-    };
-
-    const scheduleUpdateRequest = function () {
-      list.__requestDebounce = Debouncer.debounce(list.__requestDebounce, timeOut.after(50), updateRequestedItem);
-    };
-
-    requestAnimationFrame(() => updateRequestedItem);
-
-    // Add an observer function that will invoke on virtualList.renderer property
-    // change and then patches it with a wrapper renderer
-    list.patchVirtualListRenderer = function () {
-      if (!list.renderer || list.renderer.__virtualListConnectorPatched) {
-        // The list either doesn't have a renderer yet or it's already been patched
-        return;
-      }
-
-      const originalRenderer = list.renderer;
-
-      const renderer = (root, list, model) => {
-        root.__virtualListIndex = model.index;
-
-        if (model.item === undefined) {
-          if (list.$connector.placeholderElement) {
-            // ComponentRenderer
-            if (!root.__hasComponentRendererPlaceholder) {
-              // The root was previously rendered by the ComponentRenderer. Clear and add a placeholder.
-              root.innerHTML = '';
-              delete root._$litPart$;
-              root.appendChild(list.$connector.placeholderElement.cloneNode(true));
-              root.__hasComponentRendererPlaceholder = true;
-            }
-          } else {
-            // LitRenderer
-            originalRenderer.call(list, root, list, {
-              ...model,
-              item: list.$connector.placeholderItem
-            });
-          }
-        } else {
-          if (root.__hasComponentRendererPlaceholder) {
-            // The root was previously populated with a placeholder. Clear it.
-            root.innerHTML = '';
-            root.__hasComponentRendererPlaceholder = false;
-          }
-
-          originalRenderer.call(list, root, list, model);
-        }
-
-        /*
-         * Check if we need to do anything once things have settled down.
-         * This method is called multiple times in sequence for the same user
-         * action, but we only want to do the check once.
-         */
-        scheduleUpdateRequest();
-      };
-      renderer.__virtualListConnectorPatched = true;
-      renderer.__rendererId = originalRenderer.__rendererId;
-
-      list.renderer = renderer;
-    };
-
+    // The renderer is patched to render placeholders for items outside the
+    // loaded range. Observing the property re-applies the patch whenever the
+    // web component gets a new renderer.
+    list.patchVirtualListRenderer = () => this.#patchRenderer();
     list._createPropertyObserver('renderer', 'patchVirtualListRenderer', true);
     list.patchVirtualListRenderer();
 
     list.items = [];
-
-    list.$connector.set = function (index, items) {
-      list.items.splice(index, items.length, ...items);
-      list.items = [...list.items];
-    };
-
-    list.$connector.clear = function (index, length) {
-      // How many items, starting from "index", should be set as undefined
-      const clearCount = Math.min(length, list.items.length - index);
-      list.$connector.set(index, [...Array(clearCount)]);
-    };
-
-    list.$connector.updateData = function (items) {
-      const updatedItemsMap = items.reduce((map, item) => {
-        map[item.key] = item;
-        return map;
-      }, {});
-
-      list.items = list.items.map((item) => {
-        // Items can be undefined if they are outside the viewport
-        if (!item) {
-          return item;
-        }
-        // Replace existing item with updated item,
-        // return existing item as fallback if it was not updated
-        return updatedItemsMap[item.key] || item;
-      });
-    };
-
-    list.$connector.updateSize = function (newSize) {
-      const delta = newSize - list.items.length;
-      if (delta > 0) {
-        list.items = [...list.items, ...Array(delta)];
-      } else if (delta < 0) {
-        list.items = list.items.slice(0, newSize);
-      }
-    };
-
-    list.$connector.setPlaceholderItem = function (placeholderItem = {}, appId) {
-      placeholderItem.__placeholder = true;
-      list.$connector.placeholderItem = placeholderItem;
-      const nodeId = Object.entries(placeholderItem).find(([key]) => key.endsWith('_nodeid'));
-      list.$connector.placeholderElement = nodeId ? Vaadin.Flow.clients[appId].getByNodeId(nodeId[1]) : null;
-    };
   }
-};
+
+  set(index, items) {
+    const list = this.#list;
+    list.items.splice(index, items.length, ...items);
+    list.items = [...list.items];
+  }
+
+  clear(index, length) {
+    // How many items, starting from "index", should be set as undefined
+    const clearCount = Math.min(length, this.#list.items.length - index);
+    this.set(index, [...Array(clearCount)]);
+  }
+
+  updateData(items) {
+    const updatedItemsMap = items.reduce((map, item) => {
+      map[item.key] = item;
+      return map;
+    }, {});
+
+    this.#list.items = this.#list.items.map((item) => {
+      // Items can be undefined if they are outside the viewport
+      if (!item) {
+        return item;
+      }
+      // Replace existing item with updated item,
+      // return existing item as fallback if it was not updated
+      return updatedItemsMap[item.key] || item;
+    });
+  }
+
+  updateSize(newSize) {
+    const list = this.#list;
+    const delta = newSize - list.items.length;
+    if (delta > 0) {
+      list.items = [...list.items, ...Array(delta)];
+    } else if (delta < 0) {
+      list.items = list.items.slice(0, newSize);
+    }
+  }
+
+  setPlaceholderItem(placeholderItem = {}, appId) {
+    placeholderItem.__placeholder = true;
+    this.placeholderItem = placeholderItem;
+    const nodeId = Object.entries(placeholderItem).find(([key]) => key.endsWith('_nodeid'));
+    this.#placeholderElement = nodeId ? Vaadin.Flow.clients[appId].getByNodeId(nodeId[1]) : null;
+  }
+
+  /**
+   * Wraps the web component's renderer so that items outside the loaded range
+   * are rendered as placeholders, and so that the rendered range is reported
+   * back to the server.
+   */
+  #patchRenderer() {
+    const originalRenderer = this.#list.renderer;
+
+    if (!originalRenderer || originalRenderer.__virtualListConnectorPatched) {
+      // The list either doesn't have a renderer yet or it's already been patched
+      return;
+    }
+
+    const renderer = (root, list, model) => {
+      root.__virtualListIndex = model.index;
+
+      if (model.item === undefined) {
+        if (this.#placeholderElement) {
+          // ComponentRenderer
+          if (!root.__hasComponentRendererPlaceholder) {
+            // The root was previously rendered by the ComponentRenderer. Clear and add a placeholder.
+            root.innerHTML = '';
+            delete root._$litPart$;
+            root.appendChild(this.#placeholderElement.cloneNode(true));
+            root.__hasComponentRendererPlaceholder = true;
+          }
+        } else {
+          // LitRenderer
+          originalRenderer.call(list, root, list, {
+            ...model,
+            item: this.placeholderItem
+          });
+        }
+      } else {
+        if (root.__hasComponentRendererPlaceholder) {
+          // The root was previously populated with a placeholder. Clear it.
+          root.innerHTML = '';
+          root.__hasComponentRendererPlaceholder = false;
+        }
+
+        originalRenderer.call(list, root, list, model);
+      }
+
+      /*
+       * Check if we need to do anything once things have settled down.
+       * This method is called multiple times in sequence for the same user
+       * action, but we only want to do the check once.
+       */
+      this.#scheduleRangeUpdate();
+    };
+    renderer.__virtualListConnectorPatched = true;
+    renderer.__rendererId = originalRenderer.__rendererId;
+
+    this.#list.renderer = renderer;
+  }
+
+  #scheduleRangeUpdate() {
+    const list = this.#list;
+    // Kept on the element: `VirtualListElement` flushes the debouncer to make
+    // the visible range available to tests without waiting.
+    list.__requestDebounce = Debouncer.debounce(list.__requestDebounce, timeOut.after(50), () =>
+      this.#updateRequestedRange()
+    );
+  }
+
+  /**
+   * Asks the server for the rendered items, plus a buffer above and below, so
+   * that scrolling has data ready ahead of rendering.
+   */
+  #updateRequestedRange() {
+    const list = this.#list;
+
+    /*
+     * TODO virtual list seems to do a small index adjustment after scrolling
+     * has stopped. This causes a redundant request to be sent to make a
+     * corresponding minimal change to the buffer. We should avoid these
+     * requests by making the logic skip doing a request if the available
+     * buffer is within some tolerance compared to the requested buffer.
+     */
+    const visibleIndexes = [...list.children]
+      .filter((el) => '__virtualListIndex' in el)
+      .map((el) => el.__virtualListIndex);
+    const firstNeededItem = Math.min(...visibleIndexes);
+    const lastNeededItem = Math.max(...visibleIndexes);
+
+    const first = Math.max(0, firstNeededItem - EXTRA_ITEMS_BUFFER);
+    const last = Math.min(lastNeededItem + EXTRA_ITEMS_BUFFER, list.items.length);
+
+    if (this.#lastRequestedRange[0] != first || this.#lastRequestedRange[1] != last) {
+      this.#lastRequestedRange = [first, last];
+      const count = 1 + last - first;
+      list.$server.setViewportRange(first, count);
+    }
+  }
+}
+
+function initLazy(list) {
+  // Init the connector only once for the virtual list
+  list.$connector ??= new VirtualListConnector(list);
+}
+
+window.Vaadin.Flow.virtualListConnector = { initLazy };


### PR DESCRIPTION
## Description

Related to #9789, #9850

Each of these connectors was one init function that assembled the `$connector`
object out of closures, which made it hard to tell what is state, what is the API
the server calls, and what is internal wiring. As classes those are separate. The
files stay plain JavaScript so that a later typing pass can move them as a rename
git can detect, the same way #9850 set up #9855.

- Converted `virtualListConnector` to a `VirtualListConnector` class, and removed a `requestAnimationFrame` callback that only read a function reference without ever calling it
- Converted `datepickerConnector` to a `DatePickerConnector` class, moving `_lastParseStatus` and `_lastParsedDate` off the public connector object into private fields, and the format-string helpers to module level
- Converted `timepickerConnector` to a `TimePickerConnector` class, holding the locale-derived values and the parse cache as private fields that `setLocale` resets
- Converted `menubarConnector` to a `MenuBarConnector` class, moving `__generatedItems` off the element into a private field
- Converted `contextMenuTargetConnector` to a `ContextMenuTargetConnector` class, storing the open event on the connector instead of resolving it from the target on every event
  - `updateOpenOn` now skips registering the listener when the connector was removed while waiting for `vaadin-context-menu` to be defined, which previously left a listener on the target with no way to remove it
- Converted `mapConnector` to a `MapConnector` class and split the event wiring into named private setup methods. `init` stays non-lazy, so the connector and its OpenLayers listeners are still re-created on every attach
- Kept `$connector.placeholderItem` and `list.__requestDebounce` reachable from outside the virtual list connector, because `VirtualListViewIT` and `VirtualListElement` read them

## Type of change

- Refactor