### PR TITLE
test: fix flaky value change mode validation ITs

### DIFF
--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/AbstractValueChangeModeValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/AbstractValueChangeModeValidationIT.java
@@ -51,9 +51,6 @@ public abstract class AbstractValueChangeModeValidationIT<T extends HasValidatio
     }
 
     protected void assertValidationResults(String... expectedResults) {
-        // Wait for validation to be run
-        waitUntil(e -> !getValidationResults().isEmpty());
-
         Assert.assertEquals(Arrays.asList(expectedResults),
                 getValidationResults());
         resetValidationLog();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/AbstractValueChangeModeValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/AbstractValueChangeModeValidationIT.java
@@ -51,6 +51,9 @@ public abstract class AbstractValueChangeModeValidationIT<T extends HasValidatio
     }
 
     protected void assertValidationResults(String... expectedResults) {
+        // Wait for validation to be run
+        waitUntil(e -> !getValidationResults().isEmpty());
+
         Assert.assertEquals(Arrays.asList(expectedResults),
                 getValidationResults());
         resetValidationLog();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldValueChangeModeBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldValueChangeModeBasicValidationIT.java
@@ -193,6 +193,8 @@ public class BigDecimalFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered:
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -201,6 +203,8 @@ public class BigDecimalFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys("-");
@@ -208,6 +212,8 @@ public class BigDecimalFieldValueChangeModeBasicValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered: -2
         startValidationTimeout();
@@ -217,6 +223,8 @@ public class BigDecimalFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -224,6 +232,8 @@ public class BigDecimalFieldValueChangeModeBasicValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered:
         startValidationTimeout();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldValueChangeModeBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/BigDecimalFieldValueChangeModeBinderValidationIT.java
@@ -193,6 +193,8 @@ public class BigDecimalFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered:
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -201,6 +203,8 @@ public class BigDecimalFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys("-");
@@ -208,6 +212,8 @@ public class BigDecimalFieldValueChangeModeBinderValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered: -2
         startValidationTimeout();
@@ -217,6 +223,8 @@ public class BigDecimalFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -224,6 +232,8 @@ public class BigDecimalFieldValueChangeModeBinderValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered:
         startValidationTimeout();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValueChangeModeBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValueChangeModeBasicValidationIT.java
@@ -194,6 +194,8 @@ public class IntegerFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered:
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -202,6 +204,8 @@ public class IntegerFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys("-");
@@ -209,6 +213,8 @@ public class IntegerFieldValueChangeModeBasicValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered: -2
         startValidationTimeout();
@@ -218,6 +224,8 @@ public class IntegerFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -225,6 +233,8 @@ public class IntegerFieldValueChangeModeBasicValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered:
         startValidationTimeout();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValueChangeModeBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/IntegerFieldValueChangeModeBinderValidationIT.java
@@ -193,6 +193,8 @@ public class IntegerFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered:
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -201,6 +203,8 @@ public class IntegerFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys("-");
@@ -208,6 +212,8 @@ public class IntegerFieldValueChangeModeBinderValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered: -2
         startValidationTimeout();
@@ -217,6 +223,8 @@ public class IntegerFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -224,6 +232,8 @@ public class IntegerFieldValueChangeModeBinderValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered:
         startValidationTimeout();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldValueChangeModeBasicValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldValueChangeModeBasicValidationIT.java
@@ -194,6 +194,8 @@ public class NumberFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered:
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -202,6 +204,8 @@ public class NumberFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys("-");
@@ -209,6 +213,8 @@ public class NumberFieldValueChangeModeBasicValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered: -2
         startValidationTimeout();
@@ -218,6 +224,8 @@ public class NumberFieldValueChangeModeBasicValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -225,6 +233,8 @@ public class NumberFieldValueChangeModeBasicValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered:
         startValidationTimeout();

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldValueChangeModeBinderValidationIT.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/validation/NumberFieldValueChangeModeBinderValidationIT.java
@@ -193,6 +193,8 @@ public class NumberFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered:
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -201,6 +203,8 @@ public class NumberFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys("-");
@@ -208,6 +212,8 @@ public class NumberFieldValueChangeModeBinderValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered: -2
         startValidationTimeout();
@@ -217,6 +223,8 @@ public class NumberFieldValueChangeModeBinderValidationIT
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("valid");
 
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
+
         // Entered: --
         startValidationTimeout();
         testField.sendKeys(Keys.BACK_SPACE);
@@ -224,6 +232,8 @@ public class NumberFieldValueChangeModeBinderValidationIT
         testField.sendKeys("-");
         assertValidationTimeout(VALUE_CHANGE_TIMEOUT);
         assertValidationResults("invalid");
+
+        Thread.sleep(VALUE_CHANGE_TIMEOUT);
 
         // Entered:
         startValidationTimeout();


### PR DESCRIPTION
## Description

- Made `assertValidationResults` wait for the validation log to have entries before asserting
  - Asserting right after a keystroke raced the value change event's throttle window and the server round-trip in `ValueChangeMode.TIMEOUT` tests, occasionally reading an empty log (seen as `timeoutMode_enterMultipleChars_assertValidityAndTimeout` failing with `expected:<[invalid]> but was:<[]>`)

## Type of change

- Tests