### PR TITLE
docs: explain why a tool may not see Vaadin thread locals

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -309,6 +309,15 @@ public interface LLMProvider {
          * access in {@code ui.access()}, or work on state captured in
          * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}.
          * </p>
+         * <p>
+         * An unbound thread local returns {@code null} rather than throwing, so
+         * a tool that reads one without checking does not fail — it proceeds
+         * with a missing value and can return a confidently wrong answer the
+         * LLM has no way to recognize as wrong. Capture what the tool needs in
+         * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()},
+         * which always runs on the UI thread, rather than reading thread locals
+         * here.
+         * </p>
          *
          * @param arguments
          *            the tool arguments as a {@link JsonNode} matching the


### PR DESCRIPTION
## Summary
- An unbound Vaadin thread local returns `null` rather than throwing, so a tool that reads one without checking does not fail — it proceeds with a missing value and can return a confidently wrong answer the LLM has no way to recognise as wrong.