### PR TITLE
feat: add ToolException for LLM-safe tool errors (#9957) (CP: 25.3)

### DIFF
--- a/guidelines/ai-components.md
+++ b/guidelines/ai-components.md
@@ -106,10 +106,17 @@ The group has no `-testbench` module and, apart from `FormFieldMarker`'s
   the turn, but stage the result and apply it once in `onResponse(null)`;
   `onResponse(error)` discards the pending state and keeps the last good
   render.
-- Error hygiene toward the model: forward only deliberately-safe validation
-  messages verbatim; replace any other exception with a generic string so
-  SQL, schema names, or paths never leak. Tool failures are returned as
-  strings to the model, never thrown.
+- Error hygiene toward the model: only the message of a
+  `ToolException` (public, in `com.vaadin.flow.component.ai.provider`) is
+  forwarded verbatim — throw it, from built-in tool code or an application's
+  `DatabaseProvider`/`ToolSpec`, only with deliberately-safe text. Any other
+  exception is caught, logged, and replaced with a generic string so SQL,
+  schema names, or paths never leak. Tool failures are returned as strings
+  to the model, never thrown. This contract covers only framework-agnostic
+  `ToolSpec` tools; vendor-annotated tools (LangChain4j/Spring AI `@Tool`)
+  are executed by the vendor framework, whose default error handling relays
+  the raw message of any exception to the model — they are deliberately out
+  of scope, so route error-sensitive tools through `ToolSpec`.
 - Never send secrets to the LLM — `FormAIController` auto-ignores password
   fields; preserve that property for new field handling.
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProvider.java
@@ -122,6 +122,13 @@ public interface DatabaseProvider extends Serializable {
      * <p>
      * Implementations should ensure that only read-only queries are executed.
      * </p>
+     * <p>
+     * When a query fails (e.g. references an unknown column), throw a
+     * {@link ToolException} whose message describes the problem in terms safe
+     * to expose — the message is passed to the LLM so it can correct the query
+     * instead of retrying it unchanged. Any other exception is replaced with a
+     * generic error message before reaching the LLM.
+     * </p>
      *
      * @param sql
      *            the SQL query to execute, not {@code null}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -138,6 +138,11 @@ public interface LLMProvider {
          * vendor-specific annotations (e.g., LangChain4j's {@code @Tool},
          * Spring AI's {@code @Tool}) that the provider can introspect and
          * convert to native tool definitions.
+         * <p>
+         * These tools are executed by the vendor framework itself, so its own
+         * error handling decides what reaches the LLM when a tool throws; the
+         * {@link ToolException} contract only applies to the tools returned by
+         * {@link #explicitTools()}.
          *
          * @return array of tool objects, never {@code null} but may be empty
          */
@@ -258,7 +263,10 @@ public interface LLMProvider {
          * Executes the tool with the given arguments.
          * <p>
          * Implementations should return a human-readable result string on
-         * success. On failure, they may throw any runtime exception.
+         * success. On failure, throw a {@link ToolException} to pass its
+         * message to the LLM so it can correct its next attempt; any other
+         * runtime exception is caught, logged, and replaced with a generic
+         * error message so internal details are not leaked.
          * </p>
          * <p>
          * May be invoked from a background thread — with a streaming provider,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -297,9 +297,21 @@ public class LangChain4JLLMProvider implements LLMProvider {
         // Add explicit (framework-agnostic) tools
         for (var tool : explicitTools) {
             toolExecutors.put(tool.getName(), (execReq, memoryId) -> tool
-                    .execute(parseArguments(execReq.arguments())));
+                    .execute(parseExplicitToolArguments(execReq.arguments())));
         }
         return toolExecutors;
+    }
+
+    private static JsonNode parseExplicitToolArguments(String arguments) {
+        try {
+            return parseArguments(arguments);
+        } catch (Exception e) {
+            // The malformed JSON came from the model itself, so the parser
+            // message is safe to relay and lets the model repair its next
+            // attempt.
+            throw new ToolException("invalid JSON arguments: " + e.getMessage(),
+                    e);
+        }
     }
 
     private ToolExecutor getToolExecutor(Object toolObject, Method method) {
@@ -460,8 +472,13 @@ public class LangChain4JLLMProvider implements LLMProvider {
         } else {
             try {
                 result = toolExecutor.execute(toolExecRequest, null);
-            } catch (Exception e) {
+            } catch (ToolException e) {
+                LOGGER.warn("Tool '{}' failed: {}", toolExecRequest.name(),
+                        e.getMessage(), e);
                 result = "Error executing tool: " + e.getMessage();
+            } catch (Exception e) {
+                LOGGER.error("Tool '{}' failed", toolExecRequest.name(), e);
+                result = "Error executing tool.";
             }
         }
         return ToolExecutionResultMessage.from(toolExecRequest, result);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -445,10 +445,27 @@ public class SpringAILLMProvider implements LLMProvider {
 
             @Override
             public String call(String arguments) {
+                JsonNode parsed;
                 try {
-                    return tool.execute(parseArguments(arguments));
+                    parsed = parseArguments(arguments);
                 } catch (Exception e) {
+                    // The malformed JSON came from the model itself, so
+                    // the parser message is safe to relay and lets the
+                    // model repair its next attempt.
+                    LOGGER.warn("Tool '{}' received malformed JSON arguments",
+                            tool.getName(), e);
+                    return "Error executing tool: invalid JSON arguments: "
+                            + e.getMessage();
+                }
+                try {
+                    return tool.execute(parsed);
+                } catch (ToolException e) {
+                    LOGGER.warn("Tool '{}' failed: {}", tool.getName(),
+                            e.getMessage(), e);
                     return "Error executing tool: " + e.getMessage();
+                } catch (Exception e) {
+                    LOGGER.error("Tool '{}' failed", tool.getName(), e);
+                    return "Error executing tool.";
                 }
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ToolException.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ToolException.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.provider;
+
+/**
+ * Signals a tool failure whose message is safe to pass back to the LLM.
+ * <p>
+ * Throw this from tool code — a
+ * {@link LLMProvider.ToolSpec#execute(tools.jackson.databind.JsonNode)
+ * ToolSpec.execute} implementation, a controller callback, or a
+ * {@link DatabaseProvider} — when the LLM should see why the call failed so it
+ * can correct its next attempt instead of retrying blindly. The
+ * {@link #getMessage() message} is forwarded verbatim as the tool's error
+ * output, so you must ensure it is safe to expose: no PII, no internal
+ * identifiers beyond what the LLM already sent, no third-party error text.
+ * <p>
+ * Any other exception thrown from tool code is caught, logged, and replaced
+ * with a generic error message before reaching the LLM, so internal details are
+ * not leaked.
+ * <p>
+ * This contract applies only to tools defined through the framework-agnostic
+ * {@link LLMProvider.ToolSpec} API — the tools registered by
+ * {@link com.vaadin.flow.component.ai.orchestrator.AIController}
+ * implementations and by {@link DatabaseProvider}-backed tools. Tools defined
+ * with vendor-specific annotations (LangChain4j's or Spring AI's {@code @Tool})
+ * are executed by the vendor framework itself, whose own error handling decides
+ * what reaches the LLM — by default both frameworks relay the raw message of
+ * any exception, so neither the verbatim-forwarding nor the generic-replacement
+ * behavior described above applies to them.
+ *
+ * @author Vaadin Ltd
+ * @since 25.3
+ */
+public class ToolException extends RuntimeException {
+
+    /**
+     * Creates a new tool exception.
+     *
+     * @param llmFacingMessage
+     *            the failure message, forwarded verbatim to the LLM
+     */
+    public ToolException(String llmFacingMessage) {
+        super(llmFacingMessage);
+    }
+
+    /**
+     * Creates a new tool exception with a cause. Only the message is forwarded
+     * to the LLM; the cause is available for logging.
+     *
+     * @param llmFacingMessage
+     *            the failure message, forwarded verbatim to the LLM
+     * @param cause
+     *            the underlying cause
+     */
+    public ToolException(String llmFacingMessage, Throwable cause) {
+        super(llmFacingMessage, cause);
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.event.Level;
 
 import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
@@ -1340,6 +1341,104 @@ class LangChain4JLLMProviderTest {
         Assertions.assertTrue(allSucceeded,
                 "Both tool calls should have succeeded, but got: "
                         + toolResults);
+    }
+
+    @Test
+    void stream_withExplicitTool_malformedJsonArguments_relaysParserMessage() {
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "ok");
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool", "not json");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
+        Assertions.assertTrue(toolResults.getFirst().text()
+                .startsWith("Error executing tool: invalid JSON arguments: "));
+    }
+
+    @Test
+    void stream_withExplicitToolThrowingToolException_relaysMessageToModel() {
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    throw new ToolException("Unknown column 'foo'");
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
+        Assertions.assertEquals("Error executing tool: Unknown column 'foo'",
+                toolResults.getFirst().text());
+    }
+
+    @Test
+    void stream_withExplicitToolThrowingUnexpectedException_returnsGenericError() {
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    throw new RuntimeException("internal detail");
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
+        Assertions.assertEquals("Error executing tool.",
+                toolResults.getFirst().text());
+    }
+
+    @Test
+    void stream_withExplicitToolThrowingUnexpectedException_logsError() {
+        var toolFailure = new RuntimeException("internal detail");
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    throw toolFailure;
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        // The generic result hides the failure from the LLM, so the log is
+        // the only place where the actual error is visible.
+        var error = logger.getAllLoggingEvents().stream()
+                .filter(event -> event.getLevel() == Level.ERROR
+                        && event.getThrowable().orElse(null) == toolFailure)
+                .findFirst();
+        Assertions.assertTrue(error.isPresent(),
+                "Expected the tool failure to be logged");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.event.Level;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -1540,6 +1541,78 @@ class SpringAILLMProviderTest {
                 args -> args.isObject() && args.propertyNames().isEmpty());
         Assertions.assertTrue(allEmptyObjects,
                 "Missing arguments should be parsed as an empty object");
+    }
+
+    @Test
+    void stream_withExplicitToolThrowingToolException_relaysMessage() {
+        provider.setStreaming(false);
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    throw new ToolException("Unknown column 'foo'");
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        var result = toolCallbacks.getFirst().call("{}");
+
+        Assertions.assertEquals("Error executing tool: Unknown column 'foo'",
+                result);
+    }
+
+    @Test
+    void stream_withExplicitToolThrowingUnexpectedException_returnsGenericError() {
+        provider.setStreaming(false);
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    throw new RuntimeException("internal detail");
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        var result = toolCallbacks.getFirst().call("{}");
+
+        Assertions.assertEquals("Error executing tool.", result);
+    }
+
+    @Test
+    void stream_withExplicitToolThrowingUnexpectedException_logsError() {
+        provider.setStreaming(false);
+        var toolFailure = new RuntimeException("internal detail");
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    throw toolFailure;
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        toolCallbacks.getFirst().call("{}");
+
+        // The generic result hides the failure from the LLM, so the log is
+        // the only place where the actual error is visible.
+        var error = logger.getAllLoggingEvents().stream()
+                .filter(event -> event.getLevel() == Level.ERROR
+                        && event.getThrowable().orElse(null) == toolFailure)
+                .findFirst();
+        Assertions.assertTrue(error.isPresent(),
+                "Expected the tool failure to be logged");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.DatabaseProviderAITools;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.Configuration;
 import com.vaadin.flow.component.charts.util.ChartSerialization;
@@ -182,21 +183,29 @@ public class ChartAIController implements AIController {
 
             @Override
             public void updateConfiguration(String chartId, String configJson) {
-                // Parse eagerly to validate. If the JSON contains
-                // invalid values, the exception propagates back to the
-                // LLM as an error so it can fix the configuration.
-                ChartConfigurationParser.parse(configJson);
+                // Parse eagerly so an invalid configuration is rejected
+                // within the turn. The configuration is authored by the
+                // model itself, so the parse failure reason is safe to
+                // relay via ToolException, letting the model fix its own
+                // payload instead of retrying it unchanged.
+                try {
+                    ChartConfigurationParser.parse(configJson);
+                } catch (IllegalArgumentException e) {
+                    throw new ToolException(e.getMessage(), e);
+                }
                 ChartEntry.getOrCreate(chart, chartId)
                         .setPendingConfigurationJson(configJson);
             }
 
             @Override
             public void updateData(String chartId, List<String> queries) {
-                // Execute queries eagerly to validate them. If a query
-                // is invalid, the exception propagates back to the LLM
-                // as an error so it can fix the query. Results are
-                // discarded here; they will be re-executed at render
-                // time in ChartRenderer.
+                // Execute queries eagerly so an invalid query is
+                // rejected within the turn. A DatabaseProvider that
+                // throws ToolException gets its message relayed to the
+                // LLM so it can fix the query; any other exception is
+                // replaced with a generic error. Results are discarded
+                // here; they will be re-executed at render time in
+                // ChartRenderer.
                 for (String q : queries) {
                     databaseProvider.executeQuery(q);
                 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ai.extensions.AIExtensionsLicense;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 
 import tools.jackson.databind.JsonNode;
 
@@ -49,6 +50,10 @@ public final class ChartAITools {
     /**
      * Callback interface that chart tool consumers must implement to provide
      * chart state access and mutation operations.
+     * <p>
+     * A {@link ToolException} thrown from a callback relays its message to the
+     * LLM so it can correct its next attempt; any other exception is replaced
+     * with a generic error message.
      */
     public interface Callbacks extends Serializable {
 
@@ -183,18 +188,6 @@ public final class ChartAITools {
     }
 
     /**
-     * Signals a validation failure whose message is safe to pass back to the
-     * LLM. Unexpected runtime exceptions, by contrast, may carry internal
-     * detail (SQL fragments, schema names, file paths) and must be replaced
-     * with a generic message before being returned.
-     */
-    private static final class ValidationException extends RuntimeException {
-        ValidationException(String message) {
-            super(message);
-        }
-    }
-
-    /**
      * Resolves the chart ID from the tool arguments. If {@code chartId} is not
      * provided and there is exactly one chart, that chart's ID is used as the
      * default.
@@ -202,7 +195,7 @@ public final class ChartAITools {
     private static String resolveChartId(JsonNode args, Callbacks callbacks) {
         var ids = callbacks.getChartIds();
         if (ids.isEmpty()) {
-            throw new ValidationException("No charts available.");
+            throw new ToolException("No charts available.");
         }
         if (ids.size() == 1) {
             return ids.iterator().next();
@@ -211,7 +204,7 @@ public final class ChartAITools {
         if (idNode != null && ids.contains(idNode.asString())) {
             return idNode.asString();
         }
-        throw new ValidationException(
+        throw new ToolException(
                 "chartId is required when multiple charts exist. "
                         + "Available chart IDs: " + ids);
     }
@@ -267,7 +260,7 @@ public final class ChartAITools {
                     LOGGER.info("get_chart_state called");
                     String chartId = resolveChartId(arguments, callbacks);
                     return callbacks.getState(chartId);
-                } catch (ValidationException e) {
+                } catch (ToolException e) {
                     LOGGER.warn("get_chart_state validation failed", e);
                     return "Error getting chart state: " + e.getMessage();
                 } catch (Exception e) {
@@ -528,7 +521,7 @@ public final class ChartAITools {
 
                     return "Chart '" + chartId
                             + "' configuration updated. Changes will be applied when the request completes.";
-                } catch (ValidationException e) {
+                } catch (ToolException e) {
                     LOGGER.warn("update_chart_configuration validation failed",
                             e);
                     return "Error updating chart configuration: "
@@ -679,7 +672,7 @@ public final class ChartAITools {
 
                     return "Chart '" + chartId
                             + "' data source updated. Changes will be applied when the request completes.";
-                } catch (ValidationException e) {
+                } catch (ToolException e) {
                     LOGGER.warn("update_chart_data_source validation failed",
                             e);
                     return "Error updating chart data: " + e.getMessage();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.component.ai.form.FormValueConverter.RejectedValueExcepti
 import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.selection.MultiSelect;
 import com.vaadin.flow.internal.JacksonUtils;
@@ -1696,8 +1697,7 @@ public class FormAIController implements AIController {
                 int limit) {
             var hints = hintsById.get(fieldId);
             if (hints == null || hints.valueOptionsQuery == null) {
-                throw new FormAITools.ToolException(
-                        "Unknown field id: " + fieldId);
+                throw new ToolException("Unknown field id: " + fieldId);
             }
             return new ArrayList<>(
                     hints.valueOptionsQuery.apply(filter, limit));

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.internal.JacksonUtils;
 
 import tools.jackson.databind.JsonNode;
@@ -111,22 +112,6 @@ final class FormAITools {
          * result is in sync with the page.
          */
         String executeFill(JsonNode arguments);
-    }
-
-    /**
-     * Thrown by a {@link Callbacks} implementation to surface a curated message
-     * to the LLM. The exception {@link #getMessage() message} is forwarded
-     * verbatim as the tool's error output, so callers must ensure it is safe to
-     * expose: no PII, no internal identifiers other than what the LLM already
-     * sent, no third-party error text. For any uncontrolled failure throw a
-     * regular {@link RuntimeException} instead — the tool will log it and
-     * return a generic error.
-     */
-    public static class ToolException extends RuntimeException {
-
-        public ToolException(String llmFacingMessage) {
-            super(llmFacingMessage);
-        }
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -161,8 +161,11 @@ public class GridAIController implements AIController {
 
             @Override
             public void updateData(String gridId, String query) {
-                // Validate eagerly so invalid SQL propagates back
-                // to the LLM as a tool error it can fix.
+                // Validate eagerly so an invalid query is rejected
+                // within the turn. A DatabaseProvider that throws
+                // ToolException gets its message relayed to the LLM so
+                // it can fix the query; any other exception is replaced
+                // with a generic error.
                 databaseProvider.executeQuery(
                         "SELECT * FROM (" + query + ") AS _v LIMIT 1");
                 GridEntry.getOrCreate(grid, gridId).setPendingQuery(query);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ai.extensions.AIExtensionsLicense;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 
 import tools.jackson.databind.JsonNode;
 
@@ -45,18 +46,6 @@ public final class GridAITools {
     }
 
     /**
-     * Signals a validation failure whose message is safe to pass back to the
-     * LLM. Unexpected runtime exceptions, by contrast, may carry internal
-     * detail (SQL fragments, schema names, file paths) and must be replaced
-     * with a generic message before being returned.
-     */
-    private static final class ValidationException extends RuntimeException {
-        ValidationException(String message) {
-            super(message);
-        }
-    }
-
-    /**
      * Callback interface for grid state access and mutation.
      */
     public interface Callbacks extends Serializable {
@@ -74,7 +63,10 @@ public final class GridAITools {
         /**
          * Handles a SQL query for the given grid. Implementations should
          * validate the query and store it for deferred rendering. Should throw
-         * if the grid is not found or the query is invalid.
+         * if the grid is not found or the query is invalid: a
+         * {@link ToolException} relays its message to the LLM so it can correct
+         * the query, any other exception is replaced with a generic error
+         * message.
          *
          * @param gridId
          *            the grid ID
@@ -105,11 +97,10 @@ public final class GridAITools {
             return ids.iterator().next();
         }
         if (ids.isEmpty()) {
-            throw new ValidationException("No grids available.");
+            throw new ToolException("No grids available.");
         }
-        throw new ValidationException(
-                "gridId is required when multiple grids exist. "
-                        + "Available grid IDs: " + ids);
+        throw new ToolException("gridId is required when multiple grids exist. "
+                + "Available grid IDs: " + ids);
     }
 
     /**
@@ -153,7 +144,7 @@ public final class GridAITools {
                     LOGGER.info("get_grid_state called");
                     var gridId = resolveGridId(arguments, callbacks);
                     return callbacks.getState(gridId);
-                } catch (ValidationException e) {
+                } catch (ToolException e) {
                     LOGGER.warn("get_grid_state validation failed", e);
                     return "Error getting grid state: " + e.getMessage();
                 } catch (Exception e) {
@@ -166,7 +157,8 @@ public final class GridAITools {
 
     /**
      * Creates a tool that updates the grid data with a SQL query. If the
-     * handler throws, the error is returned to the LLM.
+     * handler throws a {@link ToolException}, its message is returned to the
+     * LLM; any other exception is replaced with a generic error.
      *
      * @param callbacks
      *            the callbacks for grid mutation, not {@code null}
@@ -235,7 +227,7 @@ public final class GridAITools {
                     callbacks.updateData(gridId, query);
                     return "Grid '" + gridId
                             + "' data update queued successfully";
-                } catch (ValidationException e) {
+                } catch (ToolException e) {
                     LOGGER.warn("update_grid_data validation failed", e);
                     return "Error updating grid data: " + e.getMessage();
                 } catch (Exception e) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;
@@ -169,6 +170,19 @@ class ChartAIControllerTest {
         }
 
         @Test
+        void updateConfiguration_invalidConfigJson_relaysParseError() {
+            var tool = findTool(controller.getTools(),
+                    "update_chart_configuration");
+
+            String result = tool.execute(
+                    json("{\"configuration\": \"not a json object\"}"));
+            Assertions.assertTrue(
+                    result.contains("Invalid chart configuration JSON"),
+                    "The parse failure reason should reach the model: "
+                            + result);
+        }
+
+        @Test
         void updateData_validatesQueriesEagerly() {
             databaseProvider.throwOnExecute = new RuntimeException("Bad SQL");
 
@@ -179,6 +193,33 @@ class ChartAIControllerTest {
             String result = tool
                     .execute(json("{\"queries\": [\"SELECT invalid\"]}"));
             Assertions.assertTrue(result.contains("Error"));
+        }
+
+        @Test
+        void updateData_providerThrowsToolException_relaysMessage() {
+            databaseProvider.throwOnExecute = new ToolException(
+                    "Unknown column 'foo'");
+
+            var tool = findTool(controller.getTools(),
+                    "update_chart_data_source");
+
+            String result = tool
+                    .execute(json("{\"queries\": [\"SELECT foo\"]}"));
+            Assertions.assertEquals(
+                    "Error updating chart data: Unknown column 'foo'", result);
+        }
+
+        @Test
+        void updateData_providerThrowsUnexpectedException_returnsGenericError() {
+            databaseProvider.throwOnExecute = new RuntimeException(
+                    "internal detail");
+
+            var tool = findTool(controller.getTools(),
+                    "update_chart_data_source");
+
+            String result = tool
+                    .execute(json("{\"queries\": [\"SELECT foo\"]}"));
+            Assertions.assertEquals("Error updating chart data.", result);
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.ai.form.FormTestFields.SingleSelectField;
 import com.vaadin.flow.component.ai.form.FormTestFields.TestField;
 import com.vaadin.flow.component.ai.form.FormTestFields.TimeField;
 import com.vaadin.flow.component.ai.form.FormTestFields.ValidatedField;
+import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.data.binder.Binder;
@@ -1244,9 +1245,8 @@ class FillFormToolTest {
         // message is allowed to leak into the response (callers must scrub
         // it themselves before throwing). Pins the ToolException catch in
         // FormAITools.fillForm.execute().
-        var tool = FormAITools
-                .fillForm(throwingCallbacks(new FormAITools.ToolException(
-                        "field 'foo' is no longer addressable")));
+        var tool = FormAITools.fillForm(throwingCallbacks(
+                new ToolException("field 'foo' is no longer addressable")));
 
         var result = tool.execute(wrappedValues());
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.provider.QuerySortOrder;
@@ -132,6 +133,23 @@ class GridAIControllerTest {
                 .orElseThrow();
         var result = tool.execute(json("{\"query\": \"INVALID\"}"));
         Assertions.assertTrue(result.contains("Error"));
+    }
+
+    @Test
+    void updateDataTool_providerThrowsToolException_relaysMessage() {
+        dbProvider.executeException = new ToolException("Unknown column 'foo'");
+        var tool = findTool("update_grid_data");
+        var result = tool.execute(json("{\"query\": \"SELECT foo FROM t\"}"));
+        Assertions.assertEquals(
+                "Error updating grid data: Unknown column 'foo'", result);
+    }
+
+    @Test
+    void updateDataTool_providerThrowsUnexpectedException_returnsGenericError() {
+        dbProvider.executeException = new RuntimeException("internal detail");
+        var tool = findTool("update_grid_data");
+        var result = tool.execute(json("{\"query\": \"SELECT foo FROM t\"}"));
+        Assertions.assertEquals("Error updating grid data.", result);
     }
 
     @Test
@@ -989,6 +1007,7 @@ class GridAIControllerTest {
         private String schema = "test schema";
         private List<Map<String, Object>> queryResults = List.of();
         private boolean throwOnExecute = false;
+        private RuntimeException executeException;
         private final List<String> executedQueries = new ArrayList<>();
 
         @Override
@@ -999,6 +1018,9 @@ class GridAIControllerTest {
         @Override
         public List<Map<String, Object>> executeQuery(String sql) {
             executedQueries.add(sql);
+            if (executeException != null) {
+                throw executeException;
+            }
             if (throwOnExecute) {
                 throw new RuntimeException("Query execution failed");
             }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIToolsTest.java
@@ -72,6 +72,24 @@ class GridAIToolsTest {
         };
     }
 
+    private static GridAITools.Callbacks noGridCallbacks() {
+        return new GridAITools.Callbacks() {
+            @Override
+            public String getState(String gridId) {
+                return "{\"gridId\":\"" + gridId + "\",\"status\":\"empty\"}";
+            }
+
+            @Override
+            public void updateData(String gridId, String query) {
+            }
+
+            @Override
+            public Set<String> getGridIds() {
+                return Set.of();
+            }
+        };
+    }
+
     // --- getGridState ---
 
     @Test
@@ -116,6 +134,14 @@ class GridAIToolsTest {
         var result = tool.execute(json("{}"));
         Assertions.assertTrue(result.contains("Error"));
         Assertions.assertTrue(result.contains("gridId is required"));
+    }
+
+    @Test
+    void getGridState_noGrids_returnsError() {
+        var tool = GridAITools.getGridState(noGridCallbacks());
+        var result = tool.execute(json("{}"));
+        Assertions.assertTrue(result.contains("Error"));
+        Assertions.assertTrue(result.contains("No grids available"));
     }
 
     @Test


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #9957 to branch 25.3.

---

> ## Description
>
> Part of https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=231354372
>
> Tool failures were replaced with a generic message, so the model could not learn why a call failed and was observed resubmitting the same query dozens of times in one turn.
>
> - Added public `ToolException` to the provider package; its message is relayed verbatim to the LLM, while any other exception is logged and replaced with a generic error
> - Grid, chart and form tools now use `ToolException` instead of their private validation exception types
> - Both providers apply the same rule to application-supplied `ToolSpec` failures, which previously echoed every exception message to the model
> - Malformed JSON arguments are still relayed, since the model produced them
> - Documented the opt-in on `DatabaseProvider.executeQuery`, `ToolSpec.execute` and the tool `Callbacks` interfaces, and added tests for the relayed and generic paths
>
> ## Type of change
>
> - Feature
