### PR TITLE
docs: document TreeGrid.getDataProvider without list/lazy views (vaadin/flow#19376)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -960,6 +960,17 @@ public class TreeGrid<T> extends Grid<T>
         return (HierarchicalDataCommunicator<T>) super.getDataCommunicator();
     }
 
+    /**
+     * Returns the hierarchical data provider of this tree grid.
+     * <p>
+     * Use the returned provider to inspect items and to refresh them after
+     * changes. {@link #getListDataView()} and {@link #getLazyDataView()} are
+     * not supported on TreeGrid and throw
+     * {@link UnsupportedOperationException}.
+     *
+     * @return the hierarchical data provider of this tree grid, or {@code null}
+     *         if the current provider is not hierarchical
+     */
     @SuppressWarnings("unchecked")
     @Override
     public HierarchicalDataProvider<T, SerializablePredicate<T>> getDataProvider() {


### PR DESCRIPTION
## Description

TreeGrid inherits Grid.getDataProvider javadoc, which points at getListDataView() and getLazyDataView(). Both throw on TreeGrid. I added javadoc on the override so the API docs describe the hierarchical provider instead.

Fixes vaadin/flow#19376

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
