### PR TITLE
fix: make connector Vaadin.Flow type declarations mergeable

### DIFF
--- a/guidelines/component-implementation.md
+++ b/guidelines/component-implementation.md
@@ -80,6 +80,23 @@ module and add a matching `!...tsconfig.json` negation to the root
 `.d.ts` files that ship next to the connector. `node scripts/wtr.js {component}`
 type-checks the connector against the tsconfig, in CI as well.
 
+Declare the connector's `window.Vaadin.Flow` members by merging into the
+shared global `VaadinFlow` interface — never as an object literal type on the
+`Flow` property, which conflicts with other modules' declarations when an
+application type-checks connectors from several modules in one program:
+
+```typescript
+declare global {
+  interface Vaadin {
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    exampleConnector: { initLazy(element: FlowExample): void };
+  }
+}
+```
+
 Use the `initLazy` + `$connector`-guard pattern, and initialise it in the
 attach handler:
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-types.d.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-types.d.ts
@@ -53,11 +53,15 @@ export type FlowComboBox = ComboBox<Item> & FlowComboBoxInternals;
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connector
+  // with the Flow namespace used by the connector. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
     ComboBoxPlaceholder: typeof ComboBoxPlaceholder;
-    Flow: {
-      comboBoxConnector: { initLazy(comboBox: FlowComboBox): void };
-    };
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    comboBoxConnector: { initLazy(comboBox: FlowComboBox): void };
   }
 }

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/vaadin-context-menu/contextMenuConnector.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/vaadin-context-menu/contextMenuConnector.ts
@@ -19,13 +19,13 @@ import type {
   FlowContextMenuItemComponent
 } from './vaadin-context-menu-types.js';
 
-function getContainer(appId: string, nodeId: number): Element | undefined {
+function getContainer(appId: string, nodeId: number): Element | null {
   try {
     return window.Vaadin.Flow.clients[appId].getByNodeId(nodeId);
   } catch (error) {
     console.error('Could not get node %s from app %s', nodeId, appId);
     console.error(error);
-    return undefined;
+    return null;
   }
 }
 

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/vaadin-context-menu/vaadin-context-menu-types.d.ts
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/resources/META-INF/frontend/vaadin-context-menu/vaadin-context-menu-types.d.ts
@@ -70,9 +70,9 @@ export interface ContextMenuConnectorApi {
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connector. The namespace is a separate
-  // interface so that a module importing this one, such as the menu bar, can
-  // add its own members to it.
+  // with the Flow namespace used by the connector. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
     Flow: VaadinFlow;
   }
@@ -80,6 +80,11 @@ declare global {
   interface VaadinFlow {
     contextMenuConnector: ContextMenuConnectorApi;
     /** The store of Flow DOM nodes, keyed by app id */
-    clients: Record<string, { getByNodeId(nodeId: number): Element | undefined }>;
+    clients: Record<string, VaadinFlowClient>;
+  }
+
+  /** The Flow client of an app instance on the page */
+  interface VaadinFlowClient {
+    getByNodeId(nodeId: number): HTMLElement | null;
   }
 }

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/frontend/vaadin-date-picker/vaadin-date-picker-types.d.ts
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/resources/META-INF/frontend/vaadin-date-picker/vaadin-date-picker-types.d.ts
@@ -59,10 +59,14 @@ export type FlowDatePicker = Omit<DatePicker, 'i18n' | 'isDateDisabled'> & FlowD
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connector
+  // with the Flow namespace used by the connector. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
-    Flow: {
-      datepickerConnector: { initLazy(datePicker: FlowDatePicker): void };
-    };
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    datepickerConnector: { initLazy(datePicker: FlowDatePicker): void };
   }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
@@ -120,12 +120,16 @@ export type FlowTreeGrid = FlowGrid & FlowTreeGridInternals;
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connectors
+  // with the Flow namespace used by the connectors. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
-    Flow: {
-      gridConnector: { initLazy(grid: FlowGrid): void };
-      treeGridConnector: { initLazy(grid: FlowTreeGrid): void };
-    };
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    gridConnector: { initLazy(grid: FlowGrid): void };
+    treeGridConnector: { initLazy(grid: FlowTreeGrid): void };
   }
 }
 

