### PR TITLE
fix: fail build when plot options schemas are not generated

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchema.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchema.java
@@ -16,6 +16,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.charts.model.AbstractPlotOptions;
 import com.vaadin.flow.internal.JacksonUtils;
 
@@ -29,6 +32,9 @@ import tools.jackson.databind.JsonNode;
  * @author Vaadin Ltd
  */
 final class PlotOptionsSchema implements Serializable {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(PlotOptionsSchema.class);
 
     private static final String SCHEMAS_RESOURCE = "plot-options-schemas.json";
 
@@ -75,6 +81,11 @@ final class PlotOptionsSchema implements Serializable {
         try (var input = PlotOptionsSchema.class
                 .getResourceAsStream(SCHEMAS_RESOURCE)) {
             if (input == null) {
+                LOGGER.error(
+                        "Plot options schema resource '{}' is missing from the "
+                                + "classpath. The get_plot_options_schema tool "
+                                + "will report every chart type as unknown.",
+                        SCHEMAS_RESOURCE);
                 return Map.of();
             }
             JsonNode root = JacksonUtils.getMapper().readTree(input);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaGenerator.java
@@ -72,7 +72,9 @@ import tools.jackson.databind.node.ObjectNode;
  * type's plot options, including property descriptions parsed from JavaDoc.
  * <p>
  * Invoked automatically during the Maven build via {@code exec-maven-plugin}.
- * The output is consumed by {@link PlotOptionsSchema} at runtime.
+ * The output is consumed by {@link PlotOptionsSchema} at runtime. The build
+ * fails if the chart model sources cannot be found, so the published jar never
+ * silently ships without the schemas.
  * 
  * @since 25.2
  */
@@ -151,14 +153,21 @@ public final class PlotOptionsSchemaGenerator {
         Path outputFile = Path.of(args[1]);
 
         if (!Files.isDirectory(sourceDir)) {
-            LOGGER.warn("Source directory not found: {}"
-                    + " — skipping schema generation", sourceDir);
-            return;
+            throw new IllegalStateException(
+                    "Chart model source directory not found: " + sourceDir
+                            + ". The plot options schemas cannot be generated "
+                            + "without it.");
         }
 
         // Parse descriptions from source files
         Map<String, Map<String, String>> descriptions = parseDescriptions(
                 sourceDir);
+        if (descriptions.isEmpty()) {
+            throw new IllegalStateException(
+                    "No chart model sources found in " + sourceDir
+                            + ". The plot options schemas would be generated "
+                            + "without property descriptions.");
+        }
 
         // Build complete schemas for each chart type
         var plotOptionsByType = buildTypeMap();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -85,12 +85,25 @@ class ChartAIControllerTest {
             Assertions.assertTrue(names.contains("get_chart_state"));
             Assertions.assertTrue(names.contains("update_chart_configuration"));
             Assertions.assertTrue(names.contains("update_chart_data_source"));
+            Assertions.assertTrue(names.contains("get_plot_options_schema"));
         }
 
         @Test
         void instructionsToolIsFirst() {
             Assertions.assertEquals("get_chart_instructions",
                     controller.getTools().get(0).getName());
+        }
+
+        @Test
+        void plotOptionsSchemaTool_returnsGeneratedSchema() {
+            var tool = findTool(controller.getTools(),
+                    "get_plot_options_schema");
+            var result = tool.execute(json("{\"chartType\":\"column\"}"));
+            Assertions.assertFalse(result.startsWith("Error"), result);
+            var schema = json(result);
+            Assertions.assertEquals("object", schema.get("type").asString());
+            Assertions.assertTrue(schema.get("properties").has("stacking"),
+                    "Column schema should expose plot option properties");
         }
     }
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/PlotOptionsSchemaTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
+ * license.
+ */
+package com.vaadin.flow.component.ai.chart;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.vaadin.flow.internal.JacksonUtils;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Verifies that the plot options schemas generated at build time by
+ * {@link PlotOptionsSchemaGenerator} end up on the classpath and are usable
+ * through {@link PlotOptionsSchema}.
+ */
+class PlotOptionsSchemaTest {
+
+    private static final String RESOURCE = "plot-options-schemas.json";
+
+    @Test
+    void schemaResource_isOnClasspath() {
+        Assertions.assertNotNull(PlotOptionsSchema.class.getResource(RESOURCE),
+                RESOURCE + " is missing next to PlotOptionsSchema. It is "
+                        + "generated into the build output directory by the "
+                        + "exec-maven-plugin execution in this module's pom, "
+                        + "so the module must be built with Maven.");
+    }
+
+    @Test
+    void everySupportedType_hasSchema() {
+        var types = PlotOptionsSchema.supportedTypes();
+        Assertions.assertFalse(types.isEmpty());
+        for (String type : types) {
+            String schema = PlotOptionsSchema.getSchema(type);
+            Assertions.assertNotNull(schema,
+                    "No generated schema for chart type '" + type + "'");
+            JsonNode node = JacksonUtils.readTree(schema);
+            Assertions.assertEquals("object", node.get("type").asString());
+            Assertions.assertFalse(node.get("properties").isEmpty(),
+                    "Schema for '" + type + "' has no properties");
+        }
+    }
+
+    @Test
+    void everySchema_hasDescriptionsFromChartSources() {
+        for (String type : PlotOptionsSchema.supportedTypes()) {
+            JsonNode properties = JacksonUtils
+                    .readTree(PlotOptionsSchema.getSchema(type))
+                    .get("properties");
+            boolean described = false;
+            for (var property : properties.properties()) {
+                if (property.getValue().has("description")) {
+                    described = true;
+                    break;
+                }
+            }
+            Assertions.assertTrue(described,
+                    "Schema for '" + type
+                            + "' has no property descriptions. The generator "
+                            + "could not read the chart model sources.");
+        }
+    }
+
+    @Test
+    void unknownType_returnsNull() {
+        Assertions.assertNull(PlotOptionsSchema.getSchema("nonexistent"));
+        Assertions.assertNull(
+                PlotOptionsSchema.getPlotOptionsClass("nonexistent"));
+    }
+
+    @Test
+    void generator_missingSourceDirectory_fails(@TempDir Path tempDir) {
+        var missingSources = tempDir.resolve("missing").toString();
+        var output = tempDir.resolve("out.json").toString();
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> PlotOptionsSchemaGenerator
+                        .main(new String[] { missingSources, output }));
+    }
+
+    @Test
+    void generator_sourceDirectoryWithoutChartModel_fails(
+            @TempDir Path tempDir) {
+        var output = tempDir.resolve("out.json").toString();
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> PlotOptionsSchemaGenerator
+                        .main(new String[] { tempDir.toString(), output }));
+    }
+}


### PR DESCRIPTION
## Summary
- The chart plot options schemas are generated at build time from the chart model sources and shipped in the jar. When the source directory was missing the generator only logged a warning and skipped, so a build with tests skipped could publish a jar without schemas and the tool would report every chart type as unknown. The generator now fails the build in that case, and a missing resource at runtime is logged as an error.
- Added tests that check the generated resource is on the classpath, covers every supported chart type with descriptions, and is exposed through `ChartAIController`'s tools, so a regression in generation or packaging fails the module's unit tests directly.