### PR TITLE
fix: give parameterless AI tools a non-empty parameter schema (#9971) (CP: 25.3)

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -864,7 +864,7 @@ public class AIOrchestrator implements Serializable {
 
         @Override
         public String getParametersSchema() {
-            return null;
+            return NO_PARAMETERS_SCHEMA;
         }
 
         @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAITools.java
@@ -58,7 +58,7 @@ public final class DatabaseProviderAITools {
 
             @Override
             public String getParametersSchema() {
-                return null;
+                return NO_PARAMETERS_SCHEMA;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -183,6 +183,31 @@ public interface LLMProvider {
     interface ToolSpec {
 
         /**
+         * JSON Schema for a tool that takes no parameters. Declares a single
+         * optional {@code reason} property that the tool ignores, so the LLM
+         * always has a well-formed, non-empty object to send as arguments.
+         * <p>
+         * Use this instead of {@code null} or a schema with an empty
+         * {@code properties} object: without a declared property, models
+         * disagree on what to send as arguments — some send an empty string —
+         * and some LLM APIs (for example Anthropic models on Amazon Bedrock)
+         * reject the request that replays such a tool call.
+         * </p>
+         *
+         * @since 25.3
+         */
+        String NO_PARAMETERS_SCHEMA = """
+                {
+                  "type": "object",
+                  "properties": {
+                    "reason": {
+                      "type": "string",
+                      "description": "Optional note on why this tool is being called. Ignored by the tool."
+                    }
+                  }
+                }""";
+
+        /**
          * Gets the unique name of this tool. The name must contain only
          * alphanumeric characters, underscores, and hyphens, with a maximum
          * length of 64 characters (matching the pattern
@@ -253,9 +278,18 @@ public interface LLMProvider {
          * keywords such as {@code format}, {@code pattern}, or {@code $ref}
          * that not every LLM provider accepts.
          * </p>
+         * <p>
+         * For a tool that takes no parameters, return
+         * {@link #NO_PARAMETERS_SCHEMA} rather than {@code null} or a schema
+         * with an empty {@code properties} object — see the constant's
+         * documentation for why. The built-in providers substitute
+         * {@link #NO_PARAMETERS_SCHEMA} for a {@code null} or blank return
+         * value, but an empty {@code properties} object is passed through
+         * as-is.
+         * </p>
          *
-         * @return the JSON Schema string, or {@code null} if the tool takes no
-         *         parameters
+         * @return the JSON Schema string, or {@link #NO_PARAMETERS_SCHEMA} if
+         *         the tool takes no parameters
          */
         String getParametersSchema();
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -338,9 +338,12 @@ public class LangChain4JLLMProvider implements LLMProvider {
         var builder = ToolSpecification.builder().name(tool.getName())
                 .description(tool.getDescription());
         var schema = tool.getParametersSchema();
-        if (schema != null && !schema.isBlank()) {
-            builder.parameters(parseParametersSchema(schema));
+        if (schema == null || schema.isBlank()) {
+            // A tool without a declared schema breaks some LLM APIs —
+            // see ToolSpec.NO_PARAMETERS_SCHEMA.
+            schema = LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA;
         }
+        builder.parameters(parseParametersSchema(schema));
         return builder.build();
     }
 
@@ -371,8 +374,10 @@ public class LangChain4JLLMProvider implements LLMProvider {
             return schemaBuilder.build();
         } catch (Exception e) {
             LOGGER.warn("Failed to parse tool parameters schema, "
-                    + "using empty schema", e);
-            return JsonObjectSchema.builder().build();
+                    + "using no-parameters schema", e);
+            // The constant is a well-formed literal, so this cannot recurse.
+            return parseParametersSchema(
+                    LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA);
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -547,10 +547,13 @@ public class SpringAILLMProvider implements LLMProvider {
             @Override
             public ToolDefinition getToolDefinition() {
                 var schema = tool.getParametersSchema();
+                // A tool without a declared schema breaks some LLM APIs —
+                // see ToolSpec.NO_PARAMETERS_SCHEMA.
                 return DefaultToolDefinition.builder().name(tool.getName())
                         .description(tool.getDescription())
-                        .inputSchema(schema != null ? schema
-                                : "{\"type\":\"object\",\"properties\":{}}")
+                        .inputSchema(schema != null && !schema.isBlank()
+                                ? schema
+                                : LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA)
                         .build();
             }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -61,6 +61,7 @@ import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
@@ -2537,6 +2538,31 @@ class AIOrchestratorTest {
                     "Description must mention '" + anchor + "', got: "
                             + description);
         }
+    }
+
+    @Test
+    void sessionContextTool_declaresOptionalOnlyParameterSchema() {
+        // A tool without a declared property makes models disagree on what
+        // to send as arguments, and some LLM APIs reject the request that
+        // replays such a tool call.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var schema = JacksonUtils.readTree(captor.getValue().explicitTools()
+                .getFirst().getParametersSchema());
+        Assertions.assertEquals("object", schema.path("type").asString());
+        Assertions.assertTrue(schema.path("properties").size() > 0,
+                "Schema must declare at least one property, got: " + schema);
+        Assertions.assertEquals(0, schema.path("required").size(),
+                "All declared properties must be optional, got: " + schema);
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAIToolsTest.java
@@ -65,9 +65,17 @@ class DatabaseProviderAIToolsTest {
     }
 
     @Test
-    void getDatabaseSchema_returnsToolWithNullParametersSchema() {
+    void getDatabaseSchema_declaresOptionalOnlyParametersSchema() {
+        // A tool without a declared property makes models disagree on what
+        // to send as arguments, and some LLM APIs reject the request that
+        // replays such a tool call.
         var tool = DatabaseProviderAITools.getDatabaseSchema(provider);
-        Assertions.assertNull(tool.getParametersSchema());
+        var schema = JacksonUtils.readTree(tool.getParametersSchema());
+        Assertions.assertEquals("object", schema.path("type").asString());
+        Assertions.assertTrue(schema.path("properties").size() > 0,
+                "Schema must declare at least one property, got: " + schema);
+        Assertions.assertEquals(0, schema.path("required").size(),
+                "All declared properties must be optional, got: " + schema);
     }
 
     @Test
@@ -75,6 +83,15 @@ class DatabaseProviderAIToolsTest {
         var tool = DatabaseProviderAITools.getDatabaseSchema(provider);
         Assertions.assertEquals(SCHEMA,
                 tool.execute(JacksonUtils.createObjectNode()));
+    }
+
+    @Test
+    void getDatabaseSchema_executeIgnoresDeclaredArguments() {
+        var tool = DatabaseProviderAITools.getDatabaseSchema(provider);
+        var args = JacksonUtils.createObjectNode();
+        JacksonUtils.readTree(tool.getParametersSchema()).path("properties")
+                .propertyNames().forEach(name -> args.put(name, "ignored"));
+        Assertions.assertEquals(SCHEMA, tool.execute(args));
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,6 +57,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import tools.jackson.databind.JsonNode;
@@ -1442,7 +1444,7 @@ class LangChain4JLLMProviderTest {
     }
 
     @Test
-    void stream_withExplicitToolNullSchema_createsToolWithoutParameters() {
+    void stream_withExplicitToolNullSchema_substitutesNoParametersSchema() {
         var explicitTool = createExplicitTool("simpleTool", "A simple tool",
                 null, args -> "done");
 
@@ -1460,7 +1462,118 @@ class LangChain4JLLMProviderTest {
         var spec = captor.getValue().toolSpecifications().getFirst();
         Assertions.assertEquals("simpleTool", spec.name());
         Assertions.assertEquals("A simple tool", spec.description());
-        Assertions.assertNull(spec.parameters());
+        assertNoParametersSchema(spec.parameters());
+    }
+
+    @Test
+    void stream_withExplicitToolBlankSchema_substitutesNoParametersSchema() {
+        var explicitTool = createExplicitTool("simpleTool", "A simple tool",
+                "   ", args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response = mockSimpleResponse("OK");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel).chat(captor.capture());
+        assertNoParametersSchema(
+                captor.getValue().toolSpecifications().getFirst().parameters());
+    }
+
+    @Test
+    void stream_withExplicitToolMalformedSchema_substitutesNoParametersSchema() {
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "not json", args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response = mockSimpleResponse("OK");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel).chat(captor.capture());
+        assertNoParametersSchema(
+                captor.getValue().toolSpecifications().getFirst().parameters());
+    }
+
+    @Test
+    void stream_withExplicitToolSchema_preservesDeclaredProperties() {
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":"
+                        + "{\"type\":\"string\"}},\"required\":[\"city\"]}",
+                args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response = mockSimpleResponse("OK");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel).chat(captor.capture());
+        var parameters = captor.getValue().toolSpecifications().getFirst()
+                .parameters();
+        Assertions.assertEquals(Set.of("city"),
+                parameters.properties().keySet(),
+                "A declared schema's properties must reach the tool "
+                        + "specification unmodified");
+        Assertions.assertEquals(List.of("city"), parameters.required());
+    }
+
+    @Test
+    void stream_withExplicitToolEmptyPropertiesSchema_passesSchemaThrough() {
+        // Substitution is limited to null/blank schemas: a syntactically
+        // valid schema authored by the user is passed through as-is, even
+        // when its properties object is empty.
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{}}", args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response = mockSimpleResponse("OK");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel).chat(captor.capture());
+        var parameters = captor.getValue().toolSpecifications().getFirst()
+                .parameters();
+        Assertions.assertNotNull(parameters);
+        Assertions.assertTrue(parameters.properties().isEmpty(),
+                "An explicit empty-properties schema must not be rewritten, "
+                        + "got: " + parameters);
+    }
+
+    /**
+     * Asserts the parameters are the non-empty no-parameters shape: at least
+     * one property, all of them optional. A tool without a declared property
+     * makes models disagree on what to send as arguments, and some LLM APIs
+     * reject the request that replays such a tool call.
+     */
+    private static void assertNoParametersSchema(JsonObjectSchema parameters) {
+        Assertions.assertNotNull(parameters);
+        Assertions.assertFalse(parameters.properties().isEmpty(),
+                "Schema must declare at least one property, got: "
+                        + parameters);
+        Assertions.assertTrue(
+                parameters.required() == null
+                        || parameters.required().isEmpty(),
+                "All declared properties must be optional, got: " + parameters);
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -59,6 +59,7 @@ import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.ChatMessage;
 import com.vaadin.flow.component.ai.provider.LLMProvider.LLMRequest;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.tests.MockUIExtension;
 
@@ -1819,7 +1820,7 @@ class SpringAILLMProviderTest {
     }
 
     @Test
-    void stream_withExplicitToolNullSchema_usesEmptySchema() {
+    void stream_withExplicitToolNullSchema_substitutesNoParametersSchema() {
         provider.setStreaming(false);
         var explicitTool = createExplicitTool("simpleTool", "A simple tool",
                 null, args -> "done");
@@ -1838,8 +1839,83 @@ class SpringAILLMProviderTest {
         var toolDef = toolCallbacks.getFirst().getToolDefinition();
         Assertions.assertEquals("simpleTool", toolDef.name());
         Assertions.assertEquals("A simple tool", toolDef.description());
-        // Should have a default empty schema
-        Assertions.assertNotNull(toolDef.inputSchema());
+        assertNoParametersSchema(toolDef.inputSchema());
+    }
+
+    @Test
+    void stream_withExplicitToolBlankSchema_substitutesNoParametersSchema() {
+        provider.setStreaming(false);
+        var explicitTool = createExplicitTool("simpleTool", "A simple tool",
+                "   ", args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("OK");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        assertNoParametersSchema(
+                toolCallbacks.getFirst().getToolDefinition().inputSchema());
+    }
+
+    @Test
+    void stream_withExplicitToolSchema_passesSchemaThroughVerbatim() {
+        provider.setStreaming(false);
+        var userSchema = "{\"type\":\"object\",\"properties\":{\"city\":"
+                + "{\"type\":\"string\"}},\"required\":[\"city\"]}";
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                userSchema, args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("OK");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        Assertions.assertEquals(userSchema,
+                toolCallbacks.getFirst().getToolDefinition().inputSchema(),
+                "A declared schema must reach the tool definition unmodified");
+    }
+
+    @Test
+    void stream_withExplicitToolEmptyPropertiesSchema_passesSchemaThroughVerbatim() {
+        // Substitution is limited to null/blank schemas: a syntactically
+        // valid schema authored by the user is passed through as-is, even
+        // when its properties object is empty.
+        provider.setStreaming(false);
+        var userSchema = "{\"type\":\"object\",\"properties\":{}}";
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                userSchema, args -> "done");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("OK");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        Assertions.assertEquals(userSchema,
+                toolCallbacks.getFirst().getToolDefinition().inputSchema());
+    }
+
+    /**
+     * Asserts the schema is the non-empty no-parameters shape: an object with
+     * at least one property, all of them optional. A tool without a declared
+     * property makes models disagree on what to send as arguments, and some LLM
+     * APIs reject the request that replays such a tool call.
+     */
+    private static void assertNoParametersSchema(String inputSchema) {
+        var schema = JacksonUtils.readTree(inputSchema);
+        Assertions.assertEquals("object", schema.path("type").asString());
+        Assertions.assertTrue(schema.path("properties").size() > 0,
+                "Schema must declare at least one property, got: " + schema);
+        Assertions.assertEquals(0, schema.path("required").size(),
+                "All declared properties must be optional, got: " + schema);
     }
 
     private static LLMProvider.ToolSpec createExplicitTool(String name,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -241,7 +241,7 @@ public class ChartAIController implements AIController {
 
             @Override
             public String getParametersSchema() {
-                return null;
+                return NO_PARAMETERS_SCHEMA;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -1301,7 +1301,7 @@ public class FormAIController implements AIController {
 
             @Override
             public String getParametersSchema() {
-                return null;
+                return NO_PARAMETERS_SCHEMA;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
@@ -115,7 +115,7 @@ final class FormAITools {
     }
 
     /**
-     * Creates the {@code get_form_state} tool spec. Takes no parameters and
+     * Creates the {@code get_form_state} tool spec. Ignores its arguments and
      * returns a JSON document listing every visible field with its id, merged
      * description, type metadata (type/format/pattern/enum/queryable/array/
      * items), and current value.
@@ -141,11 +141,7 @@ final class FormAITools {
 
             @Override
             public String getParametersSchema() {
-                return """
-                        {
-                            "type": "object",
-                            "properties": {}
-                        }""";
+                return NO_PARAMETERS_SCHEMA;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -203,7 +203,7 @@ public class GridAIController implements AIController {
 
             @Override
             public String getParametersSchema() {
-                return null;
+                return NO_PARAMETERS_SCHEMA;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -113,6 +113,22 @@ class ChartAIControllerTest {
             Assertions.assertFalse(result.isEmpty());
             Assertions.assertTrue(result.contains("get_chart_state"));
         }
+
+        @Test
+        void declaresOptionalOnlyParameterSchema() {
+            // A tool without a declared property makes models disagree on
+            // what to send as arguments, and some LLM APIs reject the
+            // request that replays such a tool call.
+            var schema = json(
+                    findTool(controller.getTools(), "get_chart_instructions")
+                            .getParametersSchema());
+            Assertions.assertEquals("object", schema.path("type").asString());
+            Assertions.assertTrue(schema.path("properties").size() > 0,
+                    "Schema must declare at least one property, got: "
+                            + schema);
+            Assertions.assertEquals(0, schema.path("required").size(),
+                    "All declared properties must be optional, got: " + schema);
+        }
     }
 
     @Nested

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -172,6 +172,25 @@ class FormAIControllerTest {
                             + "already read; description: " + description
                             + " execResult: " + execResult);
         }
+
+        @Test
+        void instructionsToolDeclaresOptionalOnlyParameterSchema() {
+            // A tool without a declared property makes models disagree on
+            // what to send as arguments, and some LLM APIs reject the
+            // request that replays such a tool call.
+            var controller = new FormAIController(new Div(new TestField()));
+            var instructions = findTool(controller.getTools(),
+                    "get_form_instructions");
+
+            var schema = json(instructions.getParametersSchema());
+
+            Assertions.assertEquals("object", schema.path("type").asString());
+            Assertions.assertTrue(schema.path("properties").size() > 0,
+                    "Schema must declare at least one property, got: "
+                            + schema);
+            Assertions.assertEquals(0, schema.path("required").size(),
+                    "All declared properties must be optional, got: " + schema);
+        }
     }
 
     @Nested

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -1248,7 +1248,12 @@ class FormStateToolTest {
     }
 
     @Test
-    void getFormStateSchemaIsStaticAndEmpty() {
+    void getFormStateSchemaIsStaticAndDeclaresOnlyOptionalParameters() {
+        // A schema with no properties makes models disagree on what to send
+        // as arguments, and some LLM APIs reject the request that replays
+        // such a tool call — so the tool declares an optional property it
+        // ignores. The schema stays static so providers that cache prompt
+        // prefixes hit the cache on every subsequent prompt.
         var controller = new FormAIController(new Div(new TestField()));
 
         var schema = findTool(controller.getTools(), "get_form_state")
@@ -1256,9 +1261,28 @@ class FormStateToolTest {
         var node = json(schema);
 
         Assertions.assertEquals("object", node.path("type").asString());
-        Assertions.assertTrue(node.path("properties").isObject());
-        Assertions.assertEquals(0, node.path("properties").size(),
-                "get_form_state must take no parameters");
+        Assertions.assertTrue(node.path("properties").size() > 0,
+                "Schema must declare at least one property, got: " + node);
+        Assertions.assertEquals(0, node.path("required").size(),
+                "All declared properties must be optional, got: " + node);
+        Assertions.assertEquals(schema,
+                findTool(controller.getTools(), "get_form_state")
+                        .getParametersSchema(),
+                "Schema must be byte-identical across calls");
+    }
+
+    @Test
+    void getFormStateIgnoresDeclaredOptionalArguments() {
+        var controller = new FormAIController(new Div(new TestField()));
+        var tool = findTool(controller.getTools(), "get_form_state");
+
+        var args = JacksonUtils.createObjectNode();
+        json(tool.getParametersSchema()).path("properties").propertyNames()
+                .forEach(name -> args.put(name, "ignored"));
+
+        Assertions.assertEquals(tool.execute(JacksonUtils.createObjectNode()),
+                tool.execute(args),
+                "Declared optional properties must not affect the result");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -548,6 +548,20 @@ class GridAIControllerTest {
         Assertions.assertTrue(result.contains("get_grid_state"));
     }
 
+    @Test
+    void instructionsTool_declaresOptionalOnlyParameterSchema() {
+        // A tool without a declared property makes models disagree on what
+        // to send as arguments, and some LLM APIs reject the request that
+        // replays such a tool call.
+        var schema = json(
+                findTool("get_grid_instructions").getParametersSchema());
+        Assertions.assertEquals("object", schema.path("type").asString());
+        Assertions.assertTrue(schema.path("properties").size() > 0,
+                "Schema must declare at least one property, got: " + schema);
+        Assertions.assertEquals(0, schema.path("required").size(),
+                "All declared properties must be optional, got: " + schema);
+    }
+
     // --- stripGroupPrefix ---
 
     @Nested


### PR DESCRIPTION
Cherry-pick of https://github.com/vaadin/flow-components/pull/9971 to v25.3.