### PR TITLE
fix: use the replace-in-file named export in updateNpmVer

### DIFF
--- a/scripts/updateNpmVer.js
+++ b/scripts/updateNpmVer.js
@@ -11,7 +11,6 @@
 const fs = require('fs');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
-const replace = require('replace-in-file');
 const {getAnnotations, computeVersionToUpdate} = require('./lib/versions.js');
 
 let exclude=[];
@@ -26,7 +25,8 @@ async function updateFiles(moduleData){
         to: updatedNpm,
       };
       try {
-        const results = await replace(options)
+        const { replaceInFile } = await import('replace-in-file');
+        const results = await replaceInFile(options)
         console.log('\x1b[33m', "Updated "+ moduleData.package + " from version " +
                     moduleData.version + " to " + moduleData.updatedVersion);
       }


### PR DESCRIPTION
## Summary

* `updateNpmVer.js` called `replace-in-file` as a default export, which version 8 no longer provides, so `updateFiles` threw `TypeError: replace is not a function` on all 152 annotations.
* Every failure is caught per component, so the nightly job ended with "nothing to commit" and a green status while updating nothing.
* Aligns the branch with main and 25.2, which already use `await import('replace-in-file')`.

## Context

The 24.10 `@NpmPackage` annotations have been stuck at 24.10.4 while platform moved to 24.10.5, which keeps the version consistency test red on every platform PR of that branch. The same code is still in place on 23.6, 23.7, 24.9, 25.0 and 25.1, where it will surface the next time web components ship a patch on those lines.