### PR TITLE
feat!: expose response metadata to listener and controller

### DIFF
--- a/guidelines/ai-components.md
+++ b/guidelines/ai-components.md
@@ -70,10 +70,14 @@ The group has no `-testbench` module and, apart from `FormFieldMarker`'s
   A provider publishes whenever it learns more — each publish carries the
   state of the turn so far and replaces the previous one, so a turn that
   fails midway has still reported what was observed. Finish reasons are
-  passed through as the model worded them: never map them to a Vaadin enum
-  or branch on their content, since every vendor uses its own vocabulary
-  and keeps adding to it. Checks that must tell a completed turn from a
-  truncated one use structure instead — a missing finish reason, or tool
+  relayed as the underlying framework words them and are never mapped to a
+  Vaadin enum, since every vendor uses its own vocabulary and keeps adding
+  to it. That makes the value provider-dependent rather than model-dependent
+  — LangChain4j maps the model's word to its own `FinishReason` enum before
+  we see it, so the same truncation reads `max_tokens` through Spring AI and
+  `LENGTH` through LangChain4j. Framework code therefore never branches on
+  the content of a finish reason: checks that must tell a completed turn from
+  a truncated one use structure instead — a missing finish reason, or tool
   calls still pending.
 
 ## Threading

--- a/guidelines/ai-components.md
+++ b/guidelines/ai-components.md
@@ -65,6 +65,16 @@ The group has no `-testbench` module and, apart from `FormFieldMarker`'s
   because `Flux` is part of the `LLMProvider` API. A new vendor provider
   follows the same shape: optional dependency, `transient` model fields,
   documented as not serializable.
+- The response stream carries text only; everything else the model said
+  about the turn goes to `LLMRequest.metadataSink()` as `ResponseMetadata`.
+  A provider publishes whenever it learns more — each publish carries the
+  state of the turn so far and replaces the previous one, so a turn that
+  fails midway has still reported what was observed. Finish reasons are
+  passed through as the model worded them: never map them to a Vaadin enum
+  or branch on their content, since every vendor uses its own vocabulary
+  and keeps adding to it. Checks that must tell a completed turn from a
+  truncated one use structure instead — a missing finish reason, or tool
+  calls still pending.
 
 ## Threading
 

--- a/guidelines/ai-components.md
+++ b/guidelines/ai-components.md
@@ -71,11 +71,13 @@ The group has no `-testbench` module and, apart from `FormFieldMarker`'s
   state of the turn so far and replaces the previous one, so a turn that
   fails midway has still reported what was observed. Finish reasons are
   relayed as the underlying framework words them and are never mapped to a
-  Vaadin enum, since every vendor uses its own vocabulary and keeps adding
-  to it. That makes the value provider-dependent rather than model-dependent
-  — LangChain4j maps the model's word to its own `FinishReason` enum before
-  we see it, so the same truncation reads `max_tokens` through Spring AI and
-  `LENGTH` through LangChain4j. Framework code therefore never branches on
+  Vaadin enum: every vendor words them differently and keeps adding values
+  (the same truncation is `length` on OpenAI and `max_tokens` on Anthropic),
+  so any fixed set of our own would go stale. LangChain4j shows what mapping
+  costs — it collapses the vendor's word onto a five-constant enum before we
+  see it, per integration and losing what it does not recognize, so an
+  unrecognized value arrives as `null` from its OpenAI integration and as
+  `OTHER` from its Anthropic one. Framework code therefore never branches on
   the content of a finish reason: checks that must tell a completed turn from
   a truncated one use structure instead — a missing finish reason, or tool
   calls still pending.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIFieldMarkerPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIFieldMarkerPage.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.ai.common.ConfidenceLevel;
 import com.vaadin.flow.component.ai.common.ValueSource;
 import com.vaadin.flow.component.ai.form.FieldMarkerI18n;
 import com.vaadin.flow.component.ai.form.FormAIController;
