### PR TITLE
test: add tree grid connector scrollToIndex tests

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/shared.ts
@@ -11,6 +11,7 @@ import type {} from '@web/test-runner-mocha';
 import type {} from 'sinon-chai';
 import type {
   FlowGrid as ConnectorFlowGrid,
+  FlowTreeGrid as ConnectorFlowTreeGrid,
   GridConnector as ConnectorGridConnector,
   GridServer as ConnectorGridServer,
   Item as ConnectorItem
@@ -20,6 +21,8 @@ export type GridServer = {
   [K in keyof ConnectorGridServer]: ConnectorGridServer[K] & sinon.SinonSpy;
 } & {
   setViewportRange: ConnectorGridServer['setViewportRange'] & sinon.SinonSpy & { promise?: sinon.SinonPromise<void> };
+  setViewportRangeByIndexPath: ConnectorGridServer['setViewportRangeByIndexPath'] &
+    sinon.SinonSpy & { promise?: sinon.SinonPromise<number> };
 };
 
 export type Item = ConnectorItem & {
@@ -38,13 +41,13 @@ export type GridConnector = Omit<ConnectorGridConnector, 'doSelection' | 'doDese
   updateFlatData(updatedItems: Item[]): void;
 };
 
-export type FlowGrid = {
+type TestGridInternals = {
   $connector: GridConnector;
   $server: GridServer;
-} & ConnectorFlowGrid & {
-    _flatSize: number;
-    _updateItem: (index: number, item: Item) => void;
-  };
+  _flatSize: number;
+};
+
+export type FlowGrid = TestGridInternals & ConnectorFlowGrid;
 
 export type FlowGridSorter = GridSorter & {
   _order?: number | null;
@@ -54,6 +57,8 @@ export type FlowGridSelectionColumn = GridColumn & {
   selectAll: boolean;
   $server: GridServer;
 };
+
+export type FlowTreeGrid = TestGridInternals & ConnectorFlowTreeGrid;
 
 export const gridConnector = window.Vaadin.Flow.gridConnector;
 export const treeGridConnector = window.Vaadin.Flow.treeGridConnector;
@@ -77,7 +82,11 @@ export function init(grid: FlowGrid, connector: { initLazy(grid: ConnectorFlowGr
       grid.$server.setViewportRange.promise = promise;
       return promise;
     }),
-    setViewportRangeByIndexPath: sinon.spy(),
+    setViewportRangeByIndexPath: sinon.spy(() => {
+      const promise = sinon.promise<number>();
+      grid.$server.setViewportRangeByIndexPath.promise = promise;
+      return promise;
+    }),
     sortersChanged: sinon.spy(),
     setShiftKeyDown: sinon.spy(),
     updateContextMenuTargetItem: sinon.spy()

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/tree-grid-connector-scroll-to-index.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/tree-grid-connector-scroll-to-index.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { init, setRootItems, getBodyCellText, treeGridConnector, GRID_CONNECTOR_ROOT_REQUEST_DELAY } from './shared.js';
+import type { FlowTreeGrid, Item } from './shared.js';
+
+const ITEMS = Array.from({ length: 1000 }, (_, i) => {
+  return { key: `${i}`, name: `Item-${i}` } as Item;
+});
+
+describe('tree grid connector - scroll to index', () => {
+  let grid: FlowTreeGrid;
+
+  beforeEach(() => {
+    grid = fixtureSync(`
+      <vaadin-grid style="height: 400px">
+        <vaadin-grid-tree-column path="name"></vaadin-grid-tree-column>
+      </vaadin-grid>
+      <style>
+        vaadin-grid::part(cell) {
+          min-height: 36px;
+        }
+      </style>
+    `);
+
+    init(grid, treeGridConnector);
+  });
+
+  /**
+   * Emulates the server response to setViewportRangeByIndexPath: the viewport
+   * range moves to the target, so the old range gets cleared and the range
+   * around the target gets set, while the old range is still rendered. The
+   * promise resolves with the flat index of the target after that.
+   */
+  function resolveViewportRangeByIndexPath(flatIndex: number) {
+    grid.$connector.clear(0, grid.pageSize);
+    setRootItems(grid.$connector, ITEMS, flatIndex - 100, 200);
+    grid.$server.setViewportRangeByIndexPath.promise?.resolve(flatIndex);
+  }
+
+  describe('before grid has rendered', () => {
+    beforeEach(async () => {
+      // Emulates a scroll call that runs in the same round trip in which the
+      // grid is attached, e.g. scrollToIndex() in a view constructor. The grid
+      // has not rendered yet, so the connector defers the scroll.
+      grid.scrollToIndex(500);
+      setRootItems(grid.$connector, ITEMS, 0, grid.pageSize);
+      await nextFrame();
+    });
+
+    it('should scroll to the resolved flat index once rendered', async () => {
+      expect(grid.$server.setViewportRangeByIndexPath).to.be.calledOnce;
+      expect(grid.$server.setViewportRangeByIndexPath.args[0][0]).to.eql([500]);
+
+      resolveViewportRangeByIndexPath(500);
+      await nextFrame();
+      expect(getBodyCellText(grid, 500, 0)).to.equal('Item-500');
+    });
+  });
+
+  describe('after grid has rendered', () => {
+    beforeEach(async () => {
+      await nextFrame();
+      setRootItems(grid.$connector, ITEMS, 0, grid.pageSize);
+      await nextFrame();
+      grid.$server.setViewportRange.resetHistory();
+    });
+
+    it('should scroll to the resolved flat index without requesting the old range', async () => {
+      const scrollPromise = grid.scrollToIndex(500);
+      expect(grid.$server.setViewportRangeByIndexPath).to.be.calledOnce;
+      expect(grid.$server.setViewportRangeByIndexPath.args[0][0]).to.eql([500]);
+
+      resolveViewportRangeByIndexPath(500);
+      await scrollPromise;
+      expect(getBodyCellText(grid, 500, 0)).to.equal('Item-500');
+
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setViewportRange).to.not.be.called;
+      expect(grid.loading).to.be.false;
+    });
+  });
+});

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/tree-grid-connector-scroll-to-index.test.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/test/tree-grid-connector-scroll-to-index.test.ts
@@ -42,14 +42,14 @@ describe('tree grid connector - scroll to index', () => {
       // Emulates a scroll call that runs in the same round trip in which the
       // grid is attached, e.g. scrollToIndex() in a view constructor. The grid
       // has not rendered yet, so the connector defers the scroll.
-      grid.scrollToIndex(500);
+      grid.scrollToIndex(2, 5);
       setRootItems(grid.$connector, ITEMS, 0, grid.pageSize);
       await nextFrame();
     });
 
     it('should scroll to the resolved flat index once rendered', async () => {
       expect(grid.$server.setViewportRangeByIndexPath).to.be.calledOnce;
-      expect(grid.$server.setViewportRangeByIndexPath.args[0][0]).to.eql([500]);
+      expect(grid.$server.setViewportRangeByIndexPath.args[0][0]).to.eql([2, 5]);
 
       resolveViewportRangeByIndexPath(500);
       await nextFrame();
@@ -66,9 +66,9 @@ describe('tree grid connector - scroll to index', () => {
     });
 
     it('should scroll to the resolved flat index without requesting the old range', async () => {
-      const scrollPromise = grid.scrollToIndex(500);
+      const scrollPromise = grid.scrollToIndex(2, 5);
       expect(grid.$server.setViewportRangeByIndexPath).to.be.calledOnce;
-      expect(grid.$server.setViewportRangeByIndexPath.args[0][0]).to.eql([500]);
+      expect(grid.$server.setViewportRangeByIndexPath.args[0][0]).to.eql([2, 5]);
 
       resolveViewportRangeByIndexPath(500);
       await scrollPromise;
@@ -77,6 +77,18 @@ describe('tree grid connector - scroll to index', () => {
       await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
       expect(grid.$server.setViewportRange).to.not.be.called;
       expect(grid.loading).to.be.false;
+    });
+
+    it('should keep requesting data on scroll after scrollToIndex has finished', async () => {
+      const scrollPromise = grid.scrollToIndex(2, 5);
+      resolveViewportRangeByIndexPath(500);
+      await scrollPromise;
+
+      // Emulates the user scrolling to the end, which the server has not sent
+      grid.$.table.scrollTop = grid.$.table.scrollHeight;
+      await nextFrame();
+      await aTimeout(GRID_CONNECTOR_ROOT_REQUEST_DELAY);
+      expect(grid.$server.setViewportRange).to.be.calledOnce;
     });
   });
 });

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/frontend/vaadin-grid/vaadin-grid-types.d.ts
@@ -96,7 +96,7 @@ export interface FlowGridInternals {
 }
 
 /** The Flow grid element */
-export type FlowGrid = Grid<Item> & FlowGridInternals;
+export type FlowGrid = FlowGridInternals & Grid<Item>;
 
 /**
  * The private/protected @vaadin/grid API and the Flow-specific API that the
@@ -109,10 +109,11 @@ export interface FlowTreeGridInternals {
   _scrollToFlatIndex(flatIndex: number): void;
   expandItem(item: Item | undefined): void;
   collapseItem(item: Item | undefined): void;
+  scrollToIndex(...indexes: number[]): Promise<number | undefined>;
 }
 
 /** The Flow tree grid element */
-export type FlowTreeGrid = FlowGrid & FlowTreeGridInternals;
+export type FlowTreeGrid = FlowTreeGridInternals & FlowGrid;
 
 declare global {
   // Augments the global Vaadin interface declared by @vaadin/component-base


### PR DESCRIPTION
## Description

- Added `tree-grid-connector-scroll-to-index.test.ts` covering `scrollToIndex` called before and after the grid has rendered
- Stubbed `setViewportRangeByIndexPath` with a controllable promise in the shared test helpers and added the `FlowTreeGrid` type there
- Typed `scrollToIndex` on `FlowTreeGridInternals` as returning a promise, so tests can await it

## Type of change

- Tests
