### PR TITLE
feat!: pass request event to AIController.onRequest

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIFieldMarkerPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIFieldMarkerPage.java
@@ -15,11 +15,15 @@
  */
 package com.vaadin.flow.component.ai.tests;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.ai.common.ConfidenceLevel;
 import com.vaadin.flow.component.ai.common.ValueSource;
 import com.vaadin.flow.component.ai.form.FieldMarkerI18n;
 import com.vaadin.flow.component.ai.form.FormAIController;
+import com.vaadin.flow.component.ai.orchestrator.RequestListener;
 import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
@@ -113,7 +117,9 @@ public class AIFieldMarkerPage extends VerticalLayout {
         });
 
         var startTurn = new NativeButton("Start turn",
-                event -> controller.onRequest());
+                event -> controller.onRequest(
+                        new RequestListener.RequestEvent("Start turn",
+                                UUID.randomUUID().toString(), List.of())));
         startTurn.setId("start-turn");
 
         var finishTurn = new NativeButton("Finish turn", event -> {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIController.java
@@ -44,13 +44,16 @@ public interface AIController {
 
     /**
      * Called synchronously on the UI thread just before the LLM stream opens.
-     * By the time this method fires, the user message and an empty assistant
-     * placeholder are already in the message list; the turn is committed to the
-     * conversation history and the {@link RequestListener} only after this
-     * method returns successfully. Implementations can prepare for the turn —
-     * locking UI surfaces, snapshotting state the tool definitions depend on,
-     * and so on. Since tools may execute on a background thread, this is the
-     * moment to capture any state that depends on Vaadin thread locals such as
+     * The event carries the user message, the {@code messageId} assigned to it,
+     * and the attachments included with it; it is the same event the
+     * {@link RequestListener} receives for the turn. By the time this method
+     * fires, the user message and an empty assistant placeholder are already in
+     * the message list; the turn is committed to the conversation history and
+     * the {@link RequestListener} only after this method returns successfully.
+     * Implementations can prepare for the turn — locking UI surfaces,
+     * snapshotting state the tool definitions depend on, and so on. Since tools
+     * may execute on a background thread, this is the moment to capture any
+     * state that depends on Vaadin thread locals such as
      * {@code UI.getCurrent()} or {@code VaadinSession.getCurrent()}.
      * <p>
      * The default does nothing. Throwing from this method aborts the turn
@@ -62,8 +65,12 @@ public interface AIController {
      * released, and the exception propagates back to the caller of the prompt
      * entry point.
      * </p>
+     *
+     * @param event
+     *            the request being submitted — user message, message id, and
+     *            attachments — never {@code null}
      */
-    default void onRequest() {
+    default void onRequest(RequestListener.RequestEvent event) {
     }
 
     /**
@@ -84,9 +91,10 @@ public interface AIController {
      * failure it carries the cause (stream error, timeout, or any throw on the
      * prompt path before the stream opens); release per-turn state captured in
      * {@code onRequest} (locks, pending writes, snapshots) and discard the
-     * staged work. Note that a failure before {@link #onRequest()} — for
-     * example a throwing {@link RequestInterceptor} — also fires this method,
-     * so it can run without a preceding {@code onRequest} call.
+     * staged work. Note that a failure before
+     * {@link #onRequest(RequestListener.RequestEvent)} — for example a throwing
+     * {@link RequestInterceptor} — also fires this method, so it can run
+     * without a preceding {@code onRequest} call.
      * </p>
      * <p>
      * An error is not the only abnormal ending. A turn cut off at the model's

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -550,8 +550,13 @@ public class AIOrchestrator implements Serializable {
         var assistantMessage = createAssistantMessagePlaceholder();
 
         try {
+            var messageId = UUID.randomUUID().toString();
+            // One event for both hooks: the user message, assigned messageId,
+            // and attachments (empty list when none).
+            var requestEvent = new RequestListener.RequestEvent(userMessage,
+                    messageId, attachments);
             if (controller != null) {
-                controller.onRequest();
+                controller.onRequest(requestEvent);
             }
 
             var metadataHolder = new AtomicReference<ResponseMetadata>();
@@ -560,14 +565,8 @@ public class AIOrchestrator implements Serializable {
             LOGGER.debug("Processing prompt with {} attachments",
                     attachments.size());
 
-            var messageId = UUID.randomUUID().toString();
             if (requestListener != null) {
-                // Fires on every prompt with the user message, assigned
-                // messageId, and attachments (empty list when none) — the
-                // generic "request being submitted" hook for listener users,
-                // counterpart to AIController.onRequest().
-                requestListener.onRequest(new RequestListener.RequestEvent(
-                        userMessage, messageId, List.copyOf(attachments)));
+                requestListener.onRequest(requestEvent);
             }
             conversationHistory.add(new ChatMessage(ChatMessage.Role.USER,
                     userMessage, messageId, Instant.now()));
@@ -1402,8 +1401,8 @@ public class AIOrchestrator implements Serializable {
          * Sets a listener that is called on every prompt, just before the LLM
          * stream opens. The listener receives the user message, the assigned
          * {@code messageId}, and the attachments included with the message
-         * (empty list when none). Same lifecycle moment as
-         * {@link AIController#onRequest()}.
+         * (empty list when none). Same lifecycle moment and same event as
+         * {@link AIController#onRequest(RequestListener.RequestEvent)}.
          * <p>
          * Typical use: persist attachment data in your own storage keyed by
          * {@code messageId}, so the same id can be used later to look the

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptor.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptor.java
@@ -52,17 +52,17 @@ import com.vaadin.flow.function.SerializableConsumer;
  * </pre>
  * <p>
  * The interceptor runs before the prompt has any effect: before the message
- * appears in the message list, before {@link AIController#onRequest()
- * controller} and {@link RequestListener} hooks, before the conversation
- * history entry, and before the LLM request is built. Everything downstream
- * sees only the processed content. A silently rejected prompt leaves no trace
- * in the UI or the history; rejecting with a user-facing message shows the
- * original prompt and the reason in the message list only — never in the
- * history or a request. Note that attachments pending in a configured file
- * receiver have already been taken from it when the interceptor runs, so they
- * are not resubmitted with the next prompt if this one is rejected, dropped, or
- * fails after being postponed. Prompts whose original text is blank are dropped
- * before the interceptor runs.
+ * appears in the message list, before
+ * {@link AIController#onRequest(RequestListener.RequestEvent) controller} and
+ * {@link RequestListener} hooks, before the conversation history entry, and
+ * before the LLM request is built. Everything downstream sees only the
+ * processed content. A silently rejected prompt leaves no trace in the UI or
+ * the history; rejecting with a user-facing message shows the original prompt
+ * and the reason in the message list only — never in the history or a request.
+ * Note that attachments pending in a configured file receiver have already been
+ * taken from it when the interceptor runs, so they are not resubmitted with the
+ * next prompt if this one is rejected, dropped, or fails after being postponed.
+ * Prompts whose original text is blank are dropped before the interceptor runs.
  * <p>
  * Throwing from the interceptor aborts the prompt the same way as a rejection,
  * except that the exception is reported to the {@link ResponseListener} and
@@ -262,9 +262,10 @@ public interface RequestInterceptor extends Serializable {
         /**
          * Rejects the prompt without user-facing feedback: nothing is sent to
          * the LLM, nothing is added to the message list or the conversation
-         * history, and neither {@link AIController#onRequest() controller} nor
-         * {@link RequestListener} hooks fire. Rejection is final — later
-         * content changes do not undo it.
+         * history, and neither
+         * {@link AIController#onRequest(RequestListener.RequestEvent)
+         * controller} nor {@link RequestListener} hooks fire. Rejection is
+         * final — later content changes do not undo it.
          *
          * @throws IllegalStateException
          *             if a postponed prompt has already been completed

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestListener.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.ai.orchestrator;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 import com.vaadin.flow.component.ai.common.AIAttachment;
 
@@ -24,9 +25,9 @@ import com.vaadin.flow.component.ai.common.AIAttachment;
  * Listener for request submission events.
  * <p>
  * The listener is called on every prompt, just before the LLM stream opens —
- * the same lifecycle moment as {@link AIController#onRequest()}. Use it to
- * persist the outbound request (the user message, any attachments) or to
- * correlate the assigned {@code messageId} with downstream events such as
+ * the same lifecycle moment as {@link AIController#onRequest(RequestEvent)}.
+ * Use it to persist the outbound request (the user message, any attachments) or
+ * to correlate the assigned {@code messageId} with downstream events such as
  * {@link AttachmentClickListener} and the {@code messageId} stored in
  * {@link com.vaadin.flow.component.ai.common.ChatMessage#messageId()}.
  * <p>
@@ -51,18 +52,39 @@ public interface RequestListener extends Serializable {
      * Event fired just before the LLM stream opens for a prompt. Carries the
      * user message, the assigned {@code messageId} that will be stored on the
      * resulting {@link com.vaadin.flow.component.ai.common.ChatMessage}, and
-     * the attachments included with the message (empty list when none).
+     * the attachments included with the message (empty list when none). The
+     * same event is passed to {@link AIController#onRequest(RequestEvent)
+     * AIController.onRequest}.
      */
     class RequestEvent implements Serializable {
         private final String userMessage;
         private final String messageId;
         private final List<AIAttachment> attachments;
 
-        RequestEvent(String userMessage, String messageId,
+        /**
+         * Creates a request event. The orchestrator builds this for every turn;
+         * it is public so an application can construct one when unit testing an
+         * {@link AIController} implementation.
+         *
+         * @param userMessage
+         *            the user message being submitted, not {@code null}
+         * @param messageId
+         *            the unique identifier assigned to the message, not
+         *            {@code null}
+         * @param attachments
+         *            the attachments included with the message, not
+         *            {@code null}; copied, so later changes to the given list
+         *            do not affect the event
+         * @since 25.3
+         */
+        public RequestEvent(String userMessage, String messageId,
                 List<AIAttachment> attachments) {
-            this.userMessage = userMessage;
-            this.messageId = messageId;
-            this.attachments = attachments;
+            this.userMessage = Objects.requireNonNull(userMessage,
+                    "userMessage must not be null");
+            this.messageId = Objects.requireNonNull(messageId,
+                    "messageId must not be null");
+            this.attachments = List.copyOf(Objects.requireNonNull(attachments,
+                    "attachments must not be null"));
         }
 
         /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestListener.java
@@ -75,6 +75,10 @@ public interface RequestListener extends Serializable {
          *            the attachments included with the message, not
          *            {@code null}; copied, so later changes to the given list
          *            do not affect the event
+         * @throws NullPointerException
+         *             if {@code userMessage}, {@code messageId} or
+         *             {@code attachments} is {@code null}, or
+         *             {@code attachments} contains {@code null} elements
          * @since 25.3
          */
         public RequestEvent(String userMessage, String messageId,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/ResponseListener.java
@@ -41,12 +41,14 @@ import com.vaadin.flow.component.ai.provider.ResponseMetadata;
  * <i>not</i> appended to {@link AIOrchestrator#getHistory()}.
  * <p>
  * On failure {@link ResponseEvent#getError()} carries the cause (timeout,
- * stream error, any throw between {@link AIController#onRequest()} and the
- * start of the stream, or a {@link RequestInterceptor} failure — a throw, a
+ * stream error, any throw between
+ * {@link AIController#onRequest(RequestListener.RequestEvent)} and the start of
+ * the stream, or a {@link RequestInterceptor} failure — a throw, a
  * {@link RequestInterceptor.RequestContinuation#fail(Throwable) fail}, or an
  * interception timeout); the response text is either empty or a partial stream
  * that was received before the failure. An interceptor failure fires the
- * listener without a preceding {@link AIController#onRequest()}, so an error
+ * listener without a preceding
+ * {@link AIController#onRequest(RequestListener.RequestEvent)}, so an error
  * does not imply that per-turn setup has happened.
  * <p>
  * The listener is <b>not</b> called when history is restored via

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -301,14 +301,14 @@ public interface LLMProvider {
          * or with background execution enabled — where Vaadin thread locals
          * such as {@code UI.getCurrent()} are not bound. Wrap UI component
          * access in {@code ui.access()}, or work on state captured in
-         * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}.
+         * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest}.
          * </p>
          * <p>
          * An unbound thread local returns {@code null} rather than throwing, so
          * a tool that reads one without checking does not fail — it proceeds
          * with a missing value and can return a confidently wrong answer the
          * LLM has no way to recognize as wrong. Capture what the tool needs in
-         * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()},
+         * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest},
          * which always runs on the UI thread, rather than reading thread locals
          * here.
          * </p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -209,7 +209,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * Security's {@code SecurityContext} are not bound, and UI components must
      * not be accessed directly. Wrap component access in {@code ui.access()},
      * or capture what you need in
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()},
+     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest},
      * which still runs on the UI thread. This is the same requirement a
      * {@link StreamingChatModel} already has.</li>
      *
@@ -219,7 +219,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * with it, the submit is rejected and dropped with a warning — and a
      * connected input has already cleared its text. Disable the input while a
      * turn is running, for example from
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}
+     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest}
      * and
      * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(ResponseListener.ResponseEvent)}.</li>
      * </ul>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -228,7 +228,7 @@ public class SpringAILLMProvider implements LLMProvider {
      * Security's {@code SecurityContext} are not bound, and UI components must
      * not be accessed directly. Wrap component access in {@code ui.access()},
      * or capture what you need in
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()},
+     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest},
      * which still runs on the UI thread. This is the same requirement streaming
      * mode already has.</li>
      *
@@ -238,7 +238,7 @@ public class SpringAILLMProvider implements LLMProvider {
      * with it, the submit is rejected and dropped with a warning — and a
      * connected input has already cleared its text. Disable the input while a
      * turn is running, for example from
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest()}
+     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest}
      * and
      * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(ResponseListener.ResponseEvent)}.</li>
      * </ul>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2230,9 +2230,63 @@ class AIOrchestratorTest {
         orchestratorWith(controller).prompt("Hello");
 
         var inOrder = Mockito.inOrder(controller, mockProvider);
-        inOrder.verify(controller).onRequest();
+        inOrder.verify(controller).onRequest(Mockito.any());
         inOrder.verify(mockProvider)
                 .stream(Mockito.any(LLMProvider.LLMRequest.class));
+    }
+
+    @Test
+    void builder_withController_onRequestReceivesSameEventAsRequestListener() {
+        stubAddMessage();
+        Mockito.when(mockFileReceiver.takeAttachments())
+                .thenReturn(List.of(createAttachment("a.txt")));
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var controllerEvent = new AtomicReference<RequestListener.RequestEvent>();
+        var listenerEvent = new AtomicReference<RequestListener.RequestEvent>();
+        var controller = new AIController() {
+            @Override
+            public List<LLMProvider.ToolSpec> getTools() {
+                return List.of();
+            }
+
+            @Override
+            public void onRequest(RequestListener.RequestEvent event) {
+                controllerEvent.set(event);
+            }
+        };
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList)
+                .withFileReceiver(mockFileReceiver).withController(controller)
+                .withRequestListener(listenerEvent::set).build();
+
+        orchestrator.prompt("Hello");
+
+        var event = controllerEvent.get();
+        Assertions.assertNotNull(event);
+        Assertions.assertSame(event, listenerEvent.get());
+        Assertions.assertEquals("Hello", event.getUserMessage());
+        Assertions.assertEquals(1, event.getAttachments().size());
+        Assertions.assertEquals("a.txt",
+                event.getAttachments().getFirst().name());
+        Assertions.assertEquals(event.getMessageId(),
+                orchestrator.getHistory().getFirst().messageId());
+    }
+
+    @Test
+    void requestEvent_copiesAttachmentsAndIsUnmodifiable() {
+        var attachments = new ArrayList<AIAttachment>();
+        attachments.add(createAttachment("a.txt"));
+
+        var event = new RequestListener.RequestEvent("Hello", "msg-1",
+                attachments);
+        attachments.add(createAttachment("b.txt"));
+
+        Assertions.assertEquals(1, event.getAttachments().size());
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> event.getAttachments().clear());
     }
 
     @SuppressWarnings("unchecked")
@@ -2255,7 +2309,7 @@ class AIOrchestratorTest {
         captor.getValue().accept("Hi from input");
 
         var inOrder = Mockito.inOrder(controller, mockProvider);
-        inOrder.verify(controller).onRequest();
+        inOrder.verify(controller).onRequest(Mockito.any());
         inOrder.verify(mockProvider)
                 .stream(Mockito.any(LLMProvider.LLMRequest.class));
     }
@@ -2295,7 +2349,7 @@ class AIOrchestratorTest {
         stubAddMessage();
         var thrown = new RuntimeException("controller refused");
         var controller = mockController();
-        Mockito.doThrow(thrown).when(controller).onRequest();
+        Mockito.doThrow(thrown).when(controller).onRequest(Mockito.any());
 
         var orchestrator = orchestratorWith(controller);
         var caught = Assertions.assertThrows(RuntimeException.class,
@@ -2356,7 +2410,7 @@ class AIOrchestratorTest {
         // must skip the setText update without an NPE.
         var controller = mockController();
         Mockito.doThrow(new RuntimeException("controller refused"))
-                .when(controller).onRequest();
+                .when(controller).onRequest(Mockito.any());
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withController(controller).build();
@@ -2376,7 +2430,7 @@ class AIOrchestratorTest {
         var attachmentListener = Mockito.mock(RequestListener.class);
         var controller = mockController();
         Mockito.doThrow(new RuntimeException("controller refused"))
-                .when(controller).onRequest();
+                .when(controller).onRequest(Mockito.any());
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList)
@@ -2404,7 +2458,7 @@ class AIOrchestratorTest {
 
         var thrown = new RuntimeException("simulated onRequestStart failure");
         var controller = mockController();
-        Mockito.doThrow(thrown).when(controller).onRequest();
+        Mockito.doThrow(thrown).when(controller).onRequest(Mockito.any());
 
         var orchestrator = orchestratorWith(controller);
         Assertions.assertThrows(RuntimeException.class,

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2289,6 +2289,23 @@ class AIOrchestratorTest {
                 () -> event.getAttachments().clear());
     }
 
+    @Test
+    void requestEvent_rejectsNullArguments() {
+        var attachments = List.of(createAttachment("a.txt"));
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new RequestListener.RequestEvent(null, "msg-1",
+                        attachments));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new RequestListener.RequestEvent("Hello", null,
+                        attachments));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new RequestListener.RequestEvent("Hello", "msg-1", null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new RequestListener.RequestEvent("Hello", "msg-1",
+                        Collections.singletonList(null)));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void inputSubmit_callsOnRequestStartBeforeStream() {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptorTest.java
@@ -390,7 +390,7 @@ class RequestInterceptorTest {
         Assertions.assertThrows(RuntimeException.class,
                 () -> orchestrator.prompt("Hello"));
 
-        Mockito.verify(controller, Mockito.never()).onRequest();
+        Mockito.verify(controller, Mockito.never()).onRequest(Mockito.any());
         Mockito.verify(controller).onResponse(errorIs(thrown));
     }
 
@@ -441,7 +441,7 @@ class RequestInterceptorTest {
 
         orchestrator.prompt("Hello");
 
-        Mockito.verify(controller, Mockito.never()).onRequest();
+        Mockito.verify(controller, Mockito.never()).onRequest(Mockito.any());
     }
 
     @Test
@@ -459,7 +459,7 @@ class RequestInterceptorTest {
         var inOrder = Mockito.inOrder(interceptor, controller);
         inOrder.verify(interceptor).intercept(
                 Mockito.any(RequestInterceptor.RequestInterceptEvent.class));
-        inOrder.verify(controller).onRequest();
+        inOrder.verify(controller).onRequest(Mockito.any());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.component.ai.form.FormAITools.FormFieldDescriptor;
 import com.vaadin.flow.component.ai.form.FormValueConverter.RejectedValueException;
 import com.vaadin.flow.component.ai.orchestrator.AIController;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
+import com.vaadin.flow.component.ai.orchestrator.RequestListener;
 import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.ai.provider.ToolException;
@@ -541,9 +542,10 @@ public class FormAIController implements AIController {
     /**
      * Rebuilds the fixed-options bindings on {@code hints} from the original
      * item list and the current state of {@code field} / {@code explicit}.
-     * Invoked at registration and again on every {@link #onRequest()} so the
-     * labeler captured in {@link FormFieldHints#itemLabelGenerator} reflects
-     * the field's current {@code setItemLabelGenerator(...)}.
+     * Invoked at registration and again on every
+     * {@link #onRequest(RequestListener.RequestEvent)} so the labeler captured
+     * in {@link FormFieldHints#itemLabelGenerator} reflects the field's current
+     * {@code setItemLabelGenerator(...)}.
      */
     private static void rebindFixedOptions(FormFieldHints hints,
             HasValue<?, ?> field, ItemLabelGenerator<?> explicit,
@@ -620,7 +622,8 @@ public class FormAIController implements AIController {
      * otherwise the field's own {@code getItemLabelGenerator()} (via
      * {@link FormValueConverter#renderItem}, which also covers the
      * {@link String#valueOf} fallback). Called once per turn at
-     * {@link #onRequest()} so a swap on the field between turns is picked up.
+     * {@link #onRequest(RequestListener.RequestEvent)} so a swap on the field
+     * between turns is picked up.
      */
     private static Function<Object, String> resolveItemLabeler(
             HasValue<?, ?> field, ItemLabelGenerator<?> explicit) {
@@ -1326,7 +1329,7 @@ public class FormAIController implements AIController {
     }
 
     @Override
-    public void onRequest() {
+    public void onRequest(RequestListener.RequestEvent event) {
         turn.filling = true;
         // Refresh the field set so fields added or removed between turns
         // are picked up.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHints.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldHints.java
@@ -40,14 +40,14 @@ final class FormFieldHints {
      * label wins. Populated upfront for fixed-options registrations and as each
      * query-callback batch arrives for query-mode registrations. Iteration
      * order is insertion order. Reset at each
-     * {@link FormAIController#onRequest()} turn boundary; non-{@code null}
+     * {@link FormAIController#onRequest} turn boundary; non-{@code null}
      * whenever {@link #valueOptionsQuery} is set.
      */
     Map<String, Object> valueOptionsItems;
     /**
      * Item-to-label function used to render the field's current value and to
      * compute the keys in {@link #valueOptionsItems}. Captured at each
-     * {@link FormAIController#onRequest()} from the explicit
+     * {@link FormAIController#onRequest} from the explicit
      * {@link ValueOptions#itemLabelGenerator(com.vaadin.flow.component.ItemLabelGenerator)}
      * if set, otherwise from the field's own {@code getItemLabelGenerator()}
      * (read reflectively), otherwise {@link String#valueOf(Object)}. Stable
@@ -66,10 +66,10 @@ final class FormFieldHints {
      * {@link #itemLabelGenerator} from the registration's captured config
      * (fixed list or query callback, explicit labeler or field reference).
      * Invoked once at registration so the schema works before the first turn,
-     * and again at each {@link FormAIController#onRequest()} so a labeler
-     * change on the field between turns is picked up and the query-mode map
-     * starts each turn empty. {@code null} when no value-options registration
-     * exists for this field.
+     * and again at each {@link FormAIController#onRequest} so a labeler change
+     * on the field between turns is picked up and the query-mode map starts
+     * each turn empty. {@code null} when no value-options registration exists
+     * for this field.
      */
     Runnable valueOptionsTurnSetup;
     boolean ignored;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.ai.form;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.executeQueryFieldOptions;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.findTool;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.requestEvent;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -1282,7 +1283,7 @@ class FillFormToolTest {
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options(List.of("Premium", "Basic"))
                 .itemLabelGenerator(s -> s.substring(0, 1)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"P\""));
 
@@ -1302,7 +1303,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of(apollo)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"Apollo\""));
 
@@ -1406,7 +1407,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of(apollo)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"Unknown\""));
 
@@ -1431,7 +1432,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of(apollo, vega)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller,
                 payload(field, "[\"Apollo\", \"Vega\"]"));
@@ -1530,7 +1531,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of(existing)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "[]"));
 
@@ -1551,7 +1552,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of(apollo)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"Apollo\""));
 
@@ -1577,7 +1578,7 @@ class FillFormToolTest {
                 ValueOptions.forField(field).options(List.of(first)));
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of(second)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         executeQueryFieldOptions(controller, field, "", 10);
 
         var result = fillFormResult(controller, payload(field, "[\"Second\"]"));
@@ -1600,7 +1601,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of(first, dup)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"Apollo\""));
 
@@ -1620,14 +1621,14 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of(apollo)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         fillFormResult(controller, payload(field, "\"Apollo\""));
         Assertions.assertEquals(apollo, field.getValue(),
                 "Turn 1 must resolve via Project::name");
 
         field.setValue(null);
         field.setItemLabelGenerator(Project::code);
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         var result = fillFormResult(controller, payload(field, "\"APL\""));
 
         Assertions.assertEquals(apollo, field.getValue(),
@@ -1646,7 +1647,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of(apollo)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"Apollo\""));
 
@@ -1673,7 +1674,7 @@ class FillFormToolTest {
                         .filter(p -> p.name().toLowerCase()
                                 .contains(filter.toLowerCase()))
                         .limit(limit).toList()));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         executeQueryFieldOptions(controller, field, "Apo", 10);
         executeQueryFieldOptions(controller, field, "Veg", 10);
 
@@ -1696,14 +1697,14 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of(apollo)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         executeQueryFieldOptions(controller, field, "", 10);
         fillFormResult(controller, payload(field, "\"Apollo\""));
         Assertions.assertEquals(apollo, field.getValue(),
                 "Turn 1 must fill after the query populates the cache");
 
         field.setValue(null);
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         var result = fillFormResult(controller, payload(field, "\"Apollo\""));
 
         Assertions.assertNull(field.getValue(),
@@ -1728,7 +1729,7 @@ class FillFormToolTest {
         var controller = newController(field);
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of(versions.get())));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         executeQueryFieldOptions(controller, field, "", 10);
         versions.set(second);
         executeQueryFieldOptions(controller, field, "", 10);
@@ -1753,7 +1754,7 @@ class FillFormToolTest {
         controller.fieldValueOptions(
                 ValueOptions.forField(field).options(List.of(1, 10))
                         .itemLabelGenerator(v -> v == 1 ? "low" : "high"));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = fillFormResult(controller, payload(field, "\"high\""));
 
@@ -1811,7 +1812,7 @@ class FillFormToolTest {
         var detachedForm = new Div(field);
         // No ui.add(detachedForm) — form is intentionally detached.
         var controller = new FormAIController(detachedForm);
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var raw = fillFormPayload(controller, payload(field, "\"Acme\""));
 
@@ -2006,7 +2007,7 @@ class FillFormToolTest {
         var controller = newController(fields);
         // Drive onRequest() so each discovered field has its UUID id
         // stamped — payload helpers use idOf() to look the id up.
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         return controller;
     }
 
@@ -2028,7 +2029,7 @@ class FillFormToolTest {
         var form = new Div(fields);
         ui.add(form);
         var controller = new FormAIController(form, binder);
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         return controller;
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -13,6 +13,7 @@ import static com.vaadin.flow.component.ai.form.FormTestSupport.findTool;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.formStateFields;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.json;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.requestEvent;
 
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
@@ -329,7 +330,7 @@ class FormAIControllerTest {
             var form = new Div(a, new Div(b, nested));
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertFalse(a.isReadOnly(),
                     "The controller must not flip server-side read-only");
@@ -343,7 +344,7 @@ class FormAIControllerTest {
             var b = new TestField();
             var controller = new FormAIController(new Div(a, b));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(a.isReadOnly());
@@ -361,7 +362,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(
                     new Div(editable, appReadOnly));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(AITurnEvents.success());
 
             Assertions.assertFalse(editable.isReadOnly());
@@ -399,7 +400,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(field));
             controller.fieldValueOptions(ValueOptions.forField(field)
                     .options(List.of("apple", "banana", "cherry")));
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertEquals("banana\n",
                     executeQueryFieldOptions(controller, field, "an", 10),
@@ -449,7 +450,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(field));
             controller.fieldValueOptions(
                     ValueOptions.forField(field).options(List.of(1, 2, 3)));
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertEquals("1\n2\n3\n",
                     executeQueryFieldOptions(controller, field, "", 10));
@@ -466,7 +467,7 @@ class FormAIControllerTest {
                     .options((filter, limit) -> List.of("alpha", "beta")));
             controller.fieldValueOptions(ValueOptions.forField(fixedField)
                     .options(List.of("apple", "banana", "cherry")));
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertEquals("alpha\nbeta\n",
                     executeQueryFieldOptions(controller, queriedField, "", 10));
@@ -743,7 +744,8 @@ class FormAIControllerTest {
             var field = new TestField();
             var controller = new FormAIController(new Div(field));
 
-            Assertions.assertDoesNotThrow(controller::onRequest);
+            Assertions.assertDoesNotThrow(
+                    () -> controller.onRequest(requestEvent()));
             // And no description got seeded — the no-binder path simply
             // didn't run.
             Assertions.assertTrue(
@@ -767,7 +769,7 @@ class FormAIControllerTest {
             binder.forField(field).bind("name");
             var controller = new FormAIController(new Div(field), binder);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             var entry = formStateFields(controller).get(0);
 
             Assertions.assertEquals("name",
@@ -784,7 +786,7 @@ class FormAIControllerTest {
             binder.forField(field).bind("name");
             var controller = new FormAIController(new Div(field), binder);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             var entry = formStateFields(controller).get(0);
 
             Assertions.assertEquals("Customer Name | name",
@@ -802,7 +804,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(field), binder);
             controller.describeField(field, "Full legal name");
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             var entry = formStateFields(controller).get(0);
 
             var description = entry.path("description").asString();
@@ -825,7 +827,7 @@ class FormAIControllerTest {
             binder.forField(field).bind(TestBean::getEmail, TestBean::setEmail);
             var controller = new FormAIController(new Div(field), binder);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             var entry = formStateFields(controller).get(0);
 
             Assertions.assertEquals("Email",
@@ -846,7 +848,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(bound, unbound),
                     binder);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             var entries = formStateFields(controller);
             var unboundEntry = entries.stream()
                     .filter(e -> e.path("id").asString().equals(idOf(unbound)))
@@ -870,7 +872,7 @@ class FormAIControllerTest {
             binder.bindInstanceFields(holder);
             var controller = new FormAIController(holder, binder);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             var entries = formStateFields(controller);
 
             var nameEntry = entries.stream().filter(
@@ -901,14 +903,14 @@ class FormAIControllerTest {
             var binder = new Binder<>(TestBean.class);
             var controller = new FormAIController(new Div(field), binder);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             Assertions.assertTrue(
                     formStateFields(controller).get(0).path("description")
                             .isMissingNode(),
                     "First turn: not yet bound, no seeded description");
 
             binder.forField(field).bind("name");
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertEquals("name",
                     formStateFields(controller).get(0).path("description")
@@ -931,7 +933,8 @@ class FormAIControllerTest {
             binder.forField(nonComponentField).bind("name");
             var controller = new FormAIController(new Div(formField), binder);
 
-            Assertions.assertDoesNotThrow(controller::onRequest,
+            Assertions.assertDoesNotThrow(
+                    () -> controller.onRequest(requestEvent()),
                     "Seeding must not crash on a non-Component bound field");
             // The non-Component field never participates in discovery
             // either, so the LLM-facing form state lists only the real
@@ -950,7 +953,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("John");
             controller.onResponse(AITurnEvents.success());
 
@@ -971,7 +974,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     e -> invocations.incrementAndGet());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             // No setValue between request and response.
             controller.onResponse(AITurnEvents.success());
 
@@ -987,7 +990,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     e -> invocations.incrementAndGet());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("partial");
             controller.onResponse(
                     AITurnEvents.failure(new RuntimeException("boom")));
@@ -1005,7 +1008,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             changed.setValue("X");
             controller.onResponse(AITurnEvents.success());
 
@@ -1030,7 +1033,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             visible.setValue("primary");
             controller.onResponse(AITurnEvents.success());
 
@@ -1045,7 +1048,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(new Div(field));
 
             Assertions.assertDoesNotThrow(() -> {
-                controller.onRequest();
+                controller.onRequest(requestEvent());
                 field.setValue("any");
                 controller.onResponse(AITurnEvents.success());
             }, "Lifecycle must run without a listener registered");
@@ -1061,7 +1064,7 @@ class FormAIControllerTest {
                 throw new RuntimeException("listener boom");
             });
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("anything");
             controller.onResponse(AITurnEvents.success());
 
@@ -1082,7 +1085,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             primary.setValue("driver");
             controller.onResponse(AITurnEvents.success());
 
@@ -1101,7 +1104,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             // Same content, different Set instance — Objects.equals true.
             field.setValue(Set.of("b", "a"));
             controller.onResponse(AITurnEvents.success());
@@ -1119,7 +1122,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue(Set.of("a", "c"));
             controller.onResponse(AITurnEvents.success());
 
@@ -1138,7 +1141,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             third.setValue("c");
             first.setValue("a");
             second.setValue("b");
@@ -1158,7 +1161,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue(LocalDate.of(2026, 1, 1));
             controller.onResponse(AITurnEvents.success());
 
@@ -1180,7 +1183,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue(null);
             controller.onResponse(AITurnEvents.success());
 
@@ -1200,7 +1203,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(first::add);
             controller.addFieldValueChangeListener(second::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("X");
             controller.onResponse(AITurnEvents.success());
 
@@ -1229,7 +1232,7 @@ class FormAIControllerTest {
             var registration = controller
                     .addFieldValueChangeListener(e -> calls.incrementAndGet());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first");
             controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, calls.get(),
@@ -1237,7 +1240,7 @@ class FormAIControllerTest {
 
             registration.remove();
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("second");
             controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, calls.get(),
@@ -1258,7 +1261,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     e -> followingCalls.incrementAndGet());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("X");
             controller.onResponse(AITurnEvents.success());
 
@@ -1285,7 +1288,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     e -> followerCalls.incrementAndGet());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("a");
             second.setValue("b");
             controller.onResponse(AITurnEvents.success());
@@ -1315,7 +1318,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     e -> followingCalls.incrementAndGet());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("X");
             controller.onResponse(AITurnEvents.success());
 
@@ -1325,7 +1328,7 @@ class FormAIControllerTest {
             Assertions.assertEquals(1, followingCalls.get(),
                     "Listeners following the self-removing one must still fire");
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("Y");
             controller.onResponse(AITurnEvents.success());
 
@@ -1354,7 +1357,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             primary.setValue("driver");
             controller.onResponse(AITurnEvents.success());
 
@@ -1382,7 +1385,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             primary.setValue("driver");
             controller.onResponse(AITurnEvents.success());
 
@@ -1407,7 +1410,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             primary.setValue("driver");
             controller.onResponse(AITurnEvents.success());
 
@@ -1428,7 +1431,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controlling.setValue("business"); // reveals the conditional field
             conditional.setValue("cost-center-42"); // AI fills the revealed one
             controller.onResponse(AITurnEvents.success());
@@ -1454,7 +1457,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controlling.setValue("business"); // adds the new field to the form
             added.setValue("cost-center-42"); // AI fills the newly-added field
             controller.onResponse(AITurnEvents.success());
@@ -1481,7 +1484,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controlling.setValue("business"); // adds the new field, no write
             controller.onResponse(AITurnEvents.success());
 
@@ -1502,7 +1505,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("a");
             second.setValue("b");
             controller.onResponse(AITurnEvents.success());
@@ -1532,7 +1535,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     e -> order.add("B:" + e.getNewValue()));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("a");
             second.setValue("b");
             controller.onResponse(AITurnEvents.success());
@@ -1560,7 +1563,7 @@ class FormAIControllerTest {
                 }
             });
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("from-llm");
             second.setValue("from-llm-too");
             controller.onResponse(AITurnEvents.success());
@@ -1594,7 +1597,7 @@ class FormAIControllerTest {
                 }
             });
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("a");
             second.setValue("b");
             controller.onResponse(AITurnEvents.success());
@@ -1603,7 +1606,7 @@ class FormAIControllerTest {
                     "Listener registered mid-dispatch must not receive any "
                             + "of the current turn's remaining events");
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("c");
             controller.onResponse(AITurnEvents.success());
 
@@ -1630,7 +1633,7 @@ class FormAIControllerTest {
                 }
             }));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("a");
             second.setValue("b");
             controller.onResponse(AITurnEvents.success());
@@ -1687,7 +1690,7 @@ class FormAIControllerTest {
             var form = new Div(field);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, markersOn(field).size());
@@ -1710,12 +1713,12 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("ai");
             controller.onResponse(AITurnEvents.success());
             field.setValue("user edit"); // clears the marker
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("ai again");
             controller.onResponse(AITurnEvents.success());
 
@@ -1734,7 +1737,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             form.remove(field);
@@ -1754,7 +1757,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             field.setValue("user edit");
@@ -1777,7 +1780,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -1799,7 +1802,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -1818,7 +1821,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form).setFieldMarkerI18n(
                     new FieldMarkerI18n().setMessage("Vain viesti"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             var i18n = i18nOn(field);
@@ -1843,7 +1846,7 @@ class FormAIControllerTest {
                                     .setLow("Epävarma").setMedium("Melko varma")
                                     .setHigh("Varma")));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             var confidence = i18nOn(field).get("confidence");
@@ -1867,7 +1870,7 @@ class FormAIControllerTest {
                             .setConfidence(new FieldMarkerI18n.Confidence()
                                     .setLow("Epävarma")));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             var confidence = i18nOn(field).get("confidence");
@@ -1891,7 +1894,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerI18n(new FieldMarkerI18n());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -1911,7 +1914,7 @@ class FormAIControllerTest {
                             .setBadgeLabel("Tekoälyn täyttämä arvo")
                             .setBadgeTooltip("Avaa tiedot"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             var i18n = i18nOn(field);
@@ -1934,13 +1937,13 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first");
             controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerI18n(
                     new FieldMarkerI18n().setMessage("Päivitetty viesti"));
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("second");
             controller.onResponse(AITurnEvents.success());
 
@@ -1959,7 +1962,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             keep.setValue("filled");
             edited.setValue("filled");
             controller.onResponse(AITurnEvents.success());
@@ -1984,7 +1987,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             for (var field : List.of(changed, untouched)) {
                 Assertions.assertTrue(isWorking(field),
@@ -2012,7 +2015,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form);
             controller.ignoreField(ignored);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertTrue(isWorking(editable));
             for (var field : List.of(disabled, appReadOnly, ignored)) {
@@ -2031,7 +2034,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2053,7 +2056,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(AITurnEvents.success());
 
             Assertions.assertEquals(List.of(), markersOn(field),
@@ -2070,11 +2073,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(AITurnEvents.success()); // second turn
                                                            // changes nothing
 
@@ -2092,7 +2095,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(
                     AITurnEvents.failure(new RuntimeException("boom")));
 
@@ -2109,11 +2112,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(
                     AITurnEvents.failure(new RuntimeException("boom")));
 
@@ -2133,7 +2136,8 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest(); // turn in progress, working state applied
+            controller.onRequest(requestEvent()); // turn in progress, working
+                                                  // state applied
             form.remove(field);
             form.add(field);
 
@@ -2151,7 +2155,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             controller.onResponse(AITurnEvents.success());
             form.remove(field);
             form.add(field);
@@ -2172,7 +2176,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             form.remove(field);
             controller.onResponse(AITurnEvents.success());
             form.add(field);
@@ -2194,9 +2198,10 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest(); // turn 1 starts and never completes
+            controller.onRequest(requestEvent()); // turn 1 starts and never
+                                                  // completes
             field.setVisible(false);
-            controller.onRequest(); // turn 2 starts
+            controller.onRequest(requestEvent()); // turn 2 starts
 
             Assertions.assertEquals(List.of(), markersOn(field),
                     "A new turn must clear the working state left behind by an "
@@ -2216,7 +2221,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             readOnly.setValue("filled");
             readOnly.setReadOnly(true);
             drainPendingJs(); // isolate the scripts queued at turn end
@@ -2244,7 +2249,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setReadOnly(true); // no AI write to the field
             drainPendingJs();
             controller.onResponse(AITurnEvents.success());
@@ -2268,7 +2273,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             drainPendingJs();
             controller.onResponse(AITurnEvents.success());
 
@@ -2288,11 +2293,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fireRevert(field);
 
             Assertions.assertTrue(isWorking(field),
@@ -2308,7 +2313,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2328,7 +2333,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             changed.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2350,7 +2355,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertEquals(List.of(), markersOn(revealed),
                     "A hidden field must not enter the working state");
@@ -2374,7 +2379,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("ai");
             controller.onResponse(AITurnEvents.success());
 
@@ -2393,11 +2398,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("second"); // AI write while a turn is in progress
             controller.onResponse(AITurnEvents.success());
 
@@ -2414,7 +2419,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("ai");
             controller.onResponse(AITurnEvents.success());
             field.setValue("first edit"); // clears the marker
@@ -2438,7 +2443,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form);
 
             field.setValue("old");
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("new");
             controller.onResponse(AITurnEvents.success());
 
@@ -2463,11 +2468,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest(); // snapshots "filled"
+            controller.onRequest(requestEvent()); // snapshots "filled"
             fireRevert(field); // restores "original" mid-turn
             controller.onResponse(AITurnEvents.success()); // the AI writes
                                                            // nothing
@@ -2489,11 +2494,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fireRevert(field); // restores "original" mid-turn
             field.setValue("second"); // the AI writes the field again
             controller.onResponse(AITurnEvents.success());
@@ -2516,11 +2521,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("second");
             controller.onResponse(AITurnEvents.success());
 
@@ -2543,13 +2548,13 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first ai value");
             controller.onResponse(AITurnEvents.success());
 
             field.setValue("user typed"); // clears the marker
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("second ai value");
             controller.onResponse(AITurnEvents.success());
 
@@ -2572,11 +2577,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("detour");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("original"); // the AI puts the original value back
             controller.onResponse(AITurnEvents.success());
 
@@ -2597,7 +2602,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue(42.0);
             controller.onResponse(AITurnEvents.success());
 
@@ -2619,11 +2624,11 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue(42.0);
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue(43.0);
             controller.onResponse(AITurnEvents.success());
 
@@ -2659,7 +2664,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerEnabled(false);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2680,7 +2685,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerEnabled(false);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
 
             Assertions.assertTrue(isWorking(field),
                     "The working state must apply regardless of the automatic "
@@ -2704,12 +2709,12 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("first");
             controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerEnabled(false);
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("second");
             controller.onResponse(AITurnEvents.success());
 
@@ -2727,12 +2732,12 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerEnabled(false);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("unmarked");
             controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerEnabled(true);
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("marked");
             controller.onResponse(AITurnEvents.success());
 
@@ -2753,7 +2758,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2794,7 +2799,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2836,7 +2841,7 @@ class FormAIControllerTest {
                     .setFieldMarkerPopoverContentProvider(
                             change -> new Text("plain text"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2861,7 +2866,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2879,7 +2884,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> null);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -2903,13 +2908,13 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> next.get());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("one");
             controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             next.set(second);
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("two");
             controller.onResponse(AITurnEvents.success());
 
@@ -2936,12 +2941,12 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("one");
             controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("two");
             controller.onResponse(AITurnEvents.success());
 
@@ -2970,11 +2975,11 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("one");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("two");
             controller.onResponse(AITurnEvents.success());
 
@@ -2994,13 +2999,13 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("one");
             controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
             controller.setFieldMarkerPopoverContentProvider(null);
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("two");
             controller.onResponse(AITurnEvents.success());
 
@@ -3033,19 +3038,19 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("one");
             controller.onResponse(AITurnEvents.success());
 
             controller.setFieldMarkerPopoverContentProvider(null);
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("two");
             controller.onResponse(AITurnEvents.success());
             var wrapper = wrapperOn(field);
             drainPendingJs();
 
             controller.setFieldMarkerPopoverContentProvider(change -> content);
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("three");
             controller.onResponse(AITurnEvents.success());
 
@@ -3074,7 +3079,7 @@ class FormAIControllerTest {
                         throw new IllegalStateException("boom");
                     });
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -3111,7 +3116,7 @@ class FormAIControllerTest {
             var events = new ArrayList<FieldValueChangeEvent>();
             controller.addFieldValueChangeListener(events::add);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             first.setValue("one");
             second.setValue("two");
             controller.onResponse(AITurnEvents.success());
@@ -3149,7 +3154,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -3172,7 +3177,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             field.setValue("user edit");
@@ -3191,7 +3196,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -3215,12 +3220,12 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             drainPendingJs();
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fireRevert(field);
 
             Assertions.assertNull(content.getElement().getParentNode(),
@@ -3259,7 +3264,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> new Div());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             requireMarkerOn(field).removeFromParent();
@@ -3281,7 +3286,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> content);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             var wrapper = wrapperOn(field);
@@ -3302,7 +3307,7 @@ class FormAIControllerTest {
             ui.add(form);
             var controller = new FormAIController(form);
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             drainPendingJs();
@@ -3334,7 +3339,7 @@ class FormAIControllerTest {
             controller.addFieldValueChangeListener(
                     event -> calls.add("listener"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -3355,7 +3360,7 @@ class FormAIControllerTest {
                         return null;
                     });
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
 
@@ -3374,7 +3379,7 @@ class FormAIControllerTest {
             var controller = new FormAIController(form)
                     .setFieldMarkerPopoverContentProvider(change -> new Div());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("filled");
             controller.onResponse(AITurnEvents.success());
             Assertions.assertEquals(1, markersOn(field).size());

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormStateToolTest.java
@@ -12,6 +12,7 @@ import static com.vaadin.flow.component.ai.form.FormTestSupport.findTool;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.formStateFields;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.json;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.requestEvent;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -233,7 +234,8 @@ class FormStateToolTest {
         readOnly.setReadOnly(true);
         var controller = new FormAIController(new Div(editable, readOnly));
 
-        controller.onRequest(); // locks the editable field read-only
+        controller.onRequest(requestEvent()); // locks the editable field
+                                              // read-only
         try {
             var fields = formStateFields(controller);
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormTestSupport.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormTestSupport.java
@@ -10,10 +10,12 @@ package com.vaadin.flow.component.ai.form;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.ai.orchestrator.RequestListener;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.internal.JacksonUtils;
 
@@ -51,6 +53,17 @@ final class FormTestSupport {
 
     static JsonNode json(String text) {
         return JacksonUtils.readTree(text);
+    }
+
+    /**
+     * Builds the request event a test passes to
+     * {@link FormAIController#onRequest(RequestListener.RequestEvent)} to start
+     * a turn. The form controller does not read the event, so the content is a
+     * placeholder.
+     */
+    static RequestListener.RequestEvent requestEvent() {
+        return new RequestListener.RequestEvent("prompt",
+                UUID.randomUUID().toString(), List.of());
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/QueryFieldOptionsToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/QueryFieldOptionsToolTest.java
@@ -12,6 +12,7 @@ import static com.vaadin.flow.component.ai.form.FormTestSupport.executeQueryFiel
 import static com.vaadin.flow.component.ai.form.FormTestSupport.findTool;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.json;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.requestEvent;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +45,7 @@ class QueryFieldOptionsToolTest {
         var controller = new FormAIController(new Div(field));
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options(List.of("apple", "banana", "cherry")));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "an", 10);
 
@@ -69,7 +70,7 @@ class QueryFieldOptionsToolTest {
                 new Div(registered, unregistered));
         controller.fieldValueOptions(
                 ValueOptions.forField(registered).options(List.of("apple")));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var resultUnknownId = executeQueryFieldOptions(controller,
                 json("{\"field\":\"not-a-real-id\",\"filter\":\"\"}"));
@@ -109,7 +110,7 @@ class QueryFieldOptionsToolTest {
                     capturedLimit.set(limit);
                     return List.of();
                 }));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         executeQueryFieldOptions(controller, field, "", 0);
 
@@ -151,7 +152,7 @@ class QueryFieldOptionsToolTest {
                     capturedLimit.set(limit);
                     return List.of();
                 }));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var fieldId = idOf(field);
         executeQueryFieldOptions(controller,
@@ -173,7 +174,7 @@ class QueryFieldOptionsToolTest {
                     capturedLimit.set(limit);
                     return List.of();
                 }));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         executeQueryFieldOptions(controller, field, "acme", 7);
 
@@ -187,7 +188,7 @@ class QueryFieldOptionsToolTest {
         var controller = new FormAIController(new Div(field));
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options(List.of("Apollo #P-1", "Polaris #P-2")));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "", 50);
 
@@ -209,7 +210,7 @@ class QueryFieldOptionsToolTest {
                     }
                     return items;
                 }));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "", 9999);
 
@@ -235,7 +236,7 @@ class QueryFieldOptionsToolTest {
         var controller = new FormAIController(new Div(field));
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("only-one")));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "", 9999);
 
@@ -253,7 +254,7 @@ class QueryFieldOptionsToolTest {
         var controller = new FormAIController(new Div(field));
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of()));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "zzz", 10);
 
@@ -273,7 +274,7 @@ class QueryFieldOptionsToolTest {
         var controller = new FormAIController(new Div(field));
         controller.fieldValueOptions(ValueOptions.forField(field)
                 .options((filter, limit) -> List.of("first\nsecond", "third")));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "", 10);
 
@@ -299,7 +300,7 @@ class QueryFieldOptionsToolTest {
                 ValueOptions.forField(field).options((filter, limit) -> {
                     throw new IllegalStateException(sentinel);
                 }));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, field, "", 10);
 
@@ -330,7 +331,7 @@ class QueryFieldOptionsToolTest {
         controller.fieldValueOptions(ValueOptions.forField(combo)
                 .options((filter, limit) -> List.of(alpha, beta))
                 .itemLabelGenerator(Project::code));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, combo, "", 10);
 
@@ -350,7 +351,7 @@ class QueryFieldOptionsToolTest {
         var controller = new FormAIController(new Div(combo));
         controller.fieldValueOptions(ValueOptions.forField(combo)
                 .options((filter, limit) -> List.of(alpha)));
-        controller.onRequest();
+        controller.onRequest(requestEvent());
 
         var result = executeQueryFieldOptions(controller, combo, "", 10);
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.ai.form;
 
 import static com.vaadin.flow.component.ai.form.FormTestSupport.findTool;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
+import static com.vaadin.flow.component.ai.form.FormTestSupport.requestEvent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -642,11 +643,11 @@ class SourceTrackingTest {
             fill(controller, field, trackedValue("Acme"));
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("cascaded");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("Acme");
             controller.onResponse(AITurnEvents.success());
 
@@ -666,7 +667,7 @@ class SourceTrackingTest {
             fill(controller, field, trackedValue("Acme"));
             field.setValue("edited by hand");
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fill(controller, field, "\"Acme\"");
 
             Assertions.assertTrue(controller.getFieldSource(field).isEmpty(),
@@ -866,7 +867,7 @@ class SourceTrackingTest {
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fill(controller, field, """
                     {"value": "Acme", "confidence": "low",
                      "extracts": [{"text": "re-read"}]}""");
@@ -891,7 +892,7 @@ class SourceTrackingTest {
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fill(controller, field, """
                     {"value": "Acme", "extracts": [{"text": "re-read"}]}""");
             controller.onResponse(AITurnEvents.success());
@@ -913,7 +914,7 @@ class SourceTrackingTest {
                      "extracts": [{"text": "snippet"}]}""");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fill(controller, field, "\"Acme\"");
             controller.onResponse(AITurnEvents.success());
 
@@ -931,7 +932,7 @@ class SourceTrackingTest {
                      "extracts": [{"text": "snippet"}]}""");
             controller.onResponse(AITurnEvents.success());
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             fill(controller, field, "\"second\"");
             controller.onResponse(AITurnEvents.success());
 
@@ -956,7 +957,7 @@ class SourceTrackingTest {
             Assertions.assertEquals("high",
                     markerOn(field).getProperty("confidence"));
 
-            controller.onRequest();
+            controller.onRequest(requestEvent());
             field.setValue("cascaded");
             controller.onResponse(AITurnEvents.success());
 
@@ -984,7 +985,7 @@ class SourceTrackingTest {
         var form = new Div(fields);
         ui.add(form);
         var controller = new FormAIController(form);
-        controller.onRequest();
+        controller.onRequest(requestEvent());
         return controller;
     }
 


### PR DESCRIPTION
## Description

- Changed `AIController.onRequest()` to receive the `RequestListener.RequestEvent` of the turn, the same event the request listener gets, so a controller can read the user message, message id, and attachments
- Made the `RequestEvent` constructor public so applications can unit test controller implementations; it copies the attachment list and rejects `null` arguments
- Updated `FormAIController` and the field-marker test page to the new signature
- Added tests for the shared event and its unmodifiable attachment list

## Type of change

- Feature

> [!WARNING]
> Breaking change: custom `AIController` implementations that override `onRequest()` must change the signature to `onRequest(RequestListener.RequestEvent)`.