### PR TITLE
fix: stop the LLM repeating a tool call it was given no cause for

### DIFF
--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/chart/ChartAITools.java
@@ -44,6 +44,18 @@ import tools.jackson.databind.JsonNode;
  */
 public final class ChartAITools {
 
+    /**
+     * Tail of the error a tool returns when it failed for a reason the LLM was
+     * given no detail about, because the cause was not a {@link ToolException}
+     * and so is not safe to pass on. Repeating the call unchanged can only fail
+     * the same way, which is what the LLM did without this; a rewritten attempt
+     * is still worth one try, since the cause is often something the LLM can
+     * avoid by itself, such as an identifier the database reserves.
+     */
+    private static final String RETRY_ONCE = " No details about the cause are "
+            + "available. Do not repeat the same %s: change it and try once "
+            + "more, or report the failure if you cannot.";
+
     private static final Logger LOGGER = LoggerFactory
             .getLogger(ChartAITools.class);
 
@@ -528,7 +540,8 @@ public final class ChartAITools {
                             + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_chart_configuration failed", e);
-                    return "Error updating chart configuration.";
+                    return "Error updating chart configuration."
+                            + RETRY_ONCE.formatted("configuration");
                 }
             }
         };
@@ -678,7 +691,8 @@ public final class ChartAITools {
                     return "Error updating chart data: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_chart_data_source failed", e);
-                    return "Error updating chart data.";
+                    return "Error updating chart data."
+                            + RETRY_ONCE.formatted("queries");
                 }
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/main/java/com/vaadin/flow/component/ai/grid/GridAITools.java
@@ -39,6 +39,18 @@ import tools.jackson.databind.JsonNode;
  */
 public final class GridAITools {
 
+    /**
+     * Tail of the error a tool returns when it failed for a reason the LLM was
+     * given no detail about, because the cause was not a {@link ToolException}
+     * and so is not safe to pass on. Repeating the call unchanged can only fail
+     * the same way, which is what the LLM did without this; a rewritten attempt
+     * is still worth one try, since the cause is often something the LLM can
+     * avoid by itself, such as an identifier the database reserves.
+     */
+    private static final String RETRY_ONCE = " No details about the cause are "
+            + "available. Do not repeat the same query: change it and try "
+            + "once more, or report the failure if you cannot.";
+
     private static final Logger LOGGER = LoggerFactory
             .getLogger(GridAITools.class);
 
@@ -234,7 +246,7 @@ public final class GridAITools {
                     return "Error updating grid data: " + e.getMessage();
                 } catch (Exception e) {
                     LOGGER.error("update_grid_data failed", e);
-                    return "Error updating grid data.";
+                    return "Error updating grid data." + RETRY_ONCE;
                 }
             }
         };

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/chart/ChartAIControllerTest.java
@@ -243,7 +243,9 @@ class ChartAIControllerTest {
 
             String result = tool
                     .execute(json("{\"queries\": [\"SELECT foo\"]}"));
-            Assertions.assertEquals("Error updating chart data.", result);
+            Assertions.assertTrue(result.startsWith("Error"), "Got: " + result);
+            Assertions.assertFalse(result.contains("internal detail"),
+                    "The cause must not reach the LLM, got: " + result);
         }
 
         @Test

--- a/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
+++ b/vaadin-ai-components-flow-parent/vaadin-ai-extensions-flow/src/test/java/com/vaadin/flow/component/ai/grid/GridAIControllerTest.java
@@ -152,7 +152,9 @@ class GridAIControllerTest {
         dbProvider.executeException = new RuntimeException("internal detail");
         var tool = findTool("update_grid_data");
         var result = tool.execute(json("{\"query\": \"SELECT foo FROM t\"}"));
-        Assertions.assertEquals("Error updating grid data.", result);
+        Assertions.assertTrue(result.startsWith("Error"), "Got: " + result);
+        Assertions.assertFalse(result.contains("internal detail"),
+                "The cause must not reach the LLM, got: " + result);
     }
 
     @Test


### PR DESCRIPTION
## Description

A `DatabaseProvider` that throws anything other than a `ToolException` leaves the LLM with a bare error and nothing to correct, so it sent the same failing query again and again until the turn was spent. Seen with both gpt-4o and gpt-4o-mini against a provider that threw `IllegalArgumentException`. Repeating the call unchanged can only fail the same way, but a rewritten attempt is still worth one try, because the cause is often something the LLM can avoid by itself, such as an identifier the database reserves.

- Added guidance to the error that `update_chart_data_source`, `update_chart_configuration` and `update_grid_data` return when they fail for a reason the LLM cannot be told: it now asks for a changed query rather than the same one, and for the failure to be reported if it cannot be changed
- Kept the cause itself out of the response, as before, so only a `ToolException` message reaches the LLM
- Narrowed two existing tests that asserted the whole error string down to what the wording cannot change: that the call reports an error, and that the cause never reaches the LLM

## Type of change

- Bugfix

> [!NOTE]
> Nothing enforces the "once more" count, so an LLM that ignores the guidance can still loop. Bounding it properly would mean counting attempts in the controller, which is a bigger change than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)