### PR TITLE
chore: bump com.vaadin:license-checker from 3.1.1 to 3.1.2 (CP: 25.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <properties>
         <flow.version>25.2-SNAPSHOT</flow.version>
         <testbench.version>25.2.1</testbench.version>
-        <license-checker.version>3.1.1</license-checker.version>
+        <license-checker.version>3.1.2</license-checker.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <properties>
         <flow.version>25.2-SNAPSHOT</flow.version>
         <testbench.version>25.2.1</testbench.version>
+        <license-checker.version>3.1.1</license-checker.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -153,6 +154,11 @@
                         <artifactId>junit</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>license-checker</artifactId>
+                <version>${license-checker.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Cherry pick of https://github.com/vaadin/flow-components/pull/9998 to 25.2

Also includes the dependency management change from #9887 to simplify future cherry-picking.