### PR TITLE
refactor: move no parameters schema to provider helper

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -876,7 +876,7 @@ public class AIOrchestrator implements Serializable {
 
         @Override
         public String getParametersSchema() {
-            return NO_PARAMETERS_SCHEMA;
+            return null;
         }
 
         @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAITools.java
@@ -58,7 +58,7 @@ public final class DatabaseProviderAITools {
 
             @Override
             public String getParametersSchema() {
-                return NO_PARAMETERS_SCHEMA;
+                return null;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -204,31 +204,6 @@ public interface LLMProvider {
     interface ToolSpec {
 
         /**
-         * JSON Schema for a tool that takes no parameters. Declares a single
-         * optional {@code reason} property that the tool ignores, so the LLM
-         * always has a well-formed, non-empty object to send as arguments.
-         * <p>
-         * Use this instead of {@code null} or a schema with an empty
-         * {@code properties} object: without a declared property, models
-         * disagree on what to send as arguments — some send an empty string —
-         * and some LLM APIs (for example Anthropic models on Amazon Bedrock)
-         * reject the request that replays such a tool call.
-         * </p>
-         *
-         * @since 25.3
-         */
-        String NO_PARAMETERS_SCHEMA = """
-                {
-                  "type": "object",
-                  "properties": {
-                    "reason": {
-                      "type": "string",
-                      "description": "Optional note on why this tool is being called. Ignored by the tool."
-                    }
-                  }
-                }""";
-
-        /**
          * Gets the unique name of this tool. The name must contain only
          * alphanumeric characters, underscores, and hyphens, with a maximum
          * length of 64 characters (matching the pattern
@@ -300,17 +275,14 @@ public interface LLMProvider {
          * that not every LLM provider accepts.
          * </p>
          * <p>
-         * For a tool that takes no parameters, return
-         * {@link #NO_PARAMETERS_SCHEMA} rather than {@code null} or a schema
-         * with an empty {@code properties} object — see the constant's
-         * documentation for why. The built-in providers substitute
-         * {@link #NO_PARAMETERS_SCHEMA} for a {@code null} or blank return
-         * value, but an empty {@code properties} object is passed through
-         * as-is.
+         * For a tool that takes no parameters, return {@code null}. The
+         * built-in providers then declare a placeholder schema to the LLM —
+         * some LLM APIs misbehave when a tool declares no properties at all —
+         * and pass an empty arguments object to {@link #execute(JsonNode)}.
          * </p>
          *
-         * @return the JSON Schema string, or {@link #NO_PARAMETERS_SCHEMA} if
-         *         the tool takes no parameters
+         * @return the JSON Schema string, or {@code null} if the tool takes no
+         *         parameters
          */
         String getParametersSchema();
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -278,7 +278,8 @@ public interface LLMProvider {
          * For a tool that takes no parameters, return {@code null}. The
          * built-in providers then declare a placeholder schema to the LLM —
          * some LLM APIs misbehave when a tool declares no properties at all —
-         * and pass an empty arguments object to {@link #execute(JsonNode)}.
+         * and always invoke {@link #execute(JsonNode)} with an empty arguments
+         * object, whatever the model sends.
          * </p>
          *
          * @return the JSON Schema string, or {@code null} if the tool takes no

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -45,10 +45,12 @@ final class LLMProviderHelpers {
      * string — and at least Anthropic models on Amazon Bedrock reject the
      * request that replays such a tool call.
      * <p>
-     * The placeholder never reaches the tool: a provider that substitutes this
-     * schema also passes an empty arguments object to
-     * {@link LLMProvider.ToolSpec#execute}, so the property declared here is
-     * free to change.
+     * The placeholder never reaches a tool: whenever a provider sends this
+     * schema in place of the tool's own — including the LangChain4j fallback
+     * for a declared schema that fails to parse — it skips argument parsing and
+     * invokes {@link LLMProvider.ToolSpec#execute} with an empty object,
+     * whatever the model sent. The property declared here is therefore free to
+     * change.
      */
     public static final String NO_PARAMETERS_SCHEMA = """
             {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -37,6 +37,46 @@ import tools.jackson.databind.node.ObjectNode;
 final class LLMProviderHelpers {
 
     /**
+     * JSON Schema substituted when a tool declares no parameters, i.e.
+     * {@link LLMProvider.ToolSpec#getParametersSchema()} returns {@code null}
+     * or blank. Declares a single optional {@code reason} property so the LLM
+     * always has a well-formed, non-empty object to send as arguments: without
+     * a declared property, models disagree on what to send — some send an empty
+     * string — and at least Anthropic models on Amazon Bedrock reject the
+     * request that replays such a tool call.
+     * <p>
+     * The placeholder never reaches the tool: a provider that substitutes this
+     * schema also passes an empty arguments object to
+     * {@link LLMProvider.ToolSpec#execute}, so the property declared here is
+     * free to change.
+     */
+    public static final String NO_PARAMETERS_SCHEMA = """
+            {
+              "type": "object",
+              "properties": {
+                "reason": {
+                  "type": "string",
+                  "description": "Optional note on why this tool is being called. Ignored by the tool."
+                }
+              }
+            }""";
+
+    /**
+     * Tells whether a tool declares parameters. A tool whose schema is
+     * {@code null} or blank takes none: the provider declares
+     * {@link #NO_PARAMETERS_SCHEMA} to the LLM in its place and passes an empty
+     * arguments object to the tool.
+     *
+     * @param tool
+     *            the tool to check
+     * @return {@code true} if the tool declares a parameters schema
+     */
+    public static boolean hasParameters(LLMProvider.ToolSpec tool) {
+        var schema = tool.getParametersSchema();
+        return schema != null && !schema.isBlank();
+    }
+
+    /**
      * Decodes byte array as UTF-8 text.
      *
      * @param data

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -298,18 +298,34 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
         // Add explicit (framework-agnostic) tools
         for (var tool : explicitTools) {
+            var placeholderSchema = usesPlaceholderSchema(tool);
             toolExecutors.put(tool.getName(), (execReq, memoryId) -> {
-                var arguments = parseExplicitToolArguments(execReq.arguments());
-                if (!LLMProviderHelpers.hasParameters(tool)) {
-                    // The model saw the placeholder schema and may have
-                    // filled it; the tool declared no parameters, so it
-                    // receives none.
-                    arguments = JacksonUtils.createObjectNode();
+                if (placeholderSchema) {
+                    // The model saw the placeholder schema; the tool did not
+                    // declare a usable one, so it receives no arguments.
+                    // Decided before parsing, so the tool stays callable even
+                    // on the malformed arguments — an empty string, say —
+                    // that the placeholder schema exists to work around.
+                    return tool.execute(JacksonUtils.createObjectNode());
                 }
-                return tool.execute(arguments);
+                return tool.execute(
+                        parseExplicitToolArguments(execReq.arguments()));
             });
         }
         return toolExecutors;
+    }
+
+    /**
+     * Whether the schema sent to the LLM for this tool is
+     * {@link LLMProviderHelpers#NO_PARAMETERS_SCHEMA} rather than the tool's
+     * own: the tool declares no schema, or declares one that does not parse.
+     * Every such tool gets an empty arguments object at execution time, so
+     * whatever the model filled the placeholder with never reaches a tool.
+     */
+    private static boolean usesPlaceholderSchema(LLMProvider.ToolSpec tool) {
+        return !LLMProviderHelpers.hasParameters(tool)
+                || parseParametersSchemaOrNull(
+                        tool.getParametersSchema()) == null;
     }
 
     private static JsonNode parseExplicitToolArguments(String arguments) {
@@ -346,16 +362,37 @@ public class LangChain4JLLMProvider implements LLMProvider {
             LLMProvider.ToolSpec tool) {
         var builder = ToolSpecification.builder().name(tool.getName())
                 .description(tool.getDescription());
-        // A tool without a declared schema breaks some LLM APIs —
-        // see LLMProviderHelpers.NO_PARAMETERS_SCHEMA.
-        var schema = LLMProviderHelpers.hasParameters(tool)
-                ? tool.getParametersSchema()
-                : LLMProviderHelpers.NO_PARAMETERS_SCHEMA;
-        builder.parameters(parseParametersSchema(schema));
+        JsonObjectSchema parameters = null;
+        if (LLMProviderHelpers.hasParameters(tool)) {
+            parameters = parseParametersSchemaOrNull(
+                    tool.getParametersSchema());
+            if (parameters == null) {
+                LOGGER.warn(
+                        "Failed to parse the parameters schema of tool '{}', "
+                                + "using the no-parameters schema",
+                        tool.getName());
+            }
+        }
+        if (parameters == null) {
+            // A tool without a usable schema breaks some LLM APIs —
+            // see LLMProviderHelpers.NO_PARAMETERS_SCHEMA. The constant is a
+            // well-formed literal, so this parse cannot return null.
+            parameters = parseParametersSchemaOrNull(
+                    LLMProviderHelpers.NO_PARAMETERS_SCHEMA);
+        }
+        builder.parameters(parameters);
         return builder.build();
     }
 
-    private static JsonObjectSchema parseParametersSchema(String schemaJson) {
+    /**
+     * Parses a JSON Schema string into the LangChain4j schema object, or
+     * returns {@code null} when the string does not parse. Logs nothing: the
+     * caller decides whether a failure is worth a warning, since the check runs
+     * both when building the tool specification and when deciding the arguments
+     * handed to the executor.
+     */
+    private static JsonObjectSchema parseParametersSchemaOrNull(
+            String schemaJson) {
         try {
             JsonNode root = JacksonUtils.readTree(schemaJson);
             var schemaBuilder = JsonObjectSchema.builder();
@@ -374,11 +411,8 @@ public class LangChain4JLLMProvider implements LLMProvider {
             }
             return schemaBuilder.build();
         } catch (Exception e) {
-            LOGGER.warn("Failed to parse tool parameters schema, "
-                    + "using no-parameters schema", e);
-            // The constant is a well-formed literal, so this cannot recurse.
-            return parseParametersSchema(
-                    LLMProviderHelpers.NO_PARAMETERS_SCHEMA);
+            LOGGER.debug("Tool parameters schema failed to parse", e);
+            return null;
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -298,8 +298,16 @@ public class LangChain4JLLMProvider implements LLMProvider {
         }
         // Add explicit (framework-agnostic) tools
         for (var tool : explicitTools) {
-            toolExecutors.put(tool.getName(), (execReq, memoryId) -> tool
-                    .execute(parseExplicitToolArguments(execReq.arguments())));
+            toolExecutors.put(tool.getName(), (execReq, memoryId) -> {
+                var arguments = parseExplicitToolArguments(execReq.arguments());
+                if (!LLMProviderHelpers.hasParameters(tool)) {
+                    // The model saw the placeholder schema and may have
+                    // filled it; the tool declared no parameters, so it
+                    // receives none.
+                    arguments = JacksonUtils.createObjectNode();
+                }
+                return tool.execute(arguments);
+            });
         }
         return toolExecutors;
     }
@@ -338,12 +346,11 @@ public class LangChain4JLLMProvider implements LLMProvider {
             LLMProvider.ToolSpec tool) {
         var builder = ToolSpecification.builder().name(tool.getName())
                 .description(tool.getDescription());
-        var schema = tool.getParametersSchema();
-        if (schema == null || schema.isBlank()) {
-            // A tool without a declared schema breaks some LLM APIs —
-            // see ToolSpec.NO_PARAMETERS_SCHEMA.
-            schema = LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA;
-        }
+        // A tool without a declared schema breaks some LLM APIs —
+        // see LLMProviderHelpers.NO_PARAMETERS_SCHEMA.
+        var schema = LLMProviderHelpers.hasParameters(tool)
+                ? tool.getParametersSchema()
+                : LLMProviderHelpers.NO_PARAMETERS_SCHEMA;
         builder.parameters(parseParametersSchema(schema));
         return builder.build();
     }
@@ -371,7 +378,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
                     + "using no-parameters schema", e);
             // The constant is a well-formed literal, so this cannot recurse.
             return parseParametersSchema(
-                    LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA);
+                    LLMProviderHelpers.NO_PARAMETERS_SCHEMA);
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -666,22 +666,27 @@ public class SpringAILLMProvider implements LLMProvider {
             @Override
             public String call(String arguments) {
                 JsonNode parsed;
-                try {
-                    parsed = LLMProviderHelpers.parseToolArguments(arguments);
-                } catch (Exception e) {
-                    // The bad arguments came from the model itself, so the
-                    // message is safe to relay and lets the model repair its
-                    // next attempt.
-                    LOGGER.warn("Tool '{}' received malformed JSON arguments",
-                            tool.getName(), e);
-                    return "Error executing tool: invalid JSON arguments: "
-                            + e.getMessage();
-                }
                 if (!LLMProviderHelpers.hasParameters(tool)) {
-                    // The model saw the placeholder schema and may have
-                    // filled it; the tool declared no parameters, so it
-                    // receives none.
+                    // The model saw the placeholder schema; the tool declared
+                    // no parameters, so it receives none. Decided before
+                    // parsing, so the tool stays callable even on the
+                    // malformed arguments — an empty string, say — that the
+                    // placeholder schema exists to work around.
                     parsed = JacksonUtils.createObjectNode();
+                } else {
+                    try {
+                        parsed = LLMProviderHelpers
+                                .parseToolArguments(arguments);
+                    } catch (Exception e) {
+                        // The bad arguments came from the model itself, so
+                        // the message is safe to relay and lets the model
+                        // repair its next attempt.
+                        LOGGER.warn(
+                                "Tool '{}' received malformed JSON arguments",
+                                tool.getName(), e);
+                        return "Error executing tool: invalid JSON arguments: "
+                                + e.getMessage();
+                    }
                 }
                 try {
                     return tool.execute(parsed);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.ai.common.AIAttachment;
 import com.vaadin.flow.component.ai.common.AttachmentContentType;
 import com.vaadin.flow.component.ai.common.ChatMessage;
+import com.vaadin.flow.internal.JacksonUtils;
 
 import reactor.core.publisher.Flux;
 import tools.jackson.databind.JsonNode;
@@ -652,14 +653,13 @@ public class SpringAILLMProvider implements LLMProvider {
         return new ToolCallback() {
             @Override
             public ToolDefinition getToolDefinition() {
-                var schema = tool.getParametersSchema();
                 // A tool without a declared schema breaks some LLM APIs —
-                // see ToolSpec.NO_PARAMETERS_SCHEMA.
+                // see LLMProviderHelpers.NO_PARAMETERS_SCHEMA.
                 return DefaultToolDefinition.builder().name(tool.getName())
                         .description(tool.getDescription())
-                        .inputSchema(schema != null && !schema.isBlank()
-                                ? schema
-                                : LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA)
+                        .inputSchema(LLMProviderHelpers.hasParameters(tool)
+                                ? tool.getParametersSchema()
+                                : LLMProviderHelpers.NO_PARAMETERS_SCHEMA)
                         .build();
             }
 
@@ -676,6 +676,12 @@ public class SpringAILLMProvider implements LLMProvider {
                             tool.getName(), e);
                     return "Error executing tool: invalid JSON arguments: "
                             + e.getMessage();
+                }
+                if (!LLMProviderHelpers.hasParameters(tool)) {
+                    // The model saw the placeholder schema and may have
+                    // filled it; the tool declared no parameters, so it
+                    // receives none.
+                    parsed = JacksonUtils.createObjectNode();
                 }
                 try {
                     return tool.execute(parsed);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -62,7 +62,6 @@ import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.tests.EnableFeatureFlagExtension;
 import com.vaadin.tests.MockUIExtension;
@@ -2692,10 +2691,9 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void sessionContextTool_declaresOptionalOnlyParameterSchema() {
-        // A tool without a declared property makes models disagree on what
-        // to send as arguments, and some LLM APIs reject the request that
-        // replays such a tool call.
+    void sessionContextTool_declaresNoParameters() {
+        // A null schema tells the provider the tool takes no parameters; the
+        // provider substitutes its placeholder schema in the LLM request.
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2707,13 +2705,8 @@ class AIOrchestratorTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        var schema = JacksonUtils.readTree(captor.getValue().explicitTools()
-                .getFirst().getParametersSchema());
-        Assertions.assertEquals("object", schema.path("type").asString());
-        Assertions.assertTrue(schema.path("properties").size() > 0,
-                "Schema must declare at least one property, got: " + schema);
-        Assertions.assertEquals(0, schema.path("required").size(),
-                "All declared properties must be optional, got: " + schema);
+        Assertions.assertNull(captor.getValue().explicitTools().getFirst()
+                .getParametersSchema());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAIToolsTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/DatabaseProviderAIToolsTest.java
@@ -65,17 +65,11 @@ class DatabaseProviderAIToolsTest {
     }
 
     @Test
-    void getDatabaseSchema_declaresOptionalOnlyParametersSchema() {
-        // A tool without a declared property makes models disagree on what
-        // to send as arguments, and some LLM APIs reject the request that
-        // replays such a tool call.
+    void getDatabaseSchema_declaresNoParameters() {
+        // A null schema tells the provider the tool takes no parameters; the
+        // provider substitutes its placeholder schema in the LLM request.
         var tool = DatabaseProviderAITools.getDatabaseSchema(provider);
-        var schema = JacksonUtils.readTree(tool.getParametersSchema());
-        Assertions.assertEquals("object", schema.path("type").asString());
-        Assertions.assertTrue(schema.path("properties").size() > 0,
-                "Schema must declare at least one property, got: " + schema);
-        Assertions.assertEquals(0, schema.path("required").size(),
-                "All declared properties must be optional, got: " + schema);
+        Assertions.assertNull(tool.getParametersSchema());
     }
 
     @Test
@@ -86,11 +80,10 @@ class DatabaseProviderAIToolsTest {
     }
 
     @Test
-    void getDatabaseSchema_executeIgnoresDeclaredArguments() {
+    void getDatabaseSchema_executeIgnoresUnexpectedArguments() {
         var tool = DatabaseProviderAITools.getDatabaseSchema(provider);
         var args = JacksonUtils.createObjectNode();
-        JacksonUtils.readTree(tool.getParametersSchema()).path("properties")
-                .propertyNames().forEach(name -> args.put(name, "ignored"));
+        args.put("unexpected", "ignored");
         Assertions.assertEquals(SCHEMA, tool.execute(args));
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1379,8 +1379,8 @@ class LangChain4JLLMProviderTest {
     @Test
     void stream_withExplicitTool_nonObjectJsonArguments_reportsExpectedShape() {
         var receivedArgs = new ArrayList<JsonNode>();
-        var explicitTool = createExplicitTool("myTool", "A test tool",
-                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> {
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
                     receivedArgs.add(args);
                     return "ok";
                 });
@@ -1413,8 +1413,8 @@ class LangChain4JLLMProviderTest {
 
     @Test
     void stream_withExplicitTool_jsonArrayArguments_reportsExpectedShape() {
-        var explicitTool = createExplicitTool("myTool", "A test tool",
-                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> "ok");
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "ok");
 
         var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
                 Collections.emptyList(), new Object[0], List.of(explicitTool));
@@ -1588,6 +1588,63 @@ class LangChain4JLLMProviderTest {
         Mockito.verify(mockChatModel).chat(captor.capture());
         assertNoParametersSchema(
                 captor.getValue().toolSpecifications().getFirst().parameters());
+    }
+
+    @Test
+    void stream_withExplicitToolNullSchema_executeReceivesEmptyArguments() {
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("simpleTool", "A simple tool",
+                null, args -> {
+                    receivedArgs.add(args);
+                    return "done";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        // The model may fill the placeholder schema that was substituted for
+        // the missing one; a tool that declared no parameters must not see
+        // that.
+        var response1 = mockSimpleResponseWithTool("simpleTool",
+                "{\"reason\":\"checking the form\"}");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        Assertions.assertEquals(1, receivedArgs.size());
+        Assertions.assertTrue(receivedArgs.getFirst().isEmpty(),
+                "A tool that declared no parameters must receive an empty "
+                        + "arguments object, got: " + receivedArgs.getFirst());
+    }
+
+    @Test
+    void stream_withExplicitToolMalformedSchema_executeReceivesArguments() {
+        // Only a tool that declared no schema at all gets its arguments
+        // emptied; a tool whose declared schema failed to parse still meant
+        // to receive what the model sends.
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "not json", args -> {
+                    receivedArgs.add(args);
+                    return "done";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("myTool",
+                "{\"city\":\"Helsinki\"}");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        Assertions.assertEquals(1, receivedArgs.size());
+        Assertions.assertEquals("Helsinki",
+                receivedArgs.getFirst().get("city").asString());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1351,7 +1351,8 @@ class LangChain4JLLMProviderTest {
 
     @Test
     void stream_withExplicitTool_malformedJsonArguments_relaysParserMessage() {
-        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> "ok");
 
         var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
@@ -1379,7 +1380,8 @@ class LangChain4JLLMProviderTest {
     @Test
     void stream_withExplicitTool_nonObjectJsonArguments_reportsExpectedShape() {
         var receivedArgs = new ArrayList<JsonNode>();
-        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> {
                     receivedArgs.add(args);
                     return "ok";
@@ -1388,8 +1390,8 @@ class LangChain4JLLMProviderTest {
         var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
                 Collections.emptyList(), new Object[0], List.of(explicitTool));
 
-        // A model that has nothing to fill may send an empty string. That is
-        // valid JSON, so it parses, but it is not the object a tool expects.
+        // An empty string is valid JSON, so it parses, but it is not the
+        // object a tool with declared parameters expects.
         var response1 = mockSimpleResponseWithTool("myTool", "\"\"");
         var response2 = mockSimpleResponse("Done");
         Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
@@ -1413,7 +1415,8 @@ class LangChain4JLLMProviderTest {
 
     @Test
     void stream_withExplicitTool_jsonArrayArguments_reportsExpectedShape() {
-        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> "ok");
 
         var request = new TestLLMRequestWithExplicitTools("Call my tool", null,
@@ -1620,10 +1623,12 @@ class LangChain4JLLMProviderTest {
     }
 
     @Test
-    void stream_withExplicitToolMalformedSchema_executeReceivesArguments() {
-        // Only a tool that declared no schema at all gets its arguments
-        // emptied; a tool whose declared schema failed to parse still meant
-        // to receive what the model sends.
+    void stream_withExplicitToolMalformedSchema_executeReceivesEmptyArguments() {
+        // A declared schema that fails to parse is replaced with the
+        // placeholder schema, so the model never saw the tool's real
+        // parameters — whatever it sent under the placeholder is not what the
+        // tool declared, and the tool receives no arguments, keeping the
+        // placeholder's property name a provider-internal detail.
         var receivedArgs = new ArrayList<JsonNode>();
         var explicitTool = createExplicitTool("myTool", "A test tool",
                 "not json", args -> {
@@ -1635,7 +1640,7 @@ class LangChain4JLLMProviderTest {
                 Collections.emptyList(), new Object[0], List.of(explicitTool));
 
         var response1 = mockSimpleResponseWithTool("myTool",
-                "{\"city\":\"Helsinki\"}");
+                "{\"reason\":\"exploring the data\"}");
         var response2 = mockSimpleResponse("Done");
         Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
                 .thenReturn(response1, response2);
@@ -1643,8 +1648,47 @@ class LangChain4JLLMProviderTest {
         provider.stream(request).blockFirst();
 
         Assertions.assertEquals(1, receivedArgs.size());
-        Assertions.assertEquals("Helsinki",
-                receivedArgs.getFirst().get("city").asString());
+        Assertions.assertTrue(receivedArgs.getFirst().isEmpty(),
+                "A tool whose schema was replaced with the placeholder must "
+                        + "receive an empty arguments object, got: "
+                        + receivedArgs.getFirst());
+    }
+
+    @Test
+    void stream_withExplicitToolNullSchema_malformedArgumentsStillExecute() {
+        // A model that has nothing to fill sometimes sends an empty string —
+        // the very case the placeholder schema works around. A tool that
+        // declared no parameters ignores its arguments by contract, so it
+        // must run rather than bounce an error back to the model.
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("simpleTool", "A simple tool",
+                null, args -> {
+                    receivedArgs.add(args);
+                    return "done";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+
+        var response1 = mockSimpleResponseWithTool("simpleTool", "\"\"");
+        var response2 = mockSimpleResponse("Done");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response1, response2);
+
+        provider.stream(request).blockFirst();
+
+        Assertions.assertEquals(1, receivedArgs.size());
+        Assertions.assertTrue(receivedArgs.getFirst().isEmpty(),
+                "A tool that declared no parameters must receive an empty "
+                        + "arguments object, got: " + receivedArgs.getFirst());
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel, Mockito.times(2)).chat(captor.capture());
+        Assertions.assertEquals("done",
+                getToolExecutionResults(captor.getAllValues().get(1)).getFirst()
+                        .text(),
+                "The tool's real result must go back to the model, not an "
+                        + "argument-parsing error");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1792,8 +1792,8 @@ class SpringAILLMProviderTest {
     void stream_withExplicitTool_nonObjectJsonArguments_reportsExpectedShape() {
         provider.setStreaming(false);
         var receivedArgs = new ArrayList<JsonNode>();
-        var explicitTool = createExplicitTool("myTool", "A test tool",
-                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> {
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
                     receivedArgs.add(args);
                     return "ok";
                 });
@@ -1821,8 +1821,8 @@ class SpringAILLMProviderTest {
     @Test
     void stream_withExplicitTool_jsonArrayArguments_reportsExpectedShape() {
         provider.setStreaming(false);
-        var explicitTool = createExplicitTool("myTool", "A test tool",
-                LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA, args -> "ok");
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> "ok");
 
         var request = new TestLLMRequestWithExplicitTools("Call tool", null,
                 Collections.emptyList(), new Object[0], List.of(explicitTool));
@@ -2297,6 +2297,37 @@ class SpringAILLMProviderTest {
                 .getOptions()).getToolCallbacks();
         assertNoParametersSchema(
                 toolCallbacks.getFirst().getToolDefinition().inputSchema());
+    }
+
+    @Test
+    void stream_withExplicitToolNullSchema_executeReceivesEmptyArguments() {
+        provider.setStreaming(false);
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("simpleTool", "A simple tool",
+                null, args -> {
+                    receivedArgs.add(args);
+                    return "done";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("OK");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        // The model may fill the placeholder schema that was substituted for
+        // the missing one; a tool that declared no parameters must not see
+        // that.
+        var result = toolCallbacks.getFirst()
+                .call("{\"reason\":\"checking the form\"}");
+
+        Assertions.assertEquals("done", result);
+        Assertions.assertEquals(1, receivedArgs.size());
+        Assertions.assertTrue(receivedArgs.getFirst().isEmpty(),
+                "A tool that declared no parameters must receive an empty "
+                        + "arguments object, got: " + receivedArgs.getFirst());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1792,7 +1792,8 @@ class SpringAILLMProviderTest {
     void stream_withExplicitTool_nonObjectJsonArguments_reportsExpectedShape() {
         provider.setStreaming(false);
         var receivedArgs = new ArrayList<JsonNode>();
-        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> {
                     receivedArgs.add(args);
                     return "ok";
@@ -1806,8 +1807,8 @@ class SpringAILLMProviderTest {
 
         var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
                 .getOptions()).getToolCallbacks();
-        // A model that has nothing to fill may send an empty string. That is
-        // valid JSON, so it parses, but it is not the object a tool expects.
+        // An empty string is valid JSON, so it parses, but it is not the
+        // object a tool with declared parameters expects.
         var result = toolCallbacks.getFirst().call("\"\"");
 
         Assertions.assertTrue(result.startsWith("Error executing tool:"));
@@ -1821,7 +1822,8 @@ class SpringAILLMProviderTest {
     @Test
     void stream_withExplicitTool_jsonArrayArguments_reportsExpectedShape() {
         provider.setStreaming(false);
-        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+        var explicitTool = createExplicitTool("myTool", "A test tool",
+                "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
                 args -> "ok");
 
         var request = new TestLLMRequestWithExplicitTools("Call tool", null,
@@ -1839,6 +1841,37 @@ class SpringAILLMProviderTest {
                 "The model should be told what shape to send, but got: "
                         + result);
         assertNoJavaInternals(result);
+    }
+
+    @Test
+    void stream_withExplicitToolNullSchema_malformedArgumentsStillExecute() {
+        // A model that has nothing to fill sometimes sends an empty string —
+        // the very case the placeholder schema works around. A tool that
+        // declared no parameters ignores its arguments by contract, so it
+        // must run rather than bounce an error back to the model.
+        provider.setStreaming(false);
+        var receivedArgs = new ArrayList<JsonNode>();
+        var explicitTool = createExplicitTool("myTool", "A test tool", null,
+                args -> {
+                    receivedArgs.add(args);
+                    return "done";
+                });
+
+        var request = new TestLLMRequestWithExplicitTools("Call tool", null,
+                Collections.emptyList(), new Object[0], List.of(explicitTool));
+        mockSimpleChat("Done");
+
+        provider.stream(request).blockFirst();
+
+        var toolCallbacks = ((ToolCallingChatOptions) capturePrompt()
+                .getOptions()).getToolCallbacks();
+        var result = toolCallbacks.getFirst().call("\"\"");
+
+        Assertions.assertEquals("done", result);
+        Assertions.assertEquals(1, receivedArgs.size());
+        Assertions.assertTrue(receivedArgs.getFirst().isEmpty(),
+                "A tool that declared no parameters must receive an empty "
+                        + "arguments object, got: " + receivedArgs.getFirst());
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAIController.java
@@ -248,7 +248,7 @@ public class ChartAIController implements AIController {
 
             @Override
             public String getParametersSchema() {
-                return NO_PARAMETERS_SCHEMA;
+                return null;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -1315,7 +1315,7 @@ public class FormAIController implements AIController {
 
             @Override
             public String getParametersSchema() {
-                return NO_PARAMETERS_SCHEMA;
+                return null;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
@@ -141,7 +141,7 @@ final class FormAITools {
 
             @Override
             public String getParametersSchema() {
-                return NO_PARAMETERS_SCHEMA;
+                return null;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAIController.java
@@ -209,7 +209,7 @@ public class GridAIController implements AIController {
 
             @Override
             public String getParametersSchema() {
-                return NO_PARAMETERS_SCHEMA;
+                return null;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -116,19 +116,13 @@ class ChartAIControllerTest {
         }
 
         @Test
-        void declaresOptionalOnlyParameterSchema() {
-            // A tool without a declared property makes models disagree on
-            // what to send as arguments, and some LLM APIs reject the
-            // request that replays such a tool call.
-            var schema = json(
+        void declaresNoParameters() {
+            // A null schema tells the provider the tool takes no parameters;
+            // the provider substitutes its placeholder schema in the LLM
+            // request.
+            Assertions.assertNull(
                     findTool(controller.getTools(), "get_chart_instructions")
                             .getParametersSchema());
-            Assertions.assertEquals("object", schema.path("type").asString());
-            Assertions.assertTrue(schema.path("properties").size() > 0,
-                    "Schema must declare at least one property, got: "
-                            + schema);
-            Assertions.assertEquals(0, schema.path("required").size(),
-                    "All declared properties must be optional, got: " + schema);
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -175,22 +175,15 @@ class FormAIControllerTest {
         }
 
         @Test
-        void instructionsToolDeclaresOptionalOnlyParameterSchema() {
-            // A tool without a declared property makes models disagree on
-            // what to send as arguments, and some LLM APIs reject the
-            // request that replays such a tool call.
+        void instructionsToolDeclaresNoParameters() {
+            // A null schema tells the provider the tool takes no parameters;
+            // the provider substitutes its placeholder schema in the LLM
+            // request.
             var controller = new FormAIController(new Div(new TestField()));
             var instructions = findTool(controller.getTools(),
                     "get_form_instructions");
 
-            var schema = json(instructions.getParametersSchema());
-
-            Assertions.assertEquals("object", schema.path("type").asString());
-            Assertions.assertTrue(schema.path("properties").size() > 0,
-                    "Schema must declare at least one property, got: "
-                            + schema);
-            Assertions.assertEquals(0, schema.path("required").size(),
-                    "All declared properties must be optional, got: " + schema);
+            Assertions.assertNull(instructions.getParametersSchema());
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -1249,41 +1249,28 @@ class FormStateToolTest {
     }
 
     @Test
-    void getFormStateSchemaIsStaticAndDeclaresOnlyOptionalParameters() {
-        // A schema with no properties makes models disagree on what to send
-        // as arguments, and some LLM APIs reject the request that replays
-        // such a tool call — so the tool declares an optional property it
-        // ignores. The schema stays static so providers that cache prompt
-        // prefixes hit the cache on every subsequent prompt.
+    void getFormStateDeclaresNoParameters() {
+        // A null schema tells the provider the tool takes no parameters; the
+        // provider substitutes a static placeholder schema in the LLM
+        // request, so providers that cache prompt prefixes hit the cache on
+        // every subsequent prompt.
         var controller = new FormAIController(new Div(new TestField()));
 
-        var schema = findTool(controller.getTools(), "get_form_state")
-                .getParametersSchema();
-        var node = json(schema);
-
-        Assertions.assertEquals("object", node.path("type").asString());
-        Assertions.assertTrue(node.path("properties").size() > 0,
-                "Schema must declare at least one property, got: " + node);
-        Assertions.assertEquals(0, node.path("required").size(),
-                "All declared properties must be optional, got: " + node);
-        Assertions.assertEquals(schema,
-                findTool(controller.getTools(), "get_form_state")
-                        .getParametersSchema(),
-                "Schema must be byte-identical across calls");
+        Assertions.assertNull(findTool(controller.getTools(), "get_form_state")
+                .getParametersSchema());
     }
 
     @Test
-    void getFormStateIgnoresDeclaredOptionalArguments() {
+    void getFormStateIgnoresUnexpectedArguments() {
         var controller = new FormAIController(new Div(new TestField()));
         var tool = findTool(controller.getTools(), "get_form_state");
 
         var args = JacksonUtils.createObjectNode();
-        json(tool.getParametersSchema()).path("properties").propertyNames()
-                .forEach(name -> args.put(name, "ignored"));
+        args.put("unexpected", "ignored");
 
         Assertions.assertEquals(tool.execute(JacksonUtils.createObjectNode()),
                 tool.execute(args),
-                "Declared optional properties must not affect the result");
+                "Unexpected arguments must not affect the result");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -555,17 +555,11 @@ class GridAIControllerTest {
     }
 
     @Test
-    void instructionsTool_declaresOptionalOnlyParameterSchema() {
-        // A tool without a declared property makes models disagree on what
-        // to send as arguments, and some LLM APIs reject the request that
-        // replays such a tool call.
-        var schema = json(
+    void instructionsTool_declaresNoParameters() {
+        // A null schema tells the provider the tool takes no parameters; the
+        // provider substitutes its placeholder schema in the LLM request.
+        Assertions.assertNull(
                 findTool("get_grid_instructions").getParametersSchema());
-        Assertions.assertEquals("object", schema.path("type").asString());
-        Assertions.assertTrue(schema.path("properties").size() > 0,
-                "Schema must declare at least one property, got: " + schema);
-        Assertions.assertEquals(0, schema.path("required").size(),
-                "All declared properties must be optional, got: " + schema);
     }
 
     // --- stripGroupPrefix ---


### PR DESCRIPTION
## Description

- Removed `LLMProvider.ToolSpec.NO_PARAMETERS_SCHEMA` from the public API and moved it to the package-private `LLMProviderHelpers`
- Changed the built-in parameterless tools to return `null` from `getParametersSchema()`. The providers substitute the placeholder for a `null` or blank schema, so the request sent to the LLM is unchanged
- Changed `SpringAILLMProvider` and `LangChain4JLLMProvider` to always invoke `execute()` with an empty arguments object when the placeholder schema was sent to the LLM, so the placeholder's `reason` property never reaches a tool. In `LangChain4JLLMProvider` this includes a declared schema that fails to parse, which is replaced with the placeholder. Decided before argument parsing, so a parameterless tool still runs when the model sends malformed arguments such as an empty string; parse errors are still relayed for tools with declared parameters.

Follow-up to https://github.com/vaadin/docs/pull/5919#issuecomment-5493475123

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.