### PR TITLE
test: fix flaky locale warning assertions in DatePickerLocaleIT

### DIFF
--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/datepicker/DatePickerLocaleIT.java
@@ -149,8 +149,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
         applyLocale(new Locale("i", "i", "i"));
 
-        waitUntil(driver -> getWarningEntries().toString().contains(
-                "The locale is not supported, using default format setting (ISO 8601)."));
+        waitForUnsupportedLocaleWarning();
     }
 
     @Test
@@ -161,6 +160,8 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
         Assert.assertEquals(
                 "Should display the value using the default (ISO 8601) date format",
                 "2018-05-03", picker.getInputValue());
+
+        waitForUnsupportedLocaleWarning();
     }
 
     @Test
@@ -169,8 +170,7 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
 
         applyLocale(new Locale("th", "TH"));
 
-        waitUntil(driver -> getWarningEntries().toString().contains(
-                "The locale is not supported, using default format setting (ISO 8601)."));
+        waitForUnsupportedLocaleWarning();
     }
 
     @Test
@@ -187,7 +187,21 @@ public class DatePickerLocaleIT extends AbstractComponentIT {
                     "Should display the value using the default ISO date format for locale "
                             + unsupportedLocale,
                     "2018-05-03", picker.getInputValue());
+
+            waitForUnsupportedLocaleWarning();
         });
+    }
+
+    /**
+     * Waits for the connector's unsupported locale warning to appear in the
+     * browser log. Reading the log also removes the warning from the buffer, so
+     * tests that expect the warning must consume it this way to keep it from
+     * leaking into the log assertions of tests that share the browser session
+     * (the CI runs with {@code -Dtest.reuseDriver=true}).
+     */
+    private void waitForUnsupportedLocaleWarning() {
+        waitUntil(driver -> getWarningEntries().toString().contains(
+                "The locale is not supported, using default format setting (ISO 8601)."));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Related to #9932

- Fixes a flaky test: `DatePickerLocaleIT` tests that make the date picker connector log the "locale is not supported" warning did not read the browser log afterwards; with `-Dtest.reuseDriver=true` (the merged IT run in CI) the browser session is shared, so the unread warning could intermittently leak into the log assertions of a later test in the class — most recently breaking the build of #9932
- The warning-producing tests now consume the warning by waiting for it, which also verifies it is actually shown