### PR TITLE
refactor: move grid frontend files into component subfolder

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -1,8 +1,8 @@
 import './env-setup.js';
 import '@vaadin/grid/src/all-imports.js';
-import '../frontend/generated/jar-resources/gridConnector.ts';
-import '../frontend/generated/jar-resources/treeGridConnector.ts';
-import '../frontend/generated/jar-resources/vaadin-grid-flow-selection-column.ts';
+import '../frontend/generated/jar-resources/vaadin-grid/gridConnector.ts';
+import '../frontend/generated/jar-resources/vaadin-grid/treeGridConnector.ts';
+import '../frontend/generated/jar-resources/vaadin-grid/vaadin-grid-flow-selection-column.ts';
 import sinon from 'sinon';
 import type { Grid } from '@vaadin/grid';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -42,9 +42,9 @@ export type FlowGrid = {
   $connector: GridConnector;
   $server: GridServer;
 } & ConnectorFlowGrid & {
-  _flatSize: number;
-  _updateItem: (index: number, item: Item) => void;
-};
+    _flatSize: number;
+    _updateItem: (index: number, item: Item) => void;
+  };
 
 export type FlowGridSorter = GridSorter & {
   _order?: number | null;
@@ -63,10 +63,7 @@ export const GRID_CONNECTOR_ROOT_REQUEST_DELAY = 150;
 /**
  * Initializes the grid connector and the grid server mock.
  */
-export function init(
-  grid: FlowGrid,
-  connector: { initLazy(grid: ConnectorFlowGrid): void } = gridConnector
-): void {
+export function init(grid: FlowGrid, connector: { initLazy(grid: ConnectorFlowGrid): void } = gridConnector): void {
   grid.$server = {
     confirmUpdate: sinon.spy(),
     select: sinon.spy(),
@@ -83,7 +80,7 @@ export function init(
     setViewportRangeByIndexPath: sinon.spy(),
     sortersChanged: sinon.spy(),
     setShiftKeyDown: sinon.spy(),
-    updateContextMenuTargetItem: sinon.spy(),
+    updateContextMenuTargetItem: sinon.spy()
   };
 
   connector.initLazy(grid);
@@ -124,7 +121,7 @@ export function getFooterCellContent(column: GridColumn): HTMLElement {
  */
 export function getBodyRow(grid: Grid, rowIndex: number): HTMLElement | null {
   const row = [...grid.shadowRoot!.querySelectorAll('.row')].find((row) => (row as any).index === rowIndex);
-  return row as HTMLElement ?? null;
+  return (row as HTMLElement) ?? null;
 }
 
 /**
@@ -136,11 +133,13 @@ export function getBodyCell(grid: Grid, rowIndex: number, columnIndex: number): 
     return null;
   }
 
-  const cellsInVisualOrder = [...row.children].sort((a, b) => {
-    const aOrder = parseInt(getComputedStyle(a).order) || 0;
-    const bOrder = parseInt(getComputedStyle(b).order) || 0;
-    return aOrder - bOrder;
-  }).map(cell => cell as HTMLElement);
+  const cellsInVisualOrder = [...row.children]
+    .sort((a, b) => {
+      const aOrder = parseInt(getComputedStyle(a).order) || 0;
+      const bOrder = parseInt(getComputedStyle(b).order) || 0;
+      return aOrder - bOrder;
+    })
+    .map((cell) => cell as HTMLElement);
 
   return cellsInVisualOrder[columnIndex];
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -221,7 +221,7 @@ import tools.jackson.databind.node.ObjectNode;
 @JsModule("@vaadin/grid/src/vaadin-grid-sorter.js")
 @JsModule("@vaadin/checkbox/src/vaadin-checkbox.js")
 @JsModule("./flow-component-renderer.js")
-@JsModule("./gridConnector.ts")
+@JsModule("./vaadin-grid/gridConnector.ts")
 @JsModule("@vaadin/tooltip/src/vaadin-tooltip.js")
 public class Grid<T> extends Component implements HasStyle, HasSize,
         Focusable<Grid<T>>, SortNotifier<Grid<T>, GridSortOrder<T>>, HasTheme,

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSelectionColumn.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.function.SerializableRunnable;
  * @since 1.0
  */
 @Tag("vaadin-grid-flow-selection-column")
-@JsModule("./vaadin-grid-flow-selection-column.ts")
+@JsModule("./vaadin-grid/vaadin-grid-flow-selection-column.ts")
 public class GridSelectionColumn extends Component {
 
     private final SerializableRunnable selectAllCallback;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -72,7 +72,7 @@ import tools.jackson.databind.node.ObjectNode;
  * @since 1.1
  */
 @JsModule("@vaadin/grid/src/vaadin-grid-tree-toggle.js")
-@JsModule("./treeGridConnector.ts")
+@JsModule("./vaadin-grid/treeGridConnector.ts")
 public class TreeGrid<T> extends Grid<T>
         implements HasHierarchicalDataProvider<T> {
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
@@ -6,13 +6,7 @@ import type { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import type { GridSorter } from '@vaadin/grid/src/vaadin-grid-sorter.js';
 import type { GridSorterDirection } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import type { GridCellActivateEvent } from '@vaadin/grid/src/vaadin-grid-mixin.js';
-import type {
-  FlowDataProviderController,
-  FlowGrid,
-  Item,
-  ItemRange,
-  SelectionMode
-} from './vaadin-grid-types.js';
+import type { FlowDataProviderController, FlowGrid, Item, ItemRange, SelectionMode } from './vaadin-grid-types.js';
 
 const requestDebouncerDelay = 150;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
@@ -12,7 +12,7 @@ import type {
   Item,
   ItemRange,
   SelectionMode
-} from './vaadin-grid/vaadin-grid-types.js';
+} from './vaadin-grid-types.js';
 
 const requestDebouncerDelay = 150;
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/treeGridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/treeGridConnector.ts
@@ -1,5 +1,5 @@
 import './gridConnector.ts';
-import type { FlowTreeGrid } from './vaadin-grid/vaadin-grid-types.js';
+import type { FlowTreeGrid } from './vaadin-grid-types.js';
 
 /**
  * treeGridConnector is a communication layer between TreeGrid's flow component

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-flow-selection-column.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-flow-selection-column.ts
@@ -2,7 +2,7 @@ import '@vaadin/checkbox/src/vaadin-checkbox.js';
 import '@vaadin/grid/src/vaadin-grid-column.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import { GridSelectionColumnBaseMixin } from '@vaadin/grid/src/vaadin-grid-selection-column-base-mixin.js';
-import type { GridServer, Item } from './vaadin-grid/vaadin-grid-types.js';
+import type { GridServer, Item } from './vaadin-grid-types.js';
 
 export class GridFlowSelectionColumn extends GridSelectionColumnBaseMixin<Item, typeof GridColumn>(GridColumn) {
   declare $server: GridServer;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
@@ -8,7 +8,7 @@ import type { GridSorter } from '@vaadin/grid/src/vaadin-grid-sorter.js';
 import type { GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
 import type { GridCellActivateEvent, GridItemModel } from '@vaadin/grid/src/vaadin-grid-mixin.js';
 import type { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
-import type { GridConnector } from '../gridConnector.js';
+import type { GridConnector } from './gridConnector.js';
 
 export type { GridConnector };
 


### PR DESCRIPTION
## Summary
Follow-up to #9932

- Moved `gridConnector.ts`, `treeGridConnector.ts` and `vaadin-grid-flow-selection-column.ts` from the `META-INF/frontend` root into the `vaadin-grid` subfolder, where the conventions say frontend files belong and where `vaadin-grid-types.d.ts` already lives, aligning grid with the other typed connector modules
- Updated the `@JsModule` paths, the relative type imports and the WTR test imports accordingly; the moves are renames git can detect