### PR TITLE
fix: add deprecated entrypoints for moved connector files

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector-deprecated-entrypoint.test.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/test/combo-box-connector-deprecated-entrypoint.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import './env-setup.js';
+// The path the combo box connector was available at before it was moved into
+// the vaadin-combo-box folder. An add-on built against an earlier version
+// imports it this way, so it has to keep working until the next major. This
+// file deliberately imports nothing from the new path, so that a passing test
+// can only be explained by the deprecated entrypoint itself.
+import * as deprecatedComboBoxConnector from '../frontend/generated/jar-resources/comboBoxConnector.js';
+
+describe('combo box connector - deprecated entrypoint', () => {
+  it('should register the combo box connector', () => {
+    expect(window.Vaadin.Flow.comboBoxConnector).to.exist;
+  });
+
+  it('should re-export the combo box connector class', () => {
+    expect(deprecatedComboBoxConnector.ComboBoxConnector).to.exist;
+  });
+});

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/comboBoxConnector.js
@@ -1,0 +1,6 @@
+/**
+ * @deprecated Use `./vaadin-combo-box/comboBoxConnector.ts` instead. This
+ * entrypoint is kept for backwards compatibility and is removed in the next
+ * major version.
+ */
+export * from './vaadin-combo-box/comboBoxConnector.ts';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-deprecated-entrypoints.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/grid-connector-deprecated-entrypoints.test.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import './env-setup.js';
+import '@vaadin/grid/src/all-imports.js';
+// The paths the grid frontend files were available at before they were moved
+// into the vaadin-grid folder. An add-on built against an earlier version
+// imports them this way, so they have to keep working until the next major.
+// This file deliberately imports nothing from the new paths, so that a passing
+// test can only be explained by the deprecated entrypoints themselves.
+import * as deprecatedGridConnector from '../frontend/generated/jar-resources/gridConnector.ts';
+import '../frontend/generated/jar-resources/treeGridConnector.ts';
+import * as deprecatedSelectionColumn from '../frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
+
+describe('grid connector - deprecated entrypoints', () => {
+  it('should register the grid connector', () => {
+    expect(window.Vaadin.Flow.gridConnector).to.exist;
+  });
+
+  it('should register the tree grid connector', () => {
+    expect(window.Vaadin.Flow.treeGridConnector).to.exist;
+  });
+
+  it('should define the selection column element', () => {
+    expect(customElements.get('vaadin-grid-flow-selection-column')).to.exist;
+  });
+
+  it('should re-export the grid connector class', () => {
+    expect(deprecatedGridConnector.GridConnector).to.exist;
+  });
+
+  it('should re-export the selection column class', () => {
+    expect(deprecatedSelectionColumn.GridFlowSelectionColumn).to.exist;
+    expect(deprecatedSelectionColumn.GridFlowSelectionColumn).to.equal(
+      customElements.get('vaadin-grid-flow-selection-column')
+    );
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/gridConnector.ts
@@ -1,0 +1,5 @@
+/**
+ * @deprecated Use `./vaadin-grid/gridConnector.ts` instead. This entrypoint is
+ * kept for backwards compatibility and is removed in the next major version.
+ */
+export * from './vaadin-grid/gridConnector.ts';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/treeGridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/treeGridConnector.ts
@@ -1,0 +1,5 @@
+/**
+ * @deprecated Use `./vaadin-grid/treeGridConnector.ts` instead. This entrypoint
+ * is kept for backwards compatibility and is removed in the next major version.
+ */
+import './vaadin-grid/treeGridConnector.ts';

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid-flow-selection-column.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid-flow-selection-column.js
@@ -1,0 +1,6 @@
+/**
+ * @deprecated Use `./vaadin-grid/vaadin-grid-flow-selection-column.ts` instead.
+ * This entrypoint is kept for backwards compatibility and is removed in the next
+ * major version.
+ */
+export * from './vaadin-grid/vaadin-grid-flow-selection-column.ts';


### PR DESCRIPTION
## Description

Follow-up to #9942, #9932 and #9855

- Added entrypoints at the connector paths that were public in 25.2, each re-exporting the file from its new location and marked `@deprecated` for removal in the next major
  - `gridConnector.ts`, `treeGridConnector.ts` and `vaadin-grid-flow-selection-column.js` for Grid, `comboBoxConnector.js` for ComboBox
- Kept the last released file extensions rather than the current ones, since `.ts` renames only ever shipped in 25.3 alphas

Add-ons that declare these connector modules themselves, rather than inheriting them from the Flow component, import the old paths and break on upgrade. `vaadin-component-factory/enhanced-grid-flow` is a confirmed case: its `EnhancedTreeGrid` declares `@JsModule("./treeGridConnector.ts")` because it builds on `Grid` instead of extending `TreeGrid`, so it never inherits the annotation.

Add-ons should move to `@Uses(TreeGrid.class)` and friends, which pulls the connector in without naming the file path, but already released versions cannot be retrofitted.

## Type of change

- Bugfix