### PR TITLE
feat: use component id as form field id when set

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -104,6 +104,16 @@ import tools.jackson.databind.JsonNode;
  * </p>
  *
  * <p>
+ * <b>Field ids:</b> the LLM addresses fields by id. A field that has a
+ * {@link Component#setId(String) component id} when the controller first
+ * discovers it (at the latest on the first prompt) is addressed by that id, so
+ * conversation logs and tool calls stay readable and reproducible across runs.
+ * Component ids must be unique within the form. A field without one gets a
+ * random id. Either way the id is fixed for the rest of the session; setting or
+ * changing the component id later has no effect on it.
+ * </p>
+ *
+ * <p>
  * <b>Hiding field values:</b> {@link #setFieldValuesHidden(boolean)} keeps the
  * current value of every field private while still letting the LLM see and fill
  * the fields — useful when the form may already hold data the AI should not
@@ -207,9 +217,11 @@ public class FormAIController implements AIController {
             .getLogger(FormAIController.class);
 
     /**
-     * Key under which a field's opaque id is stored on the field component via
-     * {@link ComponentUtil#setData(Component, String, Object)}. The id survives
-     * removing and re-adding the field within a session.
+     * Key under which a field's id is stored on the field component via
+     * {@link ComponentUtil#setData(Component, String, Object)}. The id is the
+     * component's own {@link Component#getId() id} when one is set at first
+     * discovery, and a random one otherwise. It survives removing and re-adding
+     * the field within a session.
      */
     static final String FIELD_ID_KEY = "vaadin.ai.form.fieldId";
 
@@ -265,8 +277,8 @@ public class FormAIController implements AIController {
             mentioned is set and "rejected" is empty.
 
             Conventions:
-            - Field ids are opaque session-scoped strings; never invent them \
-            and never reuse an id across forms.
+            - Field ids are strings the application assigns; never invent \
+            them and never reuse an id across forms.
             - Fields the application has hidden via .ignoreField() (and \
             password fields) never appear in get_form_state and cannot be \
             written by fill_form. Do not try, even if the user message asks \
@@ -1658,7 +1670,11 @@ public class FormAIController implements AIController {
         }
         var id = (String) ComponentUtil.getData(component, FIELD_ID_KEY);
         if (id == null) {
-            id = UUID.randomUUID().toString();
+            // The application's own id, when it set one, keeps tool calls
+            // and conversation logs readable and reproducible across runs;
+            // a random id is only the fallback for anonymous fields.
+            id = component.getId().filter(s -> !s.isBlank())
+                    .orElseGet(() -> UUID.randomUUID().toString());
             ComponentUtil.setData(component, FIELD_ID_KEY, id);
         }
         return id;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -248,8 +248,8 @@ public class FormAIController implements AIController {
             Form-fill workflow. Follow this for every turn:
 
             1. Call get_form_state() to see the form. Each field carries an \
-            opaque id, a description, a JSON-Schema-like type block (type, \
-            plus format / pattern / enum / queryable / array / items as \
+            id, a description, a JSON-Schema-like type block (type, plus \
+            format / pattern / enum / queryable / array / items as \
             applicable), and its current value.
             2. For each field you intend to write that declares "queryable": \
             true (single-select) or "items": {"queryable": true} \

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -108,8 +108,9 @@ import tools.jackson.databind.JsonNode;
  * {@link Component#setId(String) component id} when the controller first
  * discovers it (at the latest on the first prompt) is addressed by that id, so
  * conversation logs and tool calls stay readable and reproducible across runs.
- * Component ids must be unique within the form. A field without one gets a
- * random id. Either way the id is fixed for the rest of the session; setting or
+ * Component ids must be unique within the form. A field without one is
+ * addressed by a random id that is kept internally and never set on the
+ * component. Either way the id is fixed for the rest of the session; setting or
  * changing the component id later has no effect on it.
  * </p>
  *

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/IdStorageTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/IdStorageTest.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.flow.component.ai.form;
 
+import static com.vaadin.flow.component.ai.form.FormTestSupport.formStateFields;
 import static com.vaadin.flow.component.ai.form.FormTestSupport.idOf;
 
 import org.junit.jupiter.api.Assertions;
@@ -83,6 +84,58 @@ class IdStorageTest {
 
         Assertions.assertNotEquals(idOf(a), idOf(b),
                 "Two distinct Components must get distinct field ids");
+    }
+
+    @Test
+    void componentIdIsUsedAsFieldId() {
+        var field = new TestField();
+        field.setId("first-name");
+        var controller = new FormAIController(new Div(field));
+        controller.describeField(field, "X");
+
+        Assertions.assertEquals("first-name", idOf(field),
+                "A field with a component id must be addressed by that id");
+    }
+
+    @Test
+    void componentIdIsUsedInFormState() {
+        var field = new TestField();
+        field.setId("first-name");
+        var controller = new FormAIController(new Div(field));
+
+        var fields = formStateFields(controller);
+
+        Assertions.assertEquals(1, fields.size());
+        Assertions.assertEquals("first-name",
+                fields.get(0).get("id").asString());
+    }
+
+    @Test
+    void blankComponentIdFallsBackToGeneratedId() {
+        var field = new TestField();
+        field.setId("");
+        var controller = new FormAIController(new Div(field));
+        controller.describeField(field, "X");
+
+        var id = idOf(field);
+        Assertions.assertNotNull(id);
+        Assertions.assertFalse(id.isBlank(),
+                "A blank component id must not become the field id");
+    }
+
+    @Test
+    void componentIdSetAfterFirstDiscoveryDoesNotChangeFieldId() {
+        var field = new TestField();
+        var controller = new FormAIController(new Div(field));
+        controller.describeField(field, "X");
+        var generated = idOf(field);
+
+        field.setId("late-id");
+        controller.describeField(field, "Y");
+
+        Assertions.assertEquals(generated, idOf(field),
+                "The field id is fixed once assigned; a later component id "
+                        + "must not replace it");
     }
 
     /** HasValue that is not a Component — rejection case. */

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/IdStorageTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/IdStorageTest.java
@@ -111,9 +111,11 @@ class IdStorageTest {
     }
 
     @Test
-    void blankComponentIdFallsBackToGeneratedId() {
+    void whitespaceComponentIdFallsBackToGeneratedId() {
+        // setId("") removes the attribute, so getId() is already empty for
+        // it; a whitespace-only id is what actually reaches the blank check.
         var field = new TestField();
-        field.setId("");
+        field.setId("  ");
         var controller = new FormAIController(new Div(field));
         controller.describeField(field, "X");
 


### PR DESCRIPTION
## Description

Closes #10072

- `FormAIController` addresses a field by its component id (`setId`) when one is set at first discovery, so tool calls and conversation logs stay readable and reproducible across runs
  - Fields without a component id keep getting a random id
  - The id is fixed once assigned; setting or changing the component id later has no effect
- Documented field ids in the controller Javadoc and reworded the system prompt, which no longer calls ids opaque
- Added unit tests in `IdStorageTest`

## Type of change

- Feature