### PR TITLE
chore: upgrade to 26.0-SNAPSHOT

### DIFF
--- a/flow-components-bom/pom.xml
+++ b/flow-components-bom/pom.xml
@@ -7,7 +7,7 @@
         <version>3.0.3</version>
     </parent>
     <artifactId>flow-components-bom</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>26.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Flow Components Bill of Materials</name>
     <description>Flow Components Bill of Materials</description>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-flow-components</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>26.0-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-flow-components-integration-tests</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>3.0.3</version>
     </parent>
     <artifactId>vaadin-flow-components</artifactId>
-    <version>25.3-SNAPSHOT</version>
+    <version>26.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin Flow Components Root Project</name>
     <url>https://vaadin.com/components</url>

--- a/vaadin-accordion-flow-parent/pom.xml
+++ b/vaadin-accordion-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-accordion-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-accordion-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-testbench/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-accordion-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-accordion-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-ai-components-flow-parent/pom.xml
+++ b/vaadin-ai-components-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ai-components-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ai-components-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ai-components-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ai-components-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ai-core-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/pom.xml
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ai-components-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ai-extensions-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-app-layout-flow-parent/pom.xml
+++ b/vaadin-app-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-app-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-app-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-app-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-app-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-aura-theme-flow-parent/pom.xml
+++ b/vaadin-aura-theme-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-aura-theme-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-aura-theme-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-aura-theme-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow/pom.xml
+++ b/vaadin-aura-theme-flow-parent/vaadin-aura-theme-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-aura-theme-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-aura-theme</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-avatar-flow-parent/pom.xml
+++ b/vaadin-avatar-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-avatar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-avatar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-testbench/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-avatar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-avatar-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-badge-flow-parent/pom.xml
+++ b/vaadin-badge-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-badge-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-badge-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-badge-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-badge-flow-parent/vaadin-badge-flow/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-badge-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-badge-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-badge-flow-parent/vaadin-badge-testbench/pom.xml
+++ b/vaadin-badge-flow-parent/vaadin-badge-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-badge-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-badge-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-board-flow-parent/pom.xml
+++ b/vaadin-board-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-board-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-board-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-board-flow-parent/vaadin-board-testbench/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-board-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-board-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-breadcrumbs-flow-parent/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-breadcrumbs-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-breadcrumbs-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-breadcrumbs-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-breadcrumbs-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-breadcrumbs-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/pom.xml
+++ b/vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-breadcrumbs-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-breadcrumbs-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-button-flow-parent/pom.xml
+++ b/vaadin-button-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-button-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-button-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-button-flow-parent/vaadin-button-testbench/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-button-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-button-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-card-flow-parent/pom.xml
+++ b/vaadin-card-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-card-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-card-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-card-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-card-flow-parent/vaadin-card-flow/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-card-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-card-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-card-flow-parent/vaadin-card-testbench/pom.xml
+++ b/vaadin-card-flow-parent/vaadin-card-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-card-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-card-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-charts-flow-parent/pom.xml
+++ b/vaadin-charts-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-charts-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-svg-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-charts-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-flow-svg-generator</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-charts-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-charts-flow-parent/vaadin-charts-testbench/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-charts-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-charts-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-checkbox-flow-parent/pom.xml
+++ b/vaadin-checkbox-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-checkbox-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-checkbox-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-checkbox-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-checkbox-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-combo-box-flow-parent/pom.xml
+++ b/vaadin-combo-box-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-combo-box-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-combo-box-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-combo-box-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-combo-box-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-confirm-dialog-flow-parent/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-testbench/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-confirm-dialog-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-confirm-dialog-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-context-menu-flow-parent/pom.xml
+++ b/vaadin-context-menu-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-context-menu-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-context-menu-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-context-menu-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-context-menu-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-crud-flow-parent/pom.xml
+++ b/vaadin-crud-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-crud-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-crud-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-crud-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-crud-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-custom-field-flow-parent/pom.xml
+++ b/vaadin-custom-field-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-custom-field-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-custom-field-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-custom-field-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-custom-field-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-dashboard-flow-parent/pom.xml
+++ b/vaadin-dashboard-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dashboard-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dashboard-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dashboard-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dashboard-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dashboard-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/pom.xml
+++ b/vaadin-dashboard-flow-parent/vaadin-dashboard-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dashboard-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dashboard-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-date-picker-flow-parent/pom.xml
+++ b/vaadin-date-picker-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-picker-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-date-time-picker-flow-parent/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-date-time-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-date-time-picker-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-details-flow-parent/pom.xml
+++ b/vaadin-details-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-details-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-details-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-details-flow-parent/vaadin-details-testbench/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-details-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-details-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-dialog-flow-parent/pom.xml
+++ b/vaadin-dialog-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-testbench/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-dialog-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-field-highlighter-flow-parent/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-field-highlighter-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-field-highlighter-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-field-highlighter-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow/pom.xml
+++ b/vaadin-field-highlighter-flow-parent/vaadin-field-highlighter-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-field-highlighter-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-field-highlighter-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-flow-components-shared-parent/pom.xml
+++ b/vaadin-flow-components-shared-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-flow-components-shared-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components-shared-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-flow-components-base</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-checkstyle-rules/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-checkstyle-rules/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components-shared-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-flow-components-checkstyle-rules</artifactId>
     <name>Vaadin Flow Components Checkstyle Rules</name>

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components-shared-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-flow-components-test-util</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-form-layout-flow-parent/pom.xml
+++ b/vaadin-form-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-form-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-form-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-testbench/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-form-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-form-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-grid-flow-parent/pom.xml
+++ b/vaadin-grid-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-grid-pro-flow-parent/pom.xml
+++ b/vaadin-grid-pro-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-pro-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-pro-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-pro-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-grid-pro-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-icons-flow-parent/pom.xml
+++ b/vaadin-icons-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-icons-flow-parent/vaadin-icons-testbench/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-icons-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-list-box-flow-parent/pom.xml
+++ b/vaadin-list-box-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-list-box-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-list-box-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-testbench/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-list-box-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-list-box-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-login-flow-parent/pom.xml
+++ b/vaadin-login-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-login-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-login-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-login-flow-parent/vaadin-login-testbench/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-login-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-login-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-lumo-theme-flow-parent/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-lumo-theme-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-lumo-theme-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-lumo-theme-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-lumo-theme-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-lumo-theme</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-map-flow-parent/pom.xml
+++ b/vaadin-map-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-map-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-map-flow-parent/vaadin-map-flow/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-map-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-map-flow-parent/vaadin-map-testbench/pom.xml
+++ b/vaadin-map-flow-parent/vaadin-map-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-map-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-map-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-markdown-flow-parent/pom.xml
+++ b/vaadin-markdown-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-markdown-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-markdown-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-markdown-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-flow/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-markdown-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-markdown-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-markdown-flow-parent/vaadin-markdown-testbench/pom.xml
+++ b/vaadin-markdown-flow-parent/vaadin-markdown-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-markdown-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-markdown-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-master-detail-layout-flow-parent/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-master-detail-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-master-detail-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-master-detail-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-master-detail-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-master-detail-layout-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-testbench/pom.xml
+++ b/vaadin-master-detail-layout-flow-parent/vaadin-master-detail-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-master-detail-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-master-detail-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-menu-bar-flow-parent/pom.xml
+++ b/vaadin-menu-bar-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-menu-bar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-menu-bar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-menu-bar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-menu-bar-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-messages-flow-parent/pom.xml
+++ b/vaadin-messages-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-messages-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-messages-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-messages-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-messages-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-notification-flow-parent/pom.xml
+++ b/vaadin-notification-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-notification-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-notification-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-notification-flow-parent/vaadin-notification-testbench/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-notification-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-notification-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-ordered-layout-flow-parent/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-testbench/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-ordered-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-ordered-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-popover-flow-parent/pom.xml
+++ b/vaadin-popover-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-popover-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-popover-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-popover-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-popover-flow-parent/vaadin-popover-flow/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-popover-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-popover-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-popover-flow-parent/vaadin-popover-testbench/pom.xml
+++ b/vaadin-popover-flow-parent/vaadin-popover-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-popover-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-popover-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-progress-bar-flow-parent/pom.xml
+++ b/vaadin-progress-bar-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-progress-bar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-progress-bar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-testbench/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-progress-bar-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-progress-bar-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-radio-button-flow-parent/pom.xml
+++ b/vaadin-radio-button-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-radio-button-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-radio-button-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-testbench/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-radio-button-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-radio-button-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-renderer-flow-parent/pom.xml
+++ b/vaadin-renderer-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-renderer-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-renderer-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-renderer-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/pom.xml
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-renderer-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-renderer-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-rich-text-editor-flow-parent/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-select-flow-parent/pom.xml
+++ b/vaadin-select-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-select-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-select-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-select-flow-parent/vaadin-select-testbench/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-select-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-select-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-side-nav-flow-parent/pom.xml
+++ b/vaadin-side-nav-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-side-nav-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-side-nav-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-side-nav-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-side-nav-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-side-nav-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/pom.xml
+++ b/vaadin-side-nav-flow-parent/vaadin-side-nav-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-side-nav-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-side-nav-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-slider-flow-parent/pom.xml
+++ b/vaadin-slider-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-slider-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-slider-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-slider-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-slider-flow-parent/vaadin-slider-flow/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-slider-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-slider-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-slider-flow-parent/vaadin-slider-testbench/pom.xml
+++ b/vaadin-slider-flow-parent/vaadin-slider-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-slider-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-slider-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-split-layout-flow-parent/pom.xml
+++ b/vaadin-split-layout-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-split-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-split-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-testbench/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-split-layout-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-split-layout-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-spreadsheet-flow-parent/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-spreadsheet-flow-client</artifactId>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-flow-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-spreadsheet-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-spreadsheet-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-tabs-flow-parent/pom.xml
+++ b/vaadin-tabs-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-tabs-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-tabs-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-testbench/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-tabs-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-tabs-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-text-field-flow-parent/pom.xml
+++ b/vaadin-text-field-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-testbench/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-text-field-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-time-picker-flow-parent/pom.xml
+++ b/vaadin-time-picker-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-time-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-time-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-time-picker-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-time-picker-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-upload-flow-parent/pom.xml
+++ b/vaadin-upload-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-upload-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-upload-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-upload-flow-parent/vaadin-upload-testbench/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-upload-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-upload-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-virtual-list-flow-parent/pom.xml
+++ b/vaadin-virtual-list-flow-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-flow-components</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-flow-parent</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-virtual-list-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-integration-tests</artifactId>
     <packaging>war</packaging>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-virtual-list-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-flow</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-testbench/pom.xml
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-virtual-list-flow-parent</artifactId>
-        <version>25.3-SNAPSHOT</version>
+        <version>26.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-virtual-list-testbench</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
`flow.version` is kept at `25.3-SNAPSHOT` since there is no Flow 26.0 snapshot yet.

Blocked by

- https://github.com/vaadin/flow-components/pull/9961