### PR TITLE
fix: report the expected shape for non-object tool arguments

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -23,6 +23,9 @@ import java.util.Base64;
 import java.util.Objects;
 
 import com.vaadin.flow.component.ai.common.AIAttachment;
+import com.vaadin.flow.internal.JacksonUtils;
+
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Utility methods for LLM provider implementations.
@@ -95,5 +98,37 @@ final class LLMProviderHelpers {
                 "Attachment content type must not be null");
         Objects.requireNonNull(attachment.data(),
                 "Attachment data must not be null");
+    }
+
+    /**
+     * Parses the arguments a model sent for a tool call into the object a
+     * {@link LLMProvider.ToolSpec} expects.
+     * <p>
+     * Missing arguments become an empty object, so a tool that takes no
+     * parameters is callable whether or not the model sends anything. Anything
+     * else must parse as a JSON object: a model that has nothing to fill
+     * sometimes sends a bare value such as {@code ""} instead, which is valid
+     * JSON but carries no arguments.
+     *
+     * @param arguments
+     *            the raw argument JSON from the model, may be {@code null} or
+     *            blank
+     * @return the parsed arguments, never {@code null}
+     * @throws IllegalArgumentException
+     *             if the arguments parse to something other than a JSON object
+     */
+    public static ObjectNode parseToolArguments(String arguments) {
+        if (arguments == null || arguments.isBlank()) {
+            return JacksonUtils.createObjectNode();
+        }
+        var parsed = JacksonUtils.getMapper().readTree(arguments);
+        if (!parsed.isObject()) {
+            // Reported instead of letting the ObjectNode cast fail, so the
+            // message that goes back to the model names the shape it should
+            // send rather than a Java class cast.
+            throw new IllegalArgumentException(
+                    "expected a JSON object, but got " + parsed.getNodeType());
+        }
+        return (ObjectNode) parsed;
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.internal.JacksonUtils;
 
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
 /**
@@ -115,13 +117,22 @@ final class LLMProviderHelpers {
      *            blank
      * @return the parsed arguments, never {@code null}
      * @throws IllegalArgumentException
-     *             if the arguments parse to something other than a JSON object
+     *             if the arguments are not valid JSON or parse to something
+     *             other than a JSON object
      */
     public static ObjectNode parseToolArguments(String arguments) {
         if (arguments == null || arguments.isBlank()) {
             return JacksonUtils.createObjectNode();
         }
-        var parsed = JacksonUtils.getMapper().readTree(arguments);
+        JsonNode parsed;
+        try {
+            parsed = JacksonUtils.getMapper().readTree(arguments);
+        } catch (JacksonException e) {
+            // The message that goes back to the model keeps the parser
+            // diagnostic it can repair from, but not the location suffix
+            // full of Java library internals.
+            throw new IllegalArgumentException(e.getOriginalMessage(), e);
+        }
         if (!parsed.isObject()) {
             // Reported instead of letting the ObjectNode cast fail, so the
             // message that goes back to the model names the shape it should

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -306,11 +306,10 @@ public class LangChain4JLLMProvider implements LLMProvider {
 
     private static JsonNode parseExplicitToolArguments(String arguments) {
         try {
-            return parseArguments(arguments);
+            return LLMProviderHelpers.parseToolArguments(arguments);
         } catch (Exception e) {
-            // The malformed JSON came from the model itself, so the parser
-            // message is safe to relay and lets the model repair its next
-            // attempt.
+            // The bad arguments came from the model itself, so the message is
+            // safe to relay and lets the model repair its next attempt.
             throw new ToolException("invalid JSON arguments: " + e.getMessage(),
                     e);
         }
@@ -347,13 +346,6 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
         builder.parameters(parseParametersSchema(schema));
         return builder.build();
-    }
-
-    private static JsonNode parseArguments(String arguments) {
-        if (arguments == null || arguments.isBlank()) {
-            return JacksonUtils.createObjectNode();
-        }
-        return JacksonUtils.readTree(arguments);
     }
 
     private static JsonObjectSchema parseParametersSchema(String schemaJson) {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -48,7 +48,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.AttachmentContentType;
 import com.vaadin.flow.component.ai.common.ChatMessage;
-import com.vaadin.flow.internal.JacksonUtils;
 
 import reactor.core.publisher.Flux;
 import tools.jackson.databind.JsonNode;
@@ -668,11 +667,11 @@ public class SpringAILLMProvider implements LLMProvider {
             public String call(String arguments) {
                 JsonNode parsed;
                 try {
-                    parsed = parseArguments(arguments);
+                    parsed = LLMProviderHelpers.parseToolArguments(arguments);
                 } catch (Exception e) {
-                    // The malformed JSON came from the model itself, so
-                    // the parser message is safe to relay and lets the
-                    // model repair its next attempt.
+                    // The bad arguments came from the model itself, so the
+                    // message is safe to relay and lets the model repair its
+                    // next attempt.
                     LOGGER.warn("Tool '{}' received malformed JSON arguments",
                             tool.getName(), e);
                     return "Error executing tool: invalid JSON arguments: "
@@ -692,10 +691,4 @@ public class SpringAILLMProvider implements LLMProvider {
         };
     }
 
-    private static JsonNode parseArguments(String arguments) {
-        if (arguments == null || arguments.isBlank()) {
-            return JacksonUtils.createObjectNode();
-        }
-        return JacksonUtils.readTree(arguments);
-    }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1258,6 +1258,7 @@ class LangChain4JLLMProviderTest {
         var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
         Assertions.assertTrue(toolResults.getFirst().text()
                 .startsWith("Error executing tool:"));
+        assertNoJavaInternals(toolResults.getFirst().text());
     }
 
     @Test
@@ -1366,8 +1367,13 @@ class LangChain4JLLMProviderTest {
         var captor = ArgumentCaptor.forClass(ChatRequest.class);
         Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
         var toolResults = getToolExecutionResults(captor.getAllValues().get(1));
-        Assertions.assertTrue(toolResults.getFirst().text()
+        var result = toolResults.getFirst().text();
+        Assertions.assertTrue(result
                 .startsWith("Error executing tool: invalid JSON arguments: "));
+        Assertions.assertTrue(result.contains("Unrecognized token"),
+                "The parser diagnostic should be relayed so the model can "
+                        + "repair its next attempt, but got: " + result);
+        assertNoJavaInternals(result);
     }
 
     @Test
@@ -1439,7 +1445,7 @@ class LangChain4JLLMProviderTest {
      */
     private static void assertNoJavaInternals(String result) {
         for (var leak : List.of("tools.jackson", "cannot be cast",
-                "ClassLoader", "java.lang.")) {
+                "ClassLoader", "java.lang.", "[Source:")) {
             Assertions.assertFalse(result.contains(leak),
                     "Tool result relayed to the model must not contain '" + leak
                             + "', but got: " + result);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1371,6 +1371,82 @@ class LangChain4JLLMProviderTest {
     }
 
     @Test
+    void stream_withExplicitTool_nonObjectJsonArguments_reportsExpectedShape() {
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> {
+                    receivedArgs.add(args);
+                    return "ok";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        // A model that has nothing to fill may send an empty string. That is
+        // valid JSON, so it parses, but it is not the object a tool expects.
+        var response1 = mockSimpleResponseWithTool("myTool", "\"\"");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        Assertions.assertEquals(0, receivedArgs.size());
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        var result = getToolExecutionResults(captor.getAllValues().get(1))
+                .getFirst().text();
+
+        Assertions.assertTrue(result.startsWith("Error executing tool:"));
+        Assertions.assertTrue(result.contains("JSON object"),
+                "The model should be told what shape to send, but got: "
+                        + result);
+        assertNoJavaInternals(result);
+    }
+
+    @Test
+    void stream_withExplicitTool_jsonArrayArguments_reportsExpectedShape() {
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> "ok");
+
+        var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool", "[1, 2]");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        var result = getToolExecutionResults(captor.getAllValues().get(1))
+                .getFirst().text();
+
+        Assertions.assertTrue(result.startsWith("Error executing tool:"));
+        Assertions.assertTrue(result.contains("JSON object"),
+                "The model should be told what shape to send, but got: "
+                        + result);
+        assertNoJavaInternals(result);
+    }
+
+    /**
+     * Asserts that a tool result carries nothing from the Java runtime. Such a
+     * result goes straight back to the model, so a raw exception message would
+     * both waste tokens and leak internals.
+     */
+    private static void assertNoJavaInternals(String result) {
+        for (var leak : List.of("tools.jackson", "cannot be cast",
+                "ClassLoader", "java.lang.")) {
+            Assertions.assertFalse(result.contains(leak),
+                    "Tool result relayed to the model must not contain '" + leak
+                            + "', but got: " + result);
+        }
+    }
+
+    @Test
     void stream_withExplicitToolThrowingToolException_relaysMessageToModel() {
         var explicitTool = createExplicitTool("myTool", "A test tool", null,
                 args -> {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1787,6 +1787,73 @@ class SpringAILLMProviderTest {
         Assertions.assertEquals(0, receivedArgs.size());
     }
 
+    @Test
+    void stream_withExplicitTool_nonObjectJsonArguments_reportsExpectedShape() {
+        provider.setStreaming(false);
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> {
+                    receivedArgs.add(args);
+                    return "ok";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        // A model that has nothing to fill may send an empty string. That is
+        // valid JSON, so it parses, but it is not the object a tool expects.
+        var result = toolCallbacks.getFirst().call("\"\"");
+
+        Assertions.assertTrue(result.startsWith("Error executing tool:"));
+        Assertions.assertTrue(result.contains("JSON object"),
+                "The model should be told what shape to send, but got: "
+                        + result);
+        assertNoJavaInternals(result);
+        Assertions.assertEquals(0, receivedArgs.size());
+    }
+
+    @Test
+    void stream_withExplicitTool_jsonArrayArguments_reportsExpectedShape() {
+        provider.setStreaming(false);
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> "ok");
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        var result = toolCallbacks.getFirst().call("[1, 2]");
+
+        Assertions.assertTrue(result.startsWith("Error executing tool:"));
+        Assertions.assertTrue(result.contains("JSON object"),
+                "The model should be told what shape to send, but got: "
+                        + result);
+        assertNoJavaInternals(result);
+    }
+
+    /**
+     * Asserts that a tool result carries nothing from the Java runtime. Such a
+     * result goes straight back to the model, so a raw exception message would
+     * both waste tokens and leak internals.
+     */
+    private static void assertNoJavaInternals(String result) {
+        for (var leak : List.of("tools.jackson", "cannot be cast",
+                "ClassLoader", "java.lang.")) {
+            Assertions.assertFalse(result.contains(leak),
+                    "Tool result relayed to the model must not contain '" + leak
+                            + "', but got: " + result);
+        }
+    }
+
     // --- Response metadata tests ---
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1784,6 +1784,7 @@ class SpringAILLMProviderTest {
         var result = toolCallbacks.getFirst().call("Not json");
 
         Assertions.assertTrue(result.startsWith("Error executing tool:"));
+        assertNoJavaInternals(result);
         Assertions.assertEquals(0, receivedArgs.size());
     }
 
@@ -1847,7 +1848,7 @@ class SpringAILLMProviderTest {
      */
     private static void assertNoJavaInternals(String result) {
         for (var leak : List.of("tools.jackson", "cannot be cast",
-                "ClassLoader", "java.lang.")) {
+                "ClassLoader", "java.lang.", "[Source:")) {
             Assertions.assertFalse(result.contains(leak),
                     "Tool result relayed to the model must not contain '" + leak
                             + "', but got: " + result);


### PR DESCRIPTION
## Description

`JacksonUtils.readTree` is declared to return `ObjectNode`, so a bare JSON value like `""` fails the cast inside it rather than during parsing. Both providers caught that, labelled it "invalid JSON arguments" and relayed `getMessage()` to the model — meaning a `ClassCastException` text with Java class and classloader names went back as the tool result.

- Added `LLMProviderHelpers.parseToolArguments(String)`, which parses tool-call arguments without the `ObjectNode` cast and rejects anything that is not a JSON object with a message naming the expected shape
- Replaced the duplicated private `parseArguments` methods in `SpringAILLMProvider` and `LangChain4JLLMProvider` with the shared helper
- Added provider tests for an empty-string and a JSON-array argument, asserting the relayed message names the expected shape and carries no Java class, cast or classloader text

## Type of change

- Bugfix