### PR TITLE
test: stub VaadinContext in MockUIExtension

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -45,8 +44,6 @@ import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.tests.MockUIExtension;
 
 import tools.jackson.databind.JsonNode;
@@ -778,7 +775,6 @@ class FillFormToolTest {
         // enough — some rules only make sense across multiple fields (e.g.
         // "if format=Lightning, length<=10"). The rejection is keyed on a
         // sentinel id since the rule isn't bound to one specific field.
-        stubVaadinContext();
         var formatField = new LabeledStringField();
         var lengthField = new IntField();
         var binder = new Binder<>(TwoFieldBean.class);
@@ -827,7 +823,6 @@ class FillFormToolTest {
         // bean-level read). A field's binding-level validation status handler
         // is exactly what the binder calls to light up that field, so a
         // handler that never fires proves the field was not marked.
-        stubVaadinContext();
         var formatField = new LabeledStringField();
         var lengthField = new IntField();
         var untouchedField = new LabeledStringField();
@@ -875,7 +870,6 @@ class FillFormToolTest {
     void fillForm_binderLevelCrossFieldValidatorPassDoesNotEmitRejection() {
         // Symmetric guard: when the cross-field validator passes, no sentinel
         // rejection appears in the response.
-        stubVaadinContext();
         var formatField = new LabeledStringField();
         var lengthField = new IntField();
         var binder = new Binder<>(TwoFieldBean.class);
@@ -1064,7 +1058,6 @@ class FillFormToolTest {
         // post-write pass: beanErrors must swallow the throw and return an
         // empty (never null) list so doFill can still format a response for
         // the rest of the turn.
-        stubVaadinContext();
         var field = new LabeledStringField();
         var binder = new Binder<>(TwoFieldBean.class);
         binder.forField(field).bind("format");
@@ -2038,27 +2031,6 @@ class FillFormToolTest {
         var controller = new FormAIController(form, binder);
         controller.onRequest();
         return controller;
-    }
-
-    /**
-     * Stubs {@code service.getContext()} and the
-     * {@link ApplicationConfiguration} attribute on the
-     * {@link MockUIExtension}'s mocked {@code VaadinService} so
-     * {@code Binder.setBean(...)} can resolve its I18N / production-mode
-     * lookups without tripping over Mockito's default {@code null} return. Only
-     * the cross-field-validator tests that call {@code setBean} need this.
-     */
-    private void stubVaadinContext() {
-        var context = Mockito.mock(VaadinContext.class);
-        var appConfig = Mockito.mock(ApplicationConfiguration.class);
-        Mockito.when(appConfig.isProductionMode()).thenReturn(false);
-        // ApplicationConfiguration.get(context) uses the (Class, Supplier)
-        // getAttribute overload internally — match that exact shape, otherwise
-        // the mock returns null and DefaultBindingExceptionHandler NPEs.
-        Mockito.when(context.getAttribute(
-                ArgumentMatchers.eq(ApplicationConfiguration.class),
-                ArgumentMatchers.any())).thenReturn(appConfig);
-        Mockito.when(ui.getService().getContext()).thenReturn(context);
     }
 
     private static JsonNode payload(HasValue<?, ?> field, String jsonValue) {

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/BoardTest.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/BoardTest.java
@@ -99,7 +99,7 @@ class BoardTest {
 
     @Test
     void redrawCallsRedraw() throws Exception {
-        UI ui = new UI();
+        UI ui = FunctionCallerTest.createUI();
         Board board = new Board();
         ui.add(board);
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/RowTest.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/RowTest.java
@@ -158,7 +158,7 @@ class RowTest {
 
     @Test
     void redrawCallsRedraw() throws Exception {
-        UI ui = new UI();
+        UI ui = FunctionCallerTest.createUI();
         Board board = new Board();
         ui.add(board);
 

--- a/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/internal/FunctionCallerTest.java
+++ b/vaadin-board-flow-parent/vaadin-board-flow/src/test/java/com/vaadin/flow/component/board/internal/FunctionCallerTest.java
@@ -31,7 +31,7 @@ public class FunctionCallerTest {
         FunctionCaller.callOnceOnClientReponse(html, "foo");
         FunctionCaller.callOnceOnClientReponse(html, "foo");
 
-        UI ui = new UI();
+        UI ui = createUI();
         ui.add(html);
 
         assertPendingInvocations(ui, "return $0.foo()");
@@ -40,7 +40,7 @@ public class FunctionCallerTest {
     @Test
     void callsFunctionAfterAttach_invokedOnce() throws Exception {
         Html html = new Html("<div>foo</div>");
-        UI ui = new UI();
+        UI ui = createUI();
         ui.add(html);
         FunctionCaller.callOnceOnClientReponse(html, "foo");
         FunctionCaller.callOnceOnClientReponse(html, "foo");
@@ -55,7 +55,7 @@ public class FunctionCallerTest {
         Html html = new Html("<div>foo</div>");
         FunctionCaller.callOnceOnClientReponse(html, "foo");
         FunctionCaller.callOnceOnClientReponse(html, "foo");
-        UI ui = new UI();
+        UI ui = createUI();
         ui.add(html);
         FunctionCaller.callOnceOnClientReponse(html, "foo");
         FunctionCaller.callOnceOnClientReponse(html, "foo");
@@ -67,7 +67,7 @@ public class FunctionCallerTest {
     void trackingPropertyRemoved() throws Exception {
         Html html = new Html("<div>foo</div>");
         FunctionCaller.callOnceOnClientReponse(html, "foo");
-        UI ui = new UI();
+        UI ui = createUI();
         ui.add(html);
 
         String trackingProperty = "CALLONCE_foo";
@@ -76,11 +76,21 @@ public class FunctionCallerTest {
         Assertions.assertFalse(html.getElement().hasProperty(trackingProperty));
     }
 
+    /**
+     * Creates a UI with a mocked session. Scheduling a JavaScript invocation on
+     * an attached element requires the owning UI to have a session.
+     *
+     * @return the UI
+     */
+    public static UI createUI() {
+        UI ui = new UI();
+        ui.getInternals().setSession(Mockito.mock(VaadinSession.class));
+        return ui;
+    }
+
     public static void assertPendingInvocations(UI ui, String expectedJS)
             throws Exception {
         UIInternals internals = ui.getInternals();
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        internals.setSession(session);
         internals.getStateTree().runExecutionsBeforeClientResponse();
         Method method = UIInternals.class
                 .getDeclaredMethod("getPendingJavaScriptInvocations");

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUIExtension.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUIExtension.java
@@ -25,6 +25,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -32,8 +33,10 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 /**
  * JUnit extension to set up a UI and VaadinSession for testing.
@@ -52,6 +55,7 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
     private UI ui;
     private VaadinSession session;
     private VaadinService service;
+    private VaadinContext context;
 
     @Override
     public void beforeEach(ExtensionContext context) {
@@ -76,6 +80,20 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
         Mockito.when(deploymentConfig.isProductionMode()).thenReturn(false);
         Mockito.when(service.getDeploymentConfiguration())
                 .thenReturn(deploymentConfig);
+        context = Mockito.mock(VaadinContext.class);
+        var applicationConfiguration = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(applicationConfiguration.isProductionMode())
+                .thenReturn(false);
+        // ApplicationConfiguration.get(context) reads the configuration
+        // through the (Class, Supplier) getAttribute overload — match that
+        // exact shape, otherwise the mock returns null and every caller
+        // resolving the configuration (Binder validation, session
+        // serialization) fails with a NullPointerException.
+        Mockito.when(context.getAttribute(
+                ArgumentMatchers.eq(ApplicationConfiguration.class),
+                ArgumentMatchers.any())).thenReturn(applicationConfiguration);
+        Mockito.when(service.getContext()).thenReturn(context);
 
         session = Mockito.spy(new AlwaysLockedVaadinSession(service));
 
@@ -144,6 +162,20 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
      */
     public VaadinService getService() {
         return service;
+    }
+
+    /**
+     * Get the VaadinContext instance that the mocked {@link VaadinService}
+     * returns.
+     * <p>
+     * Note that this returns a Mockito mock, so it supports stubbing and
+     * verification. An {@link ApplicationConfiguration} attribute is stubbed on
+     * it already.
+     *
+     * @return the VaadinContext instance
+     */
+    public VaadinContext getContext() {
+        return context;
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUIExtension.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-test-util/src/main/java/com/vaadin/tests/MockUIExtension.java
@@ -25,7 +25,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -55,7 +54,7 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
     private UI ui;
     private VaadinSession session;
     private VaadinService service;
-    private VaadinContext context;
+    private VaadinContext vaadinContext;
 
     @Override
     public void beforeEach(ExtensionContext context) {
@@ -80,20 +79,27 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
         Mockito.when(deploymentConfig.isProductionMode()).thenReturn(false);
         Mockito.when(service.getDeploymentConfiguration())
                 .thenReturn(deploymentConfig);
-        context = Mockito.mock(VaadinContext.class);
+        vaadinContext = Mockito.mock(VaadinContext.class);
         var applicationConfiguration = Mockito
                 .mock(ApplicationConfiguration.class);
+        // Derive from the deployment configuration so a test that re-stubs
+        // production mode there gets a consistent answer on both lookup
+        // paths.
         Mockito.when(applicationConfiguration.isProductionMode())
-                .thenReturn(false);
-        // ApplicationConfiguration.get(context) reads the configuration
-        // through the (Class, Supplier) getAttribute overload — match that
-        // exact shape, otherwise the mock returns null and every caller
-        // resolving the configuration (Binder validation, session
-        // serialization) fails with a NullPointerException.
-        Mockito.when(context.getAttribute(
-                ArgumentMatchers.eq(ApplicationConfiguration.class),
-                ArgumentMatchers.any())).thenReturn(applicationConfiguration);
-        Mockito.when(service.getContext()).thenReturn(context);
+                .thenAnswer(query -> deploymentConfig.isProductionMode());
+        // Mockito does not run real default methods on mocks, so the
+        // delegating one-arg getAttribute(Class) overload must be stubbed
+        // separately from the two-arg one that
+        // ApplicationConfiguration.get(context) calls. An unstubbed overload
+        // returns null and every caller resolving the configuration (Binder
+        // validation, session serialization) fails with a
+        // NullPointerException.
+        Mockito.when(vaadinContext.getAttribute(
+                Mockito.eq(ApplicationConfiguration.class), Mockito.any()))
+                .thenReturn(applicationConfiguration);
+        Mockito.when(vaadinContext.getAttribute(ApplicationConfiguration.class))
+                .thenReturn(applicationConfiguration);
+        Mockito.when(service.getContext()).thenReturn(vaadinContext);
 
         session = Mockito.spy(new AlwaysLockedVaadinSession(service));
 
@@ -175,7 +181,7 @@ public class MockUIExtension implements BeforeEachCallback, AfterEachCallback {
      * @return the VaadinContext instance
      */
     public VaadinContext getContext() {
-        return context;
+        return vaadinContext;
     }
 
     /**

--- a/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
+++ b/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -30,6 +31,7 @@ import com.vaadin.flow.data.provider.KeyMapper;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.server.VaadinSession;
 
 import tools.jackson.databind.node.ObjectNode;
 
@@ -68,6 +70,9 @@ class ComponentRendererTest {
     void componentRenderer_parentAttachedBeforeChild() {
         UI ui = new TestUI();
         TestUIInternals internals = (TestUIInternals) ui.getInternals();
+        // Scheduling a JavaScript invocation on an attached element requires
+        // the owning UI to have a session
+        internals.setSession(Mockito.mock(VaadinSession.class));
 
         ComponentRenderer<TestDiv, String> renderer = new ComponentRenderer<>(
                 e -> (new TestDiv()));
@@ -104,6 +109,9 @@ class ComponentRendererTest {
     void componentRenderer_childAttachedBeforeParent() {
         UI ui = new TestUI();
         TestUIInternals internals = (TestUIInternals) ui.getInternals();
+        // Scheduling a JavaScript invocation on an attached element requires
+        // the owning UI to have a session
+        internals.setSession(Mockito.mock(VaadinSession.class));
 
         ComponentRenderer<TestDiv, String> renderer = new ComponentRenderer<>(
                 e -> (new TestDiv()));


### PR DESCRIPTION
## Description

- Stubbed `VaadinService.getContext()` in `MockUIExtension` to return a mocked `VaadinContext` with an `ApplicationConfiguration` attribute, matching the contract that a real service always has a non-null context
  - Callers that resolve `ApplicationConfiguration` through the mocked service — `Binder` validation and `VaadinSession` serialization — got a null context and failed with a `NullPointerException`. With the latest Flow snapshot this broke `AIExtensionsSerializableTest`, because a component graph can now reach the session
- Added a `getContext()` accessor so tests can stub or verify the context
- Removed the local `stubVaadinContext()` helper from `FillFormToolTest`, which worked around the same gap for the `Binder` case

## Type of change

- Tests