### PR TITLE
fix: check cell lock state when updating cell comments (#9905) (CP: 23.6)

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetHandlerImpl.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/SpreadsheetHandlerImpl.java
@@ -463,6 +463,10 @@ public class SpreadsheetHandlerImpl implements SpreadsheetServerRpc {
 
     @Override
     public void updateCellComment(String text, int col, int row) {
+        if (spreadsheet.isCellLocked(new CellAddress(row - 1, col - 1))) {
+            protectedCellWriteAttempted();
+            return;
+        }
         CreationHelper factory = spreadsheet.getWorkbook().getCreationHelper();
         RichTextString str = factory.createRichTextString(text);
         Cell cell = getOrCreateCell(spreadsheet.getActiveSheet(), row - 1,

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/LockedCellValueTest.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/src/test/java/com/vaadin/flow/component/spreadsheet/tests/LockedCellValueTest.java
@@ -68,6 +68,43 @@ public class LockedCellValueTest {
         Assert.assertEquals("Updated value", cell.getStringCellValue());
     }
 
+    @Test
+    public void lockSheet_receiveUpdateCellCommentEvent_preventsEdit() {
+        var cell = spreadsheet.createCell(1, 1, "Initial value");
+        lockSheet();
+        var protectedEditEvent = new AtomicReference<ProtectedEditEvent>();
+        spreadsheet.addProtectedEditListener(protectedEditEvent::set);
+        fireUpdateCellCommentEvent(2, 2, "Comment");
+        Assert.assertNotNull(protectedEditEvent.get());
+        Assert.assertNull(cell.getCellComment());
+    }
+
+    @Test
+    public void lockSheet_receiveUpdateCellCommentEventForMissingCell_doesNotCreateCell() {
+        lockSheet();
+        fireUpdateCellCommentEvent(5, 5, "Comment");
+        Assert.assertNull(spreadsheet.getActiveSheet().getRow(4));
+    }
+
+    @Test
+    public void lockSheet_unlockCell_receiveUpdateCellCommentEvent_allowsEdit() {
+        var cell = spreadsheet.createCell(1, 1, "Initial value");
+        lockSheet();
+        unlockCell("B2");
+        var protectedEditEvent = new AtomicReference<ProtectedEditEvent>();
+        spreadsheet.addProtectedEditListener(protectedEditEvent::set);
+        fireUpdateCellCommentEvent(2, 2, "Comment");
+        Assert.assertNull(protectedEditEvent.get());
+        Assert.assertNotNull(cell.getCellComment());
+        Assert.assertEquals("Comment",
+                cell.getCellComment().getString().getString());
+    }
+
+    private void fireUpdateCellCommentEvent(int row, int col, String text) {
+        TestHelper.fireClientEvent(spreadsheet, "updateCellComment",
+                "[\"" + text + "\", " + col + ", " + row + "]");
+    }
+
     private void fireCellValueEditedEvent(int row, int col, String value) {
         TestHelper.fireClientEvent(spreadsheet, "cellValueEdited",
                 "[" + row + ", " + col + ", \"" + value + "\"]");


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9905 to branch 23.6.

---

> The `updateCellComment` handler wrote the comment text into the workbook
> without re-checking the sheet protection state. Every other
> client-initiated write handler in `SpreadsheetHandlerImpl` re-checks it
> with `spreadsheet.isCellLocked(...)` and reports a protected write
> attempt instead of touching the workbook, because the client is not
> trusted to enforce protection on its own. This one handler was
> inconsistent with that.
>
> ## Changes
>
> Added the same check the other write handlers use. It runs before the
> target cell is resolved, because `getOrCreateCell` creates the row and
> the cell when they do not exist yet, so a later check would still leave
> an empty cell behind.
>
> Comments on cells that the application has explicitly unlocked keep
> working, as with cell values.
>
> ---
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