+import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -128,7 +129,8 @@ public class AIFieldMarkerPage extends VerticalLayout {
             // shows its confidence level.
             controller.restoreFieldSource(confident,
                     new ValueSource(ConfidenceLevel.HIGH, null));
-            controller.onResponse(null);
+            controller.onResponse(
+                    new ResponseListener.ResponseEvent("", null, null));
         });
         finishTurn.setId("finish-turn");
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -57,9 +57,10 @@ public interface AIController {
      * before the commit step: the conversation history is unchanged, the
      * request listener is not notified, the LLM stream is not opened, the
      * assistant placeholder is updated to a generic error message,
-     * {@link #onResponse(Throwable)} fires with the thrown exception so
-     * per-turn state captured before the throw can still be released, and the
-     * exception propagates back to the caller of the prompt entry point.
+     * {@link #onResponse(ResponseListener.ResponseEvent)} fires with the thrown
+     * exception so per-turn state captured before the throw can still be
+     * released, and the exception propagates back to the caller of the prompt
+     * entry point.
      * </p>
      */
     default void onRequest() {
@@ -78,23 +79,34 @@ public interface AIController {
      * when it ends also skips the hook, which requires {@code ui.access()}.
      * </p>
      * <p>
-     * On success {@code error} is {@code null}; use the call to commit staged
-     * state or run deferred UI updates. On failure {@code error} carries the
-     * cause (stream error, timeout, or any throw on the prompt path before the
-     * stream opens); release per-turn state captured in {@code onRequest}
-     * (locks, pending writes, snapshots) and discard the staged work. Note that
-     * a failure before {@link #onRequest()} — for example a throwing
-     * {@link RequestInterceptor} — also fires this method, so it can run
-     * without a preceding {@code onRequest} call.
+     * On success {@link ResponseListener.ResponseEvent#getError()} is empty;
+     * use the call to commit staged state or run deferred UI updates. On
+     * failure it carries the cause (stream error, timeout, or any throw on the
+     * prompt path before the stream opens); release per-turn state captured in
+     * {@code onRequest} (locks, pending writes, snapshots) and discard the
+     * staged work. Note that a failure before {@link #onRequest()} — for
+     * example a throwing {@link RequestInterceptor} — also fires this method,
+     * so it can run without a preceding {@code onRequest} call.
+     * </p>
+     * <p>
+     * An error is not the only abnormal ending. A turn cut off at the model's
+     * output limit ends with no error at all, and
+     * {@link ResponseListener.ResponseEvent#getMetadata()} carries the finish
+     * reason that tells the two apart — committing staged state on such a turn
+     * applies work the model never finished describing. The finish reason is
+     * the underlying framework's own word, so a controller that acts on it
+     * decides which values matter to it; see
+     * {@link com.vaadin.flow.component.ai.provider.ResponseMetadata}.
      * </p>
      * <p>
      * The default does nothing. Exceptions thrown from the hook are caught and
      * logged; Errors propagate.
      * </p>
      *
-     * @param error
-     *            the cause of failure, or {@code null} on success
+     * @param event
+     *            the outcome of the turn — response text, error, and provider
+     *            metadata — never {@code null}
      */
-    default void onResponse(Throwable error) {
+    default void onResponse(ResponseListener.ResponseEvent event) {
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -50,6 +51,7 @@ import com.vaadin.flow.component.ai.AIComponentsFeatureFlagProvider;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ResponseMetadata;
 import com.vaadin.flow.component.ai.ui.AIFileReceiver;
 import com.vaadin.flow.component.ai.ui.AIInput;
 import com.vaadin.flow.component.ai.ui.AIMessage;
@@ -432,7 +434,8 @@ public class AIOrchestrator implements Serializable {
     }
 
     private void streamResponseToMessage(LLMProvider.LLMRequest request,
-            AIMessage assistantMessage, UI ui) {
+            AIMessage assistantMessage, UI ui,
+            AtomicReference<ResponseMetadata> metadataHolder) {
         var responseBuilder = new StringBuilder();
         var responseStream = provider.stream(request)
                 .timeout(Duration.ofSeconds(TIMEOUT_SECONDS));
@@ -457,7 +460,7 @@ public class AIOrchestrator implements Serializable {
                 accessIfAttached(ui,
                         () -> assistantMessage.setText(userMessage));
             }
-            fireResponseListener("", error, ui);
+            fireResponseListener("", error, ui, metadataHolder.get());
         }, () -> {
             var responseText = responseBuilder.toString();
             if (!responseText.isEmpty()) {
@@ -465,7 +468,7 @@ public class AIOrchestrator implements Serializable {
                         .add(new ChatMessage(ChatMessage.Role.ASSISTANT,
                                 responseText, null, Instant.now()));
             }
-            fireResponseListener(responseText, null, ui);
+            fireResponseListener(responseText, null, ui, metadataHolder.get());
             LOGGER.debug("LLM streaming completed successfully");
         });
     }
@@ -551,7 +554,9 @@ public class AIOrchestrator implements Serializable {
                 controller.onRequest();
             }
 
-            var request = buildRequest(userMessage, attachments);
+            var metadataHolder = new AtomicReference<ResponseMetadata>();
+            var request = buildRequest(userMessage, attachments,
+                    metadataHolder);
             LOGGER.debug("Processing prompt with {} attachments",
                     attachments.size());
 
@@ -570,7 +575,8 @@ public class AIOrchestrator implements Serializable {
                 itemToMessageId.put(userAIMessage, messageId);
             }
 
-            streamResponseToMessage(request, assistantMessage, ui);
+            streamResponseToMessage(request, assistantMessage, ui,
+                    metadataHolder);
         } catch (Throwable t) { // NOSONAR — Throwable to surface UI on any
                                 // throw
             // Single update — stream errors are async and never reach this
@@ -730,7 +736,8 @@ public class AIOrchestrator implements Serializable {
     }
 
     private LLMProvider.LLMRequest buildRequest(String userMessage,
-            List<AIAttachment> attachments) {
+            List<AIAttachment> attachments,
+            AtomicReference<ResponseMetadata> metadataHolder) {
         final var effectiveSystemPrompt = systemPrompt != null
                 && !systemPrompt.isBlank() ? systemPrompt.trim() : null;
         var controllerTools = controller != null
@@ -762,6 +769,11 @@ public class AIOrchestrator implements Serializable {
             @Override
             public List<LLMProvider.ToolSpec> explicitTools() {
                 return explicitTools;
+            }
+
+            @Override
+            public Consumer<ResponseMetadata> metadataSink() {
+                return metadataHolder::set;
             }
         };
     }
@@ -875,10 +887,15 @@ public class AIOrchestrator implements Serializable {
 
     private void fireResponseListener(String responseText, Throwable error,
             UI ui) {
+        fireResponseListener(responseText, error, ui, null);
+    }
+
+    private void fireResponseListener(String responseText, Throwable error,
+            UI ui, ResponseMetadata metadata) {
         if (responseListener != null) {
             try {
                 responseListener.onResponse(new ResponseListener.ResponseEvent(
-                        responseText, error));
+                        responseText, error, metadata));
             } catch (Exception e) {
                 LOGGER.error("Error in response listener", e);
             }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -892,10 +892,11 @@ public class AIOrchestrator implements Serializable {
 
     private void fireResponseListener(String responseText, Throwable error,
             UI ui, ResponseMetadata metadata) {
+        var event = new ResponseListener.ResponseEvent(responseText, error,
+                metadata);
         if (responseListener != null) {
             try {
-                responseListener.onResponse(new ResponseListener.ResponseEvent(
-                        responseText, error, metadata));
+                responseListener.onResponse(event);
             } catch (Exception e) {
                 LOGGER.error("Error in response listener", e);
             }
@@ -903,7 +904,7 @@ public class AIOrchestrator implements Serializable {
         if (controller != null) {
             accessIfAttached(ui, () -> {
                 try {
-                    controller.onResponse(error);
+                    controller.onResponse(event);
                 } catch (Exception e) {
                     LOGGER.error("Error in controller onResponse", e);
                     // Append a separate assistant message instead of
@@ -1451,7 +1452,7 @@ public class AIOrchestrator implements Serializable {
          * recommended hook for persisting conversation state (via
          * {@link AIOrchestrator#getHistory()}), triggering follow-up actions,
          * or surfacing errors to the user. Same lifecycle moment as
-         * {@link AIController#onResponse(Throwable)}.
+         * {@link AIController#onResponse(ResponseListener.ResponseEvent)}.
          * <p>
          * On success the response text may be empty if the model emitted only
          * tool calls or otherwise stopped without producing visible content.
@@ -1503,9 +1504,10 @@ public class AIOrchestrator implements Serializable {
          * context is added for that turn — useful for "context only when X"
          * patterns. If the supplier throws, the turn is aborted via the normal
          * error path: the assistant placeholder is updated to a generic error
-         * message, {@link AIController#onResponse(Throwable)} fires with the
-         * thrown exception, and the exception propagates to the caller of the
-         * prompt entry point.
+         * message,
+         * {@link AIController#onResponse(ResponseListener.ResponseEvent)} fires
+         * with the thrown exception, and the exception propagates to the caller
+         * of the prompt entry point.
          * <p>
          * Passing {@code null} disables session context entirely, including the
          * built-in default. By default, the orchestrator installs a supplier

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptor.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptor.java
@@ -66,10 +66,10 @@ import com.vaadin.flow.function.SerializableConsumer;
  * <p>
  * Throwing from the interceptor aborts the prompt the same way as a rejection,
  * except that the exception is reported to the {@link ResponseListener} and
- * {@link AIController#onResponse(Throwable)}, and propagates to the caller of
- * the prompt entry point. Throw only for failures; use
- * {@link RequestInterceptEvent#reject(String) reject} for expected validation
- * outcomes.
+ * {@link AIController#onResponse(ResponseListener.ResponseEvent)}, and
+ * propagates to the caller of the prompt entry point. Throw only for failures;
+ * use {@link RequestInterceptEvent#reject(String) reject} for expected
+ * validation outcomes.
  * <p>
  * <b>Threading:</b> the interceptor is called on the UI thread under the
  * session lock, and unless the prompt is postponed its result is used as soon
@@ -111,8 +111,9 @@ import com.vaadin.flow.function.SerializableConsumer;
  *
  * A failure after postponing — {@link RequestContinuation#fail} or the timeout
  * — is reported to the {@link ResponseListener} and
- * {@link AIController#onResponse(Throwable)} only; it cannot propagate to the
- * caller of the prompt entry point, which has long returned.
+ * {@link AIController#onResponse(ResponseListener.ResponseEvent)} only; it
+ * cannot propagate to the caller of the prompt entry point, which has long
+ * returned.
  * <p>
  * <b>Serialization:</b> the interceptor is stored on the serializable
  * orchestrator and survives session serialization with it — unlike the LLM
@@ -418,10 +419,10 @@ public interface RequestInterceptor extends Serializable {
         /**
          * Aborts the postponed prompt: nothing is sent or shown, and the cause
          * is reported to the {@link ResponseListener} and
-         * {@link AIController#onResponse(Throwable)}. Safe to call when the UI
-         * is already detached: the {@link ResponseListener} is still notified,
-         * only the UI-bound controller hook is skipped. A no-op when the prompt
-         * has already been completed or timed out.
+         * {@link AIController#onResponse(ResponseListener.ResponseEvent)}. Safe
+         * to call when the UI is already detached: the {@link ResponseListener}
+         * is still notified, only the UI-bound controller hook is skipped. A
+         * no-op when the prompt has already been completed or timed out.
          *
          * @param cause
          *            the failure to report, not {@code null}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
@@ -115,12 +115,14 @@ public interface ResponseListener extends Serializable {
 
         /**
          * Gets the metadata the provider reported for this turn, such as the
-         * finish reason and token usage. Returns an empty optional when the
+         * finish reason and token usage. On a failed turn this is what was
+         * observed before the failure. Returns an empty optional when the
          * provider reported none — a custom {@link LLMProvider} that does not
          * publish metadata, or a turn that failed before any was observed.
          *
          * @return the response metadata, or empty when the provider reported
          *         none
+         * @since 25.3
          */
         public Optional<ResponseMetadata> getMetadata() {
             return Optional.ofNullable(metadata);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
@@ -97,6 +97,7 @@ public interface ResponseListener extends Serializable {
          * @param metadata
          *            the provider's metadata for the turn, or {@code null} when
          *            none was reported
+         * @since 25.3
          */
         public ResponseEvent(String response, Throwable error,
                 ResponseMetadata metadata) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.ai.orchestrator;
 import java.io.Serializable;
 import java.util.Optional;
 
+import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ResponseMetadata;
+
 /**
  * Listener for LLM response events.
  * <p>
@@ -79,10 +82,13 @@ public interface ResponseListener extends Serializable {
     class ResponseEvent implements Serializable {
         private final String response;
         private final Throwable error;
+        private final ResponseMetadata metadata;
 
-        ResponseEvent(String response, Throwable error) {
+        ResponseEvent(String response, Throwable error,
+                ResponseMetadata metadata) {
             this.response = response;
             this.error = error;
+            this.metadata = metadata;
         }
 
         /**
@@ -105,6 +111,19 @@ public interface ResponseListener extends Serializable {
          */
         public Optional<Throwable> getError() {
             return Optional.ofNullable(error);
+        }
+
+        /**
+         * Gets the metadata the provider reported for this turn, such as the
+         * finish reason and token usage. Returns an empty optional when the
+         * provider reported none — a custom {@link LLMProvider} that does not
+         * publish metadata, or a turn that failed before any was observed.
+         *
+         * @return the response metadata, or empty when the provider reported
+         *         none
+         */
+        public Optional<ResponseMetadata> getMetadata() {
+            return Optional.ofNullable(metadata);
         }
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
@@ -29,7 +29,8 @@ import com.vaadin.flow.component.ai.provider.ResponseMetadata;
  * the turn fails before a stream ever opens. It fires at most once per prompt:
  * a prompt rejected by the {@link RequestInterceptor} and a postponed prompt
  * abandoned because its UI was detached end without firing it. The same
- * lifecycle moment as {@link AIController#onResponse(Throwable)}. Use it to
+ * lifecycle moment as
+ * {@link AIController#onResponse(ResponseListener.ResponseEvent)}. Use it to
  * persist conversation state (via {@link AIOrchestrator#getHistory()}), trigger
  * follow-up actions, or surface errors to the user.
  * <p>
@@ -84,7 +85,20 @@ public interface ResponseListener extends Serializable {
         private final Throwable error;
         private final ResponseMetadata metadata;
 
-        ResponseEvent(String response, Throwable error,
+        /**
+         * Creates a turn-outcome event. The orchestrator builds this for every
+         * turn; it is public so an application can construct one when unit
+         * testing an {@link AIController} implementation.
+         *
+         * @param response
+         *            the assistant's response text, not {@code null}
+         * @param error
+         *            the cause of failure, or {@code null} on success
+         * @param metadata
+         *            the provider's metadata for the turn, or {@code null} when
+         *            none was reported
+         */
+        public ResponseEvent(String response, Throwable error,
                 ResponseMetadata metadata) {
             this.response = response;
             this.error = error;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -167,11 +167,15 @@ public interface LLMProvider {
         /**
          * Gets the consumer that receives metadata about the model's response,
          * such as the finish reason and token usage. A provider that observes
-         * such metadata passes it to this consumer, typically once when the
-         * turn completes; a provider that observes none never calls it. The
-         * default implementation discards the metadata.
+         * such metadata passes it to this consumer as the turn progresses —
+         * each call carries everything observed so far and replaces the value
+         * of any earlier call, so a turn that fails midway has still reported
+         * what was observed before the failure. A provider that observes no
+         * metadata never calls the consumer. The default implementation
+         * discards the metadata.
          *
          * @return the metadata consumer, never {@code null}
+         * @since 25.3
          */
         default Consumer<ResponseMetadata> metadataSink() {
             return metadata -> {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.ai.provider;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
@@ -161,6 +162,22 @@ public interface LLMProvider {
          */
         default List<ToolSpec> explicitTools() {
             return List.of();
+        }
+
+        /**
+         * Gets the consumer that receives metadata about the model's response,
+         * such as the finish reason and token usage. A provider that observes
+         * such metadata passes it to this consumer, typically once when the
+         * turn completes; a provider that observes none never calls it. The
+         * default implementation discards the metadata.
+         *
+         * @return the metadata consumer, never {@code null}
+         */
+        default Consumer<ResponseMetadata> metadataSink() {
+            return metadata -> {
+                // Discarded by default; the request creator overrides this to
+                // receive the metadata.
+            };
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -221,7 +221,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * turn is running, for example from
      * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}
      * and
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(Throwable)}.</li>
+     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(ResponseListener.ResponseEvent)}.</li>
      * </ul>
      *
      * <p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -454,7 +454,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
         context.observeMetadata(response);
         var aiMessage = response.aiMessage();
         if (aiMessage == null) {
-            warnOnMissingFinishReason(context);
+            warnOnMissingFinishReason(response);
             context.getSink().complete();
             return;
         }
@@ -469,21 +469,29 @@ public class LangChain4JLLMProvider implements LLMProvider {
             executeToolRequests(aiMessage, context);
             executeChat(context);
         } else {
-            warnOnMissingFinishReason(context);
+            warnOnMissingFinishReason(response);
             context.getSink().complete();
         }
     }
 
     /**
-     * Warns when a turn completes without the model ever reporting a finish
-     * reason. This provider drives the tool-calling loop itself, so unlike
+     * Warns when the round trip that ends the turn carries no finish reason.
+     * <p>
+     * Only that round trip counts. A reason reported by an earlier round trip
+     * describes why <i>that</i> round trip stopped — {@code TOOL_EXECUTION},
+     * typically — and says nothing about how the turn ended, so it must not
+     * silence the warning. This mirrors {@code SpringAILLMProvider}, whose
+     * terminal-chunk check likewise ignores a reason that arrives with tool
+     * calls still pending. Called only from the two points where the turn ends,
+     * so the response passed in is by construction the terminal one.
+     * <p>
+     * This provider drives the tool-calling loop itself, so unlike
      * {@code SpringAILLMProvider} a turn cannot end with tool calls still
      * pending; a missing finish reason is the one terminal state left that may
      * indicate a silent abnormal termination.
      */
-    private static void warnOnMissingFinishReason(
-            ChatExecutionContext context) {
-        if (context.sawFinishReason()) {
+    private static void warnOnMissingFinishReason(ChatResponse response) {
+        if (response.finishReason() != null) {
             return;
         }
         LOGGER.warn("LLM turn ended without the model reporting a finish "
@@ -648,10 +656,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
                             accumulatedUsage.totalTokenCount());
             request.metadataSink()
                     .accept(new ResponseMetadata(finishReason, tokenUsage));
-        }
-
-        boolean sawFinishReason() {
-            return lastFinishReason != null;
         }
 
         LLMRequest getRequest() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -454,6 +454,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
         context.observeMetadata(response);
         var aiMessage = response.aiMessage();
         if (aiMessage == null) {
+            warnOnMissingFinishReason(context);
             context.getSink().complete();
             return;
         }
@@ -468,8 +469,27 @@ public class LangChain4JLLMProvider implements LLMProvider {
             executeToolRequests(aiMessage, context);
             executeChat(context);
         } else {
+            warnOnMissingFinishReason(context);
             context.getSink().complete();
         }
+    }
+
+    /**
+     * Warns when a turn completes without the model ever reporting a finish
+     * reason. This provider drives the tool-calling loop itself, so unlike
+     * {@code SpringAILLMProvider} a turn cannot end with tool calls still
+     * pending; a missing finish reason is the one terminal state left that may
+     * indicate a silent abnormal termination.
+     */
+    private static void warnOnMissingFinishReason(
+            ChatExecutionContext context) {
+        if (context.sawFinishReason()) {
+            return;
+        }
+        LOGGER.warn("LLM turn ended without the model reporting a finish "
+                + "reason. This may indicate a silent abnormal termination "
+                + "such as an upstream error; if the response appears "
+                + "truncated this warning is the signal.");
     }
 
     private static ToolExecutionResultMessage executeToolRequest(
@@ -631,6 +651,10 @@ public class LangChain4JLLMProvider implements LLMProvider {
                             accumulatedUsage.totalTokenCount());
             request.metadataSink()
                     .accept(new ResponseMetadata(finishReason, tokenUsage));
+        }
+
+        boolean sawFinishReason() {
+            return lastFinishReason != null;
         }
 
         LLMRequest getRequest() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -474,17 +474,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
     }
 
-    private static ResponseMetadata.FinishReason toFinishReason(
-            FinishReason finishReason) {
-        return switch (finishReason) {
-        case STOP -> ResponseMetadata.FinishReason.STOP;
-        case LENGTH -> ResponseMetadata.FinishReason.LENGTH;
-        case CONTENT_FILTER -> ResponseMetadata.FinishReason.CONTENT_FILTER;
-        case TOOL_EXECUTION -> ResponseMetadata.FinishReason.TOOL_CALLS;
-        default -> ResponseMetadata.FinishReason.OTHER;
-        };
-    }
-
     private static ToolExecutionResultMessage executeToolRequest(
             ToolExecutor toolExecutor, ToolExecutionRequest toolExecRequest) {
         String result;
@@ -627,16 +616,14 @@ public class LangChain4JLLMProvider implements LLMProvider {
                 return;
             }
             var finishReason = lastFinishReason == null ? null
-                    : toFinishReason(lastFinishReason);
-            var rawFinishReason = lastFinishReason == null ? null
                     : lastFinishReason.name();
             var tokenUsage = accumulatedUsage == null ? null
                     : new ResponseMetadata.TokenUsage(
                             accumulatedUsage.inputTokenCount(),
                             accumulatedUsage.outputTokenCount(),
                             accumulatedUsage.totalTokenCount());
-            request.metadataSink().accept(new ResponseMetadata(finishReason,
-                    rawFinishReason, tokenUsage));
+            request.metadataSink()
+                    .accept(new ResponseMetadata(finishReason, tokenUsage));
         }
 
         LLMRequest getRequest() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -57,6 +57,8 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.tool.DefaultToolExecutor;
 import dev.langchain4j.service.tool.ToolExecutor;
 import reactor.core.publisher.Flux;
@@ -449,8 +451,10 @@ public class LangChain4JLLMProvider implements LLMProvider {
 
     private void handleResponse(ChatExecutionContext context,
             ChatResponse response) {
+        context.observeMetadata(response);
         var aiMessage = response.aiMessage();
         if (aiMessage == null) {
+            context.publishMetadata();
             context.getSink().complete();
             return;
         }
@@ -465,8 +469,20 @@ public class LangChain4JLLMProvider implements LLMProvider {
             executeToolRequests(aiMessage, context);
             executeChat(context);
         } else {
+            context.publishMetadata();
             context.getSink().complete();
         }
+    }
+
+    private static ResponseMetadata.FinishReason toFinishReason(
+            FinishReason finishReason) {
+        return switch (finishReason) {
+        case STOP -> ResponseMetadata.FinishReason.STOP;
+        case LENGTH -> ResponseMetadata.FinishReason.LENGTH;
+        case CONTENT_FILTER -> ResponseMetadata.FinishReason.CONTENT_FILTER;
+        case TOOL_EXECUTION -> ResponseMetadata.FinishReason.TOOL_CALLS;
+        default -> ResponseMetadata.FinishReason.OTHER;
+        };
     }
 
     private static ToolExecutionResultMessage executeToolRequest(
@@ -580,6 +596,8 @@ public class LangChain4JLLMProvider implements LLMProvider {
         private final FluxSink<String> sink;
         private final ChatMemory chatMemory;
         private final ToolContext toolContext;
+        private FinishReason lastFinishReason;
+        private TokenUsage accumulatedUsage;
 
         ChatExecutionContext(LLMRequest request, FluxSink<String> sink,
                 ChatMemory chatMemory, ToolContext toolContext) {
@@ -587,6 +605,38 @@ public class LangChain4JLLMProvider implements LLMProvider {
             this.sink = sink;
             this.chatMemory = chatMemory;
             this.toolContext = toolContext;
+        }
+
+        /**
+         * Records the metadata of one model round trip. The reason that ends
+         * the turn wins; token usage accumulates across the round trips.
+         */
+        void observeMetadata(ChatResponse response) {
+            if (response.finishReason() != null) {
+                lastFinishReason = response.finishReason();
+            }
+            var usage = response.tokenUsage();
+            if (usage != null) {
+                accumulatedUsage = accumulatedUsage == null ? usage
+                        : accumulatedUsage.add(usage);
+            }
+        }
+
+        void publishMetadata() {
+            if (lastFinishReason == null && accumulatedUsage == null) {
+                return;
+            }
+            var finishReason = lastFinishReason == null ? null
+                    : toFinishReason(lastFinishReason);
+            var rawFinishReason = lastFinishReason == null ? null
+                    : lastFinishReason.name();
+            var tokenUsage = accumulatedUsage == null ? null
+                    : new ResponseMetadata.TokenUsage(
+                            accumulatedUsage.inputTokenCount(),
+                            accumulatedUsage.outputTokenCount(),
+                            accumulatedUsage.totalTokenCount());
+            request.metadataSink().accept(new ResponseMetadata(finishReason,
+                    rawFinishReason, tokenUsage));
         }
 
         LLMRequest getRequest() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -639,9 +639,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
 
         private void publishMetadata() {
-            if (lastFinishReason == null && accumulatedUsage == null) {
-                return;
-            }
             var finishReason = lastFinishReason == null ? null
                     : lastFinishReason.name();
             var tokenUsage = accumulatedUsage == null ? null

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -454,7 +454,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
         context.observeMetadata(response);
         var aiMessage = response.aiMessage();
         if (aiMessage == null) {
-            context.publishMetadata();
             context.getSink().complete();
             return;
         }
@@ -469,7 +468,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
             executeToolRequests(aiMessage, context);
             executeChat(context);
         } else {
-            context.publishMetadata();
             context.getSink().complete();
         }
     }
@@ -597,10 +595,18 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
 
         /**
-         * Records the metadata of one model round trip. The reason that ends
-         * the turn wins; token usage accumulates across the round trips.
+         * Records the metadata of one model round trip and passes the state
+         * known so far to the metadata sink right away, so that a turn whose
+         * later round trip fails has still reported what the earlier ones cost.
+         * The reason that ends the turn wins; token usage accumulates across
+         * the round trips.
          */
         void observeMetadata(ChatResponse response) {
+            if (response.finishReason() == null
+                    && response.tokenUsage() == null) {
+                // Nothing new in this round trip, nothing to re-publish.
+                return;
+            }
             if (response.finishReason() != null) {
                 lastFinishReason = response.finishReason();
             }
@@ -609,9 +615,10 @@ public class LangChain4JLLMProvider implements LLMProvider {
                 accumulatedUsage = accumulatedUsage == null ? usage
                         : accumulatedUsage.add(usage);
             }
+            publishMetadata();
         }
 
-        void publishMetadata() {
+        private void publishMetadata() {
             if (lastFinishReason == null && accumulatedUsage == null) {
                 return;
             }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -488,16 +488,20 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * This provider drives the tool-calling loop itself, so unlike
      * {@code SpringAILLMProvider} a turn cannot end with tool calls still
      * pending; a missing finish reason is the one terminal state left that may
-     * indicate a silent abnormal termination.
+     * indicate a silent abnormal termination. It does not prove the model
+     * reported nothing: LangChain4j also leaves the reason unset when its
+     * integration does not recognize the value the model sent.
      */
     private static void warnOnMissingFinishReason(ChatResponse response) {
         if (response.finishReason() != null) {
             return;
         }
-        LOGGER.warn("LLM turn ended without the model reporting a finish "
-                + "reason. This may indicate a silent abnormal termination "
-                + "such as an upstream error; if the response appears "
-                + "truncated this warning is the signal.");
+        LOGGER.warn("LLM turn ended with no finish reason for its final "
+                + "round trip. Either the model reported none, which may "
+                + "indicate a silent abnormal termination such as an upstream "
+                + "error, or LangChain4j dropped a value its integration does "
+                + "not recognize; if the response appears truncated this "
+                + "warning is the signal.");
     }
 
     private static ToolExecutionResultMessage executeToolRequest(
@@ -647,10 +651,11 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
 
         private void publishMetadata() {
-            // LangChain4j maps the model's own word to its FinishReason enum
-            // before handing the response over, so the constant name is the
-            // most faithful value left to publish — see ResponseMetadata,
-            // which documents the difference to SpringAILLMProvider.
+            // LangChain4j collapses the model's own word onto its
+            // FinishReason enum before handing the response over — per
+            // integration, and losing whatever it does not recognize — so the
+            // constant name is the most faithful value left to publish. See
+            // ResponseMetadata, which documents what that costs.
             var finishReason = lastFinishReason == null ? null
                     : lastFinishReason.name();
             var tokenUsage = accumulatedUsage == null ? null

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -647,6 +647,10 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
 
         private void publishMetadata() {
+            // LangChain4j maps the model's own word to its FinishReason enum
+            // before handing the response over, so the constant name is the
+            // most faithful value left to publish — see ResponseMetadata,
+            // which documents the difference to SpringAILLMProvider.
             var finishReason = lastFinishReason == null ? null
                     : lastFinishReason.name();
             var tokenUsage = accumulatedUsage == null ? null

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.ai.provider;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metadata about an LLM response, published by an {@link LLMProvider} through
+ * {@link LLMProvider.LLMRequest#metadataSink()} when the model reports it.
+ * <p>
+ * The metadata describes the whole turn: when the turn contains tool-call round
+ * trips, the finish reason is the one that ended the turn and the token usage
+ * covers all round trips, as far as the underlying framework reports it.
+ * </p>
+ *
+ * @param finishReason
+ *            why the model stopped, normalized across vendors, or {@code null}
+ *            when the model did not report a reason
+ * @param rawFinishReason
+ *            the vendor's own finish reason value (e.g. {@code "max_tokens"}),
+ *            or {@code null} when the model did not report a reason
+ * @param tokenUsage
+ *            the token usage of the turn, or {@code null} when unknown
+ *
+ * @author Vaadin Ltd
+ * @since 25.3
+ */
+public record ResponseMetadata(FinishReason finishReason,
+        String rawFinishReason, TokenUsage tokenUsage) implements Serializable {
+
+    /**
+     * Why the model stopped producing output, normalized across vendors.
+     * Normalization is best-effort: a vendor value with no known equivalent
+     * maps to {@link #OTHER}, and {@link ResponseMetadata#rawFinishReason()}
+     * always carries the vendor's own value as the authoritative source.
+     */
+    public enum FinishReason {
+
+        /** The model finished its answer normally. */
+        STOP,
+
+        /**
+         * The response was cut off by a token limit and is incomplete.
+         */
+        LENGTH,
+
+        /** The response was stopped by a content filter or guardrail. */
+        CONTENT_FILTER,
+
+        /**
+         * The response ended with tool calls awaiting execution. Not normally
+         * observed, since providers run tool calls within the turn.
+         */
+        TOOL_CALLS,
+
+        /** A vendor-specific reason with no normalized equivalent. */
+        OTHER
+    }
+
+    /**
+     * Token usage of a turn. Counts cover every round trip of the turn, as far
+     * as the underlying framework reports them.
+     *
+     * @param inputTokens
+     *            tokens in the input, or {@code null} when unknown
+     * @param outputTokens
+     *            tokens in the generated output, or {@code null} when unknown
+     * @param totalTokens
+     *            total tokens, or {@code null} when unknown
+     */
+    public record TokenUsage(Integer inputTokens, Integer outputTokens,
+            Integer totalTokens) implements Serializable {
+    }
+
+    /**
+     * Maps a vendor finish reason value to the normalized {@link FinishReason}.
+     *
+     * @param rawFinishReason
+     *            the vendor's finish reason value, may be {@code null}
+     * @return the normalized reason, {@link FinishReason#OTHER} for an
+     *         unrecognized value, or {@code null} when the input is
+     *         {@code null} or blank
+     */
+    public static FinishReason normalizeFinishReason(String rawFinishReason) {
+        if (rawFinishReason == null || rawFinishReason.isBlank()) {
+            return null;
+        }
+        return switch (rawFinishReason.toLowerCase(Locale.ROOT)) {
+        case "stop", "end_turn", "stop_sequence", "completed" ->
+            FinishReason.STOP;
+        case "length", "max_tokens", "max_output_tokens" -> FinishReason.LENGTH;
+        case "content_filter", "content_filtered", "guardrail_intervened" ->
+            FinishReason.CONTENT_FILTER;
+        case "tool_calls", "tool_use", "tool_execution", "function_call" ->
+            FinishReason.TOOL_CALLS;
+        default -> {
+            LoggerFactory.getLogger(ResponseMetadata.class).debug(
+                    "Finish reason '{}' has no normalized equivalent, mapping to OTHER",
+                    rawFinishReason);
+            yield FinishReason.OTHER;
+        }
+        };
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
@@ -27,18 +27,31 @@ import java.io.Serializable;
  * underlying framework reports them. On a turn that completes normally the last
  * published instance therefore describes the whole turn.
  * </p>
+ * <p>
+ * <b>Finish reason vocabulary.</b> Every model vendor words the reason
+ * differently and keeps adding values: a turn cut off at the output limit is
+ * {@code "length"} on OpenAI and {@code "max_tokens"} on Anthropic. Nothing
+ * here maps those onto a fixed set of Vaadin values, because such a set goes
+ * stale the moment a vendor adds one. Compare only against the values
+ * documented for the model you call, and treat an unrecognized value as unknown
+ * rather than as an error.
+ * </p>
+ * <p>
+ * {@link LangChain4JLLMProvider} is a step further removed, and shows why the
+ * mapping is left alone: LangChain4j collapses the vendor's word onto its own
+ * five-constant {@code FinishReason} enum before Vaadin sees the response, so
+ * the value is that constant's name and both examples above arrive as
+ * {@code "LENGTH"}. The collapsing is per integration and loses whatever it
+ * does not recognize — an unrecognized value reaches this record as
+ * {@code null} through its OpenAI integration and as {@code "OTHER"} through
+ * its Anthropic one. Use {@link SpringAILLMProvider} where the application
+ * needs the model's own word.
+ * </p>
  *
  * @param finishReason
- *            why the model stopped, as reported by the underlying framework, or
- *            {@code null} when no reason was reported. The vocabulary and the
- *            casing depend on the provider, not only on the model:
- *            {@link SpringAILLMProvider} relays the model's own word, so an
- *            OpenAI turn cut off at the output limit arrives as
- *            {@code "max_tokens"}, while {@link LangChain4JLLMProvider} reports
- *            the name of the LangChain4j {@code FinishReason} constant the
- *            value was mapped to before Vaadin saw it, so the same turn arrives
- *            as {@code "LENGTH"}. Code that compares against particular values
- *            has to account for the provider it runs on.
+ *            why the model stopped, worded as the underlying framework reports
+ *            it — the vocabulary depends on both the model and the provider,
+ *            see above — or {@code null} when no reason was reported
  * @param tokenUsage
  *            the token usage of the turn, or {@code null} when unknown
  *

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
@@ -51,6 +51,7 @@ public record ResponseMetadata(String finishReason,
      *            tokens in the generated output, or {@code null} when unknown
      * @param totalTokens
      *            total tokens, or {@code null} when unknown
+     * @since 25.3
      */
     public record TokenUsage(Integer inputTokens, Integer outputTokens,
             Integer totalTokens) implements Serializable {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
@@ -21,9 +21,11 @@ import java.io.Serializable;
  * Metadata about an LLM response, published by an {@link LLMProvider} through
  * {@link LLMProvider.LLMRequest#metadataSink()} when the model reports it.
  * <p>
- * The metadata describes the whole turn: when the turn contains tool-call round
- * trips, the finish reason is the one that ended the turn and the token usage
- * covers all round trips, as far as the underlying framework reports it.
+ * The metadata describes the turn as far as the provider has observed it: when
+ * the turn contains tool-call round trips, the finish reason is the latest one
+ * observed and the token usage covers the round trips so far, as far as the
+ * underlying framework reports them. On a turn that completes normally the last
+ * published instance therefore describes the whole turn.
  * </p>
  *
  * @param finishReason

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
@@ -29,9 +29,16 @@ import java.io.Serializable;
  * </p>
  *
  * @param finishReason
- *            why the model stopped, as reported by the underlying framework
- *            (e.g. {@code "max_tokens"}); the value is vendor-specific, and
- *            {@code null} when the model did not report a reason
+ *            why the model stopped, as reported by the underlying framework, or
+ *            {@code null} when no reason was reported. The vocabulary and the
+ *            casing depend on the provider, not only on the model:
+ *            {@link SpringAILLMProvider} relays the model's own word, so an
+ *            OpenAI turn cut off at the output limit arrives as
+ *            {@code "max_tokens"}, while {@link LangChain4JLLMProvider} reports
+ *            the name of the LangChain4j {@code FinishReason} constant the
+ *            value was mapped to before Vaadin saw it, so the same turn arrives
+ *            as {@code "LENGTH"}. Code that compares against particular values
+ *            has to account for the provider it runs on.
  * @param tokenUsage
  *            the token usage of the turn, or {@code null} when unknown
  *

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/ResponseMetadata.java
@@ -16,9 +16,6 @@
 package com.vaadin.flow.component.ai.provider;
 
 import java.io.Serializable;
-import java.util.Locale;
-
-import org.slf4j.LoggerFactory;
 
 /**
  * Metadata about an LLM response, published by an {@link LLMProvider} through
@@ -30,48 +27,17 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  * @param finishReason
- *            why the model stopped, normalized across vendors, or {@code null}
- *            when the model did not report a reason
- * @param rawFinishReason
- *            the vendor's own finish reason value (e.g. {@code "max_tokens"}),
- *            or {@code null} when the model did not report a reason
+ *            why the model stopped, as reported by the underlying framework
+ *            (e.g. {@code "max_tokens"}); the value is vendor-specific, and
+ *            {@code null} when the model did not report a reason
  * @param tokenUsage
  *            the token usage of the turn, or {@code null} when unknown
  *
  * @author Vaadin Ltd
  * @since 25.3
  */
-public record ResponseMetadata(FinishReason finishReason,
-        String rawFinishReason, TokenUsage tokenUsage) implements Serializable {
-
-    /**
-     * Why the model stopped producing output, normalized across vendors.
-     * Normalization is best-effort: a vendor value with no known equivalent
-     * maps to {@link #OTHER}, and {@link ResponseMetadata#rawFinishReason()}
-     * always carries the vendor's own value as the authoritative source.
-     */
-    public enum FinishReason {
-
-        /** The model finished its answer normally. */
-        STOP,
-
-        /**
-         * The response was cut off by a token limit and is incomplete.
-         */
-        LENGTH,
-
-        /** The response was stopped by a content filter or guardrail. */
-        CONTENT_FILTER,
-
-        /**
-         * The response ended with tool calls awaiting execution. Not normally
-         * observed, since providers run tool calls within the turn.
-         */
-        TOOL_CALLS,
-
-        /** A vendor-specific reason with no normalized equivalent. */
-        OTHER
-    }
+public record ResponseMetadata(String finishReason,
+        TokenUsage tokenUsage) implements Serializable {
 
     /**
      * Token usage of a turn. Counts cover every round trip of the turn, as far
@@ -86,35 +52,5 @@ public record ResponseMetadata(FinishReason finishReason,
      */
     public record TokenUsage(Integer inputTokens, Integer outputTokens,
             Integer totalTokens) implements Serializable {
-    }
-
-    /**
-     * Maps a vendor finish reason value to the normalized {@link FinishReason}.
-     *
-     * @param rawFinishReason
-     *            the vendor's finish reason value, may be {@code null}
-     * @return the normalized reason, {@link FinishReason#OTHER} for an
-     *         unrecognized value, or {@code null} when the input is
-     *         {@code null} or blank
-     */
-    public static FinishReason normalizeFinishReason(String rawFinishReason) {
-        if (rawFinishReason == null || rawFinishReason.isBlank()) {
-            return null;
-        }
-        return switch (rawFinishReason.toLowerCase(Locale.ROOT)) {
-        case "stop", "end_turn", "stop_sequence", "completed" ->
-            FinishReason.STOP;
-        case "length", "max_tokens", "max_output_tokens" -> FinishReason.LENGTH;
-        case "content_filter", "content_filtered", "guardrail_intervened" ->
-            FinishReason.CONTENT_FILTER;
-        case "tool_calls", "tool_use", "tool_execution", "function_call" ->
-            FinishReason.TOOL_CALLS;
-        default -> {
-            LoggerFactory.getLogger(ResponseMetadata.class).debug(
-                    "Finish reason '{}' has no normalized equivalent, mapping to OTHER",
-                    rawFinishReason);
-            yield FinishReason.OTHER;
-        }
-        };
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -239,7 +239,7 @@ public class SpringAILLMProvider implements LLMProvider {
      * turn is running, for example from
      * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}
      * and
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(Throwable)}.</li>
+     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(ResponseListener.ResponseEvent)}.</li>
      * </ul>
      *
      * <p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -393,7 +394,10 @@ public class SpringAILLMProvider implements LLMProvider {
 
     private Flux<String> executeStreamingChat(LLMRequest request) {
         try {
-            var chatResponses = getPromptSpec(request).stream().chatResponse();
+            var collector = new ResponseMetadataCollector();
+            var chatResponses = getPromptSpec(request).stream().chatResponse()
+                    .doOnNext(collector::observe).doOnComplete(
+                            () -> collector.publishTo(request.metadataSink()));
             return warnOnMissingFinishReason(chatResponses)
                     .map(SpringAILLMProvider::getAssistantText)
                     .filter(text -> !text.isEmpty());
@@ -495,15 +499,76 @@ public class SpringAILLMProvider implements LLMProvider {
         return Flux.create(sink -> {
             try {
                 var promptSpec = getPromptSpec(request);
-                var response = promptSpec.call().content();
-                if (response != null && !response.isEmpty()) {
-                    sink.next(response);
+                var response = promptSpec.call().chatResponse();
+                if (response != null) {
+                    var collector = new ResponseMetadataCollector();
+                    collector.observe(response);
+                    collector.publishTo(request.metadataSink());
+                    var text = getAssistantText(response);
+                    if (!text.isEmpty()) {
+                        sink.next(text);
+                    }
                 }
                 sink.complete();
             } catch (Exception e) {
                 sink.error(e);
             }
         });
+    }
+
+    /**
+     * Collects response metadata across the chunks of a turn. The last reported
+     * finish reason and token usage win: the terminal chunk carries the reason
+     * that ended the turn, and frameworks that report usage do so cumulatively
+     * on the final chunk that carries it.
+     */
+    private static class ResponseMetadataCollector {
+
+        private String rawFinishReason;
+        private ResponseMetadata.TokenUsage tokenUsage;
+
+        void observe(ChatResponse response) {
+            var raw = getRawFinishReason(response);
+            if (raw != null) {
+                rawFinishReason = raw;
+            }
+            var usage = getTokenUsage(response);
+            if (usage != null) {
+                tokenUsage = usage;
+            }
+        }
+
+        void publishTo(Consumer<ResponseMetadata> metadataSink) {
+            if (rawFinishReason == null && tokenUsage == null) {
+                return;
+            }
+            metadataSink.accept(new ResponseMetadata(
+                    ResponseMetadata.normalizeFinishReason(rawFinishReason),
+                    rawFinishReason, tokenUsage));
+        }
+
+        private static String getRawFinishReason(ChatResponse response) {
+            var result = response.getResult();
+            if (result == null) {
+                return null;
+            }
+            var reason = result.getMetadata().getFinishReason();
+            return reason == null || reason.isBlank() ? null : reason;
+        }
+
+        private static ResponseMetadata.TokenUsage getTokenUsage(
+                ChatResponse response) {
+            var usage = response.getMetadata().getUsage();
+            if (usage == null) {
+                return null;
+            }
+            var total = usage.getTotalTokens();
+            if (total == null || total <= 0) {
+                return null;
+            }
+            return new ResponseMetadata.TokenUsage(usage.getPromptTokens(),
+                    usage.getCompletionTokens(), total);
+        }
     }
 
     private Media[] buildMedia(LLMRequest request) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -500,10 +500,15 @@ public class SpringAILLMProvider implements LLMProvider {
             try {
                 var promptSpec = getPromptSpec(request);
                 var response = promptSpec.call().chatResponse();
-                if (response != null) {
+                if (response == null) {
+                    LOGGER.warn("LLM call returned no response at all, which "
+                            + "may indicate an upstream error swallowed by "
+                            + "the client.");
+                } else {
                     var collector = new ResponseMetadataCollector();
                     collector.observe(response);
                     collector.publishTo(request.metadataSink());
+                    warnOnAbnormalCompletion(response);
                     var text = getAssistantText(response);
                     if (!text.isEmpty()) {
                         sink.next(text);
@@ -514,6 +519,29 @@ public class SpringAILLMProvider implements LLMProvider {
                 sink.error(e);
             }
         });
+    }
+
+    /**
+     * Warns when a non-streaming turn did not end in a state a completed turn
+     * can end in. Spring AI runs the tool-calling loop inside its own call and
+     * hands back only the final response, so tool calls still pending on it
+     * mean the loop stopped before the model produced its answer. The streaming
+     * path has the same checks built into
+     * {@link #warnOnMissingFinishReason(Flux)}.
+     */
+    private static void warnOnAbnormalCompletion(ChatResponse response) {
+        var finishReason = ResponseMetadataCollector.getFinishReason(response);
+        if (response.hasToolCalls()) {
+            LOGGER.warn("LLM call ended with tool calls still pending "
+                    + "(finish reason: {}). The tool-calling loop stopped "
+                    + "before the model produced its answer, so the response "
+                    + "is incomplete.", finishReason);
+        } else if (finishReason == null) {
+            LOGGER.warn("LLM call ended without a finish reason. This may "
+                    + "indicate a silent abnormal termination such as an "
+                    + "upstream error; if the response appears truncated "
+                    + "this warning is the signal.");
+        }
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -394,10 +394,10 @@ public class SpringAILLMProvider implements LLMProvider {
 
     private Flux<String> executeStreamingChat(LLMRequest request) {
         try {
-            var collector = new ResponseMetadataCollector();
+            var collector = new ResponseMetadataCollector(
+                    request.metadataSink());
             var chatResponses = getPromptSpec(request).stream().chatResponse()
-                    .doOnNext(collector::observe).doOnComplete(
-                            () -> collector.publishTo(request.metadataSink()));
+                    .doOnNext(collector::observe);
             return warnOnMissingFinishReason(chatResponses)
                     .map(SpringAILLMProvider::getAssistantText)
                     .filter(text -> !text.isEmpty());
@@ -505,9 +505,8 @@ public class SpringAILLMProvider implements LLMProvider {
                             + "may indicate an upstream error swallowed by "
                             + "the client.");
                 } else {
-                    var collector = new ResponseMetadataCollector();
-                    collector.observe(response);
-                    collector.publishTo(request.metadataSink());
+                    new ResponseMetadataCollector(request.metadataSink())
+                            .observe(response);
                     warnOnAbnormalCompletion(response);
                     var text = getAssistantText(response);
                     if (!text.isEmpty()) {
@@ -545,30 +544,35 @@ public class SpringAILLMProvider implements LLMProvider {
     }
 
     /**
-     * Collects response metadata across the chunks of a turn. The last reported
-     * finish reason and token usage win: the terminal chunk carries the reason
-     * that ended the turn, and frameworks that report usage do so cumulatively
-     * on the final chunk that carries it.
+     * Collects response metadata across the chunks of a turn and passes each
+     * new state of knowledge to the metadata sink right away, so that a turn
+     * that fails or times out midway has still reported what was observed
+     * before the failure. The last reported finish reason and token usage win:
+     * the terminal chunk carries the reason that ended the turn, and frameworks
+     * that report usage do so cumulatively on the final chunk that carries it.
      */
     private static class ResponseMetadataCollector {
 
+        private final Consumer<ResponseMetadata> metadataSink;
         private String finishReason;
         private ResponseMetadata.TokenUsage tokenUsage;
 
+        ResponseMetadataCollector(Consumer<ResponseMetadata> metadataSink) {
+            this.metadataSink = metadataSink;
+        }
+
         void observe(ChatResponse response) {
             var reason = getFinishReason(response);
+            var usage = getTokenUsage(response);
+            if (reason == null && usage == null) {
+                // Nothing new on this chunk, nothing to re-publish.
+                return;
+            }
             if (reason != null) {
                 finishReason = reason;
             }
-            var usage = getTokenUsage(response);
             if (usage != null) {
                 tokenUsage = usage;
-            }
-        }
-
-        void publishTo(Consumer<ResponseMetadata> metadataSink) {
-            if (finishReason == null && tokenUsage == null) {
-                return;
             }
             metadataSink.accept(new ResponseMetadata(finishReason, tokenUsage));
         }
@@ -588,12 +592,22 @@ public class SpringAILLMProvider implements LLMProvider {
             if (usage == null) {
                 return null;
             }
-            var total = usage.getTotalTokens();
-            if (total == null || total <= 0) {
+            var input = positiveOrNull(usage.getPromptTokens());
+            var output = positiveOrNull(usage.getCompletionTokens());
+            var total = positiveOrNull(usage.getTotalTokens());
+            if (total == null && input != null && output != null) {
+                // A backend that reports the components but no total still
+                // reported the usage; derive rather than discard it.
+                total = input + output;
+            }
+            if (input == null && output == null && total == null) {
                 return null;
             }
-            return new ResponseMetadata.TokenUsage(usage.getPromptTokens(),
-                    usage.getCompletionTokens(), total);
+            return new ResponseMetadata.TokenUsage(input, output, total);
+        }
+
+        private static Integer positiveOrNull(Integer count) {
+            return count == null || count <= 0 ? null : count;
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -524,13 +524,13 @@ public class SpringAILLMProvider implements LLMProvider {
      */
     private static class ResponseMetadataCollector {
 
-        private String rawFinishReason;
+        private String finishReason;
         private ResponseMetadata.TokenUsage tokenUsage;
 
         void observe(ChatResponse response) {
-            var raw = getRawFinishReason(response);
-            if (raw != null) {
-                rawFinishReason = raw;
+            var reason = getFinishReason(response);
+            if (reason != null) {
+                finishReason = reason;
             }
             var usage = getTokenUsage(response);
             if (usage != null) {
@@ -539,15 +539,13 @@ public class SpringAILLMProvider implements LLMProvider {
         }
 
         void publishTo(Consumer<ResponseMetadata> metadataSink) {
-            if (rawFinishReason == null && tokenUsage == null) {
+            if (finishReason == null && tokenUsage == null) {
                 return;
             }
-            metadataSink.accept(new ResponseMetadata(
-                    ResponseMetadata.normalizeFinishReason(rawFinishReason),
-                    rawFinishReason, tokenUsage));
+            metadataSink.accept(new ResponseMetadata(finishReason, tokenUsage));
         }
 
-        private static String getRawFinishReason(ChatResponse response) {
+        private static String getFinishReason(ChatResponse response) {
             var result = response.getResult();
             if (result == null) {
                 return null;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -33,6 +33,7 @@ import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.content.Media;
@@ -588,13 +589,18 @@ public class SpringAILLMProvider implements LLMProvider {
 
         private static ResponseMetadata.TokenUsage getTokenUsage(
                 ChatResponse response) {
-            var usage = response.getMetadata().getUsage();
-            if (usage == null) {
-                return null;
-            }
-            var input = positiveOrNull(usage.getPromptTokens());
-            var output = positiveOrNull(usage.getCompletionTokens());
-            var total = positiveOrNull(usage.getTotalTokens());
+            // Read through an Optional rather than dereferencing: a model
+            // reports either no usage object at all or one that leaves the
+            // counts it does not know at zero, and both mean the same thing
+            // here. Spring AI's own models always attach a usage object, but
+            // an application's ChatModel is free not to.
+            var usage = Optional.ofNullable(response.getMetadata().getUsage());
+            var input = usage.map(Usage::getPromptTokens)
+                    .filter(count -> count > 0).orElse(null);
+            var output = usage.map(Usage::getCompletionTokens)
+                    .filter(count -> count > 0).orElse(null);
+            var total = usage.map(Usage::getTotalTokens)
+                    .filter(count -> count > 0).orElse(null);
             if (total == null && input != null && output != null) {
                 // A backend that reports the components but no total still
                 // reported the usage; derive rather than discard it.
@@ -604,10 +610,6 @@ public class SpringAILLMProvider implements LLMProvider {
                 return null;
             }
             return new ResponseMetadata.TokenUsage(input, output, total);
-        }
-
-        private static Integer positiveOrNull(Integer count) {
-            return count == null || count <= 0 ? null : count;
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1884,6 +1884,35 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void responseListener_streamFails_eventCarriesMetadataObservedBeforeError() {
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        var metadata = new ResponseMetadata("tool_use",
+                new ResponseMetadata.TokenUsage(40, 10, 50));
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenAnswer(invocation -> {
+                    LLMProvider.LLMRequest request = invocation.getArgument(0);
+                    request.metadataSink().accept(metadata);
+                    return Flux.error(new RuntimeException("API Error"));
+                });
+
+        var capturedEvent = new AtomicReference<ResponseListener.ResponseEvent>();
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withResponseListener(capturedEvent::set).build();
+        orchestrator.prompt("Hi");
+
+        Assertions.assertTrue(capturedEvent.get().getError().isPresent());
+        Assertions.assertSame(metadata,
+                capturedEvent.get().getMetadata().orElse(null),
+                "The failure event must carry the metadata observed before "
+                        + "the error");
+    }
+
+    @Test
     void responseListener_providerPublishesNoMetadata_eventMetadataEmpty() {
         var mockMessage = createMockMessage();
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -452,7 +452,7 @@ class AIOrchestratorTest {
         orchestrator.prompt("do it");
 
         Mockito.verify(fakeTool).execute(Mockito.any());
-        Mockito.verify(controller).onResponse(null);
+        Mockito.verify(controller).onResponse(noError());
     }
 
     @Test
@@ -2013,7 +2013,7 @@ class AIOrchestratorTest {
                     throw new RuntimeException("listener died");
                 }).build().prompt("Hello");
 
-        Mockito.verify(controller).onResponse(streamError);
+        Mockito.verify(controller).onResponse(errorIs(streamError));
     }
 
     // --- AIController tests ---
@@ -2069,7 +2069,8 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onResponse(Throwable error) {
+            public void onResponse(ResponseListener.ResponseEvent event) {
+                var error = event.getError().orElse(null);
                 if (error != null) {
                     return;
                 }
@@ -2109,7 +2110,8 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onResponse(Throwable error) {
+            public void onResponse(ResponseListener.ResponseEvent event) {
+                var error = event.getError().orElse(null);
                 if (error != null) {
                     return;
                 }
@@ -2160,7 +2162,8 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onResponse(Throwable error) {
+            public void onResponse(ResponseListener.ResponseEvent event) {
+                var error = event.getError().orElse(null);
                 if (error != null) {
                     return;
                 }
@@ -2196,7 +2199,8 @@ class AIOrchestratorTest {
             }
 
             @Override
-            public void onResponse(Throwable error) {
+            public void onResponse(ResponseListener.ResponseEvent event) {
+                var error = event.getError().orElse(null);
                 if (error != null) {
                     return;
                 }
@@ -2268,8 +2272,8 @@ class AIOrchestratorTest {
         var controller = mockController();
         orchestratorWith(controller).prompt("Hello");
 
-        Mockito.verify(controller).onResponse(thrown);
-        Mockito.verify(controller, Mockito.never()).onResponse(null);
+        Mockito.verify(controller).onResponse(errorIs(thrown));
+        Mockito.verify(controller, Mockito.never()).onResponse(noError());
     }
 
     @Test
@@ -2283,8 +2287,8 @@ class AIOrchestratorTest {
         var controller = mockController();
         orchestratorWith(controller).prompt("Hello");
 
-        Mockito.verify(controller).onResponse(timeout);
-        Mockito.verify(controller, Mockito.never()).onResponse(null);
+        Mockito.verify(controller).onResponse(errorIs(timeout));
+        Mockito.verify(controller, Mockito.never()).onResponse(noError());
     }
 
     @Test
@@ -2301,8 +2305,8 @@ class AIOrchestratorTest {
 
         Mockito.verify(mockProvider, Mockito.never())
                 .stream(Mockito.any(LLMProvider.LLMRequest.class));
-        Mockito.verify(controller).onResponse(thrown);
-        Mockito.verify(controller, Mockito.never()).onResponse(null);
+        Mockito.verify(controller).onResponse(errorIs(thrown));
+        Mockito.verify(controller, Mockito.never()).onResponse(noError());
     }
 
     @Test
@@ -2427,7 +2431,7 @@ class AIOrchestratorTest {
 
         orchestratorWith(controller).prompt("Hello");
 
-        Mockito.verify(controller).onResponse(streamError);
+        Mockito.verify(controller).onResponse(errorIs(streamError));
         var logged = logger.getLoggingEvents().stream().filter(event -> event
                 .getMessage().equals("Error in controller onResponse"))
                 .findFirst();
@@ -2468,8 +2472,8 @@ class AIOrchestratorTest {
                 () -> orchestrator.prompt("Hello"));
         Assertions.assertSame(thrown, caught);
 
-        Mockito.verify(controller).onResponse(thrown);
-        Mockito.verify(controller, Mockito.never()).onResponse(null);
+        Mockito.verify(controller).onResponse(errorIs(thrown));
+        Mockito.verify(controller, Mockito.never()).onResponse(noError());
     }
 
     @Test
@@ -2503,8 +2507,8 @@ class AIOrchestratorTest {
         Mockito.verify(mockProvider, Mockito.times(2))
                 .stream(Mockito.any(LLMProvider.LLMRequest.class));
         Mockito.verify(controller)
-                .onResponse(Mockito.any(IllegalStateException.class));
-        Mockito.verify(controller).onResponse(null);
+                .onResponse(errorOfType(IllegalStateException.class));
+        Mockito.verify(controller).onResponse(noError());
     }
 
     @Test
@@ -2525,8 +2529,8 @@ class AIOrchestratorTest {
                 () -> orchestrator.prompt("Hello"));
         Assertions.assertSame(thrown, caught);
 
-        Mockito.verify(controller).onResponse(thrown);
-        Mockito.verify(controller, Mockito.never()).onResponse(null);
+        Mockito.verify(controller).onResponse(errorIs(thrown));
+        Mockito.verify(controller, Mockito.never()).onResponse(noError());
     }
 
     @Test
@@ -2560,11 +2564,79 @@ class AIOrchestratorTest {
         var controller = mockController();
         orchestratorWith(controller).prompt("Hello");
 
-        Mockito.verify(controller).onResponse(null);
+        Mockito.verify(controller).onResponse(noError());
         // No failure-side fire — error arg never carries a Throwable on a
         // successful turn.
         Mockito.verify(controller, Mockito.never())
-                .onResponse(Mockito.any(Throwable.class));
+                .onResponse(errorOfType(Throwable.class));
+    }
+
+    @Test
+    void controllerOnResponse_receivesProviderMetadata() {
+        // The controller is where staged state is committed, so a turn that
+        // stopped at the output limit has to be distinguishable there — an
+        // error alone cannot express it, since such a turn ends without one.
+        stubAddMessage();
+        var metadata = new ResponseMetadata("max_tokens",
+                new ResponseMetadata.TokenUsage(1200, 8, 1208));
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenAnswer(invocation -> {
+                    LLMProvider.LLMRequest request = invocation.getArgument(0);
+                    request.metadataSink().accept(metadata);
+                    return Flux.just("Truncated");
+                });
+
+        var captured = new AtomicReference<ResponseListener.ResponseEvent>();
+        var controller = new AIController() {
+            @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
+            @Override
+            public void onResponse(ResponseListener.ResponseEvent event) {
+                captured.set(event);
+            }
+        };
+        orchestratorWith(controller).prompt("Hello");
+
+        Assertions.assertNotNull(captured.get(),
+                "onResponse must fire for the controller");
+        Assertions.assertSame(metadata,
+                captured.get().getMetadata().orElse(null),
+                "Provider metadata must reach the controller, not just the "
+                        + "response listener");
+    }
+
+    @Test
+    void controllerOnResponse_failedTurnCarriesErrorInEvent() {
+        // The single hook has to express failure as well as the old
+        // Throwable parameter did.
+        stubAddMessage();
+        var streamError = new IllegalStateException("stream blew up");
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.error(streamError));
+
+        var captured = new AtomicReference<ResponseListener.ResponseEvent>();
+        var controller = new AIController() {
+            @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
+            @Override
+            public void onResponse(ResponseListener.ResponseEvent event) {
+                captured.set(event);
+            }
+        };
+        orchestratorWith(controller).prompt("Hello");
+
+        Assertions.assertNotNull(captured.get());
+        Assertions.assertSame(streamError,
+                captured.get().getError().orElse(null),
+                "The failure cause must reach the controller");
     }
 
     @Test
@@ -3638,4 +3710,23 @@ class AIOrchestratorTest {
     private static AIAttachment createAttachment(String fileName) {
         return new AIAttachment(fileName, "text/plain", "test".getBytes());
     }
+
+    /** Matches a turn outcome that ended without an error. */
+    private static ResponseListener.ResponseEvent noError() {
+        return Mockito.argThat(e -> e != null && e.getError().isEmpty());
+    }
+
+    /** Matches a turn outcome carrying exactly the given error instance. */
+    private static ResponseListener.ResponseEvent errorIs(Throwable expected) {
+        return Mockito.argThat(
+                e -> e != null && e.getError().orElse(null) == expected);
+    }
+
+    /** Matches a turn outcome whose error is of the given type. */
+    private static ResponseListener.ResponseEvent errorOfType(
+            Class<? extends Throwable> type) {
+        return Mockito.argThat(e -> e != null
+                && e.getError().filter(type::isInstance).isPresent());
+    }
+
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -1861,8 +1861,7 @@ class AIOrchestratorTest {
         Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
                 Mockito.anyString(), Mockito.anyList()))
                 .thenReturn(mockMessage);
-        var metadata = new ResponseMetadata(
-                ResponseMetadata.FinishReason.LENGTH, "max_tokens",
+        var metadata = new ResponseMetadata("max_tokens",
                 new ResponseMetadata.TokenUsage(1200, 8, 1208));
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.component.ai.AIComponentsFeatureFlagProvider;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.ResponseMetadata;
 import com.vaadin.flow.component.ai.ui.AIFileReceiver;
 import com.vaadin.flow.component.ai.ui.AIInput;
 import com.vaadin.flow.component.ai.ui.AIMessage;
@@ -1852,6 +1853,56 @@ class AIOrchestratorTest {
         Assertions.assertTrue(capturedEvent.get().getError().isEmpty(),
                 "Success path must carry an empty error optional, got: "
                         + capturedEvent.get().getError());
+    }
+
+    @Test
+    void responseListener_providerPublishesMetadata_eventCarriesIt() {
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        var metadata = new ResponseMetadata(
+                ResponseMetadata.FinishReason.LENGTH, "max_tokens",
+                new ResponseMetadata.TokenUsage(1200, 8, 1208));
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenAnswer(invocation -> {
+                    LLMProvider.LLMRequest request = invocation.getArgument(0);
+                    request.metadataSink().accept(metadata);
+                    return Flux.just("Let me load the");
+                });
+
+        var capturedEvent = new AtomicReference<ResponseListener.ResponseEvent>();
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withResponseListener(capturedEvent::set).build();
+        orchestrator.prompt("Hi");
+
+        Assertions.assertNotNull(capturedEvent.get());
+        Assertions.assertSame(metadata,
+                capturedEvent.get().getMetadata().orElse(null),
+                "Metadata published by the provider must reach the event");
+    }
+
+    @Test
+    void responseListener_providerPublishesNoMetadata_eventMetadataEmpty() {
+        var mockMessage = createMockMessage();
+        Mockito.when(mockMessageList.addMessage(Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(mockMessage);
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("ok"));
+
+        var capturedEvent = new AtomicReference<ResponseListener.ResponseEvent>();
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withResponseListener(capturedEvent::set).build();
+        orchestrator.prompt("Hi");
+
+        Assertions.assertNotNull(capturedEvent.get());
+        Assertions.assertTrue(capturedEvent.get().getMetadata().isEmpty(),
+                "No published metadata must surface as an empty optional");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
@@ -1274,11 +1274,6 @@ class RequestInterceptorTest {
         return new AIAttachment(fileName, "text/plain", "test".getBytes());
     }
 
-    /** Matches a turn outcome that ended without an error. */
-    private static ResponseListener.ResponseEvent noError() {
-        return Mockito.argThat(e -> e != null && e.getError().isEmpty());
-    }
-
     /** Matches a turn outcome carrying exactly the given error instance. */
     private static ResponseListener.ResponseEvent errorIs(Throwable expected) {
         return Mockito.argThat(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
@@ -391,7 +391,7 @@ class RequestInterceptorTest {
                 () -> orchestrator.prompt("Hello"));
 
         Mockito.verify(controller, Mockito.never()).onRequest();
-        Mockito.verify(controller).onResponse(thrown);
+        Mockito.verify(controller).onResponse(errorIs(thrown));
     }
 
     @Test
@@ -1065,7 +1065,7 @@ class RequestInterceptorTest {
         }
 
         Mockito.verify(controller)
-                .onResponse(Mockito.isA(TimeoutException.class));
+                .onResponse(errorOfType(TimeoutException.class));
     }
 
     @Test
@@ -1273,4 +1273,23 @@ class RequestInterceptorTest {
     private static AIAttachment createAttachment(String fileName) {
         return new AIAttachment(fileName, "text/plain", "test".getBytes());
     }
+
+    /** Matches a turn outcome that ended without an error. */
+    private static ResponseListener.ResponseEvent noError() {
+        return Mockito.argThat(e -> e != null && e.getError().isEmpty());
+    }
+
+    /** Matches a turn outcome carrying exactly the given error instance. */
+    private static ResponseListener.ResponseEvent errorIs(Throwable expected) {
+        return Mockito.argThat(
+                e -> e != null && e.getError().orElse(null) == expected);
+    }
+
+    /** Matches a turn outcome whose error is of the given type. */
+    private static ResponseListener.ResponseEvent errorOfType(
+            Class<? extends Throwable> type) {
+        return Mockito.argThat(e -> e != null
+                && e.getError().filter(type::isInstance).isPresent());
+    }
+
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1904,6 +1904,30 @@ class LangChain4JLLMProviderTest {
                 "The reason on the final round trip covers the turn");
     }
 
+    @Test
+    void stream_finalToolRoundTripWithoutFinishReason_logsWarning() {
+        // The turn ended on a round trip the model said nothing about. The
+        // TOOL_EXECUTION reason from the earlier round trip describes that
+        // round trip, not how the turn ended, so it must not silence the
+        // warning.
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "tool result");
+        var request = requestWithMetadataSink("Call tool",
+                List.of(explicitTool), new ArrayList<>());
+        var toolResponse = mockSimpleResponseWithTool("myTool");
+        Mockito.when(toolResponse.finishReason())
+                .thenReturn(FinishReason.TOOL_EXECUTION);
+        var finalResponse = mockSimpleResponse("done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(toolResponse).thenReturn(finalResponse);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertTrue(hasMissingFinishReasonWarning(),
+                "A turn ending on a round trip with no finish reason must "
+                        + "warn even when an earlier round trip reported one");
+    }
+
     private boolean hasMissingFinishReasonWarning() {
         return logger.getLoggingEvents().stream()
                 .anyMatch(event -> event.getMessage().contains(

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1653,9 +1653,7 @@ class LangChain4JLLMProviderTest {
         Assertions.assertEquals(1, collected.size(),
                 "Provider should publish the response metadata once");
         var metadata = collected.getFirst();
-        Assertions.assertEquals(ResponseMetadata.FinishReason.LENGTH,
-                metadata.finishReason());
-        Assertions.assertEquals("LENGTH", metadata.rawFinishReason());
+        Assertions.assertEquals("LENGTH", metadata.finishReason());
         Assertions.assertEquals(1200, metadata.tokenUsage().inputTokens());
         Assertions.assertEquals(8, metadata.tokenUsage().outputTokens());
         Assertions.assertEquals(1208, metadata.tokenUsage().totalTokens());
@@ -1687,8 +1685,8 @@ class LangChain4JLLMProviderTest {
         Assertions.assertEquals(1, collected.size(),
                 "Provider should publish the response metadata once");
         var metadata = collected.getFirst();
-        Assertions.assertEquals(ResponseMetadata.FinishReason.STOP,
-                metadata.finishReason(), "The reason that ended the turn wins");
+        Assertions.assertEquals("STOP", metadata.finishReason(),
+                "The reason that ended the turn wins");
         Assertions.assertEquals(300, metadata.tokenUsage().inputTokens());
         Assertions.assertEquals(30, metadata.tokenUsage().outputTokens());
         Assertions.assertEquals(330, metadata.tokenUsage().totalTokens());
@@ -1717,8 +1715,7 @@ class LangChain4JLLMProviderTest {
         Assertions.assertEquals(1, collected.size(),
                 "Provider should publish the response metadata once");
         var metadata = collected.getFirst();
-        Assertions.assertEquals(ResponseMetadata.FinishReason.STOP,
-                metadata.finishReason());
+        Assertions.assertEquals("STOP", metadata.finishReason());
         Assertions.assertEquals(55, metadata.tokenUsage().totalTokens());
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1802,6 +1802,58 @@ class LangChain4JLLMProviderTest {
                 "No finish reason and no usage means nothing to publish");
     }
 
+    @Test
+    void stream_turnEndsWithoutFinishReason_logsWarning() {
+        var response = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(createSimpleRequest("Hello")).collectList().block();
+
+        Assertions.assertTrue(hasMissingFinishReasonWarning(),
+                "Expected a warning about the missing finish reason");
+    }
+
+    @Test
+    void stream_turnEndsWithFinishReason_noMissingFinishReasonWarning() {
+        var response = mockSimpleResponse("Done");
+        Mockito.when(response.finishReason()).thenReturn(FinishReason.STOP);
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(createSimpleRequest("Hello")).collectList().block();
+
+        Assertions.assertFalse(hasMissingFinishReasonWarning(),
+                "A turn with a reported finish reason must not warn");
+    }
+
+    @Test
+    void stream_finishReasonOnlyOnFinalToolRoundTrip_noMissingFinishReasonWarning() {
+        // Some models report the reason only on the round trip that ends the
+        // turn; earlier tool round trips without one are not abnormal.
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "tool result");
+        var request = requestWithMetadataSink("Call tool",
+                List.of(explicitTool), new ArrayList<>());
+        var toolResponse = mockSimpleResponseWithTool("myTool");
+        var finalResponse = mockSimpleResponse("done");
+        Mockito.when(finalResponse.finishReason())
+                .thenReturn(FinishReason.STOP);
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(toolResponse).thenReturn(finalResponse);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertFalse(hasMissingFinishReasonWarning(),
+                "The reason on the final round trip covers the turn");
+    }
+
+    private boolean hasMissingFinishReasonWarning() {
+        return logger.getLoggingEvents().stream()
+                .anyMatch(event -> event.getMessage().contains(
+                        "without the model reporting a finish " + "reason"));
+    }
+
     private static LLMRequest requestWithMetadataSink(String message,
             List<LLMProvider.ToolSpec> explicitTools,
             List<ResponseMetadata> collected) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Assertions;
@@ -60,6 +61,8 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
 import tools.jackson.databind.JsonNode;
 
 class LangChain4JLLMProviderTest {
@@ -1627,6 +1630,144 @@ class LangChain4JLLMProviderTest {
             @Override
             public String execute(JsonNode arguments) {
                 return executor.apply(arguments);
+            }
+        };
+    }
+
+    // --- Response metadata tests ---
+
+    @Test
+    void stream_nonStreamingWithFinishReasonAndUsage_publishesMetadata() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", List.of(), collected);
+        var response = mockSimpleResponse("Truncated");
+        Mockito.when(response.finishReason()).thenReturn(FinishReason.LENGTH);
+        Mockito.when(response.tokenUsage())
+                .thenReturn(new TokenUsage(1200, 8, 1208));
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("Truncated"), results);
+        Assertions.assertEquals(1, collected.size(),
+                "Provider should publish the response metadata once");
+        var metadata = collected.getFirst();
+        Assertions.assertEquals(ResponseMetadata.FinishReason.LENGTH,
+                metadata.finishReason());
+        Assertions.assertEquals("LENGTH", metadata.rawFinishReason());
+        Assertions.assertEquals(1200, metadata.tokenUsage().inputTokens());
+        Assertions.assertEquals(8, metadata.tokenUsage().outputTokens());
+        Assertions.assertEquals(1208, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_nonStreamingToolRoundTrips_accumulatesTokenUsage() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "tool result");
+        var request = requestWithMetadataSink("Call tool",
+                List.of(explicitTool), collected);
+        var toolResponse = mockSimpleResponseWithTool("myTool");
+        Mockito.when(toolResponse.finishReason())
+                .thenReturn(FinishReason.TOOL_EXECUTION);
+        Mockito.when(toolResponse.tokenUsage())
+                .thenReturn(new TokenUsage(100, 10, 110));
+        var finalResponse = mockSimpleResponse("done");
+        Mockito.when(finalResponse.finishReason())
+                .thenReturn(FinishReason.STOP);
+        Mockito.when(finalResponse.tokenUsage())
+                .thenReturn(new TokenUsage(200, 20, 220));
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(toolResponse).thenReturn(finalResponse);
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("done"), results);
+        Assertions.assertEquals(1, collected.size(),
+                "Provider should publish the response metadata once");
+        var metadata = collected.getFirst();
+        Assertions.assertEquals(ResponseMetadata.FinishReason.STOP,
+                metadata.finishReason(), "The reason that ended the turn wins");
+        Assertions.assertEquals(300, metadata.tokenUsage().inputTokens());
+        Assertions.assertEquals(30, metadata.tokenUsage().outputTokens());
+        Assertions.assertEquals(330, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_streamingWithMetadata_publishesMetadata() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", List.of(), collected);
+        var response = mockSimpleResponse("Hello World");
+        Mockito.when(response.finishReason()).thenReturn(FinishReason.STOP);
+        Mockito.when(response.tokenUsage())
+                .thenReturn(new TokenUsage(50, 5, 55));
+        Mockito.doAnswer(invocation -> {
+            StreamingChatResponseHandler handler = invocation.getArgument(1);
+            handler.onPartialResponse("Hello ");
+            handler.onPartialResponse("World");
+            handler.onCompleteResponse(response);
+            return null;
+        }).when(mockStreamingChatModel).chat(Mockito.any(ChatRequest.class),
+                Mockito.any(StreamingChatResponseHandler.class));
+
+        var results = streamingProvider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("Hello ", "World"), results);
+        Assertions.assertEquals(1, collected.size(),
+                "Provider should publish the response metadata once");
+        var metadata = collected.getFirst();
+        Assertions.assertEquals(ResponseMetadata.FinishReason.STOP,
+                metadata.finishReason());
+        Assertions.assertEquals(55, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_nonStreamingWithoutMetadata_sinkNotCalled() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", List.of(), collected);
+        var response = mockSimpleResponse("plain");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertTrue(collected.isEmpty(),
+                "No finish reason and no usage means nothing to publish");
+    }
+
+    private static LLMRequest requestWithMetadataSink(String message,
+            List<LLMProvider.ToolSpec> explicitTools,
+            List<ResponseMetadata> collected) {
+        return new LLMRequest() {
+            @Override
+            public String userMessage() {
+                return message;
+            }
+
+            @Override
+            public List<AIAttachment> attachments() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public String systemPrompt() {
+                return null;
+            }
+
+            @Override
+            public Object[] tools() {
+                return new Object[0];
+            }
+
+            @Override
+            public List<LLMProvider.ToolSpec> explicitTools() {
+                return explicitTools;
+            }
+
+            @Override
+            public Consumer<ResponseMetadata> metadataSink() {
+                return collected::add;
             }
         };
     }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1720,6 +1720,46 @@ class LangChain4JLLMProviderTest {
     }
 
     @Test
+    void stream_nonStreamingWithFinishReasonButNoUsage_publishesReasonOnly() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", List.of(), collected);
+        var response = mockSimpleResponse("Done");
+        Mockito.when(response.finishReason()).thenReturn(FinishReason.STOP);
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(1, collected.size(),
+                "A reported finish reason alone is worth publishing");
+        Assertions.assertEquals("STOP", collected.getFirst().finishReason());
+        Assertions.assertNull(collected.getFirst().tokenUsage());
+    }
+
+    @Test
+    void stream_nonStreamingWithoutAiMessage_publishesMetadata() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", List.of(), collected);
+        var response = Mockito.mock(ChatResponse.class);
+        Mockito.when(response.aiMessage()).thenReturn(null);
+        Mockito.when(response.finishReason())
+                .thenReturn(FinishReason.CONTENT_FILTER);
+        Mockito.when(response.tokenUsage())
+                .thenReturn(new TokenUsage(30, 0, 30));
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(1, collected.size(),
+                "A turn that ends without a message still reports why");
+        Assertions.assertEquals("CONTENT_FILTER",
+                collected.getFirst().finishReason());
+        Assertions.assertEquals(30,
+                collected.getFirst().tokenUsage().totalTokens());
+    }
+
+    @Test
     void stream_nonStreamingWithoutMetadata_sinkNotCalled() {
         var collected = new ArrayList<ResponseMetadata>();
         var request = requestWithMetadataSink("Hello", List.of(), collected);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1929,9 +1929,8 @@ class LangChain4JLLMProviderTest {
     }
 
     private boolean hasMissingFinishReasonWarning() {
-        return logger.getLoggingEvents().stream()
-                .anyMatch(event -> event.getMessage().contains(
-                        "without the model reporting a finish " + "reason"));
+        return logger.getLoggingEvents().stream().anyMatch(
+                event -> event.getMessage().contains("no finish reason"));
     }
 
     private static LLMRequest requestWithMetadataSink(String message,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1803,6 +1803,62 @@ class LangChain4JLLMProviderTest {
     }
 
     @Test
+    void stream_nonStreamingWithUsageButNoFinishReason_publishesUsage() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", List.of(), collected);
+        var response = mockSimpleResponse("Done");
+        Mockito.when(response.tokenUsage())
+                .thenReturn(new TokenUsage(50, 5, 55));
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(1, collected.size(),
+                "Reported usage is worth publishing on its own");
+        Assertions.assertNull(collected.getFirst().finishReason());
+        Assertions.assertEquals(55,
+                collected.getFirst().tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_nonStreamingLastRoundTripReportsNothingNew_doesNotRepublish() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "tool result");
+        var request = requestWithMetadataSink("Call tool",
+                List.of(explicitTool), collected);
+        var toolResponse = mockSimpleResponseWithTool("myTool");
+        Mockito.when(toolResponse.finishReason())
+                .thenReturn(FinishReason.TOOL_EXECUTION);
+        Mockito.when(toolResponse.tokenUsage())
+                .thenReturn(new TokenUsage(100, 10, 110));
+        var finalResponse = mockSimpleResponse("done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(toolResponse).thenReturn(finalResponse);
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(1, collected.size(),
+                "A round trip that reports neither a reason nor usage must "
+                        + "not re-publish the earlier state");
+    }
+
+    @Test
+    void stream_turnEndsWithoutAiMessageAndWithoutFinishReason_logsWarning() {
+        var response = Mockito.mock(ChatResponse.class);
+        Mockito.when(response.aiMessage()).thenReturn(null);
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(createSimpleRequest("Hello")).collectList().block();
+
+        Assertions.assertTrue(hasMissingFinishReasonWarning(),
+                "A turn that ends without a message and without a finish "
+                        + "reason must warn");
+    }
+
+    @Test
     void stream_turnEndsWithoutFinishReason_logsWarning() {
         var response = mockSimpleResponse("Done");
         Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1713,8 +1713,8 @@ class LangChain4JLLMProviderTest {
                 .thenReturn(toolResponse)
                 .thenThrow(new RuntimeException("API down"));
 
-        Assertions.assertThrows(RuntimeException.class,
-                () -> provider.stream(request).collectList().block());
+        var response = provider.stream(request).collectList();
+        Assertions.assertThrows(RuntimeException.class, response::block);
 
         var metadata = collected.getLast();
         Assertions.assertEquals("TOOL_EXECUTION", metadata.finishReason());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1682,14 +1682,43 @@ class LangChain4JLLMProviderTest {
         var results = provider.stream(request).collectList().block();
 
         Assertions.assertEquals(List.of("done"), results);
-        Assertions.assertEquals(1, collected.size(),
-                "Provider should publish the response metadata once");
-        var metadata = collected.getFirst();
+        Assertions.assertEquals(2, collected.size(),
+                "Each round trip publishes the state known so far");
+        Assertions.assertEquals(110,
+                collected.getFirst().tokenUsage().totalTokens(),
+                "The first snapshot carries the first round trip alone");
+        var metadata = collected.getLast();
         Assertions.assertEquals("STOP", metadata.finishReason(),
                 "The reason that ended the turn wins");
         Assertions.assertEquals(300, metadata.tokenUsage().inputTokens());
         Assertions.assertEquals(30, metadata.tokenUsage().outputTokens());
         Assertions.assertEquals(330, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_secondToolRoundTripFails_firstRoundMetadataStillPublished() {
+        // The failed turn was still billed for the round trips that ran; the
+        // sink must have received what was observed before the failure.
+        var collected = new ArrayList<ResponseMetadata>();
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "tool result");
+        var request = requestWithMetadataSink("Call tool",
+                List.of(explicitTool), collected);
+        var toolResponse = mockSimpleResponseWithTool("myTool");
+        Mockito.when(toolResponse.finishReason())
+                .thenReturn(FinishReason.TOOL_EXECUTION);
+        Mockito.when(toolResponse.tokenUsage())
+                .thenReturn(new TokenUsage(100, 10, 110));
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(toolResponse)
+                .thenThrow(new RuntimeException("API down"));
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> provider.stream(request).collectList().block());
+
+        var metadata = collected.getLast();
+        Assertions.assertEquals("TOOL_EXECUTION", metadata.finishReason());
+        Assertions.assertEquals(110, metadata.tokenUsage().totalTokens());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1541,6 +1541,71 @@ class SpringAILLMProviderTest {
         Assertions.assertEquals(originalError, thrown);
     }
 
+    @Test
+    void stream_nonStreamingEndsWithPendingToolCalls_logsWarning() {
+        // The turn stopped between asking for a tool and answering with its
+        // result — the silent truncation that is otherwise invisible. Needs a
+        // client whose own tool execution is disabled, since the default one
+        // would run the tool and ask for another round.
+        var toolAdvisorBuilder = ToolCallingAdvisor.builder()
+                .toolExecutionEligibilityChecker(response -> false);
+        var chatClient = ChatClient.builder(mockChatModel,
+                ObservationRegistry.NOOP, null, null, toolAdvisorBuilder)
+                .build();
+        var chatClientProvider = new SpringAILLMProvider(chatClient);
+        chatClientProvider.setStreaming(false);
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(mockChatResponseWithPendingToolCall());
+
+        chatClientProvider.stream(createSimpleRequest("invoke tool"))
+                .collectList().block();
+
+        assertWarningLogged("tool calls still pending");
+    }
+
+    @Test
+    void stream_nonStreamingWithoutFinishReason_logsWarning() {
+        provider.setStreaming(false);
+        mockSimpleChatWithoutFinishReason("Done");
+
+        provider.stream(createSimpleRequest("Hello")).collectList().block();
+
+        assertWarningLogged("without a finish reason");
+    }
+
+    @Test
+    void stream_nonStreamingWithFinishReason_noAbnormalWarning() {
+        provider.setStreaming(false);
+        mockSimpleChat("Done");
+
+        provider.stream(createSimpleRequest("Hello")).collectList().block();
+
+        assertNoWarningLogged("tool calls still pending");
+        assertNoWarningLogged("without a finish reason");
+    }
+
+    private void mockSimpleChatWithoutFinishReason(String responseText) {
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(mockChatResponse(responseText, null));
+    }
+
+    private void assertWarningLogged(String phrase) {
+        var warning = logger.getAllLoggingEvents().stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .filter(event -> event.getMessage().contains(phrase))
+                .findFirst();
+        Assertions.assertTrue(warning.isPresent(),
+                "Expected a warning containing: " + phrase);
+    }
+
+    private void assertNoWarningLogged(String phrase) {
+        var warning = logger.getAllLoggingEvents().stream()
+                .filter(event -> event.getMessage().contains(phrase))
+                .findFirst();
+        Assertions.assertFalse(warning.isPresent(),
+                "Expected no warning containing: " + phrase);
+    }
+
     private void assertAbnormalTerminationWarningLogged() {
         // The warning is emitted from a Reactor scheduler thread (Spring
         // AI's chatResponse pipeline), so we have to query across all

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1876,8 +1876,8 @@ class SpringAILLMProviderTest {
                         .concatWith(Flux.error(
                                 new RuntimeException("network broken"))));
 
-        Assertions.assertThrows(RuntimeException.class,
-                () -> provider.stream(request).collectList().block());
+        var response = provider.stream(request).collectList();
+        Assertions.assertThrows(RuntimeException.class, response::block);
 
         var metadata = collected.getLast();
         Assertions.assertEquals("tool_use", metadata.finishReason());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Assertions;
@@ -47,6 +48,8 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -1716,6 +1719,116 @@ class SpringAILLMProviderTest {
 
         Assertions.assertTrue(result.startsWith("Error executing tool:"));
         Assertions.assertEquals(0, receivedArgs.size());
+    }
+
+    // --- Response metadata tests ---
+
+    @Test
+    void stream_nonStreamingWithFinishReasonAndUsage_publishesMetadata() {
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(chatResponseWithMetadata("Let me load the",
+                        "max_tokens", 1200, 8));
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("Let me load the"), results);
+        Assertions.assertEquals(1, collected.size(),
+                "Provider should publish the response metadata once");
+        var metadata = collected.getFirst();
+        Assertions.assertEquals(ResponseMetadata.FinishReason.LENGTH,
+                metadata.finishReason());
+        Assertions.assertEquals("max_tokens", metadata.rawFinishReason());
+        Assertions.assertEquals(1200, metadata.tokenUsage().inputTokens());
+        Assertions.assertEquals(8, metadata.tokenUsage().outputTokens());
+        Assertions.assertEquals(1208, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_streamingWithTerminalChunkMetadata_publishesMetadata() {
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.just(mockChatResponse("Hel", null),
+                        chatResponseWithMetadata("lo", "stop", 100, 20)));
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("Hel", "lo"), results);
+        Assertions.assertEquals(1, collected.size(),
+                "Provider should publish the response metadata once");
+        var metadata = collected.getFirst();
+        Assertions.assertEquals(ResponseMetadata.FinishReason.STOP,
+                metadata.finishReason());
+        Assertions.assertEquals("stop", metadata.rawFinishReason());
+        Assertions.assertEquals(120, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_nonStreamingWithoutMetadata_sinkNotCalled() {
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(mockChatResponse("plain", null));
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertTrue(collected.isEmpty(),
+                "No finish reason and no usage means nothing to publish");
+    }
+
+    @Test
+    void metadataSink_notOverridden_returnsNoOpConsumer() {
+        var request = createSimpleRequest("Hello");
+
+        Assertions.assertNotNull(request.metadataSink());
+        Assertions
+                .assertDoesNotThrow(() -> request.metadataSink().accept(null));
+    }
+
+    private static LLMRequest requestWithMetadataSink(String message,
+            List<ResponseMetadata> collected) {
+        return new LLMRequest() {
+            @Override
+            public String userMessage() {
+                return message;
+            }
+
+            @Override
+            public List<AIAttachment> attachments() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public String systemPrompt() {
+                return null;
+            }
+
+            @Override
+            public Object[] tools() {
+                return new Object[0];
+            }
+
+            @Override
+            public Consumer<ResponseMetadata> metadataSink() {
+                return collected::add;
+            }
+        };
+    }
+
+    private static ChatResponse chatResponseWithMetadata(String text,
+            String finishReason, int inputTokens, int outputTokens) {
+        var generation = new Generation(new AssistantMessage(text),
+                ChatGenerationMetadata.builder().finishReason(finishReason)
+                        .build());
+        return ChatResponse.builder().generations(List.of(generation))
+                .metadata(ChatResponseMetadata.builder()
+                        .usage(new DefaultUsage(inputTokens, outputTokens))
+                        .build())
+                .build();
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1908,6 +1908,54 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_streamingAcrossToolRoundTrips_publishesCumulativeUsage() {
+        // The default ChatClient consumes the tool-call round trip internally
+        // and re-emits the follow-up round with usage already accumulated
+        // across the round trips, so the last observed usage covers the whole
+        // turn. This test pins that behavior — the collector's last-wins
+        // accounting depends on it.
+        var collected = new ArrayList<ResponseMetadata>();
+        var tool = createExplicitTool("doSomething", "A test tool", null,
+                args -> "tool result");
+        var request = requestWithMetadataSink("invoke tool", List.of(tool),
+                collected);
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux.just(toolCallResponseWithUsage(30, 10)))
+                .thenReturn(Flux.just(
+                        chatResponseWithMetadata("done", "stop", 50, 20)));
+
+        var results = provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(List.of("done"), results);
+        var metadata = collected.getLast();
+        Assertions.assertEquals("stop", metadata.finishReason());
+        Assertions.assertEquals(80, metadata.tokenUsage().inputTokens());
+        Assertions.assertEquals(30, metadata.tokenUsage().outputTokens());
+        Assertions.assertEquals(110, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_streamingResendsGrowingUsageTally_lastValueWins() {
+        // Some backends resend a growing cumulative tally on every chunk
+        // instead of reporting the counts once at the end; the published
+        // usage must be the final tally, not a sum of the resends.
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(
+                        Flux.just(chatResponseWithMetadata("Hel", null, 30, 4),
+                                chatResponseWithMetadata("lo", null, 30, 9),
+                                chatResponseWithMetadata("!", "stop", 30, 12)));
+
+        provider.stream(request).collectList().block();
+
+        var usage = collected.getLast().tokenUsage();
+        Assertions.assertEquals(30, usage.inputTokens());
+        Assertions.assertEquals(12, usage.outputTokens());
+        Assertions.assertEquals(42, usage.totalTokens());
+    }
+
+    @Test
     void metadataSink_notOverridden_returnsNoOpConsumer() {
         var request = createSimpleRequest("Hello");
 
@@ -1917,6 +1965,12 @@ class SpringAILLMProviderTest {
     }
 
     private static LLMRequest requestWithMetadataSink(String message,
+            List<ResponseMetadata> collected) {
+        return requestWithMetadataSink(message, List.of(), collected);
+    }
+
+    private static LLMRequest requestWithMetadataSink(String message,
+            List<LLMProvider.ToolSpec> explicitTools,
             List<ResponseMetadata> collected) {
         return new LLMRequest() {
             @Override
@@ -1940,6 +1994,11 @@ class SpringAILLMProviderTest {
             }
 
             @Override
+            public List<LLMProvider.ToolSpec> explicitTools() {
+                return explicitTools;
+            }
+
+            @Override
             public Consumer<ResponseMetadata> metadataSink() {
                 return collected::add;
             }
@@ -1948,10 +2007,23 @@ class SpringAILLMProviderTest {
 
     private static ChatResponse chatResponseWithMetadata(String text,
             String finishReason, int inputTokens, int outputTokens) {
+        var generationMetadata = finishReason == null
+                ? ChatGenerationMetadata.NULL
+                : ChatGenerationMetadata.builder().finishReason(finishReason)
+                        .build();
         var generation = new Generation(new AssistantMessage(text),
-                ChatGenerationMetadata.builder().finishReason(finishReason)
-                        .build());
+                generationMetadata);
         return ChatResponse.builder().generations(List.of(generation))
+                .metadata(ChatResponseMetadata.builder()
+                        .usage(new DefaultUsage(inputTokens, outputTokens))
+                        .build())
+                .build();
+    }
+
+    private static ChatResponse toolCallResponseWithUsage(int inputTokens,
+            int outputTokens) {
+        var response = mockChatResponseWithPendingToolCall();
+        return ChatResponse.builder().generations(response.getResults())
                 .metadata(ChatResponseMetadata.builder()
                         .usage(new DefaultUsage(inputTokens, outputTokens))
                         .build())

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1763,6 +1763,27 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_nonStreamingWithFinishReasonButNoUsage_publishesReasonOnly() {
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        var generation = new Generation(new AssistantMessage("Done"),
+                ChatGenerationMetadata.builder().finishReason("stop").build());
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class))).thenReturn(
+                ChatResponse.builder().generations(List.of(generation))
+                        .metadata(ChatResponseMetadata.builder().usage(null)
+                                .build())
+                        .build());
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(1, collected.size(),
+                "A reported finish reason alone is worth publishing");
+        Assertions.assertEquals("stop", collected.getFirst().finishReason());
+        Assertions.assertNull(collected.getFirst().tokenUsage());
+    }
+
+    @Test
     void stream_nonStreamingWithoutMetadata_sinkNotCalled() {
         provider.setStreaming(false);
         var collected = new ArrayList<ResponseMetadata>();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -50,6 +50,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -1908,6 +1909,54 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_nonStreamingUsageWithZeroTotal_totalDerivedFromComponents() {
+        // A backend that reports the components but leaves the total at zero
+        // still reported the usage; the total must be derived, not dropped.
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        mockCallWithUsage(new DefaultUsage(100, 20, 0));
+
+        provider.stream(request).collectList().block();
+
+        Assertions.assertEquals(120,
+                collected.getLast().tokenUsage().totalTokens(),
+                "An unreported total must be derived from the components");
+    }
+
+    @Test
+    void stream_nonStreamingUsageWithoutInputTokens_publishesOutputTokensOnly() {
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        mockCallWithUsage(new DefaultUsage(0, 20, 0));
+
+        provider.stream(request).collectList().block();
+
+        var usage = collected.getLast().tokenUsage();
+        Assertions.assertNull(usage.inputTokens());
+        Assertions.assertEquals(20, usage.outputTokens());
+        Assertions.assertNull(usage.totalTokens(),
+                "A total cannot be derived without the input count");
+    }
+
+    @Test
+    void stream_nonStreamingUsageWithoutOutputTokens_publishesInputTokensOnly() {
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        mockCallWithUsage(new DefaultUsage(100, 0, 0));
+
+        provider.stream(request).collectList().block();
+
+        var usage = collected.getLast().tokenUsage();
+        Assertions.assertEquals(100, usage.inputTokens());
+        Assertions.assertNull(usage.outputTokens());
+        Assertions.assertNull(usage.totalTokens(),
+                "A total cannot be derived without the output count");
+    }
+
+    @Test
     void stream_streamingAcrossToolRoundTrips_publishesCumulativeUsage() {
         // The default ChatClient consumes the tool-call round trip internally
         // and re-emits the follow-up round with usage already accumulated
@@ -2003,6 +2052,16 @@ class SpringAILLMProviderTest {
                 return collected::add;
             }
         };
+    }
+
+    private void mockCallWithUsage(Usage usage) {
+        var generation = new Generation(new AssistantMessage("Done"),
+                ChatGenerationMetadata.builder().finishReason("stop").build());
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class))).thenReturn(
+                ChatResponse.builder().generations(List.of(generation))
+                        .metadata(ChatResponseMetadata.builder().usage(usage)
+                                .build())
+                        .build());
     }
 
     private static ChatResponse chatResponseWithMetadata(String text,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1738,9 +1738,7 @@ class SpringAILLMProviderTest {
         Assertions.assertEquals(1, collected.size(),
                 "Provider should publish the response metadata once");
         var metadata = collected.getFirst();
-        Assertions.assertEquals(ResponseMetadata.FinishReason.LENGTH,
-                metadata.finishReason());
-        Assertions.assertEquals("max_tokens", metadata.rawFinishReason());
+        Assertions.assertEquals("max_tokens", metadata.finishReason());
         Assertions.assertEquals(1200, metadata.tokenUsage().inputTokens());
         Assertions.assertEquals(8, metadata.tokenUsage().outputTokens());
         Assertions.assertEquals(1208, metadata.tokenUsage().totalTokens());
@@ -1760,9 +1758,7 @@ class SpringAILLMProviderTest {
         Assertions.assertEquals(1, collected.size(),
                 "Provider should publish the response metadata once");
         var metadata = collected.getFirst();
-        Assertions.assertEquals(ResponseMetadata.FinishReason.STOP,
-                metadata.finishReason());
-        Assertions.assertEquals("stop", metadata.rawFinishReason());
+        Assertions.assertEquals("stop", metadata.finishReason());
         Assertions.assertEquals(120, metadata.tokenUsage().totalTokens());
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1863,6 +1863,51 @@ class SpringAILLMProviderTest {
     }
 
     @Test
+    void stream_streamingErrorsAfterMetadataChunk_metadataStillPublished() {
+        // The failed turn was still billed for what ran before the error; the
+        // sink must have received everything observed up to that point.
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        Mockito.when(mockChatModel.stream(Mockito.any(Prompt.class)))
+                .thenReturn(Flux
+                        .just(chatResponseWithMetadata("Hi", "tool_use", 40,
+                                10))
+                        .concatWith(Flux.error(
+                                new RuntimeException("network broken"))));
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> provider.stream(request).collectList().block());
+
+        var metadata = collected.getLast();
+        Assertions.assertEquals("tool_use", metadata.finishReason());
+        Assertions.assertEquals(50, metadata.tokenUsage().totalTokens());
+    }
+
+    @Test
+    void stream_nonStreamingUsageWithoutTotal_totalDerivedFromComponents() {
+        // A backend that reports prompt and completion counts but no total
+        // still reported the usage; it must not be discarded.
+        provider.setStreaming(false);
+        var collected = new ArrayList<ResponseMetadata>();
+        var request = requestWithMetadataSink("Hello", collected);
+        var generation = new Generation(new AssistantMessage("Done"),
+                ChatGenerationMetadata.builder().finishReason("stop").build());
+        Mockito.when(mockChatModel.call(Mockito.any(Prompt.class)))
+                .thenReturn(ChatResponse.builder()
+                        .generations(List.of(generation))
+                        .metadata(ChatResponseMetadata.builder()
+                                .usage(new DefaultUsage(100, 20, null)).build())
+                        .build());
+
+        provider.stream(request).collectList().block();
+
+        var usage = collected.getLast().tokenUsage();
+        Assertions.assertEquals(100, usage.inputTokens());
+        Assertions.assertEquals(20, usage.outputTokens());
+        Assertions.assertEquals(120, usage.totalTokens());
+    }
+
+    @Test
     void metadataSink_notOverridden_returnsNoOpConsumer() {
         var request = createSimpleRequest("Hello");
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.ai.extensions.AIExtensionsLicense;
 import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
+import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.DatabaseProviderAITools;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
@@ -52,14 +53,15 @@ import tools.jackson.databind.JsonNode;
  * </pre>
  * <p>
  * State changes requested by the LLM are deferred and applied in
- * {@link #onResponse(Throwable)} on the success path, avoiding partial state
- * and multiple redraws during a multi-tool LLM turn. The chart state is stored
- * directly on the {@link Chart} component, so it survives serialization.
+ * {@link #onResponse(ResponseListener.ResponseEvent)} on the success path,
+ * avoiding partial state and multiple redraws during a multi-tool LLM turn. The
+ * chart state is stored directly on the {@link Chart} component, so it survives
+ * serialization.
  * </p>
  * <p>
- * If the LLM turn fails, {@link #onResponse(Throwable)} fires with the cause —
- * pending changes are discarded and the chart keeps its last
- * successfully-rendered state.
+ * If the LLM turn fails, {@link #onResponse(ResponseListener.ResponseEvent)}
+ * fires with the cause — pending changes are discarded and the chart keeps its
+ * last successfully-rendered state.
  * </p>
  * <p>
  * Data conversion from SQL query results to chart series is handled by a
@@ -310,7 +312,8 @@ public class ChartAIController implements AIController {
     }
 
     @Override
-    public void onResponse(Throwable error) {
+    public void onResponse(ResponseListener.ResponseEvent event) {
+        var error = event.getError().orElse(null);
         ChartEntry entry = ChartEntry.get(chart);
         if (error != null) {
             if (entry != null) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.component.ai.form.FormAITools.FormFieldDescriptor;
 import com.vaadin.flow.component.ai.form.FormValueConverter.RejectedValueException;
 import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
+import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.data.binder.Binder;
@@ -1336,7 +1337,8 @@ public class FormAIController implements AIController {
     }
 
     @Override
-    public void onResponse(Throwable error) {
+    public void onResponse(ResponseListener.ResponseEvent event) {
+        var error = event.getError().orElse(null);
         try {
             var changes = collectFieldValueChanges(error);
             // Marking before clearing the working state lets a changed field

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.ai.extensions.AIExtensionsLicense;
 import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
+import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.DatabaseProviderAITools;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
@@ -60,14 +61,15 @@ import tools.jackson.databind.JsonNode;
  * </ul>
  * <p>
  * State changes requested by the LLM are deferred and applied in
- * {@link #onResponse(Throwable)} on the success path, avoiding partial state
- * and multiple redraws during a multi-tool LLM turn. The grid state is stored
- * directly on the {@link Grid} component, so it survives serialization.
+ * {@link #onResponse(ResponseListener.ResponseEvent)} on the success path,
+ * avoiding partial state and multiple redraws during a multi-tool LLM turn. The
+ * grid state is stored directly on the {@link Grid} component, so it survives
+ * serialization.
  * </p>
  * <p>
- * If the LLM turn fails, {@link #onResponse(Throwable)} fires with the cause —
- * pending changes are discarded and the grid keeps its last
- * successfully-rendered state.
+ * If the LLM turn fails, {@link #onResponse(ResponseListener.ResponseEvent)}
+ * fires with the cause — pending changes are discarded and the grid keeps its
+ * last successfully-rendered state.
  * </p>
  * <p>
  * <b>Serialization:</b> This controller is not serialized with the
@@ -214,7 +216,8 @@ public class GridAIController implements AIController {
     }
 
     @Override
-    public void onResponse(Throwable error) {
+    public void onResponse(ResponseListener.ResponseEvent event) {
+        var error = event.getError().orElse(null);
         var entry = GridEntry.get(grid);
         if (error != null) {
             if (entry != null) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/AITurnEvents.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/AITurnEvents.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.ai;
+
+import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
+
+/**
+ * Turn-outcome events for driving {@code AIController#onResponse} directly from
+ * tests, standing in for the event the orchestrator would build.
+ */
+public final class AITurnEvents {
+
+    private AITurnEvents() {
+    }
+
+    /**
+     * A turn that ended successfully, with no provider metadata reported.
+     *
+     * @return the event, never {@code null}
+     */
+    public static ResponseListener.ResponseEvent success() {
+        return new ResponseListener.ResponseEvent("", null, null);
+    }
+
+    /**
+     * A turn that ended with the given failure.
+     *
+     * @param error
+     *            the cause of failure, not {@code null}
+     * @return the event, never {@code null}
+     */
+    public static ResponseListener.ResponseEvent failure(Throwable error) {
+        return new ResponseListener.ResponseEvent("", error, null);
+    }
+}

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.ai.provider.ToolException;
@@ -144,7 +145,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"column\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String state = findTool(tools, "get_chart_state")
                     .execute(json("{}"));
@@ -165,7 +166,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             ChartEntry entry = ChartEntry.get(chart);
             Assertions.assertNotNull(entry);
@@ -251,7 +252,7 @@ class ChartAIControllerTest {
                     "Render failure");
 
             var ex = Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(null));
+                    () -> controller.onResponse(AITurnEvents.success()));
             Assertions.assertEquals("Render failure", ex.getMessage());
         }
 
@@ -275,7 +276,7 @@ class ChartAIControllerTest {
                             + ChartSerialization.toJSON(configuration) + "}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Verify plot options were applied to the chart
             var applied = (PlotOptionsColumn) chart.getConfiguration()
@@ -298,7 +299,7 @@ class ChartAIControllerTest {
 
             // Queries are committed only after onResponseComplete; before
             // that, get_chart_state returns the previously-committed view.
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String state = findTool(tools, "get_chart_state")
                     .execute(json("{}"));
@@ -332,7 +333,7 @@ class ChartAIControllerTest {
                     .findFirst().get()
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -362,7 +363,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"column\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             ChartState state = controller.getState();
             Assertions.assertNotNull(state);
@@ -385,7 +386,7 @@ class ChartAIControllerTest {
 
             databaseProvider.throwOnExecute = new RuntimeException("DB error");
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(null));
+                    () -> controller.onResponse(AITurnEvents.success()));
 
             // Render threw before setQueries could commit, so the chart
             // stays in its previous (uninitialized) state.
@@ -402,7 +403,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"column\"}, \"title\": {\"text\": \"Original\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             ChartState savedState = controller.getState();
 
@@ -561,7 +562,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNotNull(captured.get());
             Assertions.assertEquals(List.of("SELECT 1"),
@@ -589,7 +590,7 @@ class ChartAIControllerTest {
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(null));
+                    () -> controller.onResponse(AITurnEvents.success()));
 
             Assertions.assertNull(captured.get());
         }
@@ -608,7 +609,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(captured.get());
         }
@@ -623,12 +624,12 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             List<ChartState> states = new ArrayList<>();
             controller.addStateChangeListener(states::add);
 
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(states.isEmpty(),
                     "Second onResponseComplete should not fire listeners "
@@ -652,7 +653,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNotNull(secondListenerState.get(),
                     "Second listener should still fire even if the "
@@ -667,7 +668,7 @@ class ChartAIControllerTest {
             var tools = controller.getTools();
             findTool(tools, "update_chart_configuration").execute(json(
                     "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(captured.get());
         }
@@ -686,11 +687,12 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(new RuntimeException("stream error"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("stream error")));
 
             // Subsequent successful turn with no tool calls must not pick
             // up the failed turn's staged configuration or queries.
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(controller.getState());
         }
@@ -704,17 +706,18 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var baselineType = chart.getConfiguration().getChart().getType();
 
             findTool(tools, "update_chart_configuration").execute(json(
                     "{\"configuration\": {\"chart\": {\"type\": \"pie\"}}}"));
-            controller.onResponse(new RuntimeException("stream error"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("stream error")));
 
             // Subsequent successful turn with no tool calls — the failed
             // turn's pending chart type must not be applied.
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(baselineType,
                     chart.getConfiguration().getChart().getType());
@@ -728,15 +731,16 @@ class ChartAIControllerTest {
 
             findTool(tools, "update_chart_data_source").execute(
                     json("{\"queries\": [\"SELECT good FROM baseline\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             findTool(tools, "update_chart_data_source").execute(
                     json("{\"queries\": [\"SELECT bad FROM half_baked\"]}"));
-            controller.onResponse(new RuntimeException("stream error"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("stream error")));
 
             // Subsequent successful turn with no tool calls — the failed
             // turn's staged queries must not bleed through.
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var state = controller.getState();
             Assertions.assertNotNull(state);
@@ -766,7 +770,7 @@ class ChartAIControllerTest {
                     "{\"configuration\": {\"chart\": {\"type\": \"bar\"}}}"));
             findTool(tools, "update_chart_data_source")
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Attachment does not gate the controller: configuration
             // lives on the server side and Flow queues any JS calls
@@ -791,7 +795,7 @@ class ChartAIControllerTest {
             // Errors propagate regardless of attach state so the
             // orchestrator can still surface them in the chat UI.
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(null));
+                    () -> controller.onResponse(AITurnEvents.success()));
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -251,8 +251,9 @@ class ChartAIControllerTest {
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
 
+            var event = AITurnEvents.success();
             var ex = Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(AITurnEvents.success()));
+                    () -> controller.onResponse(event));
             Assertions.assertEquals("Render failure", ex.getMessage());
         }
 
@@ -385,8 +386,9 @@ class ChartAIControllerTest {
                     .execute(json("{\"queries\": [\"SELECT 1\"]}"));
 
             databaseProvider.throwOnExecute = new RuntimeException("DB error");
+            var event = AITurnEvents.success();
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(AITurnEvents.success()));
+                    () -> controller.onResponse(event));
 
             // Render threw before setQueries could commit, so the chart
             // stays in its previous (uninitialized) state.
@@ -589,8 +591,9 @@ class ChartAIControllerTest {
 
             databaseProvider.throwOnExecute = new RuntimeException(
                     "Render failure");
+            var event = AITurnEvents.success();
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(AITurnEvents.success()));
+                    () -> controller.onResponse(event));
 
             Assertions.assertNull(captured.get());
         }
@@ -794,8 +797,9 @@ class ChartAIControllerTest {
 
             // Errors propagate regardless of attach state so the
             // orchestrator can still surface them in the chat UI.
+            var event = AITurnEvents.success();
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(AITurnEvents.success()));
+                    () -> controller.onResponse(event));
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.charts.Chart;
@@ -93,7 +94,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Sales\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Configuration config = chart.getConfiguration();
             Assertions.assertEquals(ChartType.COLUMN,
@@ -107,13 +108,13 @@ class ChartRenderingTest {
             // First request: config only
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Revenue\"}}");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Second request: data only
             databaseProvider.results = List
                     .of(row("category", "Q1", "value", 100));
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Configuration config = chart.getConfiguration();
             Assertions.assertEquals(ChartType.COLUMN,
@@ -130,13 +131,13 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Existing Title\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Second update: only data, no config change
             databaseProvider.results = List
                     .of(row("category", "B", "value", 20));
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("Existing Title",
                     chart.getConfiguration().getTitle().getText());
@@ -153,7 +154,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"line\"},\"title\":{\"text\":\"Original\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("Original",
                     chart.getConfiguration().getTitle().getText());
@@ -161,7 +162,7 @@ class ChartRenderingTest {
             // Second render: same type, only update title (merge path)
             updateConfiguration("{\"title\":{\"text\":\"Updated\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("Updated",
                     chart.getConfiguration().getTitle().getText());
@@ -177,7 +178,7 @@ class ChartRenderingTest {
                     + "\"pane\":{\"startAngle\":-150,\"endAngle\":150},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Verify pane was set
             String json1 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -186,7 +187,7 @@ class ChartRenderingTest {
             // Second: config-only update to column (no data change)
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"title\":{\"text\":\"Revenue\"}}");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Pane should be cleared
             String json2 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -207,13 +208,14 @@ class ChartRenderingTest {
             // Exception propagates so the orchestrator can surface it to
             // the user, but pending state must still be cleared.
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(null));
+                    () -> controller.onResponse(AITurnEvents.success()));
 
             // Pending state should be cleared despite the error: a
             // subsequent call with no pending state is a no-op and
             // must not re-trigger the DB (which would still throw).
             databaseProvider.throwOnExecute = null;
-            Assertions.assertDoesNotThrow(() -> controller.onResponse(null));
+            Assertions.assertDoesNotThrow(
+                    () -> controller.onResponse(AITurnEvents.success()));
         }
     }
 
@@ -226,7 +228,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t1", "SELECT x, y FROM t2");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(2,
                     chart.getConfiguration().getSeries().size());
@@ -244,7 +246,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -262,7 +264,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -285,7 +287,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -313,7 +315,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT 1");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -327,7 +329,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"pie\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -342,7 +344,7 @@ class ChartRenderingTest {
                     row("category", "Feb", "value", 200));
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertNotNull(
                     chart.getConfiguration().getxAxis().getCategories());
 
@@ -353,7 +355,7 @@ class ChartRenderingTest {
                     row(ColumnNames.X, 2, ColumnNames.Y, 20));
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -371,7 +373,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"line\"},\"xAxis\":{\"type\":\"linear\"}}");
             updateData("SELECT 1");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(AxisType.LINEAR,
                     chart.getConfiguration().getxAxis().getType());
@@ -382,7 +384,7 @@ class ChartRenderingTest {
             // trigger auto-detection.
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT 1");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(AxisType.LINEAR,
                     chart.getConfiguration().getxAxis().getType());
@@ -398,7 +400,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"gantt\"}}");
             updateData("SELECT name, start, end");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -416,7 +418,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"}}");
             updateData("SELECT trade_date, open, high, low, close");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Should have datetime axis, not categories
             Assertions.assertEquals(AxisType.DATETIME,
@@ -446,7 +448,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"}}");
             updateData("SELECT 1");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Even though volumeSeries has X=0, the OHLC series with epoch
             // X values should still cause datetime detection
@@ -463,7 +465,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -477,7 +479,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNotEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -490,7 +492,7 @@ class ChartRenderingTest {
                     row("category", "Feb", "value", 200));
 
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -510,7 +512,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNotEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -529,7 +531,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Revenue\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -543,7 +545,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -561,7 +563,7 @@ class ChartRenderingTest {
                     + "\"type\":\"areaspline\","
                     + "\"plotOptions\":{\"fillColor\":\"green\"}}]}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -602,7 +604,7 @@ class ChartRenderingTest {
                                {"name":"Vol","type":"column","yAxis":1}]}
                     """);
             updateData("SELECT 1", "SELECT 2");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -629,7 +631,7 @@ class ChartRenderingTest {
                                {"name":"Costs","yAxis":1}]}
                     """);
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -657,7 +659,7 @@ class ChartRenderingTest {
                     + "\"series\":[" + "{\"name\":\"Revenue\",\"yAxis\":0},"
                     + "{\"name\":\"Costs\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -697,7 +699,7 @@ class ChartRenderingTest {
                                {"name":"Count","type":"line","yAxis":1}]}
                     """);
             updateData("SELECT 1", "SELECT 2");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -736,7 +738,7 @@ class ChartRenderingTest {
                                {"name":"South","yAxis":1}]}
                     """);
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -768,7 +770,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"column\"},\"title\":{\"text\":\"Revenue\"}}");
             updateData("SELECT series_name, category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -792,7 +794,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"xAxis\":{\"categories\":[\"A\",\"B\"]}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Categories were set on X-axis
             Assertions.assertTrue(chart.getConfiguration().getxAxis()
@@ -805,7 +807,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"scatter\"}}");
             updateData("SELECT x, y FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Y-axis serialization must NOT contain "categories" — check
             // via JSON to distinguish null field from empty ArrayList
@@ -825,7 +827,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"heatmap\"},"
                     + "\"tooltip\":{\"pointFormat\":\"Day: {point.y}<br>Hour: {point.x}<br>Visitors: {point.value}\"}}");
             updateData("SELECT x, y, value");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNotNull(
                     chart.getConfiguration().getTooltip().getPointFormat());
@@ -838,7 +840,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"},"
                     + "\"title\":{\"text\":\"Stock Prices\"}}");
             updateData("SELECT trade_date, open");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Tooltip should be reset, not carry heatmap format
             Assertions.assertNull(
@@ -854,7 +856,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"candlestick\"}}");
             updateData("SELECT trade_date, open, high, low, close");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(AxisType.DATETIME,
                     chart.getConfiguration().getxAxis().getType());
@@ -867,7 +869,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"title\":{\"text\":\"Revenue\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Datetime axis type should be cleared, categories used instead
             Assertions.assertNotEquals(AxisType.DATETIME,
@@ -884,7 +886,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"gauge\"},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(0.0,
                     chart.getConfiguration().getyAxis().getMin().doubleValue());
@@ -897,7 +899,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Gauge min/max should be cleared
             Assertions.assertNull(chart.getConfiguration().getyAxis().getMin());
@@ -913,7 +915,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"plotOptions\":{\"column\":{\"stacking\":\"normal\"}}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNotNull(
                     chart.getConfiguration().getPlotOptions(ChartType.COLUMN));
@@ -924,7 +926,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Stacked column plot options should be cleared
             Assertions.assertNull(
@@ -940,7 +942,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"heatmap\"},"
                     + "\"colorAxis\":{\"min\":0,\"max\":300}}");
             updateData("SELECT x, y, value");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1,
                     chart.getConfiguration().getNumberOfColorAxes());
@@ -951,7 +953,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Color axis should be cleared
             Assertions.assertEquals(0,
@@ -968,7 +970,7 @@ class ChartRenderingTest {
                     + "\"center\":[\"50%\",\"50%\"],\"size\":\"80%\"},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Pane should be set
             String json1 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -981,7 +983,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Pane should be cleared
             String json2 = ChartSerialization.toJSON(chart.getConfiguration());
@@ -999,7 +1001,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"pie\"},"
                     + "\"legend\":{\"enabled\":false}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(
                     chart.getConfiguration().getLegend().getEnabled());
@@ -1010,7 +1012,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Legend should be reset to default (enabled=true or null)
             Boolean legendEnabled = chart.getConfiguration().getLegend()
@@ -1028,7 +1030,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"column\"},"
                     + "\"subtitle\":{\"text\":\"Q1 2024\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("Q1 2024",
                     chart.getConfiguration().getSubTitle().getText());
@@ -1039,7 +1041,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"line\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Subtitle should be cleared
             Assertions.assertNull(
@@ -1055,7 +1057,7 @@ class ChartRenderingTest {
             updateConfiguration(
                     "{\"chart\":{\"type\":\"line\",\"polar\":true}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions
                     .assertTrue(chart.getConfiguration().getChart().getPolar());
@@ -1066,7 +1068,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT category, value FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions
                     .assertNull(chart.getConfiguration().getChart().getPolar());
@@ -1081,7 +1083,7 @@ class ChartRenderingTest {
                     + "\"pane\":{\"startAngle\":-150,\"endAngle\":150},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Second gauge render (e.g. user changes the gauge value)
             databaseProvider.results = List.of(row(ColumnNames.Y, 85));
@@ -1089,7 +1091,7 @@ class ChartRenderingTest {
                     + "\"pane\":{\"startAngle\":-150,\"endAngle\":150},"
                     + "\"yAxis\":{\"min\":0,\"max\":100}}");
             updateData("SELECT current_val");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             // Should have exactly 1 pane, not 2
             String json = ChartSerialization.toJSON(chart.getConfiguration());
@@ -1120,7 +1122,7 @@ class ChartRenderingTest {
                     + "{\"name\":\"North\",\"yAxis\":0},"
                     + "{\"name\":\"South\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(2,
                     chart.getConfiguration().getNumberOfyAxes(),
@@ -1134,7 +1136,7 @@ class ChartRenderingTest {
                     + "{\"name\":\"North\",\"yAxis\":0},"
                     + "{\"name\":\"South\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(2,
                     chart.getConfiguration().getNumberOfyAxes(),
@@ -1157,7 +1159,7 @@ class ChartRenderingTest {
                     + "{\"name\":\"Revenue\",\"yAxis\":0},"
                     + "{\"name\":\"Volume\",\"yAxis\":1}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(2, series.size());
@@ -1193,7 +1195,7 @@ class ChartRenderingTest {
                             + "{\"name\":\"Revenue\",\"type\":\"column\"},"
                             + "{\"name\":\"Count\",\"type\":\"line\"}" + "]}");
             updateData("SELECT s, c, v FROM t");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             var countSeries = (com.vaadin.flow.component.charts.model.AbstractSeries) series
@@ -1233,7 +1235,7 @@ class ChartRenderingTest {
             updateConfiguration("{\"chart\":{\"type\":\"waterfall\"},"
                     + "\"title\":{\"text\":\"Budget\"}}");
             updateData("SELECT name, y, type");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             String[] categories = chart.getConfiguration().getxAxis()
                     .getCategories();
@@ -1258,7 +1260,7 @@ class ChartRenderingTest {
 
             updateConfiguration("{\"chart\":{\"type\":\"column\"}}");
             updateData("SELECT title AS _title, text AS _text FROM flags");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());
@@ -1281,7 +1283,7 @@ class ChartRenderingTest {
                     + "\"type\":\"flags\","
                     + "\"plotOptions\":{\"onSeries\":\"price\"}}]}");
             updateData("SELECT title AS _title, text AS _text FROM flags");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var series = chart.getConfiguration().getSeries();
             Assertions.assertEquals(1, series.size());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartRenderingTest.java
@@ -207,8 +207,9 @@ class ChartRenderingTest {
 
             // Exception propagates so the orchestrator can surface it to
             // the user, but pending state must still be cleared.
+            var event = AITurnEvents.success();
             Assertions.assertThrows(RuntimeException.class,
-                    () -> controller.onResponse(AITurnEvents.success()));
+                    () -> controller.onResponse(event));
 
             // Pending state should be cleared despite the error: a
             // subsequent call with no pending state is a no-op and

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.form.FormTestFields.CompositeField;
 import com.vaadin.flow.component.ai.form.FormTestFields.DoubleField;
 import com.vaadin.flow.component.ai.form.FormTestFields.IntField;
@@ -350,7 +351,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(a, b));
 
             controller.onRequest();
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(a.isReadOnly());
             Assertions.assertFalse(b.isReadOnly());
@@ -368,7 +369,7 @@ class FormAIControllerTest {
                     new Div(editable, appReadOnly));
 
             controller.onRequest();
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(editable.isReadOnly());
             Assertions.assertTrue(appReadOnly.isReadOnly(),
@@ -958,7 +959,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("John");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, events.size(), "Listener must fire "
                     + "exactly once for the single changed field");
@@ -979,7 +980,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             // No setValue between request and response.
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(0, invocations.get(),
                     "Listener must not be called when no field changed");
@@ -995,7 +996,8 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("partial");
-            controller.onResponse(new RuntimeException("boom"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("boom")));
 
             Assertions.assertEquals(0, invocations.get(),
                     "Listener must not fire when the turn ended in error, "
@@ -1012,7 +1014,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             changed.setValue("X");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, events.size(),
                     "Only the changed field must produce an event; got: "
@@ -1037,7 +1039,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             visible.setValue("primary");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(containsEventFor(events, visible));
             Assertions.assertFalse(containsEventFor(events, ignored),
@@ -1052,7 +1054,7 @@ class FormAIControllerTest {
             Assertions.assertDoesNotThrow(() -> {
                 controller.onRequest();
                 field.setValue("any");
-                controller.onResponse(null);
+                controller.onResponse(AITurnEvents.success());
             }, "Lifecycle must run without a listener registered");
         }
 
@@ -1068,7 +1070,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("anything");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(field.isReadOnly(),
                     "Field must be unlocked even if a listener threw");
@@ -1089,7 +1091,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             primary.setValue("driver");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(2, events.size(),
                     "Both the driver and cascaded fields must produce events; "
@@ -1109,7 +1111,7 @@ class FormAIControllerTest {
             controller.onRequest();
             // Same content, different Set instance — Objects.equals true.
             field.setValue(Set.of("b", "a"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(events.isEmpty(),
                     "A multi-select set equal to its previous value must "
@@ -1126,7 +1128,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue(Set.of("a", "c"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var event = eventFor(events, field);
             Assertions.assertEquals(Set.of("a", "b"), event.getOldValue());
@@ -1147,7 +1149,7 @@ class FormAIControllerTest {
             third.setValue("c");
             first.setValue("a");
             second.setValue("b");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(first, second, third),
                     events.stream().map(FieldValueChangeEvent::getField)
@@ -1165,7 +1167,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue(LocalDate.of(2026, 1, 1));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var event = eventFor(events, field);
             Assertions.assertNull(event.getOldValue(),
@@ -1187,7 +1189,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue(null);
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var event = eventFor(events, field);
             Assertions.assertEquals(LocalDate.of(2026, 1, 1),
@@ -1207,7 +1209,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("X");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, first.size(),
                     "First listener must fire once for the changed field");
@@ -1236,7 +1238,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, calls.get(),
                     "Listener must fire while registered");
 
@@ -1244,7 +1246,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("second");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, calls.get(),
                     "Listener must not fire after Registration.remove()");
         }
@@ -1265,7 +1267,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("X");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, followingCalls.get(),
                     "An exception from one listener must not prevent the "
@@ -1293,7 +1295,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("a");
             second.setValue("b");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(2, throwerCalls.get(),
                     "The throwing listener must still be invoked for every "
@@ -1322,7 +1324,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("X");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, selfRemovingCalls.get(),
                     "Self-removing listener fires for the dispatch in which "
@@ -1332,7 +1334,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("Y");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, selfRemovingCalls.get(),
                     "Self-removing listener must not fire after the turn "
@@ -1361,7 +1363,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             primary.setValue("driver");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var event = eventFor(events, conditional);
             Assertions.assertEquals("", event.getOldValue(),
@@ -1389,7 +1391,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             primary.setValue("driver");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var event = eventFor(events, conditional);
             Assertions.assertEquals("preset", event.getOldValue(),
@@ -1414,7 +1416,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             primary.setValue("driver");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(containsEventFor(events, conditional),
                     "Revealing a hidden field without changing its value "
@@ -1436,7 +1438,7 @@ class FormAIControllerTest {
             controller.onRequest();
             controlling.setValue("business"); // reveals the conditional field
             conditional.setValue("cost-center-42"); // AI fills the revealed one
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(containsEventFor(events, conditional),
                     "A field revealed and filled within the same turn must "
@@ -1462,7 +1464,7 @@ class FormAIControllerTest {
             controller.onRequest();
             controlling.setValue("business"); // adds the new field to the form
             added.setValue("cost-center-42"); // AI fills the newly-added field
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(containsEventFor(events, added),
                     "A field added to the form and filled within the same "
@@ -1488,7 +1490,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             controlling.setValue("business"); // adds the new field, no write
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(containsEventFor(events, added),
                     "A field added mid-turn but never written must not "
@@ -1510,7 +1512,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("a");
             second.setValue("b");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(2, events.size(),
                     "Expected two events for two changed fields");
@@ -1540,7 +1542,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("a");
             second.setValue("b");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of("A:a", "B:a", "A:b", "B:b"), order,
                     "Listeners must visit each event in registration order, "
@@ -1568,7 +1570,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("from-llm");
             second.setValue("from-llm-too");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var secondEvent = eventFor(events, second);
             Assertions.assertEquals("", secondEvent.getOldValue(),
@@ -1602,7 +1604,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("a");
             second.setValue("b");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(0, lateCalls.get(),
                     "Listener registered mid-dispatch must not receive any "
@@ -1610,7 +1612,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             first.setValue("c");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, lateCalls.get(),
                     "Listener registered in the previous turn must receive "
@@ -1638,7 +1640,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("a");
             second.setValue("b");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(first, second), calls,
                     "A listener that removes itself during event 1 must "
@@ -1694,7 +1696,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, markersOn(field).size());
 
             Assertions.assertDoesNotThrow(() -> {
@@ -1717,12 +1719,12 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("ai");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             field.setValue("user edit"); // clears the marker
 
             controller.onRequest();
             field.setValue("ai again");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "A turn after the marker was cleared must leave the field "
@@ -1741,7 +1743,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             form.remove(field);
             form.add(field);
 
@@ -1761,7 +1763,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             field.setValue("user edit");
             form.remove(field);
             form.add(field);
@@ -1784,7 +1786,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(inner),
                     field.getChildren().toList(),
@@ -1806,7 +1808,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(i18nOn(field).isEmpty(),
                     "An unconfigured controller must set no texts; got: "
@@ -1825,7 +1827,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             var i18n = i18nOn(field);
 
             Assertions.assertEquals("Vain viesti",
@@ -1850,7 +1852,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             var confidence = i18nOn(field).get("confidence");
 
             Assertions.assertEquals("Epävarma",
@@ -1874,7 +1876,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             var confidence = i18nOn(field).get("confidence");
 
             Assertions.assertEquals("Epävarma",
@@ -1898,7 +1900,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(i18nOn(field).isEmpty(),
                     "An empty i18n must set no texts; got: " + i18nOn(field));
@@ -1918,7 +1920,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             var i18n = i18nOn(field);
 
             Assertions.assertEquals("Tekoäly täytti tämän kentän",
@@ -1941,13 +1943,13 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerI18n(
                     new FieldMarkerI18n().setMessage("Päivitetty viesti"));
             controller.onRequest();
             field.setValue("second");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size());
             Assertions.assertEquals("Päivitetty viesti",
@@ -1967,7 +1969,7 @@ class FormAIControllerTest {
             controller.onRequest();
             keep.setValue("filled");
             edited.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             edited.setValue("user edit");
 
@@ -2038,7 +2040,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "A changed field must stay marked after the turn");
@@ -2059,7 +2061,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form);
 
             controller.onRequest();
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(), markersOn(field),
                     "An unchanged field must be left without a marker");
@@ -2077,10 +2079,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
-            controller.onResponse(null); // second turn changes nothing
+            controller.onResponse(AITurnEvents.success()); // second turn
+                                                           // changes nothing
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "A turn that changes nothing must not clear an existing "
@@ -2097,7 +2100,8 @@ class FormAIControllerTest {
             var controller = new FormAIController(form);
 
             controller.onRequest();
-            controller.onResponse(new RuntimeException("boom"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("boom")));
 
             Assertions.assertEquals(List.of(), markersOn(field),
                     "The working state must clear even when the turn fails");
@@ -2114,10 +2118,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
-            controller.onResponse(new RuntimeException("boom"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("boom")));
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "A failed turn must leave an existing mark in place");
@@ -2154,7 +2159,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form);
 
             controller.onRequest();
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             form.remove(field);
             form.add(field);
 
@@ -2176,7 +2181,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             form.remove(field);
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             form.add(field);
 
             Assertions.assertEquals(List.of(), markersOn(field),
@@ -2222,7 +2227,7 @@ class FormAIControllerTest {
             readOnly.setValue("filled");
             readOnly.setReadOnly(true);
             drainPendingJs(); // isolate the scripts queued at turn end
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var dump = drainPendingJs();
             var scripts = scriptsOn(dump, readOnly);
@@ -2249,7 +2254,7 @@ class FormAIControllerTest {
             controller.onRequest();
             field.setReadOnly(true); // no AI write to the field
             drainPendingJs();
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var scripts = scriptsOn(drainPendingJs(), field);
             Assertions.assertEquals(1, scripts.size(),
@@ -2272,7 +2277,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             drainPendingJs();
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(),
                     scriptsOn(drainPendingJs(), field),
@@ -2292,7 +2297,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             fireRevert(field);
@@ -2312,7 +2317,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "A field changed during a turn must be marked "
@@ -2332,7 +2337,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             changed.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(changed).size());
             Assertions.assertEquals(List.of(), markersOn(untouched),
@@ -2360,7 +2365,7 @@ class FormAIControllerTest {
             trigger.setValue("business");
             revealed.setVisible(true);
             revealed.setValue("cascaded");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(revealed).size(),
                     "A field revealed and filled during the turn must be "
@@ -2378,7 +2383,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("ai");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             field.setValue("edited by user");
 
@@ -2397,11 +2402,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue("second"); // AI write while a turn is in progress
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "An AI write during a turn must not clear the marker");
@@ -2418,7 +2423,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("ai");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             field.setValue("first edit"); // clears the marker
 
             field.setValue("second edit");
@@ -2442,7 +2447,7 @@ class FormAIControllerTest {
             field.setValue("old");
             controller.onRequest();
             field.setValue("new");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -2467,11 +2472,12 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest(); // snapshots "filled"
             fireRevert(field); // restores "original" mid-turn
-            controller.onResponse(null); // the AI writes nothing
+            controller.onResponse(AITurnEvents.success()); // the AI writes
+                                                           // nothing
 
             Assertions.assertEquals("original", field.getValue());
             Assertions.assertEquals(List.of(), markersOn(field),
@@ -2492,12 +2498,12 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             fireRevert(field); // restores "original" mid-turn
             field.setValue("second"); // the AI writes the field again
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size());
             fireRevert(field);
@@ -2519,11 +2525,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue("second");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -2546,13 +2552,13 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first ai value");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             field.setValue("user typed"); // clears the marker
 
             controller.onRequest();
             field.setValue("second ai value");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -2575,11 +2581,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("detour");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue("original"); // the AI puts the original value back
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -2600,7 +2606,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue(42.0);
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -2622,11 +2628,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue(42.0);
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue(43.0);
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -2662,7 +2668,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(), markersOn(field),
                     "With automatic marking off, a changed field must be "
@@ -2688,7 +2694,7 @@ class FormAIControllerTest {
                             + "marking setting");
 
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(), markersOn(field),
                     "The marker that only carried the working state must go at "
@@ -2707,12 +2713,12 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("first");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerEnabled(false);
             controller.onRequest();
             field.setValue("second");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "A mark from an earlier turn must survive the opt-out");
@@ -2730,12 +2736,12 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("unmarked");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerEnabled(true);
             controller.onRequest();
             field.setValue("marked");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, markersOn(field).size(),
                     "Re-enabling automatic marking must mark the changes "
@@ -2756,7 +2762,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, events.size(),
                     "The change listener must fire regardless of the automatic "
@@ -2797,7 +2803,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var marker = requireMarkerOn(field);
             var wrapper = wrapperOn(field);
@@ -2839,7 +2845,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var wrapper = wrapperOn(field);
             Assertions.assertNotNull(wrapper,
@@ -2864,7 +2870,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(),
                     contentScriptsOwnedBy(drainPendingJs(),
@@ -2882,7 +2888,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(),
                     contentScriptsOwnedBy(drainPendingJs(),
@@ -2906,13 +2912,13 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("one");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             next.set(second);
             controller.onRequest();
             field.setValue("two");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var marker = requireMarkerOn(field);
             Assertions.assertNull(first.getElement().getParentNode(),
@@ -2939,12 +2945,12 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("one");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             controller.onRequest();
             field.setValue("two");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(),
                     contentScriptsOwnedBy(drainPendingJs(),
@@ -2973,11 +2979,11 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("one");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue("two");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(0, detaches.get(),
                     "Re-marking with the same content instance must not "
@@ -2997,13 +3003,13 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("one");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             controller.setFieldMarkerPopoverContentProvider(null);
             controller.onRequest();
             field.setValue("two");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(content.getElement().getParentNode(),
                     "The stale content must be released from the wrapper");
@@ -3036,19 +3042,19 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("one");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerPopoverContentProvider(null);
             controller.onRequest();
             field.setValue("two");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             var wrapper = wrapperOn(field);
             drainPendingJs();
 
             controller.setFieldMarkerPopoverContentProvider(change -> content);
             controller.onRequest();
             field.setValue("three");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(wrapper, wrapperOn(field),
                     "The mark must keep its wrapper across content changes");
@@ -3077,7 +3083,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var marker = requireMarkerOn(field);
             Assertions.assertEquals(List.of(),
@@ -3115,7 +3121,7 @@ class FormAIControllerTest {
             controller.onRequest();
             first.setValue("one");
             second.setValue("two");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             var marker = requireMarkerOn(first);
             requireMarkerOn(second);
@@ -3152,7 +3158,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             requireMarkerOn(field);
             var warnings = TestLoggerFactory
@@ -3175,7 +3181,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             field.setValue("user edit");
 
             Assertions.assertEquals(List.of(), markersOn(field));
@@ -3194,7 +3200,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             fireRevert(field);
 
@@ -3218,7 +3224,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             controller.onRequest();
@@ -3241,7 +3247,7 @@ class FormAIControllerTest {
                             requireMarkerOn(field)),
                     "Clearing content must not queue another assignment");
 
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(), markersOn(field),
                     "The marker that only carried the working state must go "
@@ -3262,7 +3268,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             requireMarkerOn(field).removeFromParent();
 
             Assertions.assertDoesNotThrow(() -> field.setValue("user edit"),
@@ -3284,7 +3290,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             var wrapper = wrapperOn(field);
             drainPendingJs();
 
@@ -3305,7 +3311,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             form.remove(field);
@@ -3337,7 +3343,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of("provider", "listener"), calls,
                     "The provider must run before the change listeners");
@@ -3358,7 +3364,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(0, calls.get(),
                     "With marking off there is no popover to fill, so the "
@@ -3377,7 +3383,7 @@ class FormAIControllerTest {
 
             controller.onRequest();
             field.setValue("filled");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, markersOn(field).size());
 
             Assertions.assertDoesNotThrow(() -> {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.form.FormTestFields.BigDecField;
 import com.vaadin.flow.component.ai.form.FormTestFields.BigIntField;
 import com.vaadin.flow.component.ai.form.FormTestFields.BoolField;
@@ -248,7 +249,7 @@ class FormStateToolTest {
                     "Application-read-only field must stay flagged, got: "
                             + fields.get(1));
         } finally {
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
@@ -24,6 +24,7 @@ import org.slf4j.event.Level;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.common.ConfidenceLevel;
 import com.vaadin.flow.component.ai.common.PageRegion;
 import com.vaadin.flow.component.ai.common.SourceExtract;
@@ -584,7 +585,7 @@ class SourceTrackingTest {
             var field = new TestField();
             var controller = trackingControllerFor(field);
             fill(controller, field, trackedValue("Acme"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             field.setValue("edited by hand");
 
@@ -600,7 +601,7 @@ class SourceTrackingTest {
             var field = new TestField();
             var controller = trackingControllerFor(field);
             fill(controller, field, trackedValue("Acme"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             field.setValue("edited by hand");
             Assertions.assertTrue(controller.getFieldSource(field).isEmpty());
@@ -619,7 +620,7 @@ class SourceTrackingTest {
             var field = new TestField();
             var controller = trackingControllerFor(field);
             fill(controller, field, trackedValue("Acme"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             field.setValue("edited by hand");
             field.setValue("Acme");
@@ -639,15 +640,15 @@ class SourceTrackingTest {
             var field = new TestField();
             var controller = trackingControllerFor(field);
             fill(controller, field, trackedValue("Acme"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue("cascaded");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             field.setValue("Acme");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(controller.getFieldSource(field).isEmpty(),
                     "A source stale at turn end must not be returned when a "
@@ -703,7 +704,7 @@ class SourceTrackingTest {
             controller.addFieldValueChangeListener(events::add);
 
             fill(controller, field, trackedValue("Acme"));
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertTrue(events.isEmpty(),
                     "Writing the value the field already had must not fire a "
@@ -743,7 +744,7 @@ class SourceTrackingTest {
             var field = new TestField();
             field.setValue("persisted");
             var controller = controllerFor(field);
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             controller.restoreFieldSource(field,
                     new ValueSource(ConfidenceLevel.MEDIUM, null));
 
@@ -782,7 +783,7 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "high",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, events.size());
             var source = events.get(0).getFieldSource().orElseThrow();
@@ -798,7 +799,7 @@ class SourceTrackingTest {
             controller.addFieldValueChangeListener(events::add);
 
             fill(controller, field, "\"plain\"");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(1, events.size());
             Assertions.assertTrue(events.get(0).getFieldSource().isEmpty());
@@ -816,7 +817,7 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "high",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"),
@@ -829,7 +830,7 @@ class SourceTrackingTest {
             var controller = trackingControllerFor(field);
 
             fill(controller, field, "\"plain\"");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(markerOn(field).getProperty("confidence"),
                     "A value with no reported source must show no indicator");
@@ -844,7 +845,7 @@ class SourceTrackingTest {
 
             fill(controller, field, """
                     {"value": "Acme", "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(markerOn(field).getProperty("confidence"),
                     "A source without a level must show no indicator");
@@ -861,7 +862,7 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "high",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"));
 
@@ -869,7 +870,7 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "low",
                      "extracts": [{"text": "re-read"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("low",
                     markerOn(field).getProperty("confidence"),
@@ -886,14 +887,14 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "high",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"));
 
             controller.onRequest();
             fill(controller, field, """
                     {"value": "Acme", "extracts": [{"text": "re-read"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(markerOn(field).getProperty("confidence"),
                     "The kept marker must drop the level the new source does "
@@ -910,11 +911,11 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "high",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             fill(controller, field, "\"Acme\"");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(markerOn(field).getProperty("confidence"),
                     "The kept marker must drop its level when the rewrite "
@@ -928,11 +929,11 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "first", "confidence": "medium",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             controller.onRequest();
             fill(controller, field, "\"second\"");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(markerOn(field).getProperty("confidence"),
                     "A refill without a source must clear the indicator the "
@@ -951,13 +952,13 @@ class SourceTrackingTest {
             fill(controller, field, """
                     {"value": "Acme", "confidence": "high",
                      "extracts": [{"text": "snippet"}]}""");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"));
 
             controller.onRequest();
             field.setValue("cascaded");
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(markerOn(field).getProperty("confidence"),
                     "A cascaded value must drop the level the previous fill "

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.provider.DatabaseProvider;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.ai.provider.ToolException;
@@ -195,7 +196,7 @@ class GridAIControllerTest {
 
         dbProvider.throwOnExecute = true;
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onResponse(null));
+                () -> controller.onResponse(AITurnEvents.success()));
 
         Assertions.assertNull(controller.getState());
     }
@@ -216,7 +217,7 @@ class GridAIControllerTest {
     void onResponse_noPending_doesNotChangeGrid() {
         // No pending query — should be a no-op
         var columnsBefore = grid.getColumns().size();
-        controller.onResponse(null);
+        controller.onResponse(AITurnEvents.success());
         Assertions.assertEquals(columnsBefore, grid.getColumns().size());
         Assertions.assertNull(controller.getState());
     }
@@ -227,7 +228,7 @@ class GridAIControllerTest {
         simulateUpdate("SELECT a FROM t");
 
         // Second call — no pending query
-        controller.onResponse(null);
+        controller.onResponse(AITurnEvents.success());
 
         // State should still reflect the first update
         var stateTool = findTool("get_grid_state");
@@ -247,12 +248,13 @@ class GridAIControllerTest {
             // A second turn stages a query, then fails before completion.
             findTool("update_grid_data")
                     .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
-            controller.onResponse(new RuntimeException("stream error"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("stream error")));
 
             // A third turn fires onResponseComplete without staging anything
             // (LLM responded conversationally). The bad query must not be
             // rendered.
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals("SELECT a FROM good",
                     controller.getState().query());
@@ -264,9 +266,10 @@ class GridAIControllerTest {
             dbProvider.queryResults = List.of(row("a", 1));
             findTool("update_grid_data")
                     .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
-            controller.onResponse(new RuntimeException("stream error"));
+            controller.onResponse(
+                    AITurnEvents.failure(new RuntimeException("stream error")));
 
-            controller.onResponse(null);
+            controller.onResponse(AITurnEvents.success());
 
             Assertions.assertNull(controller.getState());
         }
@@ -371,7 +374,7 @@ class GridAIControllerTest {
                 .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
         dbProvider.throwOnExecute = true;
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onResponse(null));
+                () -> controller.onResponse(AITurnEvents.success()));
 
         // Previous successful query should be retained
         Assertions.assertEquals("SELECT a FROM good",
@@ -412,7 +415,7 @@ class GridAIControllerTest {
 
         dbProvider.throwOnExecute = true;
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onResponse(null));
+                () -> controller.onResponse(AITurnEvents.success()));
 
         Assertions.assertNull(captured.get());
     }
@@ -448,7 +451,7 @@ class GridAIControllerTest {
         var states = new ArrayList<GridState>();
         controller.addStateChangeListener(states::add);
 
-        controller.onResponse(null);
+        controller.onResponse(AITurnEvents.success());
 
         Assertions.assertTrue(states.isEmpty(),
                 "Second onResponseComplete should not fire listeners");
@@ -1002,7 +1005,7 @@ class GridAIControllerTest {
     private void simulateUpdate(String query) {
         findTool("update_grid_data")
                 .execute(json("{\"query\": \"" + query + "\"}"));
-        controller.onResponse(null);
+        controller.onResponse(AITurnEvents.success());
     }
 
     private static Map<String, Object> row(Object... keysAndValues) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -195,8 +195,9 @@ class GridAIControllerTest {
                 .execute(json("{\"query\": \"SELECT a FROM t\"}"));
 
         dbProvider.throwOnExecute = true;
+        var event = AITurnEvents.success();
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onResponse(AITurnEvents.success()));
+                () -> controller.onResponse(event));
 
         Assertions.assertNull(controller.getState());
     }
@@ -373,8 +374,9 @@ class GridAIControllerTest {
         findTool("update_grid_data")
                 .execute(json("{\"query\": \"SELECT a FROM bad\"}"));
         dbProvider.throwOnExecute = true;
+        var event = AITurnEvents.success();
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onResponse(AITurnEvents.success()));
+                () -> controller.onResponse(event));
 
         // Previous successful query should be retained
         Assertions.assertEquals("SELECT a FROM good",
@@ -414,8 +416,9 @@ class GridAIControllerTest {
                 .execute(json("{\"query\": \"SELECT a FROM t\"}"));
 
         dbProvider.throwOnExecute = true;
+        var event = AITurnEvents.success();
         Assertions.assertThrows(RuntimeException.class,
-                () -> controller.onResponse(AITurnEvents.success()));
+                () -> controller.onResponse(event));
 
         Assertions.assertNull(captured.get());
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/orgs/vaadin/projects/103/views/3?pane=issue&itemId=235867921

- Added `ResponseMetadata` (finish reason and `TokenUsage`) and a `metadataSink()` channel on `LLMProvider.LLMRequest` that providers publish to while the turn runs
  - Finish reasons are passed through exactly as the model reported them, never mapped to a fixed set of values
- Added `ResponseEvent.getMetadata()` so a `ResponseListener` can tell a completed turn from a truncated one (e.g. `max_tokens`) and read what the turn cost
- Changed `AIController.onResponse` to receive the whole `ResponseEvent` instead of only the error, so controllers can skip committing staged state when the model never finished
- Made `SpringAILLMProvider` read the full `ChatResponse` instead of only its text, publish metadata in both streaming and non-streaming mode, and warn when a non-streaming turn ends with tool calls still pending, without a finish reason, or without a response
- Made `LangChain4JLLMProvider` add up token usage across tool round trips and warn when a turn ends without the model reporting a finish reason
- Published metadata as the turn progresses, so a turn that fails or times out midway still reports what was observed before the failure

## Type of change

- Feature

> [!WARNING]
> `AIController.onResponse(Throwable)` is now `onResponse(ResponseListener.ResponseEvent)`; implementations read the cause from `event.getError()`. The AI components are behind the `aiComponents` feature flag, so the old signature is replaced rather than deprecated.