### PR TITLE
test: add web-test-runner tests for the menu connectors

### DIFF
--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/test/context-menu-connector.test.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/test/context-menu-connector.test.ts
@@ -1,0 +1,235 @@
+import { expect } from 'chai';
+import {
+  APP_ID,
+  contextMenuConnector,
+  createComponent,
+  createContainer,
+  createItem,
+  initFlowClient
+} from './shared.js';
+import type { FlowContextMenu, FlowContextMenuItem, FlowContextMenuItemComponent } from './shared.js';
+
+describe('context menu connector', () => {
+  beforeEach(() => {
+    initFlowClient();
+  });
+
+  describe('generateItemsTree', () => {
+    it('should generate an item for each element in the container', () => {
+      const nodeId = createContainer(createItem(), createItem());
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      expect(items).to.have.lengthOf(2);
+    });
+
+    it('should reference the item element as the item component', () => {
+      const item = createItem();
+      const nodeId = createContainer(item);
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      expect(items[0].component).to.equal(item);
+    });
+
+    it('should reference the generated item from the item element', () => {
+      const item = createItem();
+      const nodeId = createContainer(item);
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      expect(item._item).to.equal(items[0]);
+    });
+
+    it('should return undefined for an unknown node id', () => {
+      expect(contextMenuConnector.generateItemsTree(APP_ID, 404)).to.be.undefined;
+    });
+  });
+
+  describe('item state', () => {
+    let element: FlowContextMenuItemComponent;
+    let item: FlowContextMenuItem;
+
+    beforeEach(() => {
+      element = createItem();
+      const nodeId = createContainer(element);
+      item = contextMenuConnector.generateItemsTree(APP_ID, nodeId)![0];
+    });
+
+    it('should read the checked state from the element', () => {
+      element._checked = true;
+
+      expect(item.checked).to.be.true;
+    });
+
+    it('should read the keep open state from the element', () => {
+      element._keepOpen = true;
+
+      expect(item.keepOpen).to.be.true;
+    });
+
+    it('should read the disabled state from the element', () => {
+      element.disabled = true;
+
+      expect(item.disabled).to.be.true;
+    });
+
+    it('should read the class name from the element', () => {
+      element.className = 'custom';
+
+      expect(item.className).to.equal('custom');
+    });
+
+    it('should read the theme from the element', () => {
+      element.__theme = 'custom';
+
+      expect(item.theme).to.equal('custom');
+    });
+
+    it('should read the tooltip from the element', () => {
+      element.tooltip = 'Tooltip';
+
+      expect(item.tooltip).to.equal('Tooltip');
+    });
+
+    it('should read the tooltip position from the element', () => {
+      element.tooltipPosition = 'end';
+
+      expect(item.tooltipPosition).to.equal('end');
+    });
+  });
+
+  describe('sub menu', () => {
+    it('should have no sub menu when the element has no container node id', () => {
+      const nodeId = createContainer(createItem());
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      expect(items[0].children).to.be.undefined;
+    });
+
+    it('should generate the sub menu from the container node id', () => {
+      const subItem = createItem();
+      const element = createItem({ _containerNodeId: createContainer(subItem) });
+      const nodeId = createContainer(element);
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      expect(items[0].children![0].component).to.equal(subItem);
+    });
+
+    it('should generate the sub menu for a container node id set after generating', () => {
+      const element = createItem();
+      const nodeId = createContainer(element);
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+      expect(items[0].children).to.be.undefined;
+
+      // Flow only sends the container node id once the item is visible
+      const subItem = createItem();
+      element._containerNodeId = createContainer(subItem);
+
+      expect(items[0].children![0].component).to.equal(subItem);
+    });
+
+    it('should generate the sub menu only once', () => {
+      const element = createItem({ _containerNodeId: createContainer(createItem()) });
+      const nodeId = createContainer(element);
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      const children = items[0].children;
+      expect(items[0].children).to.equal(children);
+    });
+
+    it('should have no sub menu for an element that is not a menu item', () => {
+      const element = createComponent();
+      element._containerNodeId = createContainer(createItem());
+      const nodeId = createContainer(element);
+
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      expect(items[0].children).to.be.undefined;
+    });
+
+    it('should read the state of a sub menu item from its element', () => {
+      const subItem = createItem();
+      const element = createItem({ _containerNodeId: createContainer(subItem) });
+      const nodeId = createContainer(element);
+      const items = contextMenuConnector.generateItemsTree(APP_ID, nodeId)!;
+
+      subItem.tooltip = 'Tooltip';
+
+      expect(items[0].children![0].tooltip).to.equal('Tooltip');
+    });
+  });
+
+  describe('initLazy', () => {
+    let contextMenu: FlowContextMenu;
+
+    beforeEach(() => {
+      contextMenu = document.createElement('vaadin-context-menu') as FlowContextMenu;
+      document.body.appendChild(contextMenu);
+      contextMenuConnector.initLazy(contextMenu, APP_ID);
+    });
+
+    afterEach(() => {
+      contextMenu.remove();
+    });
+
+    it('should keep the connector of an already initialized menu', () => {
+      const connector = contextMenu.$connector;
+
+      contextMenuConnector.initLazy(contextMenu, APP_ID);
+
+      expect(contextMenu.$connector).to.equal(connector);
+    });
+
+    it('should assign the generated items to the menu', () => {
+      const element = createItem();
+      const nodeId = createContainer(element);
+
+      contextMenu.$connector.generateItems(nodeId);
+
+      expect(contextMenu.items).to.have.lengthOf(1);
+      expect(contextMenu.items![0].component).to.equal(element);
+    });
+  });
+
+  describe('setChecked', () => {
+    it('should toggle the checkmark attribute for a keep open item', () => {
+      const element = createItem({ _keepOpen: true });
+      contextMenuConnector.generateItemsTree(APP_ID, createContainer(element));
+
+      contextMenuConnector.setChecked(element, true);
+
+      expect(element.hasAttribute('menu-item-checked')).to.be.true;
+    });
+
+    it('should remove the checkmark attribute for a keep open item', () => {
+      const element = createItem({ _keepOpen: true });
+      contextMenuConnector.generateItemsTree(APP_ID, createContainer(element));
+      contextMenuConnector.setChecked(element, true);
+
+      contextMenuConnector.setChecked(element, false);
+
+      expect(element.hasAttribute('menu-item-checked')).to.be.false;
+    });
+
+    it('should not toggle the checkmark attribute for an item that does not keep open', () => {
+      const element = createItem();
+      contextMenuConnector.generateItemsTree(APP_ID, createContainer(element));
+
+      contextMenuConnector.setChecked(element, true);
+
+      expect(element.hasAttribute('menu-item-checked')).to.be.false;
+    });
+
+    it('should not fail for an element without a generated item', () => {
+      const element = createItem({ _keepOpen: true });
+
+      contextMenuConnector.setChecked(element, true);
+
+      expect(element.hasAttribute('menu-item-checked')).to.be.false;
+    });
+  });
+});

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/test/env-setup.ts
@@ -1,0 +1,3 @@
+window.Vaadin ||= {} as Vaadin;
+// @ts-expect-error
+window.Vaadin.Flow = {};

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/test/shared.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/test/shared.ts
@@ -1,0 +1,58 @@
+import './env-setup.js';
+import '@vaadin/context-menu/src/vaadin-context-menu.js';
+import '@vaadin/context-menu/src/vaadin-context-menu-item.js';
+import '../frontend/generated/jar-resources/vaadin-context-menu/contextMenuConnector.ts';
+import type {} from '@web/test-runner-mocha';
+import type {
+  FlowContextMenu,
+  FlowContextMenuItem,
+  FlowContextMenuItemComponent
+} from '../frontend/generated/jar-resources/vaadin-context-menu/vaadin-context-menu-types.js';
+
+export type { FlowContextMenu, FlowContextMenuItem, FlowContextMenuItemComponent };
+
+export const APP_ID = 'test-app';
+
+export const contextMenuConnector = window.Vaadin.Flow.contextMenuConnector;
+
+const containers = new Map<number, Element>();
+let nextNodeId = 1;
+
+/**
+ * Installs a Flow client that resolves the node ids handed out by
+ * {@link createContainer}, and forgets any containers from a previous test.
+ */
+export function initFlowClient(): void {
+  containers.clear();
+  nextNodeId = 1;
+  window.Vaadin.Flow.clients = {
+    [APP_ID]: { getByNodeId: (nodeId: number) => containers.get(nodeId) }
+  };
+}
+
+/**
+ * Registers a container holding the given item elements, the way
+ * `MenuItemsArrayGenerator` does for a menu and each of its sub menus, and
+ * returns the node id to reach it by.
+ */
+export function createContainer(...items: Element[]): number {
+  const container = document.createElement('div');
+  items.forEach((item) => container.appendChild(item));
+  const nodeId = nextNodeId++;
+  containers.set(nodeId, container);
+  return nodeId;
+}
+
+/** Creates a menu item element, optionally with some of the state Flow sets on it */
+export function createItem(state: Partial<FlowContextMenuItemComponent> = {}): FlowContextMenuItemComponent {
+  const item = document.createElement('vaadin-context-menu-item') as FlowContextMenuItemComponent;
+  return Object.assign(item, state);
+}
+
+/**
+ * Creates an element that is not a menu item, the way a separator or a
+ * component added to a menu appears among the item elements.
+ */
+export function createComponent(): FlowContextMenuItemComponent {
+  return document.createElement('div') as FlowContextMenuItemComponent;
+}

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/web-test-runner.config.mjs
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+
+/** @type {import('@web/test-runner').TestRunnerConfig} */
+export default {
+  ...sharedConfig,
+
+  plugins: [
+    frontendSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-context-menu-flow/src/main/resources/META-INF/frontend')
+    ]),
+
+    ...sharedConfig.plugins
+  ]
+};

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/test/env-setup.ts
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/test/env-setup.ts
@@ -1,0 +1,3 @@
+window.Vaadin ||= {} as Vaadin;
+// @ts-expect-error
+window.Vaadin.Flow = {};

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/test/menu-bar-connector.test.ts
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/test/menu-bar-connector.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { createContainer, createItem, getButtonTexts, init, initFlowClient } from './shared.js';
+import type { FlowMenuBar, FlowMenuBarItemComponent } from './shared.js';
+
+describe('menu bar connector', () => {
+  let menuBar: FlowMenuBar;
+
+  beforeEach(async () => {
+    initFlowClient();
+    menuBar = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>') as FlowMenuBar;
+    await nextFrame();
+    init(menuBar);
+  });
+
+  it('should keep the connector of an already initialized menu bar', () => {
+    const connector = menuBar.$connector;
+
+    init(menuBar);
+
+    expect(menuBar.$connector).to.equal(connector);
+  });
+
+  it('should assign the generated items to the menu bar', () => {
+    const nodeId = createContainer(createItem('Item 1'), createItem('Item 2'));
+
+    menuBar.$connector.generateItems(nodeId);
+
+    expect(menuBar.items).to.have.lengthOf(2);
+  });
+
+  it('should render a button for each item', async () => {
+    const nodeId = createContainer(createItem('Item 1'), createItem('Item 2'));
+
+    menuBar.$connector.generateItems(nodeId);
+    await nextFrame();
+
+    expect(getButtonTexts(menuBar)).to.eql(['Item 1', 'Item 2']);
+  });
+
+  describe('hidden items', () => {
+    let hiddenItem: FlowMenuBarItemComponent;
+
+    beforeEach(async () => {
+      hiddenItem = createItem('Item 2', { hidden: true });
+      const nodeId = createContainer(createItem('Item 1'), hiddenItem);
+      menuBar.$connector.generateItems(nodeId);
+      await nextFrame();
+    });
+
+    it('should leave a hidden item out of the items', () => {
+      expect(menuBar.items).to.have.lengthOf(1);
+      expect(getButtonTexts(menuBar)).to.eql(['Item 1']);
+    });
+
+    it('should include a shown item without generating the items again', async () => {
+      hiddenItem.hidden = false;
+
+      menuBar.$connector.generateItems();
+      await nextFrame();
+
+      expect(getButtonTexts(menuBar)).to.eql(['Item 1', 'Item 2']);
+    });
+
+    it('should include a shown item when Flow removes the hidden attribute', async () => {
+      hiddenItem.removeAttribute('hidden');
+      await nextFrame();
+
+      expect(getButtonTexts(menuBar)).to.eql(['Item 1', 'Item 2']);
+    });
+
+    it('should leave out an item that Flow hides', async () => {
+      const item = menuBar.querySelector('vaadin-menu-bar-item')!;
+
+      item.toggleAttribute('hidden', true);
+      await nextFrame();
+
+      expect(getButtonTexts(menuBar)).to.eql([]);
+    });
+  });
+
+  describe('sub menu', () => {
+    it('should give a button with a sub menu the popup role', async () => {
+      const item = createItem('Item', { _containerNodeId: createContainer(createItem('Sub item')) });
+      menuBar.$connector.generateItems(createContainer(item));
+      await nextFrame();
+
+      const button = menuBar.querySelector('vaadin-menu-bar-button')!;
+      expect(button.getAttribute('aria-haspopup')).to.equal('true');
+    });
+
+    it('should give a button a sub menu for a container node id set after generating', async () => {
+      const item = createItem('Item');
+      menuBar.$connector.generateItems(createContainer(item));
+      await nextFrame();
+      expect(menuBar.querySelector('vaadin-menu-bar-button')!.getAttribute('aria-haspopup')).to.be.null;
+
+      // Flow only sends the container node id once the item is visible
+      item._containerNodeId = createContainer(createItem('Sub item'));
+      menuBar.$connector.generateItems();
+      await nextFrame();
+
+      const button = menuBar.querySelector('vaadin-menu-bar-button')!;
+      expect(button.getAttribute('aria-haspopup')).to.equal('true');
+    });
+  });
+
+  describe('disabled items', () => {
+    it('should disable the button of a disabled item', async () => {
+      const item = createItem('Item', { disabled: true });
+      menuBar.$connector.generateItems(createContainer(item));
+      await nextFrame();
+
+      const button = menuBar.querySelector('vaadin-menu-bar-button')!;
+      expect(button.hasAttribute('disabled')).to.be.true;
+    });
+
+    it('should disable the button when Flow disables the item', async () => {
+      const item = createItem('Item');
+      menuBar.$connector.generateItems(createContainer(item));
+      await nextFrame();
+
+      item.toggleAttribute('disabled', true);
+      await nextFrame();
+
+      const button = menuBar.querySelector('vaadin-menu-bar-button')!;
+      expect(button.hasAttribute('disabled')).to.be.true;
+    });
+  });
+});

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/test/shared.ts
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/test/shared.ts
@@ -1,0 +1,62 @@
+import './env-setup.js';
+import '@vaadin/menu-bar/src/vaadin-menu-bar.js';
+import '@vaadin/menu-bar/src/vaadin-menu-bar-item.js';
+import '../frontend/generated/jar-resources/vaadin-menu-bar/menubarConnector.ts';
+import type {} from '@web/test-runner-mocha';
+import type {
+  FlowMenuBar,
+  FlowMenuBarItemComponent
+} from '../frontend/generated/jar-resources/vaadin-menu-bar/vaadin-menu-bar-types.js';
+
+export type { FlowMenuBar, FlowMenuBarItemComponent };
+
+const APP_ID = 'test-app';
+
+const menubarConnector = window.Vaadin.Flow.menubarConnector;
+
+const containers = new Map<number, Element>();
+let nextNodeId = 1;
+
+/**
+ * Installs a Flow client that resolves the node ids handed out by
+ * {@link createContainer}, and forgets any containers from a previous test.
+ */
+export function initFlowClient(): void {
+  containers.clear();
+  nextNodeId = 1;
+  window.Vaadin.Flow.clients = {
+    [APP_ID]: { getByNodeId: (nodeId: number) => containers.get(nodeId) }
+  };
+}
+
+/**
+ * Registers a container holding the given item elements, the way
+ * `MenuItemsArrayGenerator` does for a menu and each of its sub menus, and
+ * returns the node id to reach it by.
+ */
+export function createContainer(...items: Element[]): number {
+  const container = document.createElement('div');
+  items.forEach((item) => container.appendChild(item));
+  const nodeId = nextNodeId++;
+  containers.set(nodeId, container);
+  return nodeId;
+}
+
+/** Creates a menu item element, optionally with some of the state Flow sets on it */
+export function createItem(text: string, state: Partial<FlowMenuBarItemComponent> = {}): FlowMenuBarItemComponent {
+  const item = document.createElement('vaadin-menu-bar-item') as FlowMenuBarItemComponent;
+  item.textContent = text;
+  return Object.assign(item, state);
+}
+
+/** Initializes the connector for the menu bar, the way the Flow component does */
+export function init(menuBar: FlowMenuBar): void {
+  menubarConnector.initLazy(menuBar, APP_ID);
+}
+
+/** The text of the buttons the menu bar renders for its items */
+export function getButtonTexts(menuBar: FlowMenuBar): string[] {
+  return [...menuBar.querySelectorAll('vaadin-menu-bar-button')]
+    .filter((button) => !button.hasAttribute('slot'))
+    .map((button) => button.textContent!.trim());
+}

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/web-test-runner.config.mjs
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/web-test-runner.config.mjs
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { frontendSourcePlugin, sharedConfig } from '../../shared/shared-web-test-runner-config.mjs';
+
+/** @type {import('@web/test-runner').TestRunnerConfig} */
+export default {
+  ...sharedConfig,
+
+  plugins: [
+    frontendSourcePlugin([
+      path.resolve(import.meta.dirname, '../vaadin-menu-bar-flow/src/main/resources/META-INF/frontend'),
+      // The menu bar connector imports the context menu connector, which Flow
+      // merges into the same jar-resources folder
+      path.resolve(
+        import.meta.dirname,
+        '../../vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend'
+      )
+    ]),
+
+    ...sharedConfig.plugins
+  ]
+};


### PR DESCRIPTION
## Description

Follow-up to #9947, Depends on #9955

The context menu connector generates the items array that the menu web components render
from, and since #9943 it exposes the item state as getters reading from the item elements.
Only browser integration tests covered any of it, so the scenario each getter exists for was
pinned indirectly at best.

- Added a web-test-runner harness to the context menu and menu bar integration test modules,
  following the setup the grid and combo box modules already use
- Added a Flow client for the tests that resolves the containers the connectors look node ids
  up in, so a menu and its sub menus can be built without a server
  - Item elements are real `vaadin-context-menu-item` and `vaadin-menu-bar-item` elements,
    so the item mixin the connector checks for comes from the web component
- Added 23 tests for the context menu connector: tree generation, each item state getter
  reading the current element state, sub menu resolution for a container node id that arrives
  after the items were generated, caching, elements that are not menu items, `initLazy` and
  `setChecked`
- Added 11 tests for the menu bar connector: item rendering, filtering hidden items, the
  observer that re-renders on a `hidden` or `disabled` change, sub menus, and disabled items
- The tests import the connector types from the modules themselves rather than declaring their
  own, so the Flow client and the connector API are typed and no casts are needed
- Pointed the menu bar config at the context menu module's frontend as well, which the menu
  bar connector imports from the folder Flow merges jar resources into

## Type of change

- Tests

## How to test

1. Run `node scripts/wtr.js context-menu` — 23 tests pass.
2. Run `node scripts/wtr.js menu-bar` — 11 tests pass.
3. In `vaadin-context-menu/contextMenuConnector.ts`, change the `children` getter to resolve
   the sub menu while generating the items instead of on read, then run both commands again —
   the "container node id set after generating" test fails in each module.
