### PR TITLE
test: wait for freeze pane dialog to close in spreadsheet ITs

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -339,6 +339,7 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
     public void addFreezePane() {
         $("vaadin-button").id("freezePane").click();
         $("vaadin-button").id("submitValues").click();
+        waitForDialogToClose();
     }
 
     public void addFreezePane(int horizontalSplitPosition,
@@ -349,6 +350,18 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
         $(TextFieldElement.class).id("horizontalSplitPosition")
                 .setValue(String.valueOf(horizontalSplitPosition));
         $("vaadin-button").id("submitValues").click();
+        waitForDialogToClose();
+    }
+
+    /**
+     * Waits until no dialog is open or still running its closing animation. The
+     * freeze pane dialog is modal, so while it is closing its overlay still
+     * covers the page and swallows clicks meant for the sheet.
+     */
+    private void waitForDialogToClose() {
+        waitUntil(driver -> $("vaadin-dialog").all().stream()
+                .noneMatch(dialog -> dialog.hasAttribute("opened")
+                        || dialog.hasAttribute("closing")));
     }
 
     public void setLocale(Locale locale) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/AbstractSpreadsheetIT.java
@@ -359,9 +359,8 @@ public abstract class AbstractSpreadsheetIT extends AbstractComponentIT {
      * covers the page and swallows clicks meant for the sheet.
      */
     private void waitForDialogToClose() {
-        waitUntil(driver -> $("vaadin-dialog").all().stream()
-                .noneMatch(dialog -> dialog.hasAttribute("opened")
-                        || dialog.hasAttribute("closing")));
+        waitUntil(driver -> !$("vaadin-dialog").withAttribute("opened").exists()
+                && !$("vaadin-dialog").withAttribute("closing").exists());
     }
 
     public void setLocale(Locale locale) {

--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow-integration-tests/src/test/java/com/vaadin/flow/component/spreadsheet/test/CustomEditorIT.java
@@ -445,19 +445,11 @@ public class CustomEditorIT extends AbstractSpreadsheetIT {
     private void performKeyboardTestsToCell(String column) {
         final String cellAddress = column + "2";
 
-        // A click on the cell can get lost while the spreadsheet is still
-        // re-rendering (e.g. right after adding a freeze pane), so click
-        // again until the editor shows up.
-        waitUntil(driver -> {
-            try {
-                clickCell(cellAddress);
-                return getInputInCustomEditorFromCell(cellAddress).isPresent();
-            } catch (StaleElementReferenceException e) {
-                return false;
-            }
-        });
+        clickCell(cellAddress);
+        var maybeEditor = getInputInCustomEditorFromCell(cellAddress);
+        Assert.assertTrue(maybeEditor.isPresent());
 
-        var editor = getInputInCustomEditorFromCell(cellAddress).orElseThrow();
+        var editor = maybeEditor.get();
 
         // Test Esc with arrow keys persistence on cell
         editor.sendKeys("EscWithArrowKeys", Keys.ESCAPE, Keys.ARROW_DOWN);


### PR DESCRIPTION
## Description

Follow-up to #9874

`CustomEditorIT.customEditorAlwaysVisibleInFrozenCells_persistsValue` failed consistently
in a local run and is flaky in CI. The freeze pane dialog is modal and closes with an
animation of roughly 300 ms. `addFreezePane` returned as soon as the submit button was
clicked, so the next click on a cell landed on the still-closing overlay and was swallowed.
The sheet selection stayed on A1 after the freeze pane re-render, and the spreadsheet
rejects programmatic focus on a custom editor whose cell is not selected. The focus that
`sendKeys` gives the editor was bounced back to the sheet, and the typed value was lost.

- Made both `addFreezePane` helpers in `AbstractSpreadsheetIT` wait until no `vaadin-dialog` has the `opened` or `closing` attribute before returning
  - `DialogElement.isOpen()` is not enough because `opened` is already false while the closing animation runs
  - Also covers `FreezePaneIT`, `PopupButtonIT` and `FormulaFormatIT`, which use the same helpers
- Removed the click-retry loop in `CustomEditorIT.performKeyboardTestsToCell` added by #9874 and restored the single click and assertion
  - The loop only checked that the editor element exists, which is always true for always-visible editors, so it did not detect the lost click
  - Both frozen-cell tests passed 4 of 4 consecutive runs with the single click once the dialog wait was in place
- Kept the focus wait in `assertEditorInCellIsFocused` from #9874, as it covers a real server round trip unrelated to the dialog

## Type of change

- Tests
