### PR TITLE
fix: discover form fields inside Composite components

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasValue;
@@ -83,7 +84,8 @@ import tools.jackson.databind.JsonNode;
  * The controller accepts any {@link HasComponents} container. It discovers
  * fields by walking the container's component tree and collecting every
  * component that implements {@link HasValue}. The walk recurses into nested
- * {@link HasComponents} children so layouts containing layouts are handled.
+ * {@link HasComponents} and {@link Composite} children so layouts containing
+ * layouts, and fields wrapped in reusable composites, are handled.
  * </p>
  *
  * <p>

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldDiscovery.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormFieldDiscovery.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasValue;
 
@@ -29,8 +30,9 @@ final class FormFieldDiscovery {
 
     /**
      * Collects every {@link HasValue} component reachable from the given root,
-     * recursing through any {@link HasComponents} children so layouts
-     * containing layouts are handled.
+     * recursing through any {@link HasComponents} and {@link Composite}
+     * children so layouts containing layouts, and fields wrapped in reusable
+     * composites, are handled.
      *
      * @param root
      *            the component to walk, not {@code null}
@@ -46,12 +48,16 @@ final class FormFieldDiscovery {
     private static void collect(Component component,
             List<HasValue<?, ?>> sink) {
         component.getChildren().forEach(child -> {
-            // A component that is both HasValue and HasComponents is treated
-            // as a leaf field — its children are considered part of the
-            // field's internal composition, not separate form fields.
+            // A component that is both HasValue and HasComponents (or a
+            // Composite) is treated as a leaf field — its children are
+            // considered part of the field's internal composition, not
+            // separate form fields.
             if (child instanceof HasValue<?, ?> hv) {
                 sink.add(hv);
-            } else if (child instanceof HasComponents) {
+            } else if (child instanceof HasComponents
+                    || child instanceof Composite) {
+                // Composite exposes its content as its only child, so the
+                // walk reaches the fields inside a reusable composite.
                 collect(child, sink);
             }
         });

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.ai.form.FormTestFields.BigDecField;
@@ -73,6 +74,18 @@ class FillFormToolTest {
 
     @RegisterExtension
     MockUIExtension ui = new MockUIExtension();
+
+    @Test
+    void fillWritesIntoFieldInsideComposite() {
+        var inner = new TestField();
+        var controller = newController(new FieldGroup(inner));
+        controller.onRequest(requestEvent());
+
+        var result = fillFormResult(controller, payload(inner, "\"filled\""));
+
+        Assertions.assertTrue(success(result), "Result: " + result);
+        Assertions.assertEquals("filled", inner.getValue());
+    }
 
     @Test
     void fillForm_responseFieldsBlockMirrorsGetFormStateForAllVisibleFields() {
@@ -2154,6 +2167,13 @@ class FillFormToolTest {
      * required: {@code executeFill} throws {@link IllegalStateException} on a
      * detached form, matching the production contract.
      */
+    /** Reusable group of fields built the recommended way. */
+    private static class FieldGroup extends Composite<Div> {
+        FieldGroup(Component... children) {
+            getContent().add(children);
+        }
+    }
+
     private FormAIController newController(Component... fields) {
         var form = new Div(fields);
         ui.add(form);

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FormAIControllerTest.java
@@ -35,6 +35,7 @@ import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.HasValue;
@@ -301,6 +302,112 @@ class FormAIControllerTest {
                             + "should be discovered as a single field; its "
                             + "internal children should not be exposed as "
                             + "separate form fields");
+        }
+
+        @Test
+        void fieldsInsideCompositeAreDiscoveredInDocumentOrder() {
+            var before = new TestField();
+            var inner1 = new TestField();
+            var inner2 = new TestField();
+            var after = new TestField();
+            var composite = new FieldGroup(inner1, inner2);
+            var form = new Div(before, composite, after);
+
+            Assertions.assertEquals(List.of(before, inner1, inner2, after),
+                    FormFieldDiscovery.collectFields(form),
+                    "A Composite does not implement HasComponents, but the "
+                            + "fields in its content are part of the form");
+        }
+
+        @Test
+        void fieldsInsideNestedCompositesAreDiscovered() {
+            var deep = new TestField();
+            var form = new Div(new FieldGroup(new Div(new FieldGroup(deep))));
+
+            Assertions.assertEquals(List.of(deep),
+                    FormFieldDiscovery.collectFields(form));
+        }
+
+        @Test
+        void compositeWhoseContentIsAFieldContributesThatField() {
+            var field = new TestField();
+            var wrapper = new Composite<TestField>() {
+                @Override
+                protected TestField initContent() {
+                    return field;
+                }
+            };
+            var form = new Div(wrapper);
+
+            Assertions.assertEquals(List.of(field),
+                    FormFieldDiscovery.collectFields(form));
+        }
+
+        @Test
+        void compositeImplementingHasValueIsTreatedAsLeaf() {
+            var innerChild = new TestField();
+            var compositeField = new CompositeValueField(innerChild);
+            var form = new Div(compositeField);
+
+            Assertions.assertEquals(List.of(compositeField),
+                    FormFieldDiscovery.collectFields(form),
+                    "A Composite that is itself a field is discovered as one "
+                            + "field; its content is its internal composition");
+        }
+
+        /** Reusable group of fields built the recommended way. */
+        private static class FieldGroup extends Composite<Div> {
+            FieldGroup(Component... children) {
+                getContent().add(children);
+            }
+        }
+
+        /** A Composite that is itself the field, wrapping an inner one. */
+        private static class CompositeValueField extends Composite<Div>
+                implements HasValue<HasValue.ValueChangeEvent<String>, String> {
+            private String value = "";
+
+            CompositeValueField(Component... children) {
+                getContent().add(children);
+            }
+
+            @Override
+            public void setValue(String value) {
+                this.value = value;
+            }
+
+            @Override
+            public String getValue() {
+                return value;
+            }
+
+            @Override
+            public Registration addValueChangeListener(
+                    ValueChangeListener<? super ValueChangeEvent<String>> listener) {
+                return () -> {
+                    // no events in this fixture
+                };
+            }
+
+            @Override
+            public void setReadOnly(boolean readOnly) {
+                // read-only state not modelled
+            }
+
+            @Override
+            public boolean isReadOnly() {
+                return false;
+            }
+
+            @Override
+            public void setRequiredIndicatorVisible(boolean visible) {
+                // required indicator not modelled
+            }
+
+            @Override
+            public boolean isRequiredIndicatorVisible() {
+                return false;
+            }
         }
 
         @Test


### PR DESCRIPTION
## Description

Fixes #10080

- `FormAIController` now discovers fields inside `Composite` components, which the field walker skipped because `Composite` does not implement `HasComponents`
  - A `Composite` that is itself a `HasValue` is still treated as one field, as before
- Updated the controller Javadoc to describe the walk
- Added unit tests for fields in a Composite, nested Composites, a Composite whose content is the field, and a `fill_form` write into such a field

## Type of change

- Bugfix