### PR TITLE
fix: send session context in user message instead of a tool

### DIFF
--- a/guidelines/ai-components.md
+++ b/guidelines/ai-components.md
@@ -117,8 +117,15 @@ The group has no `-testbench` module and, apart from `FormFieldMarker`'s
   controller, keeping tool JSON and descriptions decoupled from the
   component type.
 - Instructions the model must always see go into a tool's *description*
-  (the `get_*_instructions` and session-context tools), with `execute()`
-  returning the same text — the model reads the manifest without a call.
+  (the `get_*_instructions` tools), with `execute()` returning the same
+  text — the model reads the manifest without a call.
+- Keep tool definitions identical from turn to turn. LLM providers cache the
+  prompt prefix in the order tools, system prompt, messages, and any change
+  to a tool name, description or schema invalidates all of it. Per-turn
+  content therefore never goes into a tool description or the system
+  prompt: the session context (`Builder.withMetadata`) travels in
+  `LLMRequest.sessionContext()` and the providers append it to the user
+  message, at the very end of the prompt.
 - Tools validate their input eagerly so errors round-trip to the LLM within
   the turn, but stage the result and apply it once in `onResponse(null)`;
   `onResponse(error)` discards the pending state and keeps the last good

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -21,7 +21,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -179,13 +178,6 @@ public class AIOrchestrator implements Serializable {
             CLAIMED_INSTANCES.remove(instance);
         }
     }
-
-    /**
-     * Name of the built-in tool that exposes per-turn session context to the
-     * LLM. Reserved — applications should not register their own tool with this
-     * name.
-     */
-    static final String SESSION_CONTEXT_TOOL_NAME = "get_session_context";
 
     private transient LLMProvider provider;
     private final String systemPrompt;
@@ -742,10 +734,10 @@ public class AIOrchestrator implements Serializable {
             AtomicReference<ResponseMetadata> metadataHolder) {
         final var effectiveSystemPrompt = systemPrompt != null
                 && !systemPrompt.isBlank() ? systemPrompt.trim() : null;
-        var controllerTools = controller != null
+        final var explicitTools = controller != null
                 && controller.getTools() != null ? controller.getTools()
                         : List.<LLMProvider.ToolSpec> of();
-        final var explicitTools = mergeWithContextTool(controllerTools);
+        final var sessionContext = resolveSessionContext();
         return new LLMProvider.LLMRequest() {
 
             @Override
@@ -774,6 +766,11 @@ public class AIOrchestrator implements Serializable {
             }
 
             @Override
+            public String sessionContext() {
+                return sessionContext;
+            }
+
+            @Override
             public Consumer<ResponseMetadata> metadataSink() {
                 return metadataHolder::set;
             }
@@ -781,44 +778,26 @@ public class AIOrchestrator implements Serializable {
     }
 
     /**
-     * Resolves the configured {@link Supplier} for session context and, if it
-     * returns non-empty content, prepends a {@value #SESSION_CONTEXT_TOOL_NAME}
-     * tool that carries that content in its description. The resolved string is
-     * captured in the per-turn tool instance so {@code execute()} can return it
-     * without re-invoking the supplier off the UI thread.
+     * Resolves the configured session context supplier for this turn. The
+     * content travels in {@link LLMProvider.LLMRequest#sessionContext()} and
+     * the provider appends it to the user message, at the very end of the
+     * prompt. That placement is deliberate: LLM providers cache the prompt
+     * prefix in the order tools, system prompt, messages, so per-turn content
+     * carried by a tool description or the system prompt would invalidate the
+     * whole cache on every turn.
      * <p>
      * A supplier that throws aborts the turn — the exception propagates through
      * {@link #buildRequest} and is handled by the existing error path in
      * {@link #processUserInput}.
+     *
+     * @return the context for this turn, or {@code null} when there is none
      */
-    private List<LLMProvider.ToolSpec> mergeWithContextTool(
-            List<LLMProvider.ToolSpec> controllerTools) {
+    private String resolveSessionContext() {
         if (contextSupplier == null) {
-            return controllerTools;
+            return null;
         }
         var resolved = contextSupplier.get();
-        if (resolved == null || resolved.isBlank()) {
-            return controllerTools;
-        }
-        var contextTool = buildSessionContextTool(resolved);
-        var merged = new ArrayList<LLMProvider.ToolSpec>(
-                controllerTools.size() + 1);
-        merged.add(contextTool);
-        merged.addAll(controllerTools);
-        return List.copyOf(merged);
-    }
-
-    /**
-     * Builds the per-turn {@value #SESSION_CONTEXT_TOOL_NAME} tool. The
-     * resolved content is baked into the description so the LLM sees it just
-     * from listing the available tools — no separate call is normally needed.
-     * {@link LLMProvider.ToolSpec#execute} returns the same content so a model
-     * that does call the tool gets exactly what the description already
-     * carries.
-     */
-    private static LLMProvider.ToolSpec buildSessionContextTool(
-            String content) {
-        return new SessionContextTool(content);
+        return resolved == null || resolved.isBlank() ? null : resolved;
     }
 
     private static final DateTimeFormatter DEFAULT_CONTEXT_DATE_TIME_FORMAT = DateTimeFormatter
@@ -839,52 +818,6 @@ public class AIOrchestrator implements Serializable {
                     now.format(DEFAULT_CONTEXT_DATE_TIME_FORMAT), dayOfWeek,
                     now.getZone().getId());
         };
-    }
-
-    /**
-     * Per-turn {@link LLMProvider.ToolSpec} that surfaces the resolved session
-     * context. {@link Serializable} so the orchestrator's per-turn explicit
-     * tools list does not break the serialization round-trip test even though
-     * tools themselves are rebuilt on every turn.
-     */
-    private static final class SessionContextTool
-            implements LLMProvider.ToolSpec, Serializable {
-        private final String content;
-        private final String description;
-
-        SessionContextTool(String content) {
-            this.content = content;
-            this.description = """
-                    Read for current session context. If a date/time is \
-                    included below, use it to resolve relative phrases in \
-                    the user's prompt — "today", "tomorrow", "yesterday", \
-                    "next Friday", "in two weeks", "end of next month", \
-                    etc. — into ISO date / date-time / time strings.
-
-                    Captured at the start of this turn:
-
-                    """ + content;
-        }
-
-        @Override
-        public String getName() {
-            return SESSION_CONTEXT_TOOL_NAME;
-        }
-
-        @Override
-        public String getDescription() {
-            return description;
-        }
-
-        @Override
-        public String getParametersSchema() {
-            return null;
-        }
-
-        @Override
-        public String execute(JsonNode arguments) {
-            return content;
-        }
     }
 
     private void fireResponseListener(String responseText, Throwable error,
@@ -949,11 +882,6 @@ public class AIOrchestrator implements Serializable {
                                 + VALID_TOOL_NAME_PATTERN.pattern() + ").");
             }
             validateParametersSchema(tool);
-            if (SESSION_CONTEXT_TOOL_NAME.equals(name)) {
-                LOGGER.warn(
-                        "Tool name '{}' is reserved for the built-in session context tool",
-                        name);
-            }
             if (!seen.add(name)) {
                 LOGGER.warn(
                         "Duplicate tool name '{}': previous tool will be replaced",
@@ -1167,7 +1095,9 @@ public class AIOrchestrator implements Serializable {
      * context. Defaults to a current-date-and-time supplier so the LLM can
      * interpret relative date/time references; pass {@code null} to disable, or
      * a custom supplier to include tenant, locale, page state, or anything else
-     * worth keeping out of the system prompt.</li>
+     * worth keeping out of the system prompt. The context is appended to the
+     * user message of the turn, so the system prompt and the tool definitions
+     * stay identical from turn to turn.</li>
      * </ul>
      * <p>
      * Both Flow components ({@link MessageInput}, {@link MessageList},
@@ -1529,6 +1459,15 @@ public class AIOrchestrator implements Serializable {
          * Sets the supplier of free-form session context the LLM sees on every
          * turn. The supplier is invoked once per turn on the UI thread when the
          * request is being built.
+         * <p>
+         * The context reaches the provider as
+         * {@link LLMProvider.LLMRequest#sessionContext()}, and the built-in
+         * providers append it to the user message of that turn, after the
+         * user's own text. This keeps the system prompt and the tool
+         * definitions identical from turn to turn, so an LLM provider that
+         * caches the prompt prefix keeps serving them from its cache. The
+         * message list and {@link AIOrchestrator#getHistory()} carry the user's
+         * text only.
          * <p>
          * The supplier may return any string the application wants the LLM to
          * have on hand — current date and time, the active tenant, the user's

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProvider.java
@@ -165,6 +165,28 @@ public interface LLMProvider {
         }
 
         /**
+         * Gets the session context for this turn: free-form text the
+         * application supplies through
+         * {@link com.vaadin.flow.component.ai.orchestrator.AIOrchestrator.Builder#withMetadata(com.vaadin.flow.function.SerializableSupplier)
+         * AIOrchestrator.Builder.withMetadata}, such as the current date and
+         * time, captured when the user sent the message.
+         * <p>
+         * Send it to the model together with the user message, after the user's
+         * text, so that the system prompt and the tool definitions stay
+         * identical from turn to turn and an LLM provider that caches the
+         * prompt prefix keeps hitting its cache. The built-in providers append
+         * it to the user message text in a delimited block. The default returns
+         * {@code null}.
+         *
+         * @return the session context for this turn, or {@code null} when there
+         *         is none
+         * @since 25.3
+         */
+        default String sessionContext() {
+            return null;
+        }
+
+        /**
          * Gets the consumer that receives metadata about the model's response,
          * such as the finish reason and token usage. A provider that observes
          * such metadata passes it to this consumer as the turn progresses —

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -114,6 +114,54 @@ final class LLMProviderHelpers {
     }
 
     /**
+     * Opening tag of the block that carries the per-turn session context at the
+     * end of the user message text, see
+     * {@link #withSessionContext(String, String)}.
+     */
+    static final String SESSION_CONTEXT_OPEN = "<session_context>";
+
+    /**
+     * Closing tag of the session context block.
+     */
+    static final String SESSION_CONTEXT_CLOSE = "</session_context>";
+
+    /**
+     * Note at the start of the session context block telling the model where
+     * the block comes from and, since the default context is the current date
+     * and time, how to use it: models otherwise tend to leave relative dates
+     * such as "tomorrow" or "next Friday" unresolved.
+     */
+    static final String SESSION_CONTEXT_NOTE = "Context captured by the "
+            + "application when this message was sent; it is not part of the "
+            + "request. If it includes a date or time, resolve relative "
+            + "phrases in the message such as \"today\" or \"tomorrow\" "
+            + "against it, into ISO date, date-time or time strings.";
+
+    /**
+     * Appends the session context of the turn, if any, to the user message text
+     * in a delimited block. The block sits at the very end of the prompt, after
+     * everything that stays the same from turn to turn (tool definitions,
+     * system prompt, conversation history), so that a provider caching the
+     * prompt prefix keeps hitting its cache even though the context changes on
+     * every turn.
+     *
+     * @param userMessage
+     *            the user's message text, not {@code null}
+     * @param sessionContext
+     *            the context of the turn, {@code null} or blank for none
+     * @return the text to send as the user message
+     */
+    public static String withSessionContext(String userMessage,
+            String sessionContext) {
+        if (sessionContext == null || sessionContext.isBlank()) {
+            return userMessage;
+        }
+        return userMessage + "\n\n" + SESSION_CONTEXT_OPEN + "\n"
+                + SESSION_CONTEXT_NOTE + "\n" + sessionContext.strip() + "\n"
+                + SESSION_CONTEXT_CLOSE;
+    }
+
+    /**
      * Formats text content as an attachment block.
      *
      * @param fileName

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -126,21 +126,23 @@ final class LLMProviderHelpers {
     static final String SESSION_CONTEXT_CLOSE = "</session_context>";
 
     /**
-     * Note at the start of the session context block telling the model where
-     * the block comes from and, since the default context is the current date
-     * and time, how to use it: models otherwise tend to leave relative dates
-     * such as "tomorrow" or "next Friday" unresolved.
+     * Note at the start of the session context block. It tells the model that
+     * the block is application-supplied rather than the user's words and, since
+     * the default context is the current date and time, how to use it: models
+     * otherwise tend to leave relative dates such as "tomorrow" or "next
+     * Friday" unresolved.
      */
-    static final String SESSION_CONTEXT_NOTE = "Context captured by the "
-            + "application when this message was sent; it is not part of the "
-            + "request. If it includes a date or time, resolve relative "
-            + "phrases in the message such as \"today\" or \"tomorrow\" "
+    static final String SESSION_CONTEXT_NOTE = "Context supplied by the "
+            + "application when this message was sent, not written by the "
+            + "user. If it includes a date or time, resolve relative phrases "
+            + "in the message (\"today\", \"tomorrow\", \"yesterday\", "
+            + "\"next Friday\", \"in two weeks\", \"end of next month\") "
             + "against it, into ISO date, date-time or time strings.";
 
     /**
      * Appends the session context of the turn, if any, to the user message text
-     * in a delimited block. The block sits at the very end of the prompt, after
-     * everything that stays the same from turn to turn (tool definitions,
+     * in a delimited block. The block ends the user message text, which comes
+     * after everything that stays the same from turn to turn (tool definitions,
      * system prompt, conversation history), so that a provider caching the
      * prompt prefix keeps hitting its cache even though the context changes on
      * every turn.

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpers.java
@@ -64,6 +64,32 @@ final class LLMProviderHelpers {
             }""";
 
     /**
+     * Opening tag of the block that carries the per-turn session context at the
+     * end of the user message text, see
+     * {@link #withSessionContext(String, String)}.
+     */
+    static final String SESSION_CONTEXT_OPEN = "<session_context>";
+
+    /**
+     * Closing tag of the session context block.
+     */
+    static final String SESSION_CONTEXT_CLOSE = "</session_context>";
+
+    /**
+     * Note at the start of the session context block. It tells the model that
+     * the block is application-supplied rather than the user's words and, since
+     * the default context is the current date and time, how to use it: models
+     * otherwise tend to leave relative dates such as "tomorrow" or "next
+     * Friday" unresolved.
+     */
+    static final String SESSION_CONTEXT_NOTE = "Context supplied by the "
+            + "application when this message was sent, not written by the "
+            + "user. If it includes a date or time, resolve relative phrases "
+            + "in the message (\"today\", \"tomorrow\", \"yesterday\", "
+            + "\"next Friday\", \"in two weeks\", \"end of next month\") "
+            + "against it, into ISO date, date-time or time strings.";
+
+    /**
      * Tells whether a tool declares parameters. A tool whose schema is
      * {@code null} or blank takes none: the provider declares
      * {@link #NO_PARAMETERS_SCHEMA} to the LLM in its place and passes an empty
@@ -112,32 +138,6 @@ final class LLMProviderHelpers {
     public static String getBase64Data(byte[] data) {
         return Base64.getEncoder().encodeToString(data);
     }
-
-    /**
-     * Opening tag of the block that carries the per-turn session context at the
-     * end of the user message text, see
-     * {@link #withSessionContext(String, String)}.
-     */
-    static final String SESSION_CONTEXT_OPEN = "<session_context>";
-
-    /**
-     * Closing tag of the session context block.
-     */
-    static final String SESSION_CONTEXT_CLOSE = "</session_context>";
-
-    /**
-     * Note at the start of the session context block. It tells the model that
-     * the block is application-supplied rather than the user's words and, since
-     * the default context is the current date and time, how to use it: models
-     * otherwise tend to leave relative dates such as "tomorrow" or "next
-     * Friday" unresolved.
-     */
-    static final String SESSION_CONTEXT_NOTE = "Context supplied by the "
-            + "application when this message was sent, not written by the "
-            + "user. If it includes a date or time, resolve relative phrases "
-            + "in the message (\"today\", \"tomorrow\", \"yesterday\", "
-            + "\"next Friday\", \"in two weeks\", \"end of next month\") "
-            + "against it, into ISO date, date-time or time strings.";
 
     /**
      * Appends the session context of the turn, if any, to the user message text

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProvider.java
@@ -570,7 +570,8 @@ public class LangChain4JLLMProvider implements LLMProvider {
 
     private UserMessage buildUserMessage(LLMRequest request) {
         var contents = new ArrayList<Content>();
-        contents.add(TextContent.from(request.userMessage()));
+        contents.add(TextContent.from(LLMProviderHelpers.withSessionContext(
+                request.userMessage(), request.sessionContext())));
         var attachments = request.attachments();
         if (attachments != null) {
             attachments.stream()

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/provider/SpringAILLMProvider.java
@@ -470,7 +470,8 @@ public class SpringAILLMProvider implements LLMProvider {
                     a -> a.param(ChatMemory.CONVERSATION_ID, CONVERSATION_ID));
         }
         promptSpec = promptSpec.user(userSpec -> {
-            userSpec.text(request.userMessage());
+            userSpec.text(LLMProviderHelpers.withSessionContext(
+                    request.userMessage(), request.sessionContext()));
             var media = buildMedia(request);
             if (media.length != 0) {
                 userSpec.media(media);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -2710,7 +2710,7 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void prompt_byDefault_includesSessionContextToolWithCurrentDateTime() {
+    void prompt_byDefault_sessionContextCarriesCurrentDateTime() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2722,66 +2722,63 @@ class AIOrchestratorTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        var tools = captor.getValue().explicitTools();
-        Assertions.assertEquals(1, tools.size());
-        var contextTool = tools.get(0);
-        Assertions.assertEquals("get_session_context", contextTool.getName());
-        Assertions.assertTrue(
-                contextTool.getDescription()
-                        .contains("Current server date and time:"),
+        var context = captor.getValue().sessionContext();
+        Assertions.assertNotNull(context,
+                "Default supplier should provide session context");
+        Assertions.assertTrue(context.contains("Current server date and time:"),
                 "Default supplier should render a date/time line; got: "
-                        + contextTool.getDescription());
+                        + context);
     }
 
     @Test
-    void sessionContextToolDescription_carriesRelativeDateGuidance() {
-        // Real LLMs often leave date fields empty on the first turn when the
-        // user writes "tomorrow" or "next Friday" because nothing in the
-        // tool surface tells them to anchor relative phrases against the
-        // date that the session-context tool carries. Pin the load-bearing
-        // phrases that close that gap; a regression here re-opens it.
+    void prompt_withSessionContext_toolsSystemPromptAndUserMessageUnchanged() {
+        // The context must not travel in the tool manifest or the system
+        // prompt: LLM providers cache the prompt prefix in the order tools,
+        // system prompt, messages, and a tool description that changes every
+        // turn invalidates all of it. The provider appends the context to the
+        // user text it sends, so the request keeps the user's own words.
+        stubAddMessage();
+        Mockito.when(
+                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
+                .thenReturn(Flux.just("Response"));
+
+        var tool1 = createToolSpec("tool1", "First controller tool");
+        var controller = createController(tool1);
+        var orchestrator = AIOrchestrator.builder(mockProvider, "Be brief")
+                .withMessageList(mockMessageList).withController(controller)
+                .withMetadata(() -> "Tenant: acme").build();
+        orchestrator.prompt("Hello");
+
+        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
+        Mockito.verify(mockProvider).stream(captor.capture());
+        var request = captor.getValue();
+        Assertions.assertEquals(List.of("tool1"), request.explicitTools()
+                .stream().map(LLMProvider.ToolSpec::getName).toList());
+        Assertions.assertEquals("Be brief", request.systemPrompt());
+        Assertions.assertEquals("Hello", request.userMessage());
+        Assertions.assertEquals("Tenant: acme", request.sessionContext());
+    }
+
+    @Test
+    void prompt_withSessionContext_historyAndMessageListKeepUserText() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
                 .thenReturn(Flux.just("Response"));
 
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).build();
+                .withMessageList(mockMessageList)
+                .withMetadata(() -> "Tenant: acme").build();
         orchestrator.prompt("Hello");
 
-        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
-        Mockito.verify(mockProvider).stream(captor.capture());
-        var description = captor.getValue().explicitTools().getFirst()
-                .getDescription();
-
-        for (var anchor : List.of("relative", "tomorrow", "ISO", "phrase")) {
-            Assertions.assertTrue(description.contains(anchor),
-                    "Description must mention '" + anchor + "', got: "
-                            + description);
-        }
+        Assertions.assertEquals("Hello",
+                orchestrator.getHistory().getFirst().content());
+        Mockito.verify(mockMessageList).addMessage(Mockito.eq("Hello"),
+                Mockito.anyString(), Mockito.anyList());
     }
 
     @Test
-    void sessionContextTool_declaresNoParameters() {
-        // A null schema tells the provider the tool takes no parameters; the
-        // provider substitutes its placeholder schema in the LLM request.
-        stubAddMessage();
-        Mockito.when(
-                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
-                .thenReturn(Flux.just("Response"));
-
-        var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).build();
-        orchestrator.prompt("Hello");
-
-        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
-        Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertNull(captor.getValue().explicitTools().getFirst()
-                .getParametersSchema());
-    }
-
-    @Test
-    void prompt_withCustomContextSupplier_replacesDefaultAndExposesContent() {
+    void prompt_withCustomContextSupplier_replacesDefault() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2794,24 +2791,13 @@ class AIOrchestratorTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        var tools = captor.getValue().explicitTools();
-        Assertions.assertEquals(1, tools.size());
-        var contextTool = tools.get(0);
-        Assertions.assertTrue(
-                contextTool.getDescription().contains("Tenant: acme"),
-                "Custom supplier value should appear in the description; got: "
-                        + contextTool.getDescription());
-        Assertions.assertFalse(
-                contextTool.getDescription()
-                        .contains("Current server date and time:"),
-                "Custom supplier should fully replace the default; got: "
-                        + contextTool.getDescription());
-        Assertions.assertEquals("Tenant: acme", contextTool.execute(null),
-                "execute should return the same content the description shows");
+        Assertions.assertEquals("Tenant: acme",
+                captor.getValue().sessionContext(),
+                "Custom supplier should fully replace the default");
     }
 
     @Test
-    void prompt_withNullContext_omitsSessionContextTool() {
+    void prompt_withNullContext_omitsSessionContext() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2823,12 +2809,12 @@ class AIOrchestratorTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
-                "withMetadata(null) should suppress the built-in tool");
+        Assertions.assertNull(captor.getValue().sessionContext(),
+                "withMetadata(null) should suppress the built-in context");
     }
 
     @Test
-    void prompt_withMetadataSupplierReturningBlank_omitsSessionContextTool() {
+    void prompt_withMetadataSupplierReturningBlank_omitsSessionContext() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2841,12 +2827,12 @@ class AIOrchestratorTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
-                "Empty/blank supplier output should suppress the tool for that turn");
+        Assertions.assertNull(captor.getValue().sessionContext(),
+                "Empty/blank supplier output should suppress the context for that turn");
     }
 
     @Test
-    void prompt_withMetadataSupplierReturningNull_omitsSessionContextTool() {
+    void prompt_withMetadataSupplierReturningNull_omitsSessionContext() {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
@@ -2859,30 +2845,8 @@ class AIOrchestratorTest {
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
-                "Null supplier output should suppress the tool for that turn");
-    }
-
-    @Test
-    void prompt_withMetadataAndController_mergesContextFirst() {
-        stubAddMessage();
-        Mockito.when(
-                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
-                .thenReturn(Flux.just("Response"));
-
-        var tool1 = createToolSpec("tool1", "First controller tool");
-        var controller = createController(tool1);
-        var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withController(controller)
-                .withMetadata(() -> "Tenant: acme").build();
-        orchestrator.prompt("Hello");
-
-        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
-        Mockito.verify(mockProvider).stream(captor.capture());
-        var tools = captor.getValue().explicitTools();
-        Assertions.assertEquals(2, tools.size());
-        Assertions.assertEquals("get_session_context", tools.get(0).getName());
-        Assertions.assertEquals("tool1", tools.get(1).getName());
+        Assertions.assertNull(captor.getValue().sessionContext(),
+                "Null supplier output should suppress the context for that turn");
     }
 
     @Test
@@ -2984,22 +2948,6 @@ class AIOrchestratorTest {
 
         Assertions.assertTrue(warning.isPresent(),
                 "Expected duplicate tool name warning");
-    }
-
-    @Test
-    void withController_reservedSessionContextToolName_logsWarning() {
-        var reserved = createToolSpec("get_session_context", "Clashing tool");
-        AIController controller = createController(reserved);
-
-        AIOrchestrator.builder(mockProvider, null).withController(controller);
-
-        var warning = logger.getLoggingEvents().stream()
-                .filter(event -> event.getMessage().equals(
-                        "Tool name '{}' is reserved for the built-in session context tool"))
-                .findFirst();
-
-        Assertions.assertTrue(warning.isPresent(),
-                "Using the reserved tool name should log a warning");
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.Assertions;
@@ -2728,6 +2729,9 @@ class AIOrchestratorTest {
         Assertions.assertTrue(context.contains("Current server date and time:"),
                 "Default supplier should render a date/time line; got: "
                         + context);
+        Assertions.assertTrue(captor.getValue().explicitTools().isEmpty(),
+                "Session context must not be delivered as a tool; got: "
+                        + captor.getValue().explicitTools());
     }
 
     @Test
@@ -2760,17 +2764,24 @@ class AIOrchestratorTest {
     }
 
     @Test
-    void prompt_withSessionContext_historyAndMessageListKeepUserText() {
+    void prompt_withSessionContext_keepsUserFacingTextClean() {
+        // The context is for the provider only: what the user sees, what a
+        // RequestListener is told, and what getHistory() returns must stay
+        // the text the user actually wrote.
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
                 .thenReturn(Flux.just("Response"));
 
+        var received = new ArrayList<String>();
         var orchestrator = AIOrchestrator.builder(mockProvider, null)
                 .withMessageList(mockMessageList)
-                .withMetadata(() -> "Tenant: acme").build();
+                .withMetadata(() -> "Tenant: acme").withRequestListener(
+                        event -> received.add(event.getUserMessage()))
+                .build();
         orchestrator.prompt("Hello");
 
+        Assertions.assertEquals(List.of("Hello"), received);
         Assertions.assertEquals("Hello",
                 orchestrator.getHistory().getFirst().content());
         Mockito.verify(mockMessageList).addMessage(Mockito.eq("Hello"),
@@ -2798,55 +2809,38 @@ class AIOrchestratorTest {
 
     @Test
     void prompt_withNullContext_omitsSessionContext() {
-        stubAddMessage();
-        Mockito.when(
-                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
-                .thenReturn(Flux.just("Response"));
-
-        var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withMetadata(null).build();
-        orchestrator.prompt("Hello");
-
-        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
-        Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertNull(captor.getValue().sessionContext(),
-                "withMetadata(null) should suppress the built-in context");
+        assertNoSessionContext(builder -> builder.withMetadata(null));
     }
 
     @Test
     void prompt_withMetadataSupplierReturningBlank_omitsSessionContext() {
-        stubAddMessage();
-        Mockito.when(
-                mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
-                .thenReturn(Flux.just("Response"));
-
-        var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withMetadata(() -> "   ")
-                .build();
-        orchestrator.prompt("Hello");
-
-        var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
-        Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertNull(captor.getValue().sessionContext(),
-                "Empty/blank supplier output should suppress the context for that turn");
+        assertNoSessionContext(builder -> builder.withMetadata(() -> "   "));
     }
 
     @Test
     void prompt_withMetadataSupplierReturningNull_omitsSessionContext() {
+        assertNoSessionContext(builder -> builder.withMetadata(() -> null));
+    }
+
+    /**
+     * Prompts an orchestrator configured by {@code configure} and asserts that
+     * the request it sent carried no session context.
+     */
+    private void assertNoSessionContext(
+            UnaryOperator<AIOrchestrator.Builder> configure) {
         stubAddMessage();
         Mockito.when(
                 mockProvider.stream(Mockito.any(LLMProvider.LLMRequest.class)))
                 .thenReturn(Flux.just("Response"));
 
-        var orchestrator = AIOrchestrator.builder(mockProvider, null)
-                .withMessageList(mockMessageList).withMetadata(() -> null)
+        var orchestrator = configure.apply(AIOrchestrator
+                .builder(mockProvider, null).withMessageList(mockMessageList))
                 .build();
         orchestrator.prompt("Hello");
 
         var captor = ArgumentCaptor.forClass(LLMProvider.LLMRequest.class);
         Mockito.verify(mockProvider).stream(captor.capture());
-        Assertions.assertNull(captor.getValue().sessionContext(),
-                "Null supplier output should suppress the context for that turn");
+        Assertions.assertNull(captor.getValue().sessionContext());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpersTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpersTest.java
@@ -37,6 +37,16 @@ class LLMProviderHelpersTest {
                 result.endsWith("\nTenant: acme\n"
                         + LLMProviderHelpers.SESSION_CONTEXT_CLOSE),
                 "Context must be the last thing in the block; got: " + result);
+        // The note's wording is tuned freely and deliberately not pinned
+        // here; what the block must always do is introduce the context
+        // with one.
+        var block = result.substring(
+                result.indexOf(LLMProviderHelpers.SESSION_CONTEXT_OPEN)
+                        + LLMProviderHelpers.SESSION_CONTEXT_OPEN.length(),
+                result.lastIndexOf(LLMProviderHelpers.SESSION_CONTEXT_CLOSE));
+        Assertions.assertFalse(block.replace("Tenant: acme", "").isBlank(),
+                "The block must introduce the context with a note; got: "
+                        + result);
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpersTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpersTest.java
@@ -29,27 +29,14 @@ class LLMProviderHelpersTest {
         var result = LLMProviderHelpers.withSessionContext("Hello",
                 "Tenant: acme");
 
-        Assertions.assertTrue(result.startsWith("Hello\n\n<session_context>\n"),
+        Assertions.assertTrue(
+                result.startsWith("Hello\n\n"
+                        + LLMProviderHelpers.SESSION_CONTEXT_OPEN + "\n"),
                 "Context block must follow the user's text; got: " + result);
         Assertions.assertTrue(
-                result.endsWith("\nTenant: acme\n</session_context>"),
+                result.endsWith("\nTenant: acme\n"
+                        + LLMProviderHelpers.SESSION_CONTEXT_CLOSE),
                 "Context must be the last thing in the block; got: " + result);
-    }
-
-    @Test
-    void withSessionContext_carriesRelativeDateGuidance() {
-        // Real LLMs often leave date fields empty when the user writes
-        // "tomorrow" or "next Friday" unless something tells them to anchor
-        // relative phrases against the date the context carries. Pin the
-        // phrases that close that gap; a regression here re-opens it.
-        var result = LLMProviderHelpers.withSessionContext("Hello",
-                "Current server date and time: 2026-05-28T17:42+03:00");
-
-        for (var anchor : new String[] { "relative", "tomorrow", "ISO",
-                "phrase" }) {
-            Assertions.assertTrue(result.contains(anchor),
-                    "Block must mention '" + anchor + "', got: " + result);
-        }
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpersTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LLMProviderHelpersTest.java
@@ -25,6 +25,42 @@ import com.vaadin.flow.component.ai.common.AIAttachment;
 class LLMProviderHelpersTest {
 
     @Test
+    void withSessionContext_appendsDelimitedBlockAfterUserText() {
+        var result = LLMProviderHelpers.withSessionContext("Hello",
+                "Tenant: acme");
+
+        Assertions.assertTrue(result.startsWith("Hello\n\n<session_context>\n"),
+                "Context block must follow the user's text; got: " + result);
+        Assertions.assertTrue(
+                result.endsWith("\nTenant: acme\n</session_context>"),
+                "Context must be the last thing in the block; got: " + result);
+    }
+
+    @Test
+    void withSessionContext_carriesRelativeDateGuidance() {
+        // Real LLMs often leave date fields empty when the user writes
+        // "tomorrow" or "next Friday" unless something tells them to anchor
+        // relative phrases against the date the context carries. Pin the
+        // phrases that close that gap; a regression here re-opens it.
+        var result = LLMProviderHelpers.withSessionContext("Hello",
+                "Current server date and time: 2026-05-28T17:42+03:00");
+
+        for (var anchor : new String[] { "relative", "tomorrow", "ISO",
+                "phrase" }) {
+            Assertions.assertTrue(result.contains(anchor),
+                    "Block must mention '" + anchor + "', got: " + result);
+        }
+    }
+
+    @Test
+    void withSessionContext_withoutContext_returnsUserTextUnchanged() {
+        Assertions.assertEquals("Hello",
+                LLMProviderHelpers.withSessionContext("Hello", null));
+        Assertions.assertEquals("Hello",
+                LLMProviderHelpers.withSessionContext("Hello", "   "));
+    }
+
+    @Test
     void decodeAsUtf8_withValidUtf8_strictMode_returnsDecodedString() {
         var data = getValidUtf8Data();
         var input = new String(data, StandardCharsets.UTF_8);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1791,6 +1791,39 @@ class LangChain4JLLMProviderTest {
         Assertions.assertTrue(names.contains("getHumidity"));
     }
 
+    @Test
+    void stream_withSessionContext_appendsContextToUserMessageText() {
+        var request = new TestLLMRequestWithSessionContext("Hello",
+                "Tenant: acme");
+        var response = mockSimpleResponse("Hi");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(request).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel).chat(captor.capture());
+        var userMessage = (UserMessage) captor.getValue().messages().getFirst();
+        var text = userMessage.singleText();
+        Assertions.assertTrue(text.startsWith("Hello\n\n<session_context>"),
+                "Context must follow the user's text; got: " + text);
+        Assertions.assertTrue(text.contains("Tenant: acme"), text);
+    }
+
+    @Test
+    void stream_withoutSessionContext_sendsUserMessageTextAsIs() {
+        var response = mockSimpleResponse("Hi");
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class)))
+                .thenReturn(response);
+
+        provider.stream(createSimpleRequest("Hello")).blockFirst();
+
+        var captor = ArgumentCaptor.forClass(ChatRequest.class);
+        Mockito.verify(mockChatModel).chat(captor.capture());
+        var userMessage = (UserMessage) captor.getValue().messages().getFirst();
+        Assertions.assertEquals("Hello", userMessage.singleText());
+    }
+
     private static LLMProvider.ToolSpec createExplicitTool(String name,
             String description, String parametersSchema,
             java.util.function.Function<JsonNode, String> executor) {
@@ -2208,6 +2241,24 @@ class LangChain4JLLMProviderTest {
     private record TestLLMRequestWithExplicitTools(String userMessage,
             String systemPrompt, List<AIAttachment> attachments, Object[] tools,
             List<LLMProvider.ToolSpec> explicitTools) implements LLMRequest {
+    }
+
+    private record TestLLMRequestWithSessionContext(String userMessage,
+            String sessionContext) implements LLMRequest {
+        @Override
+        public List<AIAttachment> attachments() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String systemPrompt() {
+            return null;
+        }
+
+        @Override
+        public Object[] tools() {
+            return new Object[0];
+        }
     }
 
     private static class SampleToolsClass {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/LangChain4JLLMProviderTest.java
@@ -1804,10 +1804,9 @@ class LangChain4JLLMProviderTest {
         var captor = ArgumentCaptor.forClass(ChatRequest.class);
         Mockito.verify(mockChatModel).chat(captor.capture());
         var userMessage = (UserMessage) captor.getValue().messages().getFirst();
-        var text = userMessage.singleText();
-        Assertions.assertTrue(text.startsWith("Hello\n\n<session_context>"),
-                "Context must follow the user's text; got: " + text);
-        Assertions.assertTrue(text.contains("Tenant: acme"), text);
+        Assertions.assertEquals(
+                LLMProviderHelpers.withSessionContext("Hello", "Tenant: acme"),
+                userMessage.singleText());
     }
 
     @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1666,6 +1666,35 @@ class SpringAILLMProviderTest {
                 List.of(new Generation(assistantMessage, metadata)));
     }
 
+    @Test
+    void stream_withSessionContext_appendsContextToUserMessageText() {
+        provider.setStreaming(false);
+        var request = new TestLLMRequestWithSessionContext("Hello",
+                "Tenant: acme");
+        mockSimpleChat("Hi");
+
+        provider.stream(request).blockFirst();
+
+        var userMessage = (UserMessage) capturePrompt().getInstructions()
+                .getFirst();
+        var text = userMessage.getText();
+        Assertions.assertTrue(text.startsWith("Hello\n\n<session_context>"),
+                "Context must follow the user's text; got: " + text);
+        Assertions.assertTrue(text.contains("Tenant: acme"), text);
+    }
+
+    @Test
+    void stream_withoutSessionContext_sendsUserMessageTextAsIs() {
+        provider.setStreaming(false);
+        mockSimpleChat("Hi");
+
+        provider.stream(createSimpleRequest("Hello")).blockFirst();
+
+        var userMessage = (UserMessage) capturePrompt().getInstructions()
+                .getFirst();
+        Assertions.assertEquals("Hello", userMessage.getText());
+    }
+
     private static LLMRequest createSimpleRequest(String message) {
         return new TestLLMRequest(message, null, Collections.emptyList(),
                 new Object[0]);
@@ -2466,6 +2495,24 @@ class SpringAILLMProviderTest {
     private record TestLLMRequestWithExplicitTools(String userMessage,
             String systemPrompt, List<AIAttachment> attachments, Object[] tools,
             List<LLMProvider.ToolSpec> explicitTools) implements LLMRequest {
+    }
+
+    private record TestLLMRequestWithSessionContext(String userMessage,
+            String sessionContext) implements LLMRequest {
+        @Override
+        public List<AIAttachment> attachments() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String systemPrompt() {
+            return null;
+        }
+
+        @Override
+        public Object[] tools() {
+            return new Object[0];
+        }
     }
 
     private static class SampleToolsClass {

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/provider/SpringAILLMProviderTest.java
@@ -1677,10 +1677,9 @@ class SpringAILLMProviderTest {
 
         var userMessage = (UserMessage) capturePrompt().getInstructions()
                 .getFirst();
-        var text = userMessage.getText();
-        Assertions.assertTrue(text.startsWith("Hello\n\n<session_context>"),
-                "Context must follow the user's text; got: " + text);
-        Assertions.assertTrue(text.contains("Tenant: acme"), text);
+        Assertions.assertEquals(
+                LLMProviderHelpers.withSessionContext("Hello", "Tenant: acme"),
+                userMessage.getText());
     }
 
     @Test


### PR DESCRIPTION
## Description

The default context supplier renders the server clock to the minute into the description of a synthetic tool placed first in the tool list. Providers cache the prompt prefix in the order tools, system prompt, messages, so the tools block changed every minute and each new turn missed the cache for the whole prefix, system prompt and history included.

- Added `LLMRequest.sessionContext()`, a default method carrying the context from `Builder.withMetadata` for the turn; the orchestrator no longer wraps it in a `get_session_context` tool
  - Custom `LLMProvider` implementations read the context from there; it no longer arrives through `explicitTools()`
- Appended the context to the user message text in both built-in providers, inside a `<session_context>` block with a short note telling the model the text is application-supplied and how to resolve relative dates against it
- Kept `LLMRequest.userMessage()`, the message list, `RequestListener` and `getHistory()` at the text the user wrote
- Removed the reserved-name warning for `get_session_context`
- Documented in `guidelines/ai-components.md` that tool definitions stay identical from turn to turn and per-turn content goes to the end of the prompt
- Replaced the session context tool tests with tests for `LLMRequest.sessionContext()`, the helper's block placement and both providers' user message text

## Type of change

- Bugfix