### PR TITLE
refactor: stop mandating get_grid_state on every request

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -118,12 +118,16 @@ public class GridAIController implements AIController {
 
             WORKFLOW:
             Complete the user's request in a SINGLE response by calling all needed tools.
-            1. Call get_grid_state() to see what's already configured
-            2. Call get_database_schema() to learn the exact table and column names
-            3. Call update_grid_data() with a SQL SELECT query using only columns from the schema
+            1. Call get_database_schema() to learn the exact table and column names
+            2. Call update_grid_data() with a SQL SELECT query using only columns from the schema
+
+            Call get_grid_state() only when the request changes what is already
+            shown (for example "sort by date" or "add a column"). Write the new
+            query from the schema rather than editing the previous one, so every
+            column keeps the table qualifier the schema gives it.
 
             IMPORTANT:
-            - Call get_grid_state() and update_grid_data() in the SAME response
+            - Always finish the response with update_grid_data()
             - Do NOT stop after get_grid_state()
             """;
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -183,16 +183,18 @@ public final class GridAITools {
                         - ALWAYS give every column a human-readable AS alias
                         - Do NOT use LIMIT or OFFSET — the grid handles pagination
                         - Use double quotes for aliases with spaces or dots
-                        Example: SELECT name AS "Employee Name", salary AS "Salary" FROM employees
+                        - Use ONLY tables and columns from get_database_schema()
+                        Shape (placeholders, not real names):
+                        SELECT ColumnA AS "Readable A", ColumnB AS "Readable B" FROM TableName
 
                         COLUMN GROUPING (only when the user asks for grouping):
                         When the user mentions "grouped under X" in their request:
                         1. Select ONLY the columns mentioned for grouping
                         2. Alias each column as "X.ReadableName" (with the group prefix and a dot)
                         3. Do NOT include columns that are not part of a group
-                        Example request: "product and category grouped under Product"
-                        Correct SQL: SELECT product AS "Product.Name", category AS "Product.Category" FROM sales
-                        Result: A "Product" header spanning both columns.
+                        Example request: "ColumnA and ColumnB grouped under GroupName"
+                        Correct SQL: SELECT ColumnA AS "GroupName.Readable A", ColumnB AS "GroupName.Readable B" FROM TableName
+                        Result: A "GroupName" header spanning both columns.
                         Do NOT use "X.Name" format unless the user asks for grouping.
                         """;
             }


### PR DESCRIPTION
## Summary
- `get_grid_state` returned nothing on a first question and the previous query on a follow-up, which invited the model to edit that query rather than write a new one — that is how a column keeps its name but loses its table qualifier, producing SQL that reads correctly and is wrong. It is now called only when the request changes what is already shown, with the new query written from the schema.
- The SQL examples selected from invented tables (`employees`, `sales`), which contradicts the instruction to use only tables from the schema the model was given. They are now unmistakably placeholders.