### PR TITLE
docs: drop input disabling advice from AI Javadocs

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptor.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/RequestInterceptor.java
@@ -80,23 +80,22 @@ import com.vaadin.flow.function.SerializableConsumer;
  * {@link RequestContinuation}.
  * <p>
  * <b>Postponing:</b> while a prompt is postponed nothing is shown in the UI and
- * further prompts are ignored, so show a pending indicator and disable the
- * input before scheduling the work, and clean up when completing the
- * continuation. Server push must be enabled — e.g. with
- * {@link com.vaadin.flow.component.page.Push @Push} on the application shell
- * class — for the resumed turn to reach the browser without user interaction.
- * Capture the {@link com.vaadin.flow.component.UI UI} before scheduling the
- * work and wrap component changes made from the completing thread in
- * {@code ui.access(...)}:
+ * further prompts are ignored, so show a pending indicator before scheduling
+ * the work and hide it when completing the continuation. Server push must be
+ * enabled — e.g. with {@link com.vaadin.flow.component.page.Push @Push} on the
+ * application shell class — for the resumed turn to reach the browser without
+ * user interaction. Capture the {@link com.vaadin.flow.component.UI UI} before
+ * scheduling the work and wrap component changes made from the completing
+ * thread in {@code ui.access(...)}:
  *
  * <pre>
  * .withRequestInterceptor(event -&gt; {
  *     var continuation = event.postpone(Duration.ofSeconds(10));
  *     var ui = UI.getCurrent();
- *     input.setEnabled(false);
+ *     progressBar.setVisible(true);
  *     moderationService.checkAsync(event.getUserMessage())
  *             .whenComplete((verdict, error) -&gt; {
- *                 ui.access(() -&gt; input.setEnabled(true));
+ *                 ui.access(() -&gt; progressBar.setVisible(false));
  *                 if (error != null) {
  *                     continuation.fail(error);
  *                     return;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -213,15 +213,11 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * which still runs on the UI thread. This is the same requirement a
      * {@link StreamingChatModel} already has.</li>
      *
-     * <li><b>A gated input.</b> The orchestrator processes one prompt at a
-     * time. Without background execution, a message submitted while a turn is
+     * <li><b>One prompt at a time.</b> The orchestrator processes one prompt at
+     * a time. Without background execution, a message submitted while a turn is
      * running waits for the session lock and is processed when the turn ends;
      * with it, the submit is rejected and dropped with a warning — and a
-     * connected input has already cleared its text. Disable the input while a
-     * turn is running, for example from
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest}
-     * and
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(ResponseListener.ResponseEvent)}.</li>
+     * connected input has already cleared its text.</li>
      * </ul>
      *
      * <p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -197,7 +197,7 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * message and the assistant placeholder render, and the response is added
      * when it arrives.
      * <p>
-     * This requires three things from the application:
+     * This requires the following from the application:
      * <ul>
      * <li><b>A way to deliver the response.</b> Annotate the application shell
      * or UI class with {@code @Push}, or enable polling with
@@ -212,13 +212,15 @@ public class LangChain4JLLMProvider implements LLMProvider {
      * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest},
      * which still runs on the UI thread. This is the same requirement a
      * {@link StreamingChatModel} already has.</li>
-     *
-     * <li><b>One prompt at a time.</b> The orchestrator processes one prompt at
-     * a time. Without background execution, a message submitted while a turn is
-     * running waits for the session lock and is processed when the turn ends;
-     * with it, the submit is rejected and dropped with a warning — and a
-     * connected input has already cleared its text.</li>
      * </ul>
+     *
+     * <p>
+     * The orchestrator processes one prompt at a time. Without background
+     * execution, a message submitted while a turn is running waits for the
+     * session lock and is processed when the turn ends; with it, the submit is
+     * rejected and dropped with a warning — and a connected input has already
+     * cleared its text.
+     * </p>
      *
      * <p>
      * Like the streaming mode, the setting is not preserved when the session is

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -216,7 +216,7 @@ public class SpringAILLMProvider implements LLMProvider {
      * the assistant placeholder render, and the response is added when it
      * arrives.
      * <p>
-     * This requires three things from the application:
+     * This requires the following from the application:
      * <ul>
      * <li><b>A way to deliver the response.</b> Annotate the application shell
      * or UI class with {@code @Push}, or enable polling with
@@ -231,13 +231,15 @@ public class SpringAILLMProvider implements LLMProvider {
      * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest},
      * which still runs on the UI thread. This is the same requirement streaming
      * mode already has.</li>
-     *
-     * <li><b>One prompt at a time.</b> The orchestrator processes one prompt at
-     * a time. Without background execution, a message submitted while a turn is
-     * running waits for the session lock and is processed when the turn ends;
-     * with it, the submit is rejected and dropped with a warning — and a
-     * connected input has already cleared its text.</li>
      * </ul>
+     *
+     * <p>
+     * The orchestrator processes one prompt at a time. Without background
+     * execution, a message submitted while a turn is running waits for the
+     * session lock and is processed when the turn ends; with it, the submit is
+     * rejected and dropped with a warning — and a connected input has already
+     * cleared its text.
+     * </p>
      *
      * <p>
      * Like the streaming mode, the setting is not preserved when the session is

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -232,15 +232,11 @@ public class SpringAILLMProvider implements LLMProvider {
      * which still runs on the UI thread. This is the same requirement streaming
      * mode already has.</li>
      *
-     * <li><b>A gated input.</b> The orchestrator processes one prompt at a
-     * time. Without background execution, a message submitted while a turn is
+     * <li><b>One prompt at a time.</b> The orchestrator processes one prompt at
+     * a time. Without background execution, a message submitted while a turn is
      * running waits for the session lock and is processed when the turn ends;
      * with it, the submit is rejected and dropped with a warning — and a
-     * connected input has already cleared its text. Disable the input while a
-     * turn is running, for example from
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onRequest}
-     * and
-     * {@link com.vaadin.flow.component.ai.orchestrator.AIController#onResponse(ResponseListener.ResponseEvent)}.</li>
+     * connected input has already cleared its text.</li>
      * </ul>
      *
      * <p>


### PR DESCRIPTION
## Description

The Javadocs still recommended disabling the Message Input while a turn is running or a prompt is postponed. The same advice was dropped from the docs during review, because disabling the input makes it lose focus and was never recommended for streaming mode either.

- Removed the "Disable the input while a turn is running" advice from the background execution Javadoc of `SpringAILLMProvider` and `LangChain4JLLMProvider`
- Replaced input disabling in the `RequestInterceptor` postponing example with toggling an indeterminate `ProgressBar`, matching the request interception docs

## Type of change

- Documentation