### PR TITLE
fix: read menu item sub menu through a getter (CP: 25.2)

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityPage.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/main/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityPage.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu.it;
+
+import com.vaadin.flow.component.contextmenu.ContextMenu;
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-context-menu/sub-menu-visibility")
+public class SubMenuVisibilityPage extends Div {
+
+    public SubMenuVisibilityPage() {
+        Paragraph target = new Paragraph("target");
+        target.setId("target");
+
+        ContextMenu contextMenu = new ContextMenu(target);
+        MenuItem item = contextMenu.addItem("Item");
+        item.getSubMenu().addItem("Sub item 1");
+        item.getSubMenu().addItem("Sub item 2");
+        item.setVisible(false);
+
+        NativeButton showItem = new NativeButton("Show item",
+                event -> item.setVisible(true));
+        showItem.setId("show-item");
+
+        // Add <vaadin-context-menu> to DOM manually, so that closing it does
+        // not detach it and generate the items again on the next open
+        add(target, contextMenu, showItem);
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityIT.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/src/test/java/com/vaadin/flow/component/contextmenu/it/SubMenuVisibilityIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.contextmenu.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.contextmenu.testbench.ContextMenuElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("vaadin-context-menu/sub-menu-visibility")
+public class SubMenuVisibilityIT extends AbstractContextMenuIT {
+
+    private TestBenchElement target;
+
+    @Before
+    public void init() {
+        open();
+        target = $("p").id("target");
+    }
+
+    @Test
+    public void hiddenItem_show_subMenuRenders() {
+        ContextMenuElement menu = ContextMenuElement.openByRightClick(target);
+        Assert.assertFalse("Expected the item to be hidden initially",
+                menu.getMenuItems().get(0).isDisplayed());
+        clickBody();
+        menu.waitUntilClosed();
+
+        $("button").id("show-item").click();
+
+        menu = ContextMenuElement.openByRightClick(target);
+        ContextMenuElement subMenu = menu.getMenuItems().get(0).openSubMenu();
+        Assert.assertArrayEquals(new String[] { "Sub item 1", "Sub item 2" },
+                getMenuItemCaptions(getMenuItems(subMenu)));
+    }
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuConnector.js
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/contextMenuConnector.js
@@ -51,6 +51,7 @@ function generateItemsTree(appId, nodeId) {
   return Array.from(container.children).map((child) => {
     // Use getters to provide up to date values for the web component when
     // the menu is rendered or tooltip is shown without regenerating items.
+    let children;
     const item = {
       component: child,
       get checked() {
@@ -73,12 +74,20 @@ function generateItemsTree(appId, nodeId) {
       },
       get tooltipPosition() {
         return child.tooltipPosition;
+      },
+      // Flow does not send the container node id for the invisible item, so
+      // reading it while generating items would leave item without sub menu.
+      // Result is cached as web component reads `children` on every render.
+      // Generating items builds both new containers and new items, so a cached
+      // sub menu never outlives the node id it was resolved from.
+      get children() {
+        // Do not hardcode tag name to allow `vaadin-menu-bar-item`
+        if (!children && child._hasVaadinItemMixin && child._containerNodeId) {
+          children = generateItemsTree(appId, child._containerNodeId);
+        }
+        return children;
       }
     };
-    // Do not hardcode tag name to allow `vaadin-menu-bar-item`
-    if (child._hasVaadinItemMixin && child._containerNodeId) {
-      item.children = generateItemsTree(appId, child._containerNodeId);
-    }
     child._item = item;
     return item;
   });

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityPage.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/main/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityPage.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-menu-bar/sub-menu-visibility")
+public class MenuBarSubMenuVisibilityPage extends Div {
+
+    public MenuBarSubMenuVisibilityPage() {
+        add(createRootItemLayout(), createSubItemLayout());
+    }
+
+    private Div createRootItemLayout() {
+        MenuBar menuBar = new MenuBar();
+        menuBar.setId("root-item-menu-bar");
+        MenuItem rootItem = menuBar.addItem("Root item");
+        rootItem.getSubMenu().addItem("Sub item 1");
+        rootItem.getSubMenu().addItem("Sub item 2");
+        rootItem.setVisible(false);
+
+        NativeButton showRootItem = new NativeButton("Show root item",
+                event -> rootItem.setVisible(true));
+        showRootItem.setId("show-root-item");
+
+        return new Div(menuBar, showRootItem);
+    }
+
+    private Div createSubItemLayout() {
+        MenuBar menuBar = new MenuBar();
+        menuBar.setId("sub-item-menu-bar");
+        MenuItem rootItem = menuBar.addItem("Root item");
+        MenuItem subItem = rootItem.getSubMenu().addItem("Sub item");
+        subItem.getSubMenu().addItem("Sub sub item");
+        subItem.setVisible(false);
+
+        NativeButton showSubItem = new NativeButton("Show sub item",
+                event -> subItem.setVisible(true));
+        showSubItem.setId("show-sub-item");
+
+        return new Div(menuBar, showSubItem);
+    }
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityIT.java
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/src/test/java/com/vaadin/flow/component/menubar/tests/MenuBarSubMenuVisibilityIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.menubar.tests;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.menubar.testbench.MenuBarElement;
+import com.vaadin.flow.component.menubar.testbench.MenuBarItemElement;
+import com.vaadin.flow.component.menubar.testbench.MenuBarSubMenuElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+@TestPath("vaadin-menu-bar/sub-menu-visibility")
+public class MenuBarSubMenuVisibilityIT extends AbstractComponentIT {
+
+    @Before
+    public void init() {
+        open();
+        $(MenuBarElement.class).waitForFirst();
+    }
+
+    @Test
+    public void hiddenRootItem_show_subMenuRenders() {
+        MenuBarElement menuBar = $(MenuBarElement.class)
+                .id("root-item-menu-bar");
+        Assert.assertTrue("Expected no buttons while the root item is hidden",
+                menuBar.getButtons().isEmpty());
+
+        $("button").id("show-root-item").click();
+
+        MenuBarSubMenuElement subMenu = menuBar.getButtons().get(0)
+                .openSubMenu();
+        Assert.assertArrayEquals(new String[] { "Sub item 1", "Sub item 2" },
+                getMenuItemContents(subMenu.getMenuItems()));
+    }
+
+    @Test
+    public void hiddenSubItem_show_subSubMenuRenders() {
+        MenuBarElement menuBar = $(MenuBarElement.class)
+                .id("sub-item-menu-bar");
+        MenuBarSubMenuElement subMenu = menuBar.getButtons().get(0)
+                .openSubMenu();
+        Assert.assertTrue("Expected no sub item while it is hidden",
+                subMenu.getMenuItem("Sub item").isEmpty());
+        menuBar.getButtons().get(0).click();
+        subMenu.waitUntilClosed();
+
+        $("button").id("show-sub-item").click();
+
+        subMenu = menuBar.getButtons().get(0).openSubMenu();
+        MenuBarSubMenuElement subSubMenu = subMenu.getMenuItem("Sub item")
+                .orElseThrow().openSubMenu();
+        Assert.assertArrayEquals(new String[] { "Sub sub item" },
+                getMenuItemContents(subSubMenu.getMenuItems()));
+    }
+
+    private String[] getMenuItemContents(List<MenuBarItemElement> menuItems) {
+        return menuItems.stream().map(MenuBarItemElement::getText)
+                .toArray(String[]::new);
+    }
+}


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9947 to branch 25.2.

---

> ## Description
>
> Fixes #1042
> Follow-up to #9943
>
> Flow does not send property changes for invisible elements, so an item that was hidden when
> the items were generated was left without the container node id that links it to its sub
> menu. Showing the item delivers the id, but the items were not generated again, so the sub
> menu stayed missing. #9943 made the item state properties getters for the same reason; the
> sub menu was the one field still read eagerly.
>
> - Read the sub menu of a menu item through a getter in `generateItemsTree`, so the container
>   node id is read whenever the web component renders instead of only when the items are
>   generated
>   - The result is cached, as the web component reads `children` on every render and the node
>     id only changes when the items are generated anew
> - Added integration tests for a menu bar root item, a nested menu bar sub item and a context
>   menu item hidden at first render
>
> ## Type of change
>
> - Bugfix
>
> ## How to test
>
> 1. Open `vaadin-menu-bar/sub-menu-visibility` (`MenuBarSubMenuVisibilityPage.java`), click
>    **Show root item**, then click the **Root item** button — the sub menu opens with
>    `Sub item 1` and `Sub item 2`.
> 2. In the second menu bar, click **Show sub item**, open **Root item**, then hover
>    **Sub item** — its sub menu opens with `Sub sub item`.
> 3. Open `vaadin-context-menu/sub-menu-visibility` (`SubMenuVisibilityPage.java`), click
>    **Show item**, right-click **target**, then open the sub menu of **Item** — it lists both
>    sub items.
