### PR TITLE
chore: upgrade log4j-api to 2.25.5 (25.1)

### DIFF
--- a/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
+++ b/vaadin-spreadsheet-flow-parent/vaadin-spreadsheet-flow/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.25.4</version>
+            <version>2.25.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/cve-2026-49844

Version in main and 25.2 has been upgrade to 2.26.x
