### PR TITLE
refactor: reduce private grid API usage in grid connector

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
@@ -319,7 +319,7 @@ export class GridConnector {
     this.#selectionMode = mode;
     this.#selectedKeys = {};
     this.#grid.selectedItems = [];
-    this.#grid.__a11yUpdateMutiSelectable();
+    this.#updateAriaMultiSelectable();
   }
 
   setHeaderRenderer(
@@ -369,10 +369,7 @@ export class GridConnector {
   scrollToItem(itemKey: string, ...args: number[]): void {
     const grid = this.#grid;
 
-    const targetRow = grid._getRenderedRows().find((row) => {
-      const { item } = grid.__getRowModel(row);
-      return grid.getItemId(item) === itemKey;
-    });
+    const targetRow = grid._getRenderedRows().find((row) => row._item && grid.getItemId(row._item) === itemKey);
     if (targetRow && this.#isRowFullyInViewport(targetRow)) {
       return;
     }
@@ -386,6 +383,11 @@ export class GridConnector {
    */
   #patchGrid(): void {
     const grid = this.#grid;
+
+    grid.ready = () => {
+      Object.getPrototypeOf(grid).ready.call(grid);
+      this.#updateAriaMultiSelectable();
+    };
 
     // The grid requests a page only when a row from that page gets rendered,
     // which is too late to keep up while scrolling and leads to blank rows.
@@ -443,29 +445,6 @@ export class GridConnector {
 
       Object.getPrototypeOf(grid).__a11yUpdateRowSelected.call(grid, row, selected);
     };
-
-    /*
-     * Manage aria-multiselectable attribute depending on the selection mode.
-     * see more: https://github.com/vaadin/web-components/issues/1536
-     * or: https://www.w3.org/TR/wai-aria-1.1/#aria-multiselectable
-     */
-    grid.__a11yUpdateMutiSelectable = () => {
-      if (!grid.$) {
-        return;
-      }
-
-      switch (this.#selectionMode) {
-        case 'SINGLE':
-          grid.$.table.setAttribute('aria-multiselectable', 'false');
-          break;
-        case 'MULTI':
-          grid.$.table.setAttribute('aria-multiselectable', 'true');
-          break;
-        default:
-          grid.$.table.removeAttribute('aria-multiselectable');
-      }
-    };
-    grid._createPropertyObserver('isAttached', '__a11yUpdateMutiSelectable');
 
     // This method is overridden to prevent the grid web component from
     // automatically excluding columns from sorting when they get hidden.
@@ -555,7 +534,7 @@ export class GridConnector {
     grid.addEventListener('dblclick', (e) => this.#fireClickEvent(e, 'item-double-click'));
 
     grid.addEventListener('column-resize', (e) => {
-      const cols = grid._getColumnsInOrder().filter((col) => !col.hidden);
+      const cols = grid._columnTree.at(-1)!.filter((col) => !col.hidden);
 
       cols.forEach((col) => {
         col.dispatchEvent(new CustomEvent('column-drag-resize'));
@@ -606,7 +585,7 @@ export class GridConnector {
     grid.addEventListener('grid-dragstart', (e) => {
       const { draggedItems, setDragData, setDraggedItemsCount } = e.detail;
 
-      if (grid._isSelected(draggedItems[0])) {
+      if (this.#selectedKeys[draggedItems[0].key]) {
         // Dragging selected (possibly multiple) items
         if (grid.__selectionDragData) {
           Object.entries(grid.__selectionDragData).forEach(([type, data]) => setDragData(type, data));
@@ -700,6 +679,29 @@ export class GridConnector {
         event.internalColumnId = eventContext.column._flowId;
       }
       grid.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+    }
+  }
+
+  /*
+   * Manage aria-multiselectable attribute depending on the selection mode.
+   * see more: https://github.com/vaadin/web-components/issues/1536
+   * or: https://www.w3.org/TR/wai-aria-1.1/#aria-multiselectable
+   */
+  #updateAriaMultiSelectable(): void {
+    if (!this.#grid.$) {
+      return;
+    }
+
+    const { table } = this.#grid.$;
+    switch (this.#selectionMode) {
+      case 'SINGLE':
+        table.setAttribute('aria-multiselectable', 'false');
+        break;
+      case 'MULTI':
+        table.setAttribute('aria-multiselectable', 'true');
+        break;
+      default:
+        table.removeAttribute('aria-multiselectable');
     }
   }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/gridConnector.ts
@@ -1,5 +1,6 @@
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
+import { setOrRemoveAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { isFocusable } from '@vaadin/grid/src/vaadin-grid-active-item-mixin.js';
 import { GridFlowSelectionColumn } from './vaadin-grid-flow-selection-column.ts';
 import type { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
@@ -692,17 +693,8 @@ export class GridConnector {
       return;
     }
 
-    const { table } = this.#grid.$;
-    switch (this.#selectionMode) {
-      case 'SINGLE':
-        table.setAttribute('aria-multiselectable', 'false');
-        break;
-      case 'MULTI':
-        table.setAttribute('aria-multiselectable', 'true');
-        break;
-      default:
-        table.removeAttribute('aria-multiselectable');
-    }
+    const multiSelectable = { SINGLE: 'false', MULTI: 'true', NONE: null }[this.#selectionMode];
+    setOrRemoveAttribute(this.#grid.$.table, 'aria-multiselectable', multiSelectable);
   }
 
   #preventRowUpdates(callback: () => void): void {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
@@ -6,7 +6,7 @@ import type { Grid, GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
 import type { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import type { GridSorter } from '@vaadin/grid/src/vaadin-grid-sorter.js';
 import type { GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid-data-provider-mixin.js';
-import type { GridCellActivateEvent, GridItemModel } from '@vaadin/grid/src/vaadin-grid-mixin.js';
+import type { GridCellActivateEvent } from '@vaadin/grid/src/vaadin-grid-mixin.js';
 import type { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
 import type { GridConnector } from './gridConnector.js';
 
@@ -67,6 +67,7 @@ export type FlowDataProviderController = DataProviderController<Item | undefined
  */
 export interface FlowGridInternals {
   $: { scroller: HTMLElement; table: HTMLElement; header: HTMLElement; footer: HTMLElement };
+  ready(): void;
   $connector: GridConnector;
   $server: GridServer;
   __deselectDisallowed: boolean;
@@ -80,19 +81,14 @@ export interface FlowGridInternals {
   _previousSorters: GridSorterDefinition[];
   _shouldLoadAllRenderedRowsAfterPageLoad: boolean;
   _sorters: GridSorter[];
-  __a11yUpdateMutiSelectable(): void;
   __a11yUpdateRowSelected(row: HTMLElement, selected: boolean): void;
   __applySorters(...args: unknown[]): void;
-  __getRowModel(row: FlowGridRow): GridItemModel<Item>;
   __updateRow(row: HTMLElement, ...args: unknown[]): void;
   __updateVirtualizerElement(...args: unknown[]): void;
   __updateVisibleRows(start?: number, end?: number): void;
-  _createPropertyObserver(property: string, methodName: string): void;
   _getActiveSorters(): GridSorter[];
-  _getColumnsInOrder(): GridColumn<Item>[];
   _getRenderedRows(): FlowGridRow[];
   _isDetailsOpened(item: Item | undefined): boolean;
-  _isSelected(item: Item): boolean;
   isItemSelectable(item: Item | null | undefined): boolean;
   _mapSorters(): GridSorterDefinition[];
   getContextMenuBeforeOpenDetail(event: CustomEvent<{ sourceEvent?: Event }>): { key: string; columnId: string };


### PR DESCRIPTION
## Summary
- The grid connector reached into several private grid members it did not need: `__getRowModel` (only for `row._item`), `_isSelected` (the connector already tracks selection), `_getColumnsInOrder` (order was irrelevant), and an `isAttached` property observer paired with a method the connector defined on the grid instance. Fewer private touchpoints means fewer things that break when the web component changes internals.
- `aria-multiselectable` handling now lives in the connector class, applied directly when the grid has rendered and from a `ready()` override when the connector is created before first render. `ready()` is public Polylit API, unlike the observer it replaces.
- The type declarations drop the five members that are no longer used, so the remaining list reflects the real coupling to the web component.