### PR TITLE
fix: relay ToolException raised while writing form values

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -1784,6 +1784,13 @@ public class FormAIController implements AIController {
                 Thread.currentThread().interrupt();
                 return "Error: fill interrupted.";
             } catch (ExecutionException ex) {
+                // Unwrap so a ToolException thrown by application code on the
+                // UI thread — a Binder validator, a converter, a field —
+                // keeps its LLM-facing message instead of being replaced
+                // with the generic string.
+                if (ex.getCause() instanceof ToolException toolException) {
+                    throw toolException;
+                }
                 LOGGER.warn("fill_form execution failed", ex.getCause());
                 return "Error: fill failed.";
             }
@@ -1902,6 +1909,15 @@ public class FormAIController implements AIController {
                 rejected.add(
                         new RejectedEntry(field.id(), value, ex.getMessage()));
                 return false;
+            } catch (ToolException ex) {
+                // The application sanctioned this text for the model, so it
+                // becomes the rejection reason instead of the curated
+                // fallback — the LLM needs to know why to fix the value.
+                LOGGER.warn("Converter reported user-facing error for field {}",
+                        field.id(), ex);
+                rejected.add(
+                        new RejectedEntry(field.id(), value, ex.getMessage()));
+                return false;
             } catch (Exception ex) {
                 // Anything other than RejectedValueException is an uncontrolled
                 // converter failure — surface a curated rejection so a single
@@ -1916,6 +1932,13 @@ public class FormAIController implements AIController {
             HasValue raw = field.field();
             try {
                 raw.setValue(converted);
+            } catch (ToolException ex) {
+                // As above: text the application marked safe to relay.
+                LOGGER.warn("Field reported user-facing error for field {}",
+                        field.id(), ex);
+                rejected.add(
+                        new RejectedEntry(field.id(), value, ex.getMessage()));
+                return false;
             } catch (Exception ex) {
                 LOGGER.debug("setValue rejected for field {}: {}", field.id(),
                         ex.getMessage());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.ValidationResult;
+import com.vaadin.flow.data.binder.Validator;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.tests.MockUIExtension;
 
@@ -712,6 +713,45 @@ class FillFormToolTest {
     }
 
     @Test
+    void fillForm_bindingValidatorThrowingToolException_relaysMessage() {
+        // A binder validator runs from the value-change listener that
+        // setValue fires, so a ToolException it throws surfaces on the write
+        // branch of applyValue rather than in the later validation pass. Its
+        // sanctioned message must reach the LLM as the rejection reason.
+        var field = new LabeledStringField();
+        var binder = new Binder<>(TestBean.class);
+        binder.forField(field)
+                .withValidator((Validator<String>) (value, context) -> {
+                    throw new ToolException(
+                            "name is reserved for internal accounts");
+                }).bind("name");
+        var controller = controllerForBound(binder, field);
+
+        var result = fillFormResult(controller, payload(field, "\"root\""));
+
+        Assertions.assertEquals("name is reserved for internal accounts",
+                rejectionReason(result, idOf(field)));
+    }
+
+    @Test
+    void fillForm_bindingValidatorThrowingRuntimeException_staysSilent() {
+        // The counterpart: an uncontrolled validator failure stays curated,
+        // so unsanctioned exception text cannot reach the model.
+        var field = new LabeledStringField();
+        var binder = new Binder<>(TestBean.class);
+        binder.forField(field).withValidator(v -> {
+            throw new IllegalStateException("internal-validator-detail");
+        }, "unused").bind("name");
+        var controller = controllerForBound(binder, field);
+
+        var raw = fillFormPayload(controller, payload(field, "\"root\""));
+
+        Assertions.assertFalse(raw.contains("internal-validator-detail"),
+                "Unsanctioned validator text must not reach the LLM; got: "
+                        + raw);
+    }
+
+    @Test
     void fillForm_bindingValidatorRejectionLeavesValueInField() {
         var field = new LabeledStringField();
         var binder = new Binder<>(TestBean.class);
@@ -1252,6 +1292,52 @@ class FillFormToolTest {
 
         Assertions.assertEquals("Error: field 'foo' is no longer addressable",
                 result);
+    }
+
+    @Test
+    void fillForm_converterThrowingToolException_relaysMessageAsReason() {
+        // A ToolException raised while converting the LLM's value is the
+        // application saying "this text is safe, tell the model why". It must
+        // become the per-field rejection reason instead of the curated
+        // fallback, otherwise the model has nothing to correct and resubmits
+        // the same value.
+        var field = new ToolExceptionConverterField();
+        var controller = controllerFor(field);
+
+        var args = JacksonUtils.createObjectNode();
+        args.putNull(idOf(field));
+        var result = fillFormResult(controller, args);
+
+        Assertions.assertEquals("clearing this field needs a reason code",
+                rejectionReason(result, idOf(field)));
+    }
+
+    @Test
+    void fillForm_fieldWriteThrowingToolException_relaysMessageAsReason() {
+        // Same contract on the write branch: a field that refuses a value with
+        // a ToolException gets its message relayed rather than replaced with
+        // "Field rejected the value."
+        var field = new ToolExceptionOnWriteField();
+        var controller = controllerFor(field);
+
+        var result = fillFormResult(controller, payload(field, "\"Initech\""));
+
+        Assertions.assertEquals("value must be one of: ACME, GLOBEX",
+                rejectionReason(result, idOf(field)));
+    }
+
+    @Test
+    void fillForm_fieldWriteThrowingRuntimeException_keepsCuratedReason() {
+        // The counterpart: an uncontrolled failure must still be curated, so
+        // exception text the application never sanctioned cannot reach the
+        // model.
+        var field = new RuntimeExceptionOnWriteField();
+        var controller = controllerFor(field);
+
+        var result = fillFormResult(controller, payload(field, "\"Initech\""));
+
+        Assertions.assertEquals("Field rejected the value.",
+                rejectionReason(result, idOf(field)));
     }
 
     @Test
@@ -1992,6 +2078,74 @@ class FillFormToolTest {
         @Override
         public String getEmptyValue() {
             throw new RuntimeException("internal-detail-from-getemptyvalue");
+        }
+
+        @Override
+        protected void setPresentationValue(String value) {
+            // not exercised
+        }
+    }
+
+    /**
+     * Field whose {@link #getEmptyValue} throws a {@link ToolException} —
+     * exercises the converter branch of {@code applyValue} with text the
+     * application has marked safe for the model.
+     */
+    @com.vaadin.flow.component.Tag("tool-exception-converter-field")
+    private static class ToolExceptionConverterField extends
+            com.vaadin.flow.component.AbstractField<ToolExceptionConverterField, String> {
+        ToolExceptionConverterField() {
+            super("");
+        }
+
+        @Override
+        public String getEmptyValue() {
+            throw new ToolException("clearing this field needs a reason code");
+        }
+
+        @Override
+        protected void setPresentationValue(String value) {
+            // not exercised
+        }
+    }
+
+    /**
+     * Field whose {@link #setValue} throws a {@link ToolException} — exercises
+     * the write branch of {@code applyValue}.
+     */
+    @com.vaadin.flow.component.Tag("tool-exception-set-value-field")
+    private static class ToolExceptionOnWriteField extends
+            com.vaadin.flow.component.AbstractField<ToolExceptionOnWriteField, String> {
+        ToolExceptionOnWriteField() {
+            super("");
+        }
+
+        @Override
+        public void setValue(String value) {
+            throw new ToolException("value must be one of: ACME, GLOBEX");
+        }
+
+        @Override
+        protected void setPresentationValue(String value) {
+            // not exercised
+        }
+    }
+
+    /**
+     * Field whose {@link #setValue} throws an uncontrolled exception — the
+     * counterpart to {@link ToolExceptionOnWriteField}, pinning that
+     * unsanctioned text stays curated.
+     */
+    @com.vaadin.flow.component.Tag("runtime-exception-set-value-field")
+    private static class RuntimeExceptionOnWriteField extends
+            com.vaadin.flow.component.AbstractField<RuntimeExceptionOnWriteField, String> {
+        RuntimeExceptionOnWriteField() {
+            super("");
+        }
+
+        @Override
+        public void setValue(String value) {
+            throw new IllegalStateException("internal-detail-from-setvalue");
         }
 
         @Override


### PR DESCRIPTION
## Summary
- An application marks a message safe for the model by throwing `ToolException`, but the form-fill path replaced it with `"Field rejected the value."`, so the model was told a field rejected its value without ever learning why — and resubmitted the same value.
- The fix covers both branches where application code runs during a fill, the converter and the write. Binder validators run from the value-change listener `setValue` fires, so they take the same path.