### PR TITLE
feat: add mode to disable on click until response is handled

### DIFF
--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.shared.DisableOnClickMode;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
@@ -49,6 +50,7 @@ public class ButtonView extends Div {
         createDisabledButton();
         createButtonWithDisableOnClick();
         createButtonWithDisableOnClickThatEnablesInSameRoundTrip();
+        createButtonWithDisableOnClickUntilResponse();
         createButtonWithDisableOnClickThatIsHidden();
         createButtonWithDisableOnClickAndPointerEventsAuto();
         createButtonsWithShortcuts();
@@ -243,6 +245,27 @@ public class ButtonView extends Div {
         button.setId("disable-on-click-re-enable-button");
         addCard("Button disabled on click and re-enabled in same roundtrip",
                 button);
+    }
+
+    private void createButtonWithDisableOnClickUntilResponse() {
+        Div clickCount = new Div();
+        clickCount.setId("disable-on-click-until-response-count");
+        AtomicInteger count = new AtomicInteger();
+
+        Button button = new Button("Disabled on click until response",
+                event -> {
+                    try {
+                        // Simulate a slow request so that the disabled state
+                        // can be observed on the client side
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    clickCount.setText(String.valueOf(count.incrementAndGet()));
+                });
+        button.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+        button.setId("disable-on-click-until-response-button");
+        addCard("Button disabled on click until response", button, clickCount);
     }
 
     private void createButtonWithDisableOnClickThatIsHidden() {

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/button/tests/ButtonView.java
@@ -259,6 +259,7 @@ public class ButtonView extends Div {
                         // can be observed on the client side
                         Thread.sleep(500);
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     }
                     clickCount.setText(String.valueOf(count.incrementAndGet()));

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/button/tests/ButtonIT.java
@@ -332,6 +332,56 @@ public class ButtonIT extends AbstractComponentIT {
     }
 
     @Test
+    public void disableOnClickUntilResponse_click_disabledDuringRoundTrip_enabledAfterResponse() {
+        var button = $(ButtonElement.class)
+                .id("disable-on-click-until-response-button");
+        var clickCount = findElement(
+                By.id("disable-on-click-until-response-count"));
+        scrollToElement(button);
+
+        getCommandExecutor().disableWaitForVaadin();
+        try {
+            for (int i = 1; i <= 3; i++) {
+                button.click();
+                Assert.assertFalse(
+                        "The button should be disabled while the click is handled",
+                        button.isEnabled());
+                waitUntil(driver -> button.isEnabled());
+                Assert.assertEquals(String.valueOf(i), clickCount.getText());
+            }
+        } finally {
+            getCommandExecutor().enableWaitForVaadin();
+        }
+    }
+
+    @Test
+    public void disableOnClickUntilResponse_clientEnablesAndClicksInSameRoundTrip_onlyFirstClickHandled() {
+        var button = $(ButtonElement.class)
+                .id("disable-on-click-until-response-button");
+        var clickCount = findElement(
+                By.id("disable-on-click-until-response-count"));
+        scrollToElement(button);
+
+        // Re-enable the button from the client side and click again, all in
+        // the same task, so that every click is sent in the same request
+        executeScript("""
+                const button = arguments[0];
+                for (let i = 0; i < 4; i++) {
+                  button.disabled = false;
+                  button.click();
+                }
+                """, button);
+
+        waitUntil(driver -> button.isEnabled());
+        Assert.assertEquals("Only the first click should have been handled",
+                "1", clickCount.getText());
+
+        button.click();
+        waitUntil(driver -> button.isEnabled());
+        Assert.assertEquals("2", clickCount.getText());
+    }
+
+    @Test
     public void disableOnClick_hideWhenDisabled_showWhenEnabled_clientSideButtonIsEnabled() {
         WebElement button = layout
                 .findElement(By.id("disable-on-click-hidden-button"));

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/Button.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.button;
 
+import java.util.Objects;
+
 import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.ClickEvent;
@@ -37,6 +39,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.shared.DisableOnClickMode;
 import com.vaadin.flow.component.shared.HasPrefix;
 import com.vaadin.flow.component.shared.HasSuffix;
 import com.vaadin.flow.component.shared.HasThemeVariant;
@@ -412,8 +415,13 @@ public class Button extends Component
      * Sets whether the button should be disabled when clicked.
      * <p>
      * When set to {@code true}, the button will be immediately disabled on the
-     * client-side when clicked, preventing further clicks until re-enabled from
-     * the server-side.
+     * client-side when clicked, preventing further clicks. How long the button
+     * stays disabled depends on the current {@link #getDisableOnClickMode()
+     * disable on click mode}. By default, the button stays disabled until it is
+     * enabled again by the application. Use
+     * {@link #setDisableOnClick(DisableOnClickMode)} to change the mode, for
+     * example to enable the button again automatically with the next response
+     * after the click.
      * <p>
      * When the enabled state is bound to a signal, the disable on click feature
      * can not be used. Disable on click requires the component to automatically
@@ -428,16 +436,54 @@ public class Button extends Component
      * @since 1.2
      */
     public void setDisableOnClick(boolean disableOnClick) {
+        if (disableOnClick) {
+            checkNoEnabledBinding();
+        }
+        disableOnClickController.setDisableOnClick(disableOnClick);
+    }
+
+    /**
+     * Sets the button to be disabled when clicked, using the given mode to
+     * determine how long the button stays disabled:
+     * <ul>
+     * <li>{@link DisableOnClickMode#UNTIL_ENABLED}: The button stays disabled
+     * until it is enabled again by the application. This is the default mode.
+     * <li>{@link DisableOnClickMode#UNTIL_RESPONSE}: The button is enabled
+     * again automatically with the next response the server sends after the
+     * click, normally the response to the request that delivered the click. If
+     * you explicitly set the enabled state of the button while the click is
+     * handled, the automatic enabling is skipped for that click. See the
+     * constant's documentation for how manual push affects this.
+     * </ul>
+     * <p>
+     * Calling this method is equivalent to calling
+     * {@link #setDisableOnClick(boolean) setDisableOnClick(true)} after setting
+     * the mode. The mode is kept when disable on click is later turned off and
+     * on again with {@link #setDisableOnClick(boolean)}.
+     *
+     * @param mode
+     *            the disable on click mode, not {@code null}
+     * @throws IllegalStateException
+     *             if the enabled state is already bound to a signal
+     * @see #setDisableOnClick(boolean)
+     * @since 25.3
+     */
+    public void setDisableOnClick(DisableOnClickMode mode) {
+        Objects.requireNonNull(mode, "DisableOnClickMode must not be null");
+        checkNoEnabledBinding();
+        disableOnClickController.setDisableOnClick(mode);
+    }
+
+    private void checkNoEnabledBinding() {
         boolean hasEnabledBinding = getElement().getNode()
                 .getFeatureIfInitialized(SignalBindingFeature.class)
                 .map(feature -> feature
                         .hasBinding(SignalBindingFeature.ENABLED))
                 .orElse(false);
-        if (disableOnClick && hasEnabledBinding) {
+        if (hasEnabledBinding) {
             throw new IllegalStateException(
                     "Disable on click is not supported when the enabled state is bound to a signal. ");
         }
-        disableOnClickController.setDisableOnClick(disableOnClick);
     }
 
     /**
@@ -448,6 +494,18 @@ public class Button extends Component
      */
     public boolean isDisableOnClick() {
         return disableOnClickController.isDisableOnClick();
+    }
+
+    /**
+     * Gets the mode that determines how long the button stays disabled after it
+     * has been disabled on click. {@link DisableOnClickMode#UNTIL_ENABLED} by
+     * default.
+     *
+     * @return the disable on click mode, not {@code null}
+     * @since 25.3
+     */
+    public DisableOnClickMode getDisableOnClickMode() {
+        return disableOnClickController.getDisableOnClickMode();
     }
 
     /**

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonSignalTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.shared.DisableOnClickMode;
 import com.vaadin.flow.component.*;
 import com.vaadin.flow.dom.SignalBinding;
 import com.vaadin.flow.signals.BindingActiveException;
@@ -224,6 +225,16 @@ class ButtonSignalTest extends AbstractSignalsTest {
 
         Assertions.assertThrows(IllegalStateException.class,
                 () -> button.setDisableOnClick(true));
+    }
+
+    @Test
+    void setDisableOnClickMode_enabledBindingActive_throws() {
+        button = new Button("foo");
+        UI.getCurrent().add(button);
+        button.bindEnabled(new ValueSignal<>(true));
+
+        Assertions.assertThrows(IllegalStateException.class, () -> button
+                .setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE));
     }
 
     @Test

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/test/java/com/vaadin/flow/component/button/tests/ButtonTest.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.shared.DisableOnClickMode;
 import com.vaadin.flow.component.shared.HasTooltip;
 
 class ButtonTest {
@@ -298,6 +299,29 @@ class ButtonTest {
         button.setDisableOnClick(true);
         button.click();
         Assertions.assertTrue(button.isEnabled(), "Button should be enabled");
+    }
+
+    @Test
+    void disableOnClickModeUntilEnabledByDefault() {
+        button = new Button();
+        Assertions.assertEquals(DisableOnClickMode.UNTIL_ENABLED,
+                button.getDisableOnClickMode());
+    }
+
+    @Test
+    void setDisableOnClickMode_modeUpdated_disableOnClickEnabled() {
+        button = new Button();
+        button.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+        Assertions.assertEquals(DisableOnClickMode.UNTIL_RESPONSE,
+                button.getDisableOnClickMode());
+        Assertions.assertTrue(button.isDisableOnClick());
+    }
+
+    @Test
+    void setDisableOnClickMode_null_throws() {
+        button = new Button();
+        Assertions.assertThrows(NullPointerException.class,
+                () -> button.setDisableOnClick((DisableOnClickMode) null));
     }
 
     @Test

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/DisableOnClickMode.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/DisableOnClickMode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.shared;
+
+/**
+ * Defines how long a component stays disabled after it has been disabled on
+ * click.
+ *
+ * @since 25.3
+ */
+public enum DisableOnClickMode {
+
+    /**
+     * The component stays disabled until it is enabled again by the
+     * application, for example by calling {@code setEnabled(true)} from a click
+     * listener. This is the default mode.
+     */
+    UNTIL_ENABLED,
+
+    /**
+     * The component is enabled again automatically with the next response the
+     * server sends to the client after the click. Normally this is the response
+     * to the request that delivered the click, so the component stays disabled
+     * while the click listeners run and is enabled again once they are done.
+     * This prevents accidental extra clicks while the server processes the
+     * click, without requiring you to enable the component again from a click
+     * listener. If the component is detached before that response, it is
+     * enabled again when it is attached the next time.
+     * <p>
+     * If push is enabled and a click listener calls {@code UI.push()} while it
+     * is still running, that push is the next response and enables the
+     * component before the listener has finished. Use {@link #UNTIL_ENABLED}
+     * when the component must stay disabled in that case.
+     * <p>
+     * If the component's enabled state is explicitly set while the click is
+     * handled, for example by calling {@code setEnabled(false)} from a click
+     * listener, the automatic enabling is skipped for that click.
+     */
+    UNTIL_RESPONSE;
+}

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.shared.DisableOnClickMode;
 
 /**
  * An internal controller for handling disabling a component when it is clicked.
@@ -46,7 +47,10 @@ public class DisableOnClickController<C extends Component & HasEnabled>
 
     private final C component;
     private boolean disableOnClick = false;
+    private DisableOnClickMode disableOnClickMode = DisableOnClickMode.UNTIL_ENABLED;
     private boolean clientUpdateScheduled = false;
+    private boolean enableScheduled = false;
+    private boolean updatingEnabled = false;
 
     /**
      * Creates a new controller for the given component.
@@ -63,7 +67,14 @@ public class DisableOnClickController<C extends Component & HasEnabled>
         ComponentUtil.addListener(component, ClickEvent.class,
                 (ComponentEventListener) (event -> {
                     if (isDisableOnClick()) {
-                        component.setEnabled(false);
+                        // Schedule enabling before disabling so that the
+                        // component is enabled again before the client-side
+                        // disabled property is updated, which results in a
+                        // single update with the final state.
+                        if (disableOnClickMode == DisableOnClickMode.UNTIL_RESPONSE) {
+                            scheduleEnable();
+                        }
+                        setEnabledInternal(false);
                     }
                 }));
     }
@@ -72,8 +83,9 @@ public class DisableOnClickController<C extends Component & HasEnabled>
      * Sets whether the component should be disabled when clicked.
      * <p>
      * When set to {@code true}, the component will be immediately disabled on
-     * the client-side when clicked, preventing further clicks until re-enabled
-     * from the server-side.
+     * the client-side when clicked, preventing further clicks. How long the
+     * component stays disabled depends on the current
+     * {@link #getDisableOnClickMode() disable on click mode}.
      *
      * @param disableOnClick
      *            whether the component should be disabled when clicked
@@ -97,6 +109,30 @@ public class DisableOnClickController<C extends Component & HasEnabled>
     }
 
     /**
+     * Enables disabling the component when clicked, using the given mode to
+     * determine how long the component stays disabled.
+     *
+     * @param mode
+     *            the disable on click mode, not {@code null}
+     * @see #setDisableOnClick(boolean)
+     */
+    public void setDisableOnClick(DisableOnClickMode mode) {
+        this.disableOnClickMode = Objects.requireNonNull(mode,
+                "DisableOnClickMode must not be null");
+        setDisableOnClick(true);
+    }
+
+    /**
+     * Gets the mode that determines how long the component stays disabled after
+     * it has been disabled on click.
+     *
+     * @return the disable on click mode, not {@code null}
+     */
+    public DisableOnClickMode getDisableOnClickMode() {
+        return disableOnClickMode;
+    }
+
+    /**
      * Forces the client-side component's {@code disabled} property to be
      * updated before the response is sent to the client, so that it matches the
      * component's effective enabled state, including whether any parent is
@@ -107,6 +143,11 @@ public class DisableOnClickController<C extends Component & HasEnabled>
      * updated.
      */
     public void onSetEnabled() {
+        if (!updatingEnabled) {
+            // The enabled state was set explicitly by application code, so
+            // don't override it after the round trip.
+            enableScheduled = false;
+        }
         // If the component is disabled and re-enabled during the same round
         // trip, Flow will not detect any changes and the client side component
         // would not be enabled again. The property is updated before the
@@ -121,6 +162,26 @@ public class DisableOnClickController<C extends Component & HasEnabled>
                     clientUpdateScheduled = false;
                     component.getElement().executeJs("this.disabled = $0",
                             !component.isEnabled());
+                }));
+    }
+
+    private void setEnabledInternal(boolean enabled) {
+        updatingEnabled = true;
+        try {
+            component.setEnabled(enabled);
+        } finally {
+            updatingEnabled = false;
+        }
+    }
+
+    private void scheduleEnable() {
+        enableScheduled = true;
+        component.getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(component, context -> {
+                    if (enableScheduled) {
+                        enableScheduled = false;
+                        setEnabledInternal(true);
+                    }
                 }));
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/internal/DisableOnClickController.java
@@ -25,6 +25,8 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.shared.DisableOnClickMode;
+import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * An internal controller for handling disabling a component when it is clicked.
@@ -48,8 +50,8 @@ public class DisableOnClickController<C extends Component & HasEnabled>
     private final C component;
     private boolean disableOnClick = false;
     private DisableOnClickMode disableOnClickMode = DisableOnClickMode.UNTIL_ENABLED;
-    private boolean clientUpdateScheduled = false;
-    private boolean enableScheduled = false;
+    private final BeforeClientResponseAction clientUpdate;
+    private final BeforeClientResponseAction enable;
     private boolean updatingEnabled = false;
 
     /**
@@ -61,8 +63,11 @@ public class DisableOnClickController<C extends Component & HasEnabled>
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public DisableOnClickController(C component) {
         this.component = Objects.requireNonNull(component);
-
-        component.addDetachListener((event) -> clientUpdateScheduled = false);
+        clientUpdate = new BeforeClientResponseAction(component,
+                () -> component.getElement().executeJs("this.disabled = $0",
+                        !component.isEnabled()));
+        enable = new BeforeClientResponseAction(component,
+                () -> setEnabledInternal(true));
 
         ComponentUtil.addListener(component, ClickEvent.class,
                 (ComponentEventListener) (event -> {
@@ -72,7 +77,7 @@ public class DisableOnClickController<C extends Component & HasEnabled>
                         // disabled property is updated, which results in a
                         // single update with the final state.
                         if (disableOnClickMode == DisableOnClickMode.UNTIL_RESPONSE) {
-                            scheduleEnable();
+                            enable.schedule();
                         }
                         setEnabledInternal(false);
                     }
@@ -146,23 +151,14 @@ public class DisableOnClickController<C extends Component & HasEnabled>
         if (!updatingEnabled) {
             // The enabled state was set explicitly by application code, so
             // don't override it after the round trip.
-            enableScheduled = false;
+            enable.cancel();
         }
         // If the component is disabled and re-enabled during the same round
         // trip, Flow will not detect any changes and the client side component
         // would not be enabled again. The property is updated before the
         // response so that the effective state at that point is used, for
         // example when a parent is disabled or enabled in the same round trip.
-        if (clientUpdateScheduled) {
-            return;
-        }
-        clientUpdateScheduled = true;
-        component.getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(component, context -> {
-                    clientUpdateScheduled = false;
-                    component.getElement().executeJs("this.disabled = $0",
-                            !component.isEnabled());
-                }));
+        clientUpdate.schedule();
     }
 
     private void setEnabledInternal(boolean enabled) {
@@ -174,14 +170,56 @@ public class DisableOnClickController<C extends Component & HasEnabled>
         }
     }
 
-    private void scheduleEnable() {
-        enableScheduled = true;
-        component.getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(component, context -> {
-                    if (enableScheduled) {
-                        enableScheduled = false;
-                        setEnabledInternal(true);
-                    }
-                }));
+    /**
+     * Runs an action once before the client response, even if the component is
+     * detached and attached again in between, possibly to another UI.
+     * <p>
+     * {@link UI#beforeClientResponse} is bound to the UI the component is
+     * attached to when the action is registered, and the action is dropped if
+     * the component is not attached to that same UI when the response is sent.
+     * This class instead registers the action whenever the component is
+     * attached, removes the registration whenever it is detached, and stops
+     * doing so once the action has run or has been cancelled.
+     */
+    private static class BeforeClientResponseAction implements Serializable {
+
+        private final Component component;
+        private final SerializableRunnable action;
+        private Registration attachRegistration;
+
+        BeforeClientResponseAction(Component component,
+                SerializableRunnable action) {
+            this.component = component;
+            this.action = action;
+        }
+
+        /**
+         * Schedules the action to run before the next client response while the
+         * component is attached. Does nothing if the action is already
+         * scheduled.
+         */
+        void schedule() {
+            if (attachRegistration != null) {
+                return;
+            }
+            attachRegistration = component.whenAttached(
+                    ui -> ui.beforeClientResponse(component, context -> {
+                        cancel();
+                        action.run();
+                    }));
+        }
+
+        /**
+         * Cancels the scheduled action. Does nothing if the action is not
+         * scheduled.
+         */
+        void cancel() {
+            if (attachRegistration == null) {
+                return;
+            }
+            Registration registration = attachRegistration;
+            attachRegistration = null;
+            registration.remove();
+        }
     }
 }

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.shared;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,10 @@ import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.shared.internal.DisableOnClickController;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.MockUIExtension;
 
 class DisableOnClickControllerTest {
@@ -183,6 +188,162 @@ class DisableOnClickControllerTest {
         Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
     }
 
+    @Test
+    void disableOnClickModeUntilEnabledByDefault() {
+        Assertions.assertEquals(DisableOnClickMode.UNTIL_ENABLED,
+                component.getDisableOnClickMode());
+    }
+
+    @Test
+    void setDisableOnClickMode_modeUpdated_disableOnClickEnabled() {
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+        Assertions.assertEquals(DisableOnClickMode.UNTIL_RESPONSE,
+                component.getDisableOnClickMode());
+        Assertions.assertTrue(component.isDisableOnClick());
+        Assertions.assertTrue(
+                component.getElement().hasAttribute("disableonclick"));
+    }
+
+    @Test
+    void setDisableOnClickMode_disableOnClickToggled_modeKept() {
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+        component.setDisableOnClick(false);
+        Assertions.assertFalse(component.isDisableOnClick());
+        Assertions.assertEquals(DisableOnClickMode.UNTIL_RESPONSE,
+                component.getDisableOnClickMode());
+
+        component.setDisableOnClick(true);
+        Assertions.assertTrue(component.isDisableOnClick());
+        Assertions.assertEquals(DisableOnClickMode.UNTIL_RESPONSE,
+                component.getDisableOnClickMode());
+    }
+
+    @Test
+    void setDisableOnClickMode_null_throws() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> component.setDisableOnClick(null));
+    }
+
+    @Test
+    void untilEnabled_click_componentStaysDisabledAfterRoundTrip() {
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_ENABLED);
+        component.click();
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_click_componentIsDisabledDuringClick_enabledAfterRoundTrip() {
+        var componentIsEnabled = new AtomicBoolean(true);
+        component.addClickListener(
+                event -> componentIsEnabled.set(event.getSource().isEnabled()));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        Assertions.assertFalse(componentIsEnabled.get());
+        Assertions.assertFalse(component.isEnabled());
+
+        ui.fakeClientCommunication();
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_click_clientSideDisabledPropertyIsReset() {
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+    }
+
+    @Test
+    void untilResponse_clientClicksMultipleTimesInSameRoundTrip_onlyFirstClickHandled() {
+        var clickCount = new AtomicInteger();
+        component.addClickListener(event -> clickCount.incrementAndGet());
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        fakeClientClick();
+        fakeClientClick();
+        fakeClientClick();
+        Assertions.assertEquals(1, clickCount.get());
+        Assertions.assertFalse(component.isEnabled());
+
+        ui.fakeClientCommunication();
+        Assertions.assertTrue(component.isEnabled());
+
+        fakeClientClick();
+        Assertions.assertEquals(2, clickCount.get());
+    }
+
+    @Test
+    void untilResponse_listenerDisablesComponent_componentStaysDisabledAfterRoundTrip() {
+        component
+                .addClickListener(event -> event.getSource().setEnabled(false));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_listenerEnablesComponent_componentIsEnabledAfterRoundTrip() {
+        component.addClickListener(event -> event.getSource().setEnabled(true));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        Assertions.assertTrue(component.isEnabled());
+        ui.fakeClientCommunication();
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_listenerDisablesParent_clientSideStaysDisabled() {
+        component.addClickListener(event -> parent.setEnabled(false));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
+        Assertions.assertFalse(component.isEnabled());
+        Assertions.assertTrue(component.getElement().getNode().isEnabledSelf());
+    }
+
+    @Test
+    void untilResponse_disableOnClickTurnedOff_click_componentStaysEnabled() {
+        var componentIsEnabled = new AtomicBoolean(false);
+        component.addClickListener(
+                event -> componentIsEnabled.set(event.getSource().isEnabled()));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+        component.setDisableOnClick(false);
+
+        component.click();
+        Assertions.assertTrue(componentIsEnabled.get());
+        ui.fakeClientCommunication();
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_detachedComponentClicked_enabledAfterAttachAndRoundTrip() {
+        parent.remove(component);
+        ui.fakeClientCommunication();
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        Assertions.assertFalse(component.isEnabled());
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+
+        parent.add(component);
+        ui.fakeClientCommunication();
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    private void fakeClientClick() {
+        Element element = component.getElement();
+        DomEvent event = new DomEvent(element, "click",
+                JacksonUtils.createObjectNode());
+        element.getNode().getFeature(ElementListenerMap.class).fireEvent(event);
+    }
+
     private List<Object> dumpClientSideDisabledValues() {
         return ui.dumpPendingJavaScriptInvocations().stream()
                 .map(PendingJavaScriptInvocation::getInvocation)
@@ -208,6 +369,14 @@ class DisableOnClickControllerTest {
 
         public boolean isDisableOnClick() {
             return disableOnClickController.isDisableOnClick();
+        }
+
+        public void setDisableOnClick(DisableOnClickMode mode) {
+            disableOnClickController.setDisableOnClick(mode);
+        }
+
+        public DisableOnClickMode getDisableOnClickMode() {
+            return disableOnClickController.getDisableOnClickMode();
         }
 
         public void click() {

--- a/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
+++ b/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/test/java/com/vaadin/flow/component/shared/DisableOnClickControllerTest.java
@@ -182,7 +182,7 @@ class DisableOnClickControllerTest {
 
         ui.replaceUI();
         ui.add(component);
-        ui.fakeClientCommunication();
+        Assertions.assertEquals(List.of(true), dumpClientSideDisabledValues());
 
         component.setEnabled(true);
         Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
@@ -334,6 +334,69 @@ class DisableOnClickControllerTest {
 
         parent.add(component);
         ui.fakeClientCommunication();
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_listenerDetachesComponent_enabledAfterAttachAndRoundTrip() {
+        component.addClickListener(event -> parent.remove(component));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+
+        parent.add(component);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_listenerDetachesComponent_attachedToAnotherUi_enabledAfterRoundTrip() {
+        component.addClickListener(event -> parent.remove(component));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+
+        // Simulates what @PreserveOnRefresh does before moving components to
+        // the UI created for the reloaded page
+        component.getElement().removeFromTree(false);
+        ui.replaceUI();
+        ui.add(component);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+        Assertions.assertTrue(component.isEnabled());
+    }
+
+    @Test
+    void untilResponse_detachedAndAttachedMultipleTimes_clientSideEnabledOnce() {
+        component.addClickListener(event -> parent.remove(component));
+        component.setDisableOnClick(DisableOnClickMode.UNTIL_RESPONSE);
+
+        component.click();
+        // Several detach / attach cycles within the same round trip
+        parent.add(component);
+        parent.remove(component);
+        parent.add(component);
+        parent.remove(component);
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+
+        // And across round trips
+        parent.add(component);
+        parent.remove(component);
+        ui.fakeClientCommunication();
+        Assertions.assertFalse(component.isEnabled());
+
+        parent.add(component);
+        Assertions.assertEquals(List.of(false), dumpClientSideDisabledValues());
+        Assertions.assertTrue(component.isEnabled());
+
+        // Nothing left pending: further round trips and cycles do nothing
+        parent.remove(component);
+        parent.add(component);
+        Assertions.assertEquals(List.of(), dumpClientSideDisabledValues());
         Assertions.assertTrue(component.isEnabled());
     }
 


### PR DESCRIPTION
## Description

Closes #1553

[PR explanation](https://github.com/user-attachments/files/31849053/explanation-10030.html)

Disable on click protects against accidental double clicks, but until now the button stayed disabled until the application enabled it again from a click listener. For the common case, where the button should only be blocked while the server handles the click, that meant extra code in every listener. This adds a mode where the button is enabled again automatically once the click has been handled, so preventing double submits becomes a one-liner.

- Added `DisableOnClickMode` with two modes for how long a button stays disabled after it was disabled on click
  - `UNTIL_ENABLED` is the existing behavior and the default: the button stays disabled until the application enables it again
  - `UNTIL_RESPONSE` enables the button again automatically once the click has been handled, with the response to the click
- Added `Button.setDisableOnClick(DisableOnClickMode)` and `Button.getDisableOnClickMode()`
- In `UNTIL_RESPONSE` mode, a click listener can still decide the final state by calling `setEnabled(true)` or `setEnabled(false)`, in which case the automatic enabling is skipped for that click
- Clicks that reach the server in the same round trip after the first one are ignored, so a fast double click runs the listener only once
- The automatic enabling also works when the click listener detaches the button, for example by closing a dialog, and the button is attached again later, also in another UI after a reload with `@PreserveOnRefresh`
- Clarified in the Javadoc that the default mode requires the application to enable the button again
- Added unit tests for both modes and an integration test view and tests for `UNTIL_RESPONSE`


## Type of change

- Feature

> [!NOTE]
> `UNTIL_RESPONSE` enables the button with the next response the server sends after the click. If a click listener calls `UI.push()` while it is still running, that push is the next response and enables the button before the listener has finished. This is documented on the enum constant.