### PR TITLE
fix: enforce the source envelope in the fill_form schema

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAIController.java
@@ -772,6 +772,10 @@ public class FormAIController implements AIController {
      * extracts are what the model says it read — they are not checked against
      * the document.
      * <p>
+     * A source describes where in an attached document a value was read. A
+     * value with nothing to point at, such as one taken from the chat prompt,
+     * carries no source.
+     * <p>
      * A source says where a snippet is inside a document, but not which
      * document. Send at most one attachment per prompt while source tracking is
      * on: with several, there is no way to tell which one a reported location
@@ -1742,34 +1746,36 @@ public class FormAIController implements AIController {
         }
 
         @Override
+        public boolean isSourceTrackingEnabled() {
+            return sourceTrackingEnabled;
+        }
+
+        @Override
         public String sourceInstructions() {
             if (!sourceTrackingEnabled) {
                 return "";
             }
             return """
                     \s\
-                    Source tracking is on. When a value comes from an \
-                    attached document, wrap it in an object instead of \
-                    sending it plainly: {"value": <the value as you would \
-                    otherwise send it>, "confidence": <level>, "extracts": \
-                    [{"text": <snippet>, "location": {"type": \
-                    "page-region", "page": <page>, "rect": [x, y, width, \
-                    height]}}]}. "value" is required; plain values stay \
-                    valid for fields with nothing to point at. List in \
-                    "extracts" every snippet you read to produce the \
-                    value, each with its text copied verbatim from the \
-                    document. "rect" is the snippet's bounding box as \
+                    Source tracking is on. Send every entry of "values" as \
+                    an object: {"value": <the value as you would otherwise \
+                    send it>, "confidence": <level>, "extracts": [{"text": \
+                    <snippet>, "location": {"type": "page-region", "page": \
+                    <page>, "rect": [x, y, width, height]}}]}. "value" is \
+                    required. When the value was read from an attached \
+                    document, list in "extracts" every snippet you read to \
+                    produce it, each with its text copied verbatim from \
+                    the document. "rect" is the snippet's bounding box as \
                     fractions of the page as displayed, [left, top, width, \
                     height] measured from the top-left corner. "page" \
                     starts at 1; leave it out when the source has a single \
                     surface, such as an image. Leave "location" out when \
-                    the snippet has no position, such as pasted text; \
-                    leave "extracts" out when there is no source document \
-                    at all. "confidence" is "high" when %s; "medium" when \
-                    %s; "low" when %s. Leave "confidence" out when you \
-                    cannot judge it, such as for a value taken from the \
-                    chat prompt. Never invent a snippet, a location, or a \
-                    confidence level.""".formatted(
+                    the snippet has no position, such as pasted text. \
+                    "confidence" is "high" when %s; "medium" when %s; \
+                    "low" when %s. Leave "confidence" and "extracts" out \
+                    when the value did not come from a document, such as a \
+                    value taken from the chat prompt. Never invent a \
+                    snippet, a location, or a confidence level.""".formatted(
                     describeConfidence(ConfidenceLevel.HIGH),
                     describeConfidence(ConfidenceLevel.MEDIUM),
                     describeConfidence(ConfidenceLevel.LOW));

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/form/FormAITools.java
@@ -8,12 +8,16 @@
  */
 package com.vaadin.flow.component.ai.form;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.ai.common.ConfidenceLevel;
 import com.vaadin.flow.component.ai.provider.LLMProvider;
 import com.vaadin.flow.component.ai.provider.ToolException;
 import com.vaadin.flow.internal.JacksonUtils;
@@ -32,6 +36,89 @@ final class FormAITools {
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(FormAITools.class);
+
+    /**
+     * The {@code fill_form} parameter schema while source tracking is off: an
+     * open-keyed map of field ids to plain values.
+     */
+    private static final String FILL_FORM_SCHEMA = """
+            {
+              "type": "object",
+              "properties": {
+                "values": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "required": ["values"]
+            }""";
+
+    /**
+     * The {@code fill_form} parameter schema while source tracking is on: every
+     * entry of the {@code values} map is the source-reporting envelope
+     * {@link ValueSourceParser} reads, with only {@code value} required. The
+     * envelope is the only value shape the schema offers on purpose: given the
+     * choice between a plain value and the envelope, smaller models always pick
+     * the plain one and never report a source, while a mandatory object they
+     * fill. A plain value that arrives anyway is still written, without a
+     * source.
+     */
+    private static final String TRACKED_FILL_FORM_SCHEMA = """
+            {
+              "type": "object",
+              "properties": {
+                "values": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "description": "One field's value, with its source when the value was read from an attached document.",
+                    "properties": {
+                      "value": {
+                        "description": "The value as you would otherwise send it."
+                      },
+                      "confidence": {
+                        "type": "string",
+                        "enum": [%s]
+                      },
+                      "extracts": {
+                        "type": "array",
+                        "description": "Every snippet read from the attached document to produce the value. Leave out when the value did not come from a document.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "text": {
+                              "type": "string",
+                              "description": "The snippet, copied verbatim from the document."
+                            },
+                            "location": {
+                              "type": "object",
+                              "properties": {
+                                "type": { "type": "string", "enum": ["page-region"] },
+                                "page": { "type": "integer", "minimum": 1 },
+                                "rect": {
+                                  "type": "array",
+                                  "description": "[left, top, width, height] as fractions of the page.",
+                                  "items": { "type": "number" },
+                                  "minItems": 4,
+                                  "maxItems": 4
+                                }
+                              },
+                              "required": ["type", "rect"]
+                            }
+                          },
+                          "required": ["text"]
+                        }
+                      }
+                    },
+                    "required": ["value"]
+                  }
+                }
+              },
+              "required": ["values"]
+            }"""
+            .formatted(Arrays.stream(ConfidenceLevel.values()).map(
+                    level -> '"' + level.name().toLowerCase(Locale.ROOT) + '"')
+                    .collect(Collectors.joining(", ")));
 
     private FormAITools() {
     }
@@ -100,6 +187,16 @@ final class FormAITools {
          *         off; never {@code null}
          */
         String sourceInstructions();
+
+        /**
+         * Returns whether source tracking is on. While it is, the
+         * {@code fill_form} parameter schema describes the source-reporting
+         * envelope every value is sent in; otherwise the schema is the plain
+         * open-keyed one.
+         *
+         * @return {@code true} while source tracking is on
+         */
+        boolean isSourceTrackingEnabled();
 
         /**
          * Applies the {@code fill_form} payload onto the form's fields and
@@ -266,14 +363,17 @@ final class FormAITools {
      * The parameter schema is static and open-keyed so the tool definition
      * stays byte-identical across the session — LLM providers that cache prompt
      * prefixes (system prompt + tool defs) hit the cache on every subsequent
-     * prompt. The LLM discovers per-field shape via {@code get_form_state} on
-     * each turn; this keeps the two tools' view of the form coherent and lets
-     * structural changes between tool calls within a single turn surface on the
-     * next {@code get_form_state} call (the dynamic per-field shape would
-     * freeze at stream open and silently miss such changes). The {@code values}
-     * wrapper exists so future top-level parameters (e.g. a {@code dryRun}
-     * flag) can be added without breaking the field-map shape. Per-field type
-     * validation is enforced server-side by
+     * prompt. The only variation is the source-tracking toggle: while it is on,
+     * the schema describes the envelope every value is sent in and the
+     * description carries the matching instructions; while it is off, both are
+     * the untracked ones. The LLM discovers per-field shape via
+     * {@code get_form_state} on each turn; this keeps the two tools' view of
+     * the form coherent and lets structural changes between tool calls within a
+     * single turn surface on the next {@code get_form_state} call (the dynamic
+     * per-field shape would freeze at stream open and silently miss such
+     * changes). The {@code values} wrapper exists so future top-level
+     * parameters (e.g. a {@code dryRun} flag) can be added without breaking the
+     * field-map shape. Per-field type validation is enforced server-side by
      * {@code FormValueConverter.convert(...)} — failures surface in the
      * {@code rejected} array of the JSON response, keyed by the offending
      * field's id.
@@ -317,17 +417,9 @@ final class FormAITools {
 
             @Override
             public String getParametersSchema() {
-                return """
-                        {
-                          "type": "object",
-                          "properties": {
-                            "values": {
-                              "type": "object",
-                              "additionalProperties": true
-                            }
-                          },
-                          "required": ["values"]
-                        }""";
+                return callbacks.isSourceTrackingEnabled()
+                        ? TRACKED_FILL_FORM_SCHEMA
+                        : FILL_FORM_SCHEMA;
             }
 
             @Override

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/FillFormToolTest.java
@@ -2308,6 +2308,11 @@ class FillFormToolTest {
             }
 
             @Override
+            public boolean isSourceTrackingEnabled() {
+                return false;
+            }
+
+            @Override
             public String executeFill(JsonNode arguments) {
                 throw toThrow;
             }

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/form/SourceTrackingTest.java
@@ -97,6 +97,96 @@ class SourceTrackingTest {
     }
 
     @Nested
+    class ToolSchema {
+
+        @Test
+        void schemaDescribesEnvelopeOnlyWhileTrackingIsOn() {
+            var controller = controllerFor(new TestField());
+            var untracked = fillFormSchema(controller);
+            Assertions.assertTrue(valueSchema(untracked).isBoolean(),
+                    "Untracked schema must keep the open-keyed values map, "
+                            + "got: " + untracked);
+
+            controller.setSourceTrackingEnabled(true);
+            var tracked = fillFormSchema(controller);
+            Assertions.assertEquals("object",
+                    valueSchema(tracked).path("type").asString(),
+                    "Tracking must make every value the envelope object, "
+                            + "got: " + tracked);
+            Assertions.assertEquals(tracked, fillFormSchema(controller),
+                    "Tracked schema must be byte-identical across calls so "
+                            + "providers can cache the tool definition");
+
+            controller.setSourceTrackingEnabled(false);
+            Assertions.assertEquals(untracked, fillFormSchema(controller),
+                    "Toggling tracking off must restore the untracked "
+                            + "schema");
+        }
+
+        @Test
+        void envelopeRequiresOnlyTheValue() {
+            var controller = controllerFor(new TestField())
+                    .setSourceTrackingEnabled(true);
+
+            var envelope = valueSchema(fillFormSchema(controller));
+            var properties = envelope.path("properties");
+            Assertions.assertTrue(properties.has("value"));
+            Assertions.assertTrue(properties.has("confidence"));
+            Assertions.assertTrue(properties.has("extracts"));
+            Assertions.assertEquals(List.of("value"),
+                    stringsOf(envelope.path("required")),
+                    "A value with nothing to point at is sent without "
+                            + "confidence and extracts");
+        }
+
+        @Test
+        void envelopeListsEveryConfidenceLevel() {
+            var controller = controllerFor(new TestField())
+                    .setSourceTrackingEnabled(true);
+
+            var levels = stringsOf(valueSchema(fillFormSchema(controller))
+                    .path("properties").path("confidence").path("enum"));
+
+            var expected = new ArrayList<String>();
+            for (var level : ConfidenceLevel.values()) {
+                expected.add(level.name().toLowerCase());
+            }
+            Assertions.assertEquals(expected, levels,
+                    "The schema must offer exactly the levels the parser "
+                            + "accepts, in lower case");
+        }
+
+        @Test
+        void envelopeDescribesExtractsAsParserReadsThem() {
+            var controller = controllerFor(new TestField())
+                    .setSourceTrackingEnabled(true);
+
+            var extract = valueSchema(fillFormSchema(controller))
+                    .path("properties").path("extracts").path("items");
+            Assertions.assertEquals(List.of("text"),
+                    stringsOf(extract.path("required")),
+                    "An extract needs its text, the location is optional");
+            var location = extract.path("properties").path("location")
+                    .path("properties");
+            Assertions.assertTrue(location.has("type"));
+            Assertions.assertTrue(location.has("page"));
+            Assertions.assertTrue(location.has("rect"));
+        }
+
+        /** The schema of one entry of the {@code values} map. */
+        private JsonNode valueSchema(String schema) {
+            return JacksonUtils.readTree(schema).path("properties")
+                    .path("values").path("additionalProperties");
+        }
+
+        private List<String> stringsOf(JsonNode array) {
+            var strings = new ArrayList<String>();
+            array.forEach(node -> strings.add(node.asString()));
+            return strings;
+        }
+    }
+
+    @Nested
     class ToolDescription {
 
         @Test
@@ -1022,5 +1112,10 @@ class SourceTrackingTest {
 
     private static String fillFormDescription(FormAIController controller) {
         return findTool(controller.getTools(), "fill_form").getDescription();
+    }
+
+    private static String fillFormSchema(FormAIController controller) {
+        return findTool(controller.getTools(), "fill_form")
+                .getParametersSchema();
     }
 }


### PR DESCRIPTION
Fixes #10071

## Summary
- With source tracking on, the request to report a source lived only in the `fill_form` description prose. gpt-4o follows it, gpt-4o-mini never does, so smaller models filled every field from an attached document but reported no source.
- The `fill_form` schema now makes the existing envelope `{"value", "confidence", "extracts"}` the shape of every value while source tracking is on, with only `value` required. Asked for by the schema, gpt-4o-mini reports a source for every value read from an attachment and still sends prompt-derived values without one.
- The parser and result structure are unchanged, plain values are still accepted, and when source tracking is off the tool definition is byte-identical to before.