### PR TITLE
fix: remove restoreFieldSource from FormAIController

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIFieldMarkerPage.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-components-flow-integration-tests/src/main/java/com/vaadin/flow/component/ai/tests/AIFieldMarkerPage.java
@@ -19,17 +19,19 @@ import java.util.List;
 import java.util.UUID;
 
 import com.vaadin.flow.component.Text;
-import com.vaadin.flow.component.ai.common.ConfidenceLevel;
-import com.vaadin.flow.component.ai.common.ValueSource;
 import com.vaadin.flow.component.ai.form.FieldMarkerI18n;
 import com.vaadin.flow.component.ai.form.FormAIController;
 import com.vaadin.flow.component.ai.orchestrator.RequestListener;
 import com.vaadin.flow.component.ai.orchestrator.ResponseListener;
+import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.router.Route;
+
+import tools.jackson.databind.JsonNode;
 
 /**
  * Test page for the AI field marker that {@link FormAIController} applies to
@@ -42,6 +44,9 @@ import com.vaadin.flow.router.Route;
  * from the web component's defaults, so a test can tell the texts sent by the
  * server apart from the built-in ones, and with a field-marker popover content
  * provider that adds a recognizable node to the name field's popover only.
+ * Source tracking is on, so the quantity field is written through the
+ * controller's {@code fill_form} tool with a source reporting a confidence
+ * level, the way a real fill reports one.
  *
  * @author Vaadin Ltd
  */
@@ -63,6 +68,7 @@ public class AIFieldMarkerPage extends VerticalLayout {
     static final String UNCHANGED_VALUE = "Unchanged";
     static final String LOCKED_VALUE = "CC-1024";
     static final String CONFIDENT_VALUE = "42";
+    static final String CONFIDENT_LABEL = "Quantity";
 
     public AIFieldMarkerPage() {
         var name = new TextField("Name");
@@ -87,9 +93,10 @@ public class AIFieldMarkerPage extends VerticalLayout {
         locked.setId("locked");
         name.addValueChangeListener(event -> locked.setReadOnly(true));
 
-        // Filled together with a source reporting a confidence level, so its
-        // marker must show the confidence indicator.
-        var confident = new TextField("Quantity");
+        // Filled through the fill_form tool together with a source reporting
+        // a confidence level, so its marker must show the confidence
+        // indicator.
+        var confident = new TextField(CONFIDENT_LABEL);
         confident.setId("confident");
 
         var form = new VerticalLayout(name, company, unchanged, locked,
@@ -97,6 +104,7 @@ public class AIFieldMarkerPage extends VerticalLayout {
         form.setId("form");
 
         var controller = new FormAIController(form);
+        controller.setSourceTrackingEnabled(true);
         controller.setFieldMarkerI18n(new FieldMarkerI18n().setMessage(MESSAGE)
                 .setRevert(REVERT).setBadgeLabel(BADGE_LABEL)
                 .setBadgeTooltip(BADGE_TOOLTIP)
@@ -129,17 +137,51 @@ public class AIFieldMarkerPage extends VerticalLayout {
             name.setValue(NAME_VALUE);
             company.setValue(COMPANY_VALUE);
             unchanged.setValue(UNCHANGED_VALUE);
-            confident.setValue(CONFIDENT_VALUE);
-            // Attach a source to the value just written, standing in for the
-            // one a real fill would report, so the marker applied at turn end
-            // shows its confidence level.
-            controller.restoreFieldSource(confident,
-                    new ValueSource(ConfidenceLevel.HIGH, null));
+            // A source only reaches a field through a fill, so this value is
+            // written the way the LLM writes one: through the fill_form tool,
+            // wrapped in a source envelope reporting a confidence level. The
+            // marker applied at turn end then shows the level.
+            fillWithSource(controller, CONFIDENT_LABEL, CONFIDENT_VALUE,
+                    "high");
             controller.onResponse(
                     new ResponseListener.ResponseEvent("", null, null));
         });
         finishTurn.setId("finish-turn");
 
         add(form, startTurn, finishTurn);
+    }
+
+    /**
+     * Writes a value to a field through the controller's {@code fill_form}
+     * tool, wrapped in the envelope the LLM uses to report a source with a
+     * confidence level. The field is addressed by its description in the
+     * {@code get_form_state} output, which for a plain labeled field is its
+     * label.
+     */
+    private static void fillWithSource(FormAIController controller,
+            String label, String value, String confidence) {
+        var tools = controller.getTools();
+        var formState = JacksonUtils
+                .readTree(executeTool(tools, "get_form_state", "{}"));
+        executeTool(tools, "fill_form", """
+                {"values": {"%s": {"value": "%s", "confidence": "%s"}}}"""
+                .formatted(fieldIdOf(formState, label), value, confidence));
+    }
+
+    private static String fieldIdOf(JsonNode formState, String description) {
+        for (var field : formState.path("fields")) {
+            if (description.equals(field.path("description").asString())) {
+                return field.path("id").asString();
+            }
+        }
+        throw new IllegalStateException(
+                "get_form_state lists no field described as " + description);
+    }
+
+    private static String executeTool(List<LLMProvider.ToolSpec> tools,
+            String name, String arguments) {
+        return tools.stream().filter(tool -> tool.getName().equals(name))
+                .findFirst().orElseThrow()
+                .execute(JacksonUtils.readTree(arguments));
     }
 }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -185,8 +185,7 @@ import tools.jackson.databind.JsonNode;
  * the LLM also reports, per filled value, the snippets it read, where each one
  * sits in the document, and a confidence level. The data is available from
  * {@link FieldValueChangeEvent#getFieldSource()} and
- * {@link #getFieldSource(HasValue)}, and can be stored and put back later with
- * {@link #restoreFieldSource(HasValue, ValueSource)}. Off by default.
+ * {@link #getFieldSource(HasValue)}. Off by default.
  * </p>
  *
  * <p>
@@ -363,17 +362,16 @@ public class FormAIController implements AIController {
      * {@link ComponentUtil#setData(Component, Class, Object)} — tying its
      * lifecycle to the field rather than to the controller — and tied to the
      * field value the source was reported with. The value is captured from the
-     * field right after the write (or at {@link #restoreFieldSource} time) so
-     * any normalisation the field applied is reflected; {@link #getFieldSource}
-     * compares it against the field's current value to detect a source a turn
-     * left stale. A source lasts as long as the value it describes: the
-     * registration belongs to a value-change listener that drops the source the
-     * moment the value changes outside a fill turn, so a stale source can never
-     * come back by the field regaining the value. The listener stands down
-     * during a turn — the AI's own write sequence must not drop the source it
-     * just stored — so sources a turn leaves stale (a value-change cascade
-     * overwriting a sourced field) are swept at turn end instead by
-     * {@link #purgeStaleFieldSources}.
+     * field right after the write so any normalisation the field applied is
+     * reflected; {@link #getFieldSource} compares it against the field's
+     * current value to detect a source a turn left stale. A source lasts as
+     * long as the value it describes: the registration belongs to a
+     * value-change listener that drops the source the moment the value changes
+     * outside a fill turn, so a stale source can never come back by the field
+     * regaining the value. The listener stands down during a turn — the AI's
+     * own write sequence must not drop the source it just stored — so sources a
+     * turn leaves stale (a value-change cascade overwriting a sourced field)
+     * are swept at turn end instead by {@link #purgeStaleFieldSources}.
      */
     private record StoredFieldSource(Object value, ValueSource source,
             Registration registration) implements Serializable {
@@ -829,30 +827,6 @@ public class FormAIController implements AIController {
             return Optional.empty();
         }
         return Optional.of(stored.source());
-    }
-
-    /**
-     * Attaches a previously stored source to the field, so an application that
-     * persisted the data (see {@link FieldValueChangeEvent#getFieldSource()})
-     * can show it again after a reload without the original chat session.
-     * Restore the field's value first and the source after: the source is tied
-     * to the field's value at the moment of this call, so it is dropped on the
-     * next edit just like a fresh one.
-     *
-     * @param field
-     *            the field the source describes, not {@code null}
-     * @param source
-     *            the source to restore, not {@code null}
-     * @throws NullPointerException
-     *             if {@code field} or {@code source} is {@code null}
-     * @throws IllegalArgumentException
-     *             if {@code field} is not a {@link Component}
-     * @since 25.3
-     */
-    public void restoreFieldSource(HasValue<?, ?> field, ValueSource source) {
-        Objects.requireNonNull(field, "Field must not be null");
-        Objects.requireNonNull(source, "Source must not be null");
-        putFieldSource(field, source);
     }
 
     /**

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.component.ai.AITurnEvents;
 import com.vaadin.flow.component.ai.common.ConfidenceLevel;
 import com.vaadin.flow.component.ai.common.PageRegion;
 import com.vaadin.flow.component.ai.common.SourceExtract;
-import com.vaadin.flow.component.ai.common.ValueSource;
 import com.vaadin.flow.component.ai.form.FormTestFields.DoubleField;
 import com.vaadin.flow.component.ai.form.FormTestFields.TestField;
 import com.vaadin.flow.component.html.Div;
@@ -720,54 +719,6 @@ class SourceTrackingTest {
 
             Assertions.assertThrows(NullPointerException.class,
                     () -> controller.getFieldSource(null));
-        }
-    }
-
-    @Nested
-    class Restore {
-
-        @Test
-        void restoredSourceIsReturnedForTheCurrentValue() {
-            var field = new TestField();
-            field.setValue("persisted");
-            var controller = controllerFor(field);
-            var source = new ValueSource(ConfidenceLevel.MEDIUM,
-                    List.of(new SourceExtract("snippet", null)));
-
-            controller.restoreFieldSource(field, source);
-
-            Assertions.assertEquals(source,
-                    controller.getFieldSource(field).orElseThrow());
-        }
-
-        @Test
-        void restoredSourceGoesStaleOnNextEdit() {
-            var field = new TestField();
-            field.setValue("persisted");
-            var controller = controllerFor(field);
-            controller.onResponse(AITurnEvents.success());
-            controller.restoreFieldSource(field,
-                    new ValueSource(ConfidenceLevel.MEDIUM, null));
-
-            field.setValue("edited");
-
-            Assertions.assertTrue(controller.getFieldSource(field).isEmpty());
-        }
-
-        @Test
-        void restoreFieldSourceRejectsNullArguments() {
-            var field = new TestField();
-            var controller = controllerFor(field);
-            var source = new ValueSource(null, null);
-
-            var thrown = Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.restoreFieldSource(null, source));
-            Assertions.assertEquals("Field must not be null",
-                    thrown.getMessage(),
-                    "The guard must fail fast with its own message, not "
-                            + "through a downstream NPE");
-            Assertions.assertThrows(NullPointerException.class,
-                    () -> controller.restoreFieldSource(field, null));
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #10078

Making the method also mark the field was considered and rejected. The value from before the fill is not part of the restored data, so the revert control would have had nothing to restore, and applications without source tracking would still have had no way to bring a mark back at all.

- Removed `restoreFieldSource(HasValue, ValueSource)` from `FormAIController`, along with its tests and Javadoc mentions
  - A form rebuilt from application data loses its field marks together with the sources, and only the source could be put back, so a restored value looked like user input with nothing to show for the restore. Restoring sources and marks will be designed as one round trip, together with an API for putting marks back.
- Changed `AIFieldMarkerPage` to write the quantity field through the `fill_form` tool with a source envelope, the way a real fill reports a source

## Type of change

- Bugfix

> [!NOTE]
> The method shipped in the 25.3 betas, so this needs a pick to the 25.3 branch before GA.