### PR TITLE
feat: allow history restore with Spring AI ChatClient

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -342,8 +342,9 @@ public class AIOrchestrator implements Serializable {
      * <p>
      * Calling {@link Reconnector#apply()} replays the existing conversation
      * history onto the new provider so it has full context for subsequent
-     * prompts. The UI is not modified -- message list, input, and file receiver
-     * components retain their state across serialization.
+     * prompts, unless the provider manages its conversation memory outside the
+     * orchestrator. The UI is not modified -- message list, input, and file
+     * receiver components retain their state across serialization.
      * </p>
      * <p>
      * This method should only be called on a deserialized instance where the
@@ -1041,7 +1042,10 @@ public class AIOrchestrator implements Serializable {
          * Applies the reconnection, restoring the provider, tools, and
          * conversation history on the new provider. The existing conversation
          * history is replayed onto the new provider's memory so that it has
-         * full context for subsequent prompts.
+         * full context for subsequent prompts. A provider that manages its
+         * conversation memory outside the orchestrator ignores the replay, in
+         * which case the application must restore that memory itself before
+         * passing the provider in.
          * <p>
          * The UI (message list, input, file receiver) is not modified -- those
          * components survive serialization and retain their state
@@ -1518,6 +1522,12 @@ public class AIOrchestrator implements Serializable {
          * conversation context (including multimodal content), the message list
          * UI with attachment thumbnails, and the internal message ID mappings
          * for attachment click handling.
+         * <p>
+         * A provider that manages its conversation memory outside the
+         * orchestrator ignores the provider part of the restore, so the
+         * application must load that memory itself. The message list, the
+         * attachment mappings, and the {@link AIOrchestrator#getHistory()}
+         * snapshot are restored either way.
          * <p>
          * The attachment map is keyed by {@link ChatMessage#messageId()} and
          * contains the list of {@link AIAttachment} objects for each message.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -261,9 +261,11 @@ public class SpringAILLMProvider implements LLMProvider {
      * nothing when the provider was created with the
      * {@link #SpringAILLMProvider(ChatClient) ChatClient} constructor, because
      * the application owns the chat memory in that case and is expected to have
-     * populated it before passing the client in. A warning is logged if that
-     * client has no chat memory at all, since the restored conversation can
-     * then never reach the LLM.
+     * populated it before passing the client in. A warning is logged when that
+     * client is missing the chat memory configuration the conversation would
+     * need. Whether the memory actually holds the conversation is not visible
+     * to the provider, so a client configured correctly but never loaded is
+     * indistinguishable from one that was.
      */
     @Override
     public void setHistory(List<ChatMessage> history,
@@ -290,42 +292,44 @@ public class SpringAILLMProvider implements LLMProvider {
      * Reports a client that cannot hold the conversation the application asked
      * to restore. The provider cannot populate an application-owned chat
      * memory, but it can tell that a client carrying no memory advisor, or one
-     * whose memory has no conversation to read, will never see the restored
-     * messages -- the first case forgets every turn, the second fails each
-     * prompt inside the advisor. Both are worth a warning at the point where
-     * the application asks for a restore that cannot happen.
+     * whose memory has no conversation to read, is very likely to never see the
+     * restored messages -- the first case forgets every turn, the second fails
+     * each prompt inside the standard advisor. Both are worth a warning at the
+     * point where the application asks for a restore that cannot happen.
+     * Neither is certain, since a client can carry the conversation in ways
+     * this check cannot see, so both messages say what was observed rather than
+     * promising the outcome.
      * <p>
      * Only clients built by {@link ChatClient#builder(ChatModel)} can be
      * inspected. Anything else is left alone, since a custom implementation may
      * carry the conversation in its own way.
      */
     private void warnIfClientMemoryUnusable() {
-        if (!(chatClient
-                .prompt() instanceof DefaultChatClientRequestSpec requestSpec)) {
-            LOGGER.debug("Skipping history restoration: the provider was "
-                    + "created with a ChatClient whose chat memory the "
-                    + "application owns, and whose configuration cannot be "
-                    + "inspected.");
+        var requestSpec = inspectableRequestSpec();
+        if (requestSpec == null) {
+            // inspectableRequestSpec() logged why it could not be read
             return;
         }
         if (requestSpec.getAdvisors().stream()
                 .noneMatch(MemoryAdvisor.class::isInstance)) {
-            LOGGER.warn("History restoration was requested, but the "
-                    + "ChatClient given to this provider has no chat memory "
-                    + "advisor, so the LLM will see neither the restored "
-                    + "conversation nor the turns that follow. Add for "
-                    + "example a MessageChatMemoryAdvisor to the client, and "
-                    + "load the restored conversation into its ChatMemory "
-                    + "before passing the client to the provider.");
+            LOGGER.warn("History restoration was requested, but no chat "
+                    + "memory advisor was found on the ChatClient given to "
+                    + "this provider. Unless that client keeps the "
+                    + "conversation some other way, the LLM will see neither "
+                    + "the restored conversation nor the turns that follow. "
+                    + "Add for example a MessageChatMemoryAdvisor to the "
+                    + "client, and load the restored conversation into its "
+                    + "ChatMemory before passing the client to the provider.");
             return;
         }
         if (requestSpec.getAdvisorParams()
                 .get(ChatMemory.CONVERSATION_ID) == null) {
             LOGGER.warn("History restoration was requested, but the "
                     + "ChatClient given to this provider has no default "
-                    + "{} advisor parameter, so its memory advisor has no "
-                    + "conversation to read and every prompt will fail. Set "
-                    + "the parameter on the client, for example with "
+                    + "{} advisor parameter. Unless something sets it per "
+                    + "request, its memory advisor has no conversation to "
+                    + "read and every prompt will fail. Set the parameter on "
+                    + "the client, for example with "
                     + "ChatClient.Builder.defaultAdvisors(advisors -> "
                     + "advisors.param(ChatMemory.CONVERSATION_ID, id)).",
                     ChatMemory.CONVERSATION_ID);
@@ -335,6 +339,36 @@ public class SpringAILLMProvider implements LLMProvider {
                 + "with a ChatClient whose chat memory the application owns. "
                 + "Populate that memory before passing the client to the "
                 + "provider.");
+    }
+
+    /**
+     * Returns the client's request spec when it is Spring AI's own
+     * implementation, or {@code null} -- after logging why -- when the client
+     * cannot be read. Inspection is only a diagnostic, so a client that rejects
+     * a bare {@link ChatClient#prompt()} must not break the restore it is being
+     * asked about.
+     *
+     * @return the request spec to inspect, or {@code null} if there is none to
+     *         read
+     */
+    private DefaultChatClientRequestSpec inspectableRequestSpec() {
+        try {
+            if (chatClient
+                    .prompt() instanceof DefaultChatClientRequestSpec spec) {
+                return spec;
+            }
+        } catch (RuntimeException e) {
+            LOGGER.debug("Skipping history restoration: the provider was "
+                    + "created with a ChatClient whose chat memory the "
+                    + "application owns, and which did not accept a bare "
+                    + "prompt() for inspection.", e);
+            return null;
+        }
+        LOGGER.debug("Skipping history restoration: the provider was "
+                + "created with a ChatClient whose chat memory the "
+                + "application owns, and whose configuration cannot be "
+                + "inspected.");
+        return null;
     }
 
     private static org.springframework.ai.chat.messages.Message toVendorMessage(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -25,7 +25,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.DefaultChatClient.DefaultChatClientRequestSpec;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.api.MemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -259,7 +261,9 @@ public class SpringAILLMProvider implements LLMProvider {
      * nothing when the provider was created with the
      * {@link #SpringAILLMProvider(ChatClient) ChatClient} constructor, because
      * the application owns the chat memory in that case and is expected to have
-     * populated it before passing the client in.
+     * populated it before passing the client in. A warning is logged if that
+     * client has no chat memory at all, since the restored conversation can
+     * then never reach the LLM.
      */
     @Override
     public void setHistory(List<ChatMessage> history,
@@ -268,10 +272,7 @@ public class SpringAILLMProvider implements LLMProvider {
         Objects.requireNonNull(attachmentsByMessageId,
                 "Attachments map must not be null");
         if (!hasManagedMemory) {
-            LOGGER.debug("Skipping history restoration: the provider was "
-                    + "created with a ChatClient whose chat memory the "
-                    + "application owns. Populate that memory before passing "
-                    + "the client to the provider.");
+            warnIfClientMemoryUnusable();
             return;
         }
         chatMemory.clear(CONVERSATION_ID);
@@ -283,6 +284,57 @@ public class SpringAILLMProvider implements LLMProvider {
             return toVendorMessage(message, attachments);
         }).toList();
         chatMemory.add(CONVERSATION_ID, messages);
+    }
+
+    /**
+     * Reports a client that cannot hold the conversation the application asked
+     * to restore. The provider cannot populate an application-owned chat
+     * memory, but it can tell that a client carrying no memory advisor, or one
+     * whose memory has no conversation to read, will never see the restored
+     * messages -- the first case forgets every turn, the second fails each
+     * prompt inside the advisor. Both are worth a warning at the point where
+     * the application asks for a restore that cannot happen.
+     * <p>
+     * Only clients built by {@link ChatClient#builder(ChatModel)} can be
+     * inspected. Anything else is left alone, since a custom implementation may
+     * carry the conversation in its own way.
+     */
+    private void warnIfClientMemoryUnusable() {
+        if (!(chatClient
+                .prompt() instanceof DefaultChatClientRequestSpec requestSpec)) {
+            LOGGER.debug("Skipping history restoration: the provider was "
+                    + "created with a ChatClient whose chat memory the "
+                    + "application owns, and whose configuration cannot be "
+                    + "inspected.");
+            return;
+        }
+        if (requestSpec.getAdvisors().stream()
+                .noneMatch(MemoryAdvisor.class::isInstance)) {
+            LOGGER.warn("History restoration was requested, but the "
+                    + "ChatClient given to this provider has no chat memory "
+                    + "advisor, so the LLM will see neither the restored "
+                    + "conversation nor the turns that follow. Add for "
+                    + "example a MessageChatMemoryAdvisor to the client, and "
+                    + "load the restored conversation into its ChatMemory "
+                    + "before passing the client to the provider.");
+            return;
+        }
+        if (requestSpec.getAdvisorParams()
+                .get(ChatMemory.CONVERSATION_ID) == null) {
+            LOGGER.warn("History restoration was requested, but the "
+                    + "ChatClient given to this provider has no default "
+                    + "{} advisor parameter, so its memory advisor has no "
+                    + "conversation to read and every prompt will fail. Set "
+                    + "the parameter on the client, for example with "
+                    + "ChatClient.Builder.defaultAdvisors(advisors -> "
+                    + "advisors.param(ChatMemory.CONVERSATION_ID, id)).",
+                    ChatMemory.CONVERSATION_ID);
+            return;
+        }
+        LOGGER.debug("Skipping history restoration: the provider was created "
+                + "with a ChatClient whose chat memory the application owns. "
+                + "Populate that memory before passing the client to the "
+                + "provider.");
     }
 
     private static org.springframework.ai.chat.messages.Message toVendorMessage(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -73,12 +73,13 @@ import tools.jackson.databind.JsonNode;
  * user's message renders while the LLM works.
  * </p>
  * <p>
- * Each provider instance maintains its own chat memory. To share conversation
- * history across components, reuse the same provider instance. History
- * restoration (via {@link #setHistory(List, Map)}) is only supported when using
- * the {@link #SpringAILLMProvider(ChatModel)} constructor; the
- * {@link #SpringAILLMProvider(ChatClient)} constructor does not provide access
- * to the internal chat memory.
+ * With the {@link #SpringAILLMProvider(ChatModel)} constructor the provider
+ * maintains its own chat memory, and {@link #setHistory(List, Map)} restores a
+ * saved conversation into it. To share conversation history across components,
+ * reuse the same provider instance. With the
+ * {@link #SpringAILLMProvider(ChatClient)} constructor the application owns the
+ * chat memory, so restoring the LLM's context is up to the application and
+ * {@link #setHistory(List, Map)} does nothing.
  * </p>
  * <p>
  * <b>Note:</b> SpringAILLMProvider is not serializable. If your application
@@ -124,9 +125,17 @@ public class SpringAILLMProvider implements LLMProvider {
     }
 
     /**
-     * Constructor with a chat client. Note: When using this constructor,
-     * conversation memory must be configured externally in the
-     * {@link ChatClient}.
+     * Constructor with a chat client. Conversation memory must be configured on
+     * the {@link ChatClient} itself, for example with a
+     * {@link MessageChatMemoryAdvisor} and a default
+     * {@link ChatMemory#CONVERSATION_ID} advisor parameter.
+     * <p>
+     * The application owns that memory, so {@link #setHistory(List, Map)} does
+     * nothing on a provider created this way. A conversation loaded from
+     * external storage must be written into the {@link ChatMemory} before the
+     * client is passed here. Passing the same conversation to
+     * {@code AIOrchestrator.Builder.withHistory(List, Map)} still restores the
+     * message list and the orchestrator's own history snapshot.
      *
      * @param chatClient
      *            the chat client, not {@code null}
@@ -243,6 +252,15 @@ public class SpringAILLMProvider implements LLMProvider {
         this.backgroundExecution.setEnabled(backgroundExecution);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Restores the conversation into the provider's own chat memory. Does
+     * nothing when the provider was created with the
+     * {@link #SpringAILLMProvider(ChatClient) ChatClient} constructor, because
+     * the application owns the chat memory in that case and is expected to have
+     * populated it before passing the client in.
+     */
     @Override
     public void setHistory(List<ChatMessage> history,
             Map<String, List<AIAttachment>> attachmentsByMessageId) {
@@ -250,9 +268,11 @@ public class SpringAILLMProvider implements LLMProvider {
         Objects.requireNonNull(attachmentsByMessageId,
                 "Attachments map must not be null");
         if (!hasManagedMemory) {
-            throw new UnsupportedOperationException(
-                    "Chat history restoration is not supported when using the ChatClient constructor. "
-                            + "Use the ChatModel constructor instead.");
+            LOGGER.debug("Skipping history restoration: the provider was "
+                    + "created with a ChatClient whose chat memory the "
+                    + "application owns. Populate that memory before passing "
+                    + "the client to the provider.");
+            return;
         }
         chatMemory.clear(CONVERSATION_ID);
         var messages = history.stream().map(message -> {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -80,8 +80,11 @@ import tools.jackson.databind.JsonNode;
  * saved conversation into it. To share conversation history across components,
  * reuse the same provider instance. With the
  * {@link #SpringAILLMProvider(ChatClient)} constructor the application owns the
- * chat memory, so restoring the LLM's context is up to the application and
- * {@link #setHistory(List, Map)} does nothing.
+ * chat memory, so giving the LLM its context is up to the application and
+ * {@link #setHistory(List, Map)} does nothing. Restoring a conversation through
+ * {@code AIOrchestrator.Builder.withHistory(List, Map)} still matters on that
+ * path: the message list the user sees and the orchestrator's own conversation
+ * history are restored by the orchestrator, not by the provider.
  * </p>
  * <p>
  * <b>Note:</b> SpringAILLMProvider is not serializable. If your application
@@ -265,7 +268,9 @@ public class SpringAILLMProvider implements LLMProvider {
      * client is missing the chat memory configuration the conversation would
      * need. Whether the memory actually holds the conversation is not visible
      * to the provider, so a client configured correctly but never loaded is
-     * indistinguishable from one that was.
+     * indistinguishable from one that was. Doing nothing here does not reduce
+     * what the caller restores: an orchestrator rebuilds the message list and
+     * its own conversation history itself.
      */
     @Override
     public void setHistory(List<ChatMessage> history,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.event.Level;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
@@ -969,6 +970,58 @@ class SpringAILLMProviderTest {
                 .anyMatch(msg -> Objects.equals(msg.getText(), "Old answer")));
         Assertions.assertTrue(messages.stream().anyMatch(
                 msg -> Objects.equals(msg.getText(), "New question")));
+    }
+
+    @Test
+    void setHistory_chatClientWithoutMemoryAdvisor_warns() {
+        var chatClientProvider = new SpringAILLMProvider(
+                ChatClient.builder(mockChatModel).build());
+
+        chatClientProvider.setHistory(List
+                .of(new ChatMessage(ChatMessage.Role.USER, "Hi", null, null)),
+                Collections.emptyMap());
+
+        Assertions.assertEquals(1, warningCount("no chat memory advisor"));
+    }
+
+    @Test
+    void setHistory_chatClientWithoutConversationId_warns() {
+        var chatMemory = MessageWindowChatMemory.builder().build();
+        var chatClientProvider = new SpringAILLMProvider(ChatClient
+                .builder(mockChatModel)
+                .defaultAdvisors(
+                        MessageChatMemoryAdvisor.builder(chatMemory).build())
+                .build());
+
+        chatClientProvider.setHistory(List
+                .of(new ChatMessage(ChatMessage.Role.USER, "Hi", null, null)),
+                Collections.emptyMap());
+
+        Assertions.assertEquals(1, warningCount("conversation to read"));
+    }
+
+    @Test
+    void setHistory_chatClientWithConfiguredMemory_doesNotWarn() {
+        var chatMemory = MessageWindowChatMemory.builder().build();
+        var chatClientProvider = new SpringAILLMProvider(ChatClient
+                .builder(mockChatModel)
+                .defaultAdvisors(a -> a
+                        .advisors(MessageChatMemoryAdvisor.builder(chatMemory)
+                                .build())
+                        .param(ChatMemory.CONVERSATION_ID, "conv-1"))
+                .build());
+
+        chatClientProvider.setHistory(List
+                .of(new ChatMessage(ChatMessage.Role.USER, "Hi", null, null)),
+                Collections.emptyMap());
+
+        Assertions.assertEquals(0, warningCount(""));
+    }
+
+    private long warningCount(String phrase) {
+        return logger.getLoggingEvents().stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .filter(event -> event.getMessage().contains(phrase)).count();
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1038,6 +1038,43 @@ class SpringAILLMProviderTest {
         Assertions.assertEquals(1, debugCount("cannot be inspected"));
     }
 
+    @Test
+    void setHistory_chatClientRejectingPrompt_doesNotThrowAndDoesNotWarn() {
+        var chatClientProvider = new SpringAILLMProvider(
+                clientRejectingPrompt());
+
+        Assertions
+                .assertDoesNotThrow(
+                        () -> chatClientProvider.setHistory(
+                                List.of(new ChatMessage(ChatMessage.Role.USER,
+                                        "Hi", null, null)),
+                                Collections.emptyMap()));
+
+        Assertions.assertEquals(0, warningCount(""));
+        Assertions.assertEquals(1,
+                debugCount("provider was created with a ChatClient"));
+        Assertions.assertEquals(1,
+                debugCount("did not accept a bare prompt()"));
+        Assertions.assertEquals(1, debugCount(""),
+                "Expected the rejected inspection to be reported once");
+    }
+
+    /**
+     * A client that refuses the bare {@code prompt()} the inspection uses. Only
+     * {@code prompt} throws, so logging and equality on the proxy still work.
+     */
+    private static ChatClient clientRejectingPrompt() {
+        return (ChatClient) Proxy.newProxyInstance(
+                ChatClient.class.getClassLoader(),
+                new Class<?>[] { ChatClient.class }, (proxy, method, args) -> {
+                    if (method.getName().equals("prompt")) {
+                        throw new UnsupportedOperationException(
+                                "prompt() requires an explicit prompt");
+                    }
+                    return null;
+                });
+    }
+
     /**
      * Wraps a client so that its request spec is no longer Spring AI's own
      * implementation, which is how an application-provided ChatClient looks to

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -36,7 +36,10 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -913,13 +916,70 @@ class SpringAILLMProviderTest {
     }
 
     @Test
-    void setHistory_withChatClientConstructor_throwsUnsupportedOperationException() {
+    void setHistory_withChatClientConstructor_isNoOp() {
         var chatClient = ChatClient.builder(mockChatModel).build();
         var chatClientProvider = new SpringAILLMProvider(chatClient);
-        var history = new ArrayList<ChatMessage>();
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> chatClientProvider.setHistory(history,
+        chatClientProvider.setStreaming(false);
+        var history = List.of(
+                new ChatMessage(ChatMessage.Role.USER, "Old message", null,
+                        null),
+                new ChatMessage(ChatMessage.Role.ASSISTANT, "Old answer", null,
+                        null));
+
+        Assertions.assertDoesNotThrow(() -> chatClientProvider
+                .setHistory(history, Collections.emptyMap()));
+
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(mockSimpleChatResponse("Response"));
+        chatClientProvider.stream(createSimpleRequest("New question"))
+                .blockFirst();
+
+        var captor = ArgumentCaptor.forClass(Prompt.class);
+        Mockito.verify(mockChatModel).call(captor.capture());
+        var messages = captor.getValue().getInstructions();
+        Assertions.assertFalse(messages.stream()
+                .anyMatch(msg -> Objects.equals(msg.getText(), "Old message")));
+    }
+
+    @Test
+    void chatClientConstructor_withPreloadedChatMemory_sendsHistoryToModel() {
+        var chatMemory = MessageWindowChatMemory.builder().build();
+        chatMemory.add("conv-1", List.of(new UserMessage("Old message"),
+                new AssistantMessage("Old answer")));
+        var chatClient = ChatClient.builder(mockChatModel)
+                .defaultAdvisors(a -> a
+                        .advisors(MessageChatMemoryAdvisor.builder(chatMemory)
+                                .build())
+                        .param(ChatMemory.CONVERSATION_ID, "conv-1"))
+                .build();
+        var chatClientProvider = new SpringAILLMProvider(chatClient);
+        chatClientProvider.setStreaming(false);
+
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(mockSimpleChatResponse("Response"));
+        chatClientProvider.stream(createSimpleRequest("New question"))
+                .blockFirst();
+
+        var captor = ArgumentCaptor.forClass(Prompt.class);
+        Mockito.verify(mockChatModel).call(captor.capture());
+        var messages = captor.getValue().getInstructions();
+        Assertions.assertTrue(messages.stream()
+                .anyMatch(msg -> Objects.equals(msg.getText(), "Old message")));
+        Assertions.assertTrue(messages.stream()
+                .anyMatch(msg -> Objects.equals(msg.getText(), "Old answer")));
+        Assertions.assertTrue(messages.stream().anyMatch(
+                msg -> Objects.equals(msg.getText(), "New question")));
+    }
+
+    @Test
+    void setHistory_withChatClientConstructor_nullHistoryStillThrows() {
+        var chatClient = ChatClient.builder(mockChatModel).build();
+        var chatClientProvider = new SpringAILLMProvider(chatClient);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> chatClientProvider.setHistory(null,
                         Collections.emptyMap()));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> chatClientProvider.setHistory(List.of(), null));
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.ai.provider;
 
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -982,6 +983,8 @@ class SpringAILLMProviderTest {
                 Collections.emptyMap());
 
         Assertions.assertEquals(1, warningCount("no chat memory advisor"));
+        Assertions.assertEquals(1, warningCount(""),
+                "Expected the missing-advisor warning to be the only one");
     }
 
     @Test
@@ -998,6 +1001,8 @@ class SpringAILLMProviderTest {
                 Collections.emptyMap());
 
         Assertions.assertEquals(1, warningCount("conversation to read"));
+        Assertions.assertEquals(0, debugCount("Skipping history restoration"),
+                "Expected the warning to replace the debug line, not precede it");
     }
 
     @Test
@@ -1018,9 +1023,58 @@ class SpringAILLMProviderTest {
         Assertions.assertEquals(0, warningCount(""));
     }
 
+    @Test
+    void setHistory_chatClientNotInspectable_logsDebugOnly() {
+        var chatClientProvider = new SpringAILLMProvider(
+                uninspectableClient(ChatClient.builder(mockChatModel).build()));
+
+        chatClientProvider.setHistory(List
+                .of(new ChatMessage(ChatMessage.Role.USER, "Hi", null, null)),
+                Collections.emptyMap());
+
+        Assertions.assertEquals(0, warningCount(""));
+        Assertions.assertEquals(1,
+                debugCount("provider was created with a ChatClient"));
+        Assertions.assertEquals(1, debugCount("cannot be inspected"));
+    }
+
+    /**
+     * Wraps a client so that its request spec is no longer Spring AI's own
+     * implementation, which is how an application-provided ChatClient looks to
+     * the provider. The spec has too many methods to delegate by hand, so a
+     * proxy stands in for a hand-written implementation.
+     */
+    private static ChatClient uninspectableClient(ChatClient delegate) {
+        return (ChatClient) Proxy.newProxyInstance(
+                ChatClient.class.getClassLoader(),
+                new Class<?>[] { ChatClient.class }, (proxy, method, args) -> {
+                    var result = method.invoke(delegate, args);
+                    if (result instanceof ChatClient.ChatClientRequestSpec spec) {
+                        return uninspectableSpec(spec);
+                    }
+                    return result;
+                });
+    }
+
+    private static ChatClient.ChatClientRequestSpec uninspectableSpec(
+            ChatClient.ChatClientRequestSpec delegate) {
+        return (ChatClient.ChatClientRequestSpec) Proxy.newProxyInstance(
+                ChatClient.class.getClassLoader(),
+                new Class<?>[] { ChatClient.ChatClientRequestSpec.class },
+                (proxy, method, args) -> method.invoke(delegate, args));
+    }
+
+    private long debugCount(String phrase) {
+        return countEvents(Level.DEBUG, phrase);
+    }
+
     private long warningCount(String phrase) {
+        return countEvents(Level.WARN, phrase);
+    }
+
+    private long countEvents(Level level, String phrase) {
         return logger.getLoggingEvents().stream()
-                .filter(event -> event.getLevel() == Level.WARN)
+                .filter(event -> event.getLevel() == level)
                 .filter(event -> event.getMessage().contains(phrase)).count();
     }
 


### PR DESCRIPTION
## Description

The `ChatClient` constructor exists for applications that need more control than the `ChatModel` one gives — their own chat memory, advisors, or model configuration. Restoring a saved conversation was refused on exactly that path, so an application could have its own client or its conversation history, but not both.

- `SpringAILLMProvider.setHistory(List, Map)` no longer throws `UnsupportedOperationException` when the provider was created with the `ChatClient` constructor. The application owns the chat memory on that path and loads it before passing the client in, so the call returns instead of aborting.
- Previously the throw failed `AIOrchestrator.Builder.withHistory(List, Map)` and `reconnect(LLMProvider)` outright, so the message list, the attachment id mappings and the `getHistory()` snapshot were left unrestored as well — none of which depend on the provider.
- Added a warning when the given `ChatClient` cannot hold the conversation being restored: either it carries no chat memory advisor, or its memory advisor has no default `ChatMemory.CONVERSATION_ID` parameter, which makes every prompt fail inside the advisor.
- Read through `ChatClient.prompt()` and the public getters on `DefaultChatClientRequestSpec`; a client that is not Spring AI's own implementation is left alone, since it may carry the conversation its own way.
- Corrected the `withHistory`, `reconnect` and `Reconnector.apply` Javadoc, which stated that conversation history is always replayed onto the new provider.
- Added tests for the no-op restore, a preloaded `ChatMemory` reaching the model, both warnings, the uninspectable-client branch, and that neither warning falls through into a second log line.

## Type of change

- Feature/bugfix