### PR TITLE
docs: clarify SelectAllCheckboxVisibility javadoc for lazy data

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
@@ -40,26 +40,25 @@ public interface GridMultiSelectionModel<T>
      * State for showing the select all checkbox in the grid's default header
      * row for the selection column.
      * <p>
-     * Default value is {@link #DEFAULT}, which means that the select all is
-     * only visible if an in-memory data is used.
+     * Default value is {@link #DEFAULT}, which means that the select all
+     * checkbox is only visible for in-memory data.
      */
     public enum SelectAllCheckboxVisibility {
 
         /**
-         * Shows the select all checkbox, if in-memory data is used.
+         * Shows the select all checkbox for in-memory data, and for lazy data
+         * with a known item count, for example when a count callback is
+         * provided. For lazy data with unknown item count, the checkbox is
+         * never shown.
          * <p>
-         * For lazy data, the checkbox is only shown when a count callback has
-         * been provided. For lazy data with unknown count, the checkbox will
-         * never be shown.
-         * <p>
-         * <b>For lazy data, selecting all will result in to all rows being
-         * fetched from backend to application memory!</b>
+         * <b>For lazy data, selecting all fetches all rows from the backend
+         * into application memory!</b>
          */
         VISIBLE,
 
         /**
-         * Never shows the select all checkbox, regardless of data is in-memory
-         * or not (lazy).
+         * Never shows the select all checkbox, regardless of whether the data
+         * is in-memory or lazy.
          */
         HIDDEN,
 


### PR DESCRIPTION
## Description

Related to #10063

- Reworded the `SelectAllCheckboxVisibility.VISIBLE` javadoc so the first sentence no longer says the checkbox is shown only for in-memory data
  - `VISIBLE` also shows the checkbox for lazy data with a known item count, and that sentence was read as "not possible for lazy data" in #10063 and #3462
- Tidied the grammar of the enum and `HIDDEN` javadoc

## Type of change

- Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
