### PR TITLE
refactor: rename AutoFocusPartialMatch to PartialMatchMode

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -336,78 +336,80 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * currently selected item.
      * <p>
      * Custom values cannot be used together with
-     * {@link #setAutoFocusPartialMatch(AutoFocusPartialMatch)}. Enabling custom
-     * values while the auto focus partial match mode is other than
-     * {@link AutoFocusPartialMatch#NONE} throws an exception.
+     * {@link #setPartialMatchMode(PartialMatchMode)}. Enabling custom values
+     * while the partial match mode is other than {@link PartialMatchMode#NONE}
+     * throws an exception.
      *
      * @param allowCustomValue
      *            {@code true} to enable custom value set events, {@code false}
      *            to disable them
      * @throws IllegalStateException
-     *             when enabling custom values while the auto focus partial
-     *             match mode is other than {@link AutoFocusPartialMatch#NONE}
+     *             when enabling custom values while the partial match mode is
+     *             other than {@link PartialMatchMode#NONE}
      * @see #addCustomValueSetListener(ComponentEventListener)
      */
     public void setAllowCustomValue(boolean allowCustomValue) {
         if (allowCustomValue
-                && getAutoFocusPartialMatch() != AutoFocusPartialMatch.NONE) {
+                && getPartialMatchMode() != PartialMatchMode.NONE) {
             throw new IllegalStateException("""
-                    Custom values cannot be allowed when auto focus partial \
-                    match is used. Disable it with \
-                    setAutoFocusPartialMatch(AutoFocusPartialMatch.NONE) \
-                    first.""");
+                    Custom values cannot be allowed when partial match mode \
+                    is used. Disable it with \
+                    setPartialMatchMode(PartialMatchMode.NONE) first.""");
         }
         getElement().setProperty("allowCustomValue", allowCustomValue);
     }
 
     /**
-     * Gets the mode that controls whether an item whose label partially matches
-     * the typed filter is automatically focused. Defaults to
-     * {@link AutoFocusPartialMatch#NONE}.
+     * Gets the mode that controls which item is automatically set to be
+     * selected on Enter or outside click when the typed filter only partially
+     * matches its label. Defaults to {@link PartialMatchMode#NONE}.
      *
      * @return the mode, not {@code null}
-     * @see #setAutoFocusPartialMatch(AutoFocusPartialMatch)
+     * @see #setPartialMatchMode(PartialMatchMode)
      * @since 25.3
      */
-    public AutoFocusPartialMatch getAutoFocusPartialMatch() {
-        return AutoFocusPartialMatch.fromClientName(
-                getElement().getProperty("autoFocusPartialMatch"));
+    public PartialMatchMode getPartialMatchMode() {
+        return PartialMatchMode
+                .fromClientName(getElement().getProperty("partialMatchMode"));
     }
 
     /**
-     * Sets the mode that controls whether an item whose label partially matches
-     * the typed filter is automatically focused. The focused item is
-     * highlighted in the dropdown while typing and is selected when committing
-     * the value, for example on Enter press. Defaults to
-     * {@link AutoFocusPartialMatch#NONE}.
+     * Sets the mode that controls which item is automatically set to be
+     * selected on Enter or outside click when the typed filter only partially
+     * matches its label. The item that will be selected is highlighted in the
+     * dropdown while typing.
      * <p>
-     * An item whose label matches the filter exactly is always focused,
-     * regardless of the mode. Matching is case-insensitive. A partial match is
-     * not focused while the dropdown is closed. For example, when auto-open is
-     * disabled with {@link #setAutoOpen(boolean)}, typing does not focus or
-     * select a match until the dropdown is opened.
+     * Defaults to {@link PartialMatchMode#NONE}, which means that an item is
+     * automatically set to be selected only when the filter matches its label
+     * exactly. In general, an exact match is always set to be selected and
+     * takes precedence over partial matches, regardless of the mode.
      * <p>
-     * This feature cannot be used together with custom values. Setting a mode
-     * other than {@link AutoFocusPartialMatch#NONE} while custom values are
-     * allowed with {@link #setAllowCustomValue(boolean)} throws an exception.
+     * A partial match is only applied while the dropdown is open. For example,
+     * when auto-open is disabled with {@link #setAutoOpen(boolean)}, typing
+     * does not highlight a match or set it to be selected until the dropdown is
+     * opened.
+     * <p>
+     * This feature cannot be used together with custom values, because a
+     * partial match is also a valid custom value. Setting a mode other than
+     * {@link PartialMatchMode#NONE} while custom values are allowed with
+     * {@link #setAllowCustomValue(boolean)} throws an exception.
      *
      * @param mode
      *            the mode to set, not {@code null}
      * @throws IllegalStateException
-     *             when setting a mode other than
-     *             {@link AutoFocusPartialMatch#NONE} while custom values are
-     *             allowed
+     *             when setting a mode other than {@link PartialMatchMode#NONE}
+     *             while custom values are allowed
      * @since 25.3
      */
-    public void setAutoFocusPartialMatch(AutoFocusPartialMatch mode) {
+    public void setPartialMatchMode(PartialMatchMode mode) {
         Objects.requireNonNull(mode, "The mode cannot be null");
-        if (mode != AutoFocusPartialMatch.NONE && isAllowCustomValue()) {
+        if (mode != PartialMatchMode.NONE && isAllowCustomValue()) {
             throw new IllegalStateException("""
-                    Auto focus partial match cannot be used when custom \
-                    values are allowed. Disable custom values with \
+                    Partial match mode cannot be used when custom values are \
+                    allowed. Disable custom values with \
                     setAllowCustomValue(false) first.""");
         }
-        getElement().setProperty("autoFocusPartialMatch", mode.getClientName());
+        getElement().setProperty("partialMatchMode", mode.getClientName());
     }
 
     /**
@@ -1331,7 +1333,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * Use this method when none of the {@code setItems} methods are applicable,
      * e.g. when having a data provider with filter that cannot be transformed
      * to {@code DataProvider<T, Void>}.
-     * 
+     *
      * @since 24.2
      */
     public <C> void setDataProvider(DataProvider<TItem, C> dataProvider,
@@ -1511,7 +1513,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
      * message defined in the i18n object is used.
      * <p>
      * The method does nothing if the manual validation mode is enabled.
-     * 
+     *
      * @since 23.2.12
      */
     protected void validate() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBoxBase.java
@@ -361,7 +361,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
 
     /**
      * Gets the mode that controls which item is automatically set to be
-     * selected on Enter or outside click when the typed filter only partially
+     * selected, for example on Enter, when the typed filter only partially
      * matches its label. Defaults to {@link PartialMatchMode#NONE}.
      *
      * @return the mode, not {@code null}
@@ -375,7 +375,7 @@ public abstract class ComboBoxBase<TComponent extends ComboBoxBase<TComponent, T
 
     /**
      * Sets the mode that controls which item is automatically set to be
-     * selected on Enter or outside click when the typed filter only partially
+     * selected, for example on Enter, when the typed filter only partially
      * matches its label. The item that will be selected is highlighted in the
      * dropdown while typing.
      * <p>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/PartialMatchMode.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/PartialMatchMode.java
@@ -18,33 +18,38 @@ package com.vaadin.flow.component.combobox;
 import java.util.Arrays;
 
 /**
- * Defines whether an item whose label partially matches the typed filter is
- * automatically focused in the dropdown of a combo box.
+ * Defines which item in a combo box is automatically set to be selected on
+ * Enter or outside click when the typed filter only partially matches its
+ * label. The item that will be selected is highlighted in the dropdown while
+ * typing.
  *
  * @author Vaadin Ltd.
- * @see ComboBoxBase#setAutoFocusPartialMatch(AutoFocusPartialMatch)
+ * @see ComboBoxBase#setPartialMatchMode(PartialMatchMode)
  * @since 25.3
  */
-public enum AutoFocusPartialMatch {
+public enum PartialMatchMode {
 
     /**
-     * Partial matches are not focused.
+     * An item is automatically set to be selected only when the filter matches
+     * its label exactly.
      */
     NONE("none"),
 
     /**
-     * The first item in the filtered results is focused.
+     * The first item in the filtered results is automatically set to be
+     * selected.
      */
     FIRST_MATCH("first-match"),
 
     /**
-     * The item is focused when filtering narrows the results to a single item.
+     * The item is automatically set to be selected when filtering narrows the
+     * results to a single item.
      */
     ONLY_MATCH("only-match");
 
     private final String clientName;
 
-    AutoFocusPartialMatch(String clientName) {
+    PartialMatchMode(String clientName) {
         this.clientName = clientName;
     }
 
@@ -66,7 +71,7 @@ public enum AutoFocusPartialMatch {
      *            the client-side name of the mode
      * @return the matching mode, or {@link #NONE}
      */
-    static AutoFocusPartialMatch fromClientName(String clientName) {
+    static PartialMatchMode fromClientName(String clientName) {
         return Arrays.stream(values())
                 .filter(mode -> mode.getClientName().equals(clientName))
                 .findFirst().orElse(NONE);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/PartialMatchMode.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/PartialMatchMode.java
@@ -18,10 +18,9 @@ package com.vaadin.flow.component.combobox;
 import java.util.Arrays;
 
 /**
- * Defines which item in a combo box is automatically set to be selected on
- * Enter or outside click when the typed filter only partially matches its
- * label. The item that will be selected is highlighted in the dropdown while
- * typing.
+ * Defines which item in a combo box is automatically set to be selected, for
+ * example on Enter, when the typed filter only partially matches its label. The
+ * item that will be selected is highlighted in the dropdown while typing.
  *
  * @author Vaadin Ltd.
  * @see ComboBoxBase#setPartialMatchMode(PartialMatchMode)

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxBaseTest.java
@@ -121,39 +121,39 @@ abstract class ComboBoxBaseTest {
     }
 
     @Test
-    void setAutoFocusPartialMatch_getAutoFocusPartialMatch() {
+    void setPartialMatchMode_getPartialMatchMode() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
-        Assertions.assertEquals(AutoFocusPartialMatch.NONE,
-                comboBox.getAutoFocusPartialMatch());
+        Assertions.assertEquals(PartialMatchMode.NONE,
+                comboBox.getPartialMatchMode());
 
-        comboBox.setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH);
+        comboBox.setPartialMatchMode(PartialMatchMode.FIRST_MATCH);
         Assertions.assertEquals("first-match",
-                comboBox.getElement().getProperty("autoFocusPartialMatch"));
-        Assertions.assertEquals(AutoFocusPartialMatch.FIRST_MATCH,
-                comboBox.getAutoFocusPartialMatch());
+                comboBox.getElement().getProperty("partialMatchMode"));
+        Assertions.assertEquals(PartialMatchMode.FIRST_MATCH,
+                comboBox.getPartialMatchMode());
     }
 
     @Test
-    void setAutoFocusPartialMatchNull_throws() {
+    void setPartialMatchModeNull_throws() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
         Assertions.assertThrows(NullPointerException.class,
-                () -> comboBox.setAutoFocusPartialMatch(null));
+                () -> comboBox.setPartialMatchMode(null));
     }
 
     @Test
-    void allowCustomValue_setAutoFocusPartialMatch_throws() {
+    void allowCustomValue_setPartialMatchMode_throws() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
         comboBox.setAllowCustomValue(true);
         Assertions.assertThrows(IllegalStateException.class, () -> comboBox
-                .setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH));
-        Assertions.assertDoesNotThrow(() -> comboBox
-                .setAutoFocusPartialMatch(AutoFocusPartialMatch.NONE));
+                .setPartialMatchMode(PartialMatchMode.FIRST_MATCH));
+        Assertions.assertDoesNotThrow(
+                () -> comboBox.setPartialMatchMode(PartialMatchMode.NONE));
     }
 
     @Test
-    void autoFocusPartialMatch_setAllowCustomValue_throws() {
+    void partialMatchMode_setAllowCustomValue_throws() {
         ComboBoxBase<?, String, ?> comboBox = createComboBox(String.class);
-        comboBox.setAutoFocusPartialMatch(AutoFocusPartialMatch.FIRST_MATCH);
+        comboBox.setPartialMatchMode(PartialMatchMode.FIRST_MATCH);
         Assertions.assertThrows(IllegalStateException.class,
                 () -> comboBox.setAllowCustomValue(true));
         Assertions


### PR DESCRIPTION
## Description

Renames `AutoFocusPartialMatch` to `PartialMatchMode` as decided in an internal survey

Part of https://github.com/vaadin/web-components/issues/1280

## Type of change

- Refactor