--- a/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/frontend/vaadin-map/vaadin-map-types.d.ts
+++ b/vaadin-map-flow-parent/vaadin-map-flow/src/main/resources/META-INF/frontend/vaadin-map/vaadin-map-types.d.ts
@@ -42,14 +42,18 @@ export interface MapFeatureInfo {
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connector
+  // with the Flow namespace used by the connector. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
-    Flow: {
-      mapConnector: {
-        init(mapElement: FlowMap): void;
-        setUserProjection(projection: string): void;
-        defineProjection(projection: string, wksDefinition: string): void;
-      };
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    mapConnector: {
+      init(mapElement: FlowMap): void;
+      setUserProjection(projection: string): void;
+      defineProjection(projection: string, wksDefinition: string): void;
     };
   }
 }

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/vaadin-time-picker-types.d.ts
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/resources/META-INF/frontend/vaadin-time-picker/vaadin-time-picker-types.d.ts
@@ -37,10 +37,14 @@ export type FlowTimePicker = Omit<TimePicker, 'i18n'> & FlowTimePickerInternals;
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connector
+  // with the Flow namespace used by the connector. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
-    Flow: {
-      timepickerConnector: { initLazy(timePicker: FlowTimePicker): void };
-    };
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    timepickerConnector: { initLazy(timePicker: FlowTimePicker): void };
   }
 }

--- a/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/frontend/vaadin-virtual-list/vaadin-virtual-list-types.d.ts
+++ b/vaadin-virtual-list-flow-parent/vaadin-virtual-list-flow/src/main/resources/META-INF/frontend/vaadin-virtual-list/vaadin-virtual-list-types.d.ts
@@ -32,11 +32,6 @@ export interface VirtualListServer {
   setViewportRange(startIndex: number, size: number): void;
 }
 
-/** The Flow client of an app instance on the page */
-export interface FlowClient {
-  getByNodeId(nodeId: number): HTMLElement;
-}
-
 /** A root element the renderer renders an item into, extended with the connector's bookkeeping properties */
 export interface VirtualListRenderRoot extends HTMLElement {
   __virtualListIndex: number;
@@ -80,11 +75,21 @@ export type FlowVirtualList = Omit<
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base
-  // with the Flow namespace used by the connector
+  // with the Flow namespace used by the connector. The namespace is a shared
+  // interface that each module merges its own members into, so that connectors
+  // from different modules can be type-checked in the same program.
   interface Vaadin {
-    Flow: {
-      virtualListConnector: { initLazy(list: FlowVirtualList): void };
-      clients: Record<string, FlowClient>;
-    };
+    Flow: VaadinFlow;
+  }
+
+  interface VaadinFlow {
+    virtualListConnector: { initLazy(list: FlowVirtualList): void };
+    /** The store of Flow DOM nodes, keyed by app id */
+    clients: Record<string, VaadinFlowClient>;
+  }
+
+  /** The Flow client of an app instance on the page */
+  interface VaadinFlowClient {
+    getByNodeId(nodeId: number): HTMLElement | null;
   }
 }


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/docs/pull/5904

Each connector module declared `Vaadin.Flow` with its own object literal type. Re-declaring the same property with different types is illegal in TypeScript, so when connectors from several modules were type-checked in one program, the first declaration silently won and every other module's `window.Vaadin.Flow.*` access failed with TS2339. This never shows up per-module or in regular apps (they import connectors as untyped generated `.js`), but it broke the docs build, which imports connectors from a TypeScript file.

- Converted the connector `.d.ts` files of combo-box, context-menu, date-picker, grid, map, time-picker and virtual-list to merge their members into the shared global `VaadinFlow` interface, the pattern context-menu and menu-bar already used
- Unified the two different `Vaadin.Flow.clients` declarations into a shared `VaadinFlowClient` interface
  - `getByNodeId` is typed to return the element or `null`, matching what the Flow client implementation actually returns
- Documented the shared-interface pattern in the connector guideline

## Type of change

- Bugfix