### PR TITLE
test: assert the badge renders its content, not only that its text is in the DOM

### DIFF
--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/src/test/java/com/vaadin/flow/component/badge/tests/BadgeBasicIT.java
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/src/test/java/com/vaadin/flow/component/badge/tests/BadgeBasicIT.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.badge.testbench.BadgeElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-badge/basic")
@@ -37,5 +38,25 @@ public class BadgeBasicIT extends AbstractComponentIT {
         Assert.assertEquals("messages", badge.getText());
         Assert.assertEquals((Integer) 5, badge.getNumber());
         Assert.assertNotNull(badge.getIcon());
+    }
+
+    /**
+     * The badge keeps its content part hidden until the web component has seen
+     * text in the default slot, so a badge can carry its text in the light DOM
+     * and render as an empty pill. {@link BadgeElement#getText()} reads those
+     * text nodes with a script, which is the right answer for the component's
+     * text and cannot tell the two states apart, so this asserts what the
+     * browser paints instead.
+     */
+    @Test
+    public void badgeContentRendered() {
+        var badge = $(BadgeElement.class).id("badge");
+        Assert.assertTrue("Badge should have the has-content attribute",
+                badge.hasAttribute("has-content"));
+
+        var content = badge.$(TestBenchElement.class)
+                .withAttribute("part", "content").first();
+        Assert.assertTrue("Badge content should be rendered",
+                content.getPropertyDouble("offsetWidth") > 0);
     }
 }

--- a/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/src/test/java/com/vaadin/flow/component/badge/tests/BadgeBasicIT.java
+++ b/vaadin-badge-flow-parent/vaadin-badge-flow-integration-tests/src/test/java/com/vaadin/flow/component/badge/tests/BadgeBasicIT.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.badge.testbench.BadgeElement;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.tests.AbstractComponentIT;
 
 @TestPath("vaadin-badge/basic")
@@ -41,22 +40,16 @@ public class BadgeBasicIT extends AbstractComponentIT {
     }
 
     /**
-     * The badge keeps its content part hidden until the web component has seen
-     * text in the default slot, so a badge can carry its text in the light DOM
-     * and render as an empty pill. {@link BadgeElement#getText()} reads those
-     * text nodes with a script, which is the right answer for the component's
-     * text and cannot tell the two states apart, so this asserts what the
-     * browser paints instead.
+     * The content part is hidden while the badge has no {@code has-content}
+     * attribute, so a badge can carry its text in the light DOM and render as
+     * an empty pill. {@link BadgeElement#getText()} reads those text nodes with
+     * a script, which is the right answer for the component's text and cannot
+     * tell the two states apart.
      */
     @Test
     public void badgeContentRendered() {
         var badge = $(BadgeElement.class).id("badge");
         Assert.assertTrue("Badge should have the has-content attribute",
                 badge.hasAttribute("has-content"));
-
-        var content = badge.$(TestBenchElement.class)
-                .withAttribute("part", "content").first();
-        Assert.assertTrue("Badge content should be rendered",
-                content.getPropertyDouble("offsetWidth") > 0);
     }
 }


### PR DESCRIPTION
## Summary

- `BadgeBasicIT` asserted only `BadgeElement.getText()`, which reads the light DOM text nodes with a script. The text is there even when the badge renders nothing, so the test cannot fail for the one thing this tier exists to check.
- Adds an assertion on what the browser paints: `has-content` on the host, and a non zero `offsetWidth` for `[part="content"]`.

## Context

This is the blind spot behind vaadin/web-components#12663. Flow appends an empty text node and writes its data afterwards, the badge never received `has-content`, and every Flow badge carrying text rendered as an empty pill with its text sitting in the DOM. No tier saw it: the unit and visual tests upstream set the text with `element.textContent`, which replaces the node and fires `slotchange`, and this IT read the light DOM.

The new assertion fails against the badge this module installs today, `@vaadin/badge` 25.3.0-beta2, which is the newest published version, and passes with vaadin/web-components#12664 patched into `node_modules`. That fix is merged and not published yet, so this is a draft: it is ready to merge once the badge pin moves to a version carrying it, and until then it is the check that says whether the pin is good.
