### PR TITLE
fix: respect disabled parent when syncing client disabled state

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -475,7 +475,7 @@ public class Button extends Component
     @Override
     public void setEnabled(boolean enabled) {
         Focusable.super.setEnabled(enabled);
-        disableOnClickController.onSetEnabled(enabled);
+        disableOnClickController.onSetEnabled();
     }
 
     /**

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/MenuItemBase.java
@@ -280,7 +280,7 @@ public abstract class MenuItemBase<C extends ContextMenuBase<C, I, S>, I extends
     @Override
     public void setEnabled(boolean enabled) {
         HasComponents.super.setEnabled(enabled);
-        disableOnClickController.onSetEnabled(enabled);
+        disableOnClickController.onSetEnabled();
     }
 
     /**

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -58,6 +58,8 @@ public class DisableOnClickController<C extends Component & HasEnabled>
     public DisableOnClickController(C component) {
         this.component = Objects.requireNonNull(component);
 
+        component.addDetachListener((event) -> clientUpdateScheduled = false);
+
         ComponentUtil.addListener(component, ClickEvent.class,
                 (ComponentEventListener) (event -> {
                     if (isDisableOnClick()) {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -46,6 +46,7 @@ public class DisableOnClickController<C extends Component & HasEnabled>
 
     private final C component;
     private boolean disableOnClick = false;
+    private boolean clientUpdateScheduled = false;
 
     /**
      * Creates a new controller for the given component.
@@ -95,18 +96,29 @@ public class DisableOnClickController<C extends Component & HasEnabled>
 
     /**
      * Forces the client-side component's {@code disabled} property to be
-     * updated immediately.
+     * updated before the response is sent to the client, so that it matches the
+     * component's effective enabled state, including whether any parent is
+     * disabled.
      * <p>
      * This method should be called from the component's
-     * {@link HasEnabled#setEnabled} method.
-     *
-     * @param enabled
-     *            value to set
+     * {@link HasEnabled#setEnabled} method, after the enabled state has been
+     * updated.
      */
-    public void onSetEnabled(boolean enabled) {
-        // If the component is then disabled and re-enabled during the same
-        // round trip, Flow will not detect any changes and the client side
-        // component would not be enabled again.
-        component.getElement().executeJs("this.disabled = $0", !enabled);
+    public void onSetEnabled() {
+        // If the component is disabled and re-enabled during the same round
+        // trip, Flow will not detect any changes and the client side component
+        // would not be enabled again. The property is updated before the
+        // response so that the effective state at that point is used, for
+        // example when a parent is disabled or enabled in the same round trip.
+        if (clientUpdateScheduled) {
+            return;
+        }
+        clientUpdateScheduled = true;
+        component.getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(component, context -> {
+                    clientUpdateScheduled = false;
+                    component.getElement().executeJs("this.disabled = $0",
+                            !component.isEnabled());
+                }));
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
@@ -169,6 +169,20 @@ class DisableOnClickControllerTest {
         Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
     }
 
+    @Test
+    void detachedBeforeResponse_attachedToAnotherUi_setEnabled_clientSideDisabledPropertyUpdated() {
+        component.setEnabled(false);
+        component.getElement().removeFromTree();
+        ui.fakeClientCommunication();
+
+        ui.replaceUI();
+        ui.add(component);
+        ui.fakeClientCommunication();
+
+        component.setEnabled(true);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
     private List<Object> dumpClientSideDisabledValues() {
         return ui.dumpPendingJavaScriptInvocations().stream()
                 .map(PendingJavaScriptInvocation::getInvocation)

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
@@ -15,26 +15,39 @@
  */
 package com.vaadin.flow.component.shared;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
+import com.vaadin.tests.MockUIExtension;
 
 class DisableOnClickControllerTest {
 
+    @RegisterExtension
+    final MockUIExtension ui = new MockUIExtension();
+
+    private TestParent parent;
     private TestComponent component;
 
     @BeforeEach
     void setup() {
+        parent = new TestParent();
         component = new TestComponent();
+        parent.add(component);
+        ui.add(parent);
+        ui.fakeClientCommunication();
     }
 
     @Test
@@ -88,6 +101,87 @@ class DisableOnClickControllerTest {
         Assertions.assertTrue(component.isEnabled());
     }
 
+    @Test
+    void setEnabled_clientSideDisabledPropertyUpdated() {
+        component.setEnabled(false);
+        Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
+
+        component.setEnabled(true);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void setEnabled_noChange_clientSideDisabledPropertyUpdated() {
+        component.setEnabled(true);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void disabledAndEnabledInSameRoundTrip_clientSideEnabledOnce() {
+        component.setEnabled(false);
+        component.setEnabled(true);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void click_clickListenerEnablesComponent_clientSideEnabled() {
+        component.addClickListener(event -> event.getSource().setEnabled(true));
+        component.setDisableOnClick(true);
+        component.click();
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void parentDisabled_setEnabled_clientSideStaysDisabled() {
+        parent.setEnabled(false);
+        ui.fakeClientCommunication();
+
+        component.setEnabled(true);
+        Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void parentDisabled_setEnabledAndParentEnabledInSameRoundTrip_clientSideEnabled() {
+        parent.setEnabled(false);
+        ui.fakeClientCommunication();
+
+        component.setEnabled(true);
+        parent.setEnabled(true);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void parentDisabledInSameRoundTrip_setEnabled_clientSideDisabled() {
+        component.setEnabled(true);
+        parent.setEnabled(false);
+        Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void detached_setEnabled_clientSideUpdatedAfterAttach() {
+        parent.remove(component);
+        ui.fakeClientCommunication();
+
+        component.setEnabled(false);
+        Assertions.assertEquals(List.of(), dumpClientSideDisabledValues());
+
+        parent.add(component);
+        Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
+    }
+
+    private List<Object> dumpClientSideDisabledValues() {
+        return ui.dumpPendingJavaScriptInvocations().stream()
+                .map(PendingJavaScriptInvocation::getInvocation)
+                .filter(invocation -> invocation.getExpression()
+                        .contains("this.disabled = $0"))
+                .map(invocation -> invocation.getParameters().get(0)).toList();
+    }
+
+    @Tag("test-parent")
+    private static class TestParent extends Component
+            implements HasComponents, HasEnabled {
+    }
+
     @Tag("test")
     private static class TestComponent extends Component
             implements HasEnabled, ClickNotifier<TestComponent> {
@@ -112,7 +206,7 @@ class DisableOnClickControllerTest {
         @Override
         public void setEnabled(boolean enabled) {
             HasEnabled.super.setEnabled(enabled);
-            disableOnClickController.onSetEnabled(enabled);
+            disableOnClickController.onSetEnabled();
         }
     }
 }


### PR DESCRIPTION
## Description

`DisableOnClickController` forces the client-side `disabled` property from `setEnabled`, because Flow does not send a change when a component is disabled and re-enabled in the same round trip. It used the value passed to `setEnabled`, so enabling a button under a disabled parent cleared `disabled` on the client while the server kept rejecting clicks.

- Changed `DisableOnClickController.onSetEnabled()` to schedule the client update with `beforeClientResponse` and read the effective enabled state at that point, so a disabled parent keeps the component disabled on the client
- Coalesced repeated `setEnabled` calls in one round trip into a single client update
- Deferred the update until the component is attached instead of queueing a JavaScript call per `setEnabled` call while detached
- Removed the unused `enabled` parameter from `onSetEnabled()` and updated `Button` and `MenuItemBase`
- Added unit tests for the disabled parent, same round trip, and detached cases

## Type of change

- Bugfix