### PR TITLE
chore: use upstream types for combo box placeholder

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
@@ -13,7 +13,7 @@ import type { FlowComboBox, Item, ItemRange } from './vaadin-combo-box-types.js'
  */
 export class ComboBoxConnector {
   readonly #comboBox: FlowComboBox;
-  readonly #placeholder = new window.Vaadin.ComboBoxPlaceholder();
+  readonly #placeholder = new ComboBoxPlaceholder();
 
   #cache: Record<number, Item[]> = {};
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/comboBoxConnector.ts
@@ -48,8 +48,9 @@ export class ComboBoxConnector {
     const filteredItems = comboBox.filteredItems ?? [];
     for (let index = firstPage * pageSize; index < lastPage * pageSize; index++) {
       if (filteredItems[index]) {
-        // The placeholder stands in for an item that is being loaded
-        filteredItems[index] = this.#placeholder as Item;
+        // The placeholder stands in for an item that is being loaded. It is not
+        // an Item, but the combo box expects placeholders in the items array.
+        filteredItems[index] = this.#placeholder as unknown as Item;
       }
     }
   }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-placeholder.d.ts
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/frontend/vaadin-combo-box/vaadin-combo-box-placeholder.d.ts
@@ -1,5 +1,0 @@
-// Declares the untyped @vaadin/combo-box placeholder module
-declare module '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js' {
-  /** Placeholder object representing an item that is being loaded */
-  export class ComboBoxPlaceholder {}
-}


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/12622

- Removed the local ambient declaration for `@vaadin/combo-box/src/vaadin-combo-box-placeholder.js`, now that the package ships its own type declarations.
- Cast the placeholder through `unknown` when writing it into `filteredItems`, since the upstream type is nominal and no longer overlaps with `Item`.

## Type of change

- Internal change