### PR TITLE
fix: validate tool schemas on registration, naming the tool

### DIFF
--- a/guidelines/ai-components.md
+++ b/guidelines/ai-components.md
@@ -109,8 +109,9 @@ The group has no `-testbench` module and, apart from `FormFieldMarker`'s
 
 ## LLM tools
 
-- Tool names are `snake_case` and must match `^[a-zA-Z0-9_-]{1,64}$`
-  (validated on registration).
+- Tool names are `snake_case` and must match `^[a-zA-Z0-9_-]{1,64}$`, and a
+  declared parameters schema must be a JSON object (both validated on
+  registration, so a broken definition fails fast and names the tool).
 - Each controller keeps its tool definitions in a sibling `XxxAITools`
   factory class with a nested `Callbacks` interface implemented by the
   controller, keeping tool JSON and descriptions decoupled from the

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -63,13 +63,14 @@ import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadHelper;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableSupplier;
-import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.streams.UploadHandler;
 
 import reactor.core.scheduler.Schedulers;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Orchestrator for AI-powered chat interfaces.
@@ -967,6 +968,14 @@ public class AIOrchestrator implements Serializable {
     }
 
     /**
+     * Parser for tool schemas. Flow's shared mapper accepts non-standard JSON
+     * such as single-quoted strings, which the providers would pass on as-is
+     * and then fail with on every request.
+     */
+    private static final ObjectMapper STRICT_JSON = JsonMapper.builder()
+            .build();
+
+    /**
      * Checks that the tool's parameters schema, when it declares one, is a JSON
      * object. A {@code null} or blank schema means the tool takes no parameters
      * and is valid.
@@ -978,7 +987,7 @@ public class AIOrchestrator implements Serializable {
         }
         JsonNode parsed;
         try {
-            parsed = JacksonUtils.getMapper().readTree(schema);
+            parsed = STRICT_JSON.readTree(schema);
         } catch (JacksonException e) {
             throw new IllegalArgumentException("Tool '" + tool.getName()
                     + "' has a parameters schema that is not valid JSON: "

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -63,10 +63,12 @@ import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadHelper;
 import com.vaadin.flow.component.upload.UploadManager;
 import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.streams.UploadHandler;
 
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 
 /**
@@ -923,7 +925,13 @@ public class AIOrchestrator implements Serializable {
         }
     }
 
-    private static void validateToolNames(List<LLMProvider.ToolSpec> tools) {
+    /**
+     * Validates the tools a controller exposes at registration time, so a
+     * malformed definition fails fast and names the tool. The alternative is
+     * the vendor framework rejecting the schema on every request with a JSON
+     * parse error that says nothing about which tool it came from.
+     */
+    private static void validateTools(List<LLMProvider.ToolSpec> tools) {
         var seen = new HashSet<String>();
         for (var tool : tools) {
             var name = tool.getName();
@@ -940,6 +948,7 @@ public class AIOrchestrator implements Serializable {
                                 + "(pattern: "
                                 + VALID_TOOL_NAME_PATTERN.pattern() + ").");
             }
+            validateParametersSchema(tool);
             if (SESSION_CONTEXT_TOOL_NAME.equals(name)) {
                 LOGGER.warn(
                         "Tool name '{}' is reserved for the built-in session context tool",
@@ -950,6 +959,30 @@ public class AIOrchestrator implements Serializable {
                         "Duplicate tool name '{}': previous tool will be replaced",
                         name);
             }
+        }
+    }
+
+    /**
+     * Checks that the tool's parameters schema, when it declares one, is a JSON
+     * object. A {@code null} or blank schema means the tool takes no parameters
+     * and is valid.
+     */
+    private static void validateParametersSchema(LLMProvider.ToolSpec tool) {
+        var schema = tool.getParametersSchema();
+        if (schema == null || schema.isBlank()) {
+            return;
+        }
+        JsonNode parsed;
+        try {
+            parsed = JacksonUtils.getMapper().readTree(schema);
+        } catch (JacksonException e) {
+            throw new IllegalArgumentException("Tool '" + tool.getName()
+                    + "' has a parameters schema that is not valid JSON: "
+                    + e.getOriginalMessage(), e);
+        }
+        if (parsed == null || !parsed.isObject()) {
+            throw new IllegalArgumentException("Tool '" + tool.getName()
+                    + "' has a parameters schema that is not a JSON object.");
         }
     }
 
@@ -1017,13 +1050,13 @@ public class AIOrchestrator implements Serializable {
          *            the controller to use, not {@code null}
          * @return this reconnector
          * @throws IllegalArgumentException
-         *             if any tool name is invalid
+         *             if any tool name or parameters schema is invalid
          * @since 25.2
          */
         public Reconnector withController(AIController controller) {
             Objects.requireNonNull(controller, "Controller cannot be null");
             if (controller.getTools() != null) {
-                validateToolNames(controller.getTools());
+                validateTools(controller.getTools());
             }
             this.controller = controller;
             return this;
@@ -1322,13 +1355,13 @@ public class AIOrchestrator implements Serializable {
          * @throws NullPointerException
          *             if controller is {@code null}
          * @throws IllegalArgumentException
-         *             if any tool name is invalid
+         *             if any tool name or parameters schema is invalid
          * @since 25.2
          */
         public Builder withController(AIController controller) {
             Objects.requireNonNull(controller, "Controller cannot be null");
             if (controller.getTools() != null) {
-                validateToolNames(controller.getTools());
+                validateTools(controller.getTools());
             }
             warnIfAlreadySet(this.controller, "Controller");
             this.controller = controller;

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -962,11 +962,6 @@ public class AIOrchestrator implements Serializable {
         }
     }
 
-    /**
-     * Parser for tool schemas. Flow's shared mapper accepts non-standard JSON
-     * such as single-quoted strings, which the providers would pass on as-is
-     * and then fail with on every request.
-     */
     private static final ObjectMapper STRICT_JSON = JsonMapper.builder()
             .build();
 

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -928,13 +928,8 @@ public class AIOrchestrator implements Serializable {
 
     /**
      * Validates the tools a controller exposes at registration time, so a
-     * malformed definition fails fast and names the tool. Left to the
-     * providers, a broken schema is handled inconsistently: Spring AI rejects
-     * it on every request with a parse error that does not say which tool it
-     * came from, while LangChain4j logs a warning and declares the tool without
-     * parameters, so it stays callable but receives empty arguments. Failing
-     * here replaces both with one error at the point where the tool is
-     * registered.
+     * malformed definition fails fast and names the tool instead of failing
+     * later at request time.
      */
     private static void validateTools(List<LLMProvider.ToolSpec> tools) {
         var seen = new HashSet<String>();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/main/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestrator.java
@@ -927,9 +927,13 @@ public class AIOrchestrator implements Serializable {
 
     /**
      * Validates the tools a controller exposes at registration time, so a
-     * malformed definition fails fast and names the tool. The alternative is
-     * the vendor framework rejecting the schema on every request with a JSON
-     * parse error that says nothing about which tool it came from.
+     * malformed definition fails fast and names the tool. Left to the
+     * providers, a broken schema is handled inconsistently: Spring AI rejects
+     * it on every request with a parse error that does not say which tool it
+     * came from, while LangChain4j logs a warning and declares the tool without
+     * parameters, so it stays callable but receives empty arguments. Failing
+     * here replaces both with one error at the point where the tool is
+     * registered.
      */
     private static void validateTools(List<LLMProvider.ToolSpec> tools) {
         var seen = new HashSet<String>();

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -3107,6 +3107,73 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void builder_withMalformedToolSchema_throwsNamingTool() {
+        // An unescaped quote inside a description: the kind of typo that
+        // otherwise surfaces as an anonymous Jackson error on every request.
+        var broken = """
+                {"type": "object", "properties": {
+                  "q": {"type": "string", "description": "the "user"s query"}
+                }}""";
+        var controller = createController(createToolSpec("good_tool", "Fine"),
+                createToolSpec("broken_tool", "Broken", broken));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'broken_tool'"),
+                "Exception should name the tool with the broken schema; got: "
+                        + exception.getMessage());
+        Assertions.assertNotNull(exception.getCause(),
+                "The parse error should be kept as the cause");
+    }
+
+    @Test
+    void builder_withNonObjectToolSchema_throwsNamingTool() {
+        var controller = createController(
+                createToolSpec("array_tool", "Array", "[1, 2]"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'array_tool'"),
+                "Exception should name the tool; got: "
+                        + exception.getMessage());
+    }
+
+    @Test
+    void builder_withValidOrAbsentToolSchema_doesNotThrow() {
+        var controller = createController(
+                createToolSpec("no_schema", "None", null),
+                createToolSpec("blank_schema", "Blank", "  "),
+                createToolSpec("object_schema", "Object", """
+                        {"type": "object", "properties": {
+                          "q": {"type": "string"}}, "required": ["q"]}"""));
+
+        Assertions.assertDoesNotThrow(() -> AIOrchestrator
+                .builder(mockProvider, null).withController(controller));
+    }
+
+    @Test
+    void reconnect_withMalformedToolSchema_throwsNamingTool() throws Exception {
+        var orchestrator = AIOrchestrator.builder(mockProvider, null)
+                .withMessageList(mockMessageList).build();
+
+        var providerField = AIOrchestrator.class.getDeclaredField("provider");
+        providerField.setAccessible(true);
+        providerField.set(orchestrator, null);
+
+        var controller = createController(
+                createToolSpec("broken_tool", "Broken", "{not json"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> orchestrator.reconnect(mockProvider)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'broken_tool'"),
+                "Exception should name the tool; got: "
+                        + exception.getMessage());
+    }
+
+    @Test
     void builder_withControllerCalledTwice_logsWarning() {
         var orchestratorBuilder = AIOrchestrator.builder(mockProvider, null)
                 .withController(createController());
@@ -3336,6 +3403,11 @@ class AIOrchestratorTest {
 
     private static LLMProvider.ToolSpec createToolSpec(String name,
             String description) {
+        return createToolSpec(name, description, null);
+    }
+
+    private static LLMProvider.ToolSpec createToolSpec(String name,
+            String description, String parametersSchema) {
         return new LLMProvider.ToolSpec() {
             @Override
             public String getName() {
@@ -3349,7 +3421,7 @@ class AIOrchestratorTest {
 
             @Override
             public String getParametersSchema() {
-                return null;
+                return parametersSchema;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-core-flow/src/test/java/com/vaadin/flow/component/ai/orchestrator/AIOrchestratorTest.java
@@ -3128,6 +3128,22 @@ class AIOrchestratorTest {
     }
 
     @Test
+    void builder_withSingleQuotedToolSchema_throwsNamingTool() {
+        // Single quotes are not JSON. Flow's own mapper accepts them, but the
+        // providers hand the schema on as text, so a lenient check here would
+        // let the schema through only to fail on every request.
+        var controller = createController(createToolSpec("quoted_tool",
+                "Quoted", "{'type': 'object', 'properties': {}}"));
+
+        var exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> AIOrchestrator.builder(mockProvider, null)
+                        .withController(controller));
+        Assertions.assertTrue(exception.getMessage().contains("'quoted_tool'"),
+                "Exception should name the tool; got: "
+                        + exception.getMessage());
+    }
+
+    @Test
     void builder_withNonObjectToolSchema_throwsNamingTool() {
         var controller = createController(
                 createToolSpec("array_tool", "Array", "[1, 2]"));


### PR DESCRIPTION
## Description

Fixes #10079

- `withController` on `AIOrchestrator.Builder` and `Reconnector` now parses each tool's parameters schema and throws `IllegalArgumentException` naming the tool when the schema is not valid JSON or not a JSON object
  - Before, the provider framework rejected the schema on every request with a Jackson error that did not say which tool it came from
- Updated the tool rules in `guidelines/ai-components.md`
- Added unit tests for malformed, non-object, valid, and absent schemas on both the builder and the reconnector

## Type of change

- Bugfix

> [!NOTE]
> A controller with a broken tool schema now fails when it is registered instead of at request time